### PR TITLE
Bugfix in example code

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -147,7 +147,7 @@ int main (int argc, char **argv) {
 		while (run && (fgets(buf, sizeof(buf), stdin))) {
 			int len = strlen(buf);
 			char *opbuf = malloc(len + 1);
-			strncpy(opbuf, buf, len);
+			strncpy(opbuf, buf, len + 1);
 
 			/* Send/Produce message. */
 			rd_kafka_produce(rk, topic, partition, RD_KAFKA_OP_F_FREE, opbuf, len);


### PR DESCRIPTION
Hey

Have a look at this bugfix.  Without it the producer example code corrupts messages in some cases (e.g., when piping output from cat or similar into the example).

The fix I did works, but it's a bit quick.  You can pull it in now, or wait until I do some more fixes.

Thank you for open-sourcing your work!

b
