### PR TITLE
Librdkafka now compiles on OSX 10.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.a
 *.d
 core
+*dSYM/

--- a/endian_compat.h
+++ b/endian_compat.h
@@ -1,0 +1,75 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2012 - 2014 Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __FreeBSD__
+  #include <sys/endian.h>
+#elif defined __linux__
+  #include <endian.h>
+#elif defined __BSD__
+  #include <sys/endian.h>
+#elif defined __APPLE__
+  #include <sys/_endian.h>
+  #include <libkern/OSByteOrder.h>
+  #define __bswap_64(x)      OSSwapInt64(x)
+  #define __bswap_32(x)      OSSwapInt32(x)
+  #define __bswap_16(x)      OSSwapInt16(x)
+
+  #if __DARWIN_BYTE_ORDER == __DARWIN_BIG_ENDIAN
+    #define htobe16(x) (x)
+    #define htole16(x) __bswap_16 (x)
+    #define be16toh(x) (x)
+    #define le16toh(x) __bswap_16 (x)
+
+    #define htobe32(x) (x)
+    #define htole32(x) __bswap_32 (x)
+    #define be32toh(x) (x)
+    #define le32toh(x) __bswap_32 (x)
+
+    #define htobe64(x) (x)
+    #define htole64(x) __bswap_64 (x)
+    #define be64toh(x) (x)
+    #define le64toh(x) __bswap_64 (x)
+  #else
+    #define htobe16(x) __bswap_16 (x)
+    #define htole16(x) (x)
+    #define be16toh(x) __bswap_16 (x)
+    #define le16toh(x) (x)
+
+    #define htobe32(x) __bswap_32 (x)
+    #define htole32(x) (x)
+    #define be32toh(x) __bswap_32 (x)
+    #define le32toh(x) (x)
+
+    #define htobe64(x) __bswap_64 (x)
+    #define htole64(x) (x)
+    #define be64toh(x) __bswap_64 (x)
+    #define le64toh(x) (x)
+  #endif
+#else
+  #error Unknown location for endian.h
+#endif

--- a/rdaddr.c
+++ b/rdaddr.c
@@ -140,10 +140,10 @@ rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
 				    int flags, int family,
 				    int socktype, int protocol,
 				    const char **errstr) {
-	struct addrinfo hints = { ai_family: family,
-				  ai_socktype: socktype,
-				  ai_protocol: protocol,
-				  ai_flags: flags };
+	struct addrinfo hints = { .ai_family = family,
+				  .ai_socktype = socktype,
+				  .ai_protocol = protocol,
+				  .ai_flags = flags };
 	struct addrinfo *ais, *ai;
 	char *node, *svc;
 	int r;

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -1062,7 +1062,7 @@ int rd_kafka_consume_callback (rd_kafka_topic_t *rkt, int32_t partition,
 						   void *opaque),
 			       void *opaque) {
 	rd_kafka_toppar_t *rktp;
-	struct consume_ctx ctx = { consume_cb: consume_cb, opaque: opaque };
+	struct consume_ctx ctx = { .consume_cb = consume_cb, .opaque = opaque };
 	int r;
 
 	/* Get toppar */

--- a/rdkafka_broker.c
+++ b/rdkafka_broker.c
@@ -48,6 +48,7 @@
 #include "rdrand.h"
 #include "rdgz.h"
 #include "snappy.h"
+#include "endian_compat.h"
 
 const char *rd_kafka_broker_state_names[] = {
 	"DOWN",

--- a/rdkafka_defaultconf.c
+++ b/rdkafka_defaultconf.c
@@ -74,7 +74,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	/* Global properties */
 	{ _RK_GLOBAL, "client.id", _RK_C_STR, _RK(clientid),
 	  "Client identifier.",
-	  sdef: "rdkafka" },
+	  .sdef =  "rdkafka" },
 	{ _RK_GLOBAL, "metadata.broker.list", _RK_C_STR, _RK(brokerlist),
 	  "Initial list of brokers. "
 	  "The application may also use `rd_kafka_brokers_add()` to add "
@@ -109,7 +109,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	{ _RK_GLOBAL, "debug", _RK_C_S2F, _RK(debug),
 	  "A comma-separated list of debug contexts to enable: "
 	  RD_KAFKA_DEBUG_CONTEXTS,
-	  s2i: {
+	  .s2i = {
 			{ RD_KAFKA_DBG_GENERIC,  "generic" },
 			{ RD_KAFKA_DBG_BROKER,   "broker" },
 			{ RD_KAFKA_DBG_TOPIC,    "topic" },
@@ -187,8 +187,8 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	{ _RK_GLOBAL|_RK_PRODUCER, "compression.codec", _RK_C_S2I,
 	  _RK(compression_codec),
 	  "Compression codec to use for compressing message sets.",
-	  vdef: RD_KAFKA_COMPRESSION_NONE,
-	  s2i: {
+	  .vdef = RD_KAFKA_COMPRESSION_NONE,
+	  .s2i = {
 			{ RD_KAFKA_COMPRESSION_NONE,   "none" },
 			{ RD_KAFKA_COMPRESSION_GZIP,   "gzip" },
 			{ RD_KAFKA_COMPRESSION_SNAPPY, "snappy" },

--- a/rdkafka_int.h
+++ b/rdkafka_int.h
@@ -262,7 +262,7 @@ typedef struct rd_kafka_msgq_s {
 } rd_kafka_msgq_t;
 
 #define RD_KAFKA_MSGQ_INITIALIZER(rkmq) \
-	{ rkmq_msgs: TAILQ_HEAD_INITIALIZER((rkmq).rkmq_msgs) }
+	{ .rkmq_msgs = TAILQ_HEAD_INITIALIZER((rkmq).rkmq_msgs) }
 
 #define RD_KAFKA_MSGQ_FOREACH(elm,head) \
 	TAILQ_FOREACH(elm, &(head)->rkmq_msgs, rkm_link)

--- a/snappy_compat.h
+++ b/snappy_compat.h
@@ -1,23 +1,3 @@
-#ifdef __FreeBSD__
-#  include <sys/endian.h>
-#elif defined(__APPLE_CC_) || defined(__MACH__)  /* MacOS/X support */
-#  include <machine/endian.h>
-
-#if    __DARWIN_BYTE_ORDER == __DARWIN_LITTLE_ENDIAN
-#  define	htole16(x) (x)
-#  define	le32toh(x) (x)
-#elif  __DARWIN_BYTE_ORDER == __DARWIN_BIG_ENDIAN
-#  define	htole16(x) __DARWIN_OSSwapInt16(x)
-#  define	le32toh(x) __DARWIN_OSSwapInt32(x)
-#else
-#  error "Endianness is undefined"
-#endif
-
-
-#else
-#  include <endian.h>
-#endif
-
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
@@ -25,6 +5,8 @@
 #include <stdbool.h>
 #include <limits.h>
 #include <sys/uio.h>
+
+#include "endian_compat.h"
 
 #if defined(__arm__) && \
 	!defined(__ARM_ARCH_4__) &&		\


### PR DESCRIPTION
Refactored endian support to seperate file called endian_compat.h
that will fix two implicit declaration of function errors. Also
fixed a whole bunch of use of GNU old-style field designator
extension errors
