### PR TITLE
Add return code for Kafka::produce and free message payload memory in rd_kafka_example when queue is full

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -155,7 +155,11 @@ int main (int argc, char **argv) {
 			strncpy(opbuf, buf, len + 1);
 
 			/* Send/Produce message. */
-			rd_kafka_produce(rk, topic, partition, RD_KAFKA_OP_F_FREE, opbuf, len);
+			if(rd_kafka_produce(rk, topic, partition,
+				RD_KAFKA_OP_F_FREE, opbuf, len) == -1){
+				free(opbuf);
+				continue;
+			}
 			fprintf(stderr, "%% Sent %i bytes to topic "
 				"%s partition %i\n", len, topic, partition);
 			sendcnt++;

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -127,7 +127,11 @@ int main (int argc, char **argv) {
 			strncpy(opbuf, buf, len + 1);
 
 			/* Send/Produce message. */
-			kafka.produce(topic, partition, RD_KAFKA_OP_F_FREE, opbuf, len);
+			if (kafka.produce(topic, partition,
+				RD_KAFKA_OP_F_FREE, opbuf, len) == -1){
+				free(opbuf);
+				continue;
+			}
 			fprintf(stderr, "%% Sent %i bytes to topic "
 				"%s partition %i\n", len, topic, partition);
 			sendcnt++;

--- a/rdkafkacpp.h
+++ b/rdkafkacpp.h
@@ -30,7 +30,7 @@ public:
 	const char * getTopic()const{return topic;}
 	*/
 
-	void produce(char *topic, uint32_t partition,int msgflags, char *payload, size_t len);
+	int produce(char *topic, uint32_t partition,int msgflags, char *payload, size_t len);
 
 private:
 	rd_kafka_t *rk;
@@ -56,8 +56,8 @@ bool Kafka::setHandle(rd_kafka_type_t type,const char * broker,const rd_kafka_co
 	return (rk = rd_kafka_new(type, broker, conf))!=NULL;
 }
 
-void Kafka::produce(char *topic, uint32_t partition,int msgflags, char *payload, size_t len){
-	rd_kafka_produce(rk, topic, partition, msgflags, payload, len);
+int Kafka::produce(char *topic, uint32_t partition,int msgflags, char *payload, size_t len){
+	return rd_kafka_produce(rk, topic, partition, msgflags, payload, len);
 }
 
 }


### PR DESCRIPTION
Hi, Edenhill.

Many thanks for you reply.

I've made a clear patch and pull it for your review.

Changes:
(1) Add return code for Kafka::produce
(2) Free message payload memory in rd_kafka_example 
