### PR TITLE
get rid of warnings in gcc 4.4.3

### DIFF
--- a/rdkafka.h
+++ b/rdkafka.h
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <inttypes.h>
+#include <sys/types.h>
 
 
 /**


### PR DESCRIPTION
This doesn't compile with gcc 4.4.3 on Ubuntu 10.04.4 LTS because it produces the following warning, and warnings are treated as errors.

In file included from rdkafka_performance.c:42:
../rdkafka.h:575: error: expected '=', ',', ';', 'asm' or '**attribute**' before 'rd_kafka_consume_batch'
cc1: warnings being treated as errors
rdkafka_performance.c: In function 'main':
rdkafka_performance.c:722: error: implicit declaration of function 'rd_kafka_consume_batch'

Adding this #include fixes that.
