### PR TITLE
Producer OOM precaution

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -155,7 +155,11 @@ int main (int argc, char **argv) {
 			strncpy(opbuf, buf, len + 1);
 
 			/* Send/Produce message. */
-			rd_kafka_produce(rk, topic, partition, RD_KAFKA_OP_F_FREE, opbuf, len);
+			if( rd_kafka_produce(rk, topic, partition,
+				RD_KAFKA_OP_F_FREE, opbuf, len) == -1){
+				free(opbuf);
+				continue;
+			}
 			fprintf(stderr, "%% Sent %i bytes to topic "
 				"%s partition %i\n", len, topic, partition);
 			sendcnt++;

--- a/rdkafka.h
+++ b/rdkafka.h
@@ -82,10 +82,6 @@ typedef enum {
  * See comment below for rd_kafka_defaultconf use.
  */
 typedef struct rd_kafka_conf_s {
-	uint64_t max_payload_size;  /* Maximum payload size sum.
-				       * This is a safety precaution to prevent oom
-				       * caused by producer */
-
 	int max_msg_size;             /* Maximum receive message size.
 				       * This is a safety precaution to
 				       * avoid memory exhaustion in case of


### PR DESCRIPTION
Hi, Edenhill.

In current librdkafka, if producer produce data at a rate faster than broker can handle, then data will accumulate in rk->rk_op, will may cause OOM (This does happen in my case).

To prevent this, this patch adds a new parameter max_payload_size, if sum of payload exceeds max_payload_size, comming msgs will be dropped.
