### PR TITLE
fixed syntax error: missing paren

### DIFF
--- a/rdkafka_broker.c
+++ b/rdkafka_broker.c
@@ -1311,8 +1311,7 @@ static int rd_kafka_broker_connect (rd_kafka_broker_t *rkb) {
 
 #ifdef SO_NOSIGPIPE
 	/* Disable SIGPIPE signalling for this socket on OSX */
-	if (setsockopt(rkb->rkb_s, SOL_SOCKET, SO_NOSIGPIPE,
-		       &one, sizeof(one) == -1)
+	if (setsockopt(rkb->rkb_s, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)) == -1)
 	    rd_rkb_dbg(rkb, BROKER, "SOCKET", "Failed to set SO_NOSIGPIPE: %s",
 		       strerror(errno));
 #endif


### PR DESCRIPTION
Script started on Fri Jan 17 00:30:31 2014
[?1034hbash-4.2$ pwd
/Users/gpatmore/repos/librdkafka
bash-4.2$ make clean
rm -f rdkafka.o rdkafka_broker.o rdkafka_msg.o rdkafka_topic.o rdkafka_defaultconf.o rdkafka_timer.o rdkafka_offset.o rdcrc32.o rdgz.o rdaddr.o rdrand.o rdthread.o rdqueue.o rdlog.o snappy.o rdkafka.d rdkafka_broker.d rdkafka_msg.d rdkafka_topic.d rdkafka_defaultconf.d rdkafka_timer.d rdkafka_offset.d rdcrc32.d rdgz.d rdaddr.d rdrand.d rdthread.d rdqueue.d rdlog.d snappy.d \
        librdkafka_.a librdkafka_.so librdkafka*.so.1
make -C tests clean
rm -f 0001-multiobj.test 0002-unkpart.test 0003-msgmaxsize.test
make -C examples clean
rm -f rdkafka_example rdkafka_performance
bash-4.2$ make insta[K[K[K[K[K[K
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_broker.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_msg.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_topic.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_defaultconf.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_timer.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdkafka_offset.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdcrc32.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdgz.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdaddr.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdrand.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdthread.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdqueue.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c rdlog.c
cc -MD -MP -O2 -Wall -Werror -Wfloat-equal -Wpointer-arith -I. -g -DSG -fPIC -c snappy.c
ar rcs librdkafka.a rdkafka.o rdkafka_broker.o rdkafka_msg.o rdkafka_topic.o rdkafka_defaultconf.o rdkafka_timer.o rdkafka_offset.o rdcrc32.o rdgz.o rdaddr.o rdrand.o rdthread.o rdqueue.o rdlog.o snappy.o
make -C examples
# rdkafka_example is ready
# 
# Run producer (write messages on stdin)

./rdkafka_example -P -t <topic> -p <partition>
# or consumer

./rdkafka_example -C -t <topic> -p <partition>
# 
# More usage options:

./rdkafka_example --help
# rdkafka_performance is ready
# 
# Run producer

./rdkafka_performance -P -t <topic> -p <partition> -s <msgsize>
# or consumer

./rdkafka_performance -C -t <topic> -p <partition>
# 
# More usage options:

./rdkafka_performance --help
examples/rdkafka_performance -X list > CONFIGURATION.md.tmp
cmp CONFIGURATION.md CONFIGURATION.md.tmp || \
        mv CONFIGURATION.md.tmp CONFIGURATION.md
rm -f CONFIGURATION.md.tmp
bash-4.2$ make tests
librdkafka.so.1                [32mOK[0m
librdkafka.a                   [32mOK[0m
CONFIGURATION.md               [32mOK[0m
examples/rdkafka_example       [32mOK[0m
examples/rdkafka_performance   [32mOK[0m
make -C tests
cc -g -Wall -Werror -Wfloat-equal -Wpointer-arith -O2 -I../ -c test.c
cc -g -Wall -Werror -Wfloat-equal -Wpointer-arith -O2 -I../ ../librdkafka.a test.o 0001-multiobj.c -o 0001-multiobj.test ../librdkafka.a -lpthread -lz
cc -g -Wall -Werror -Wfloat-equal -Wpointer-arith -O2 -I../ ../librdkafka.a test.o 0002-unkpart.c -o 0002-unkpart.test ../librdkafka.a -lpthread -lz
cc -g -Wall -Werror -Wfloat-equal -Wpointer-arith -O2 -I../ ../librdkafka.a test.o 0003-msgmaxsize.c -o 0003-msgmaxsize.test ../librdkafka.a -lpthread -lz
for i in 0001-multiobj.test 0002-unkpart.test 0003-msgmaxsize.test ; do ./run-test.sh $i || exit 1 ; done
[36m############## 0001-multiobj.test ################[0m
[36m### Running test 0001-multiobj.test in bare mode ###[0m
Creating and destroying 100 kafka instances
### Test failed at test.c:77:test_conf_init():

test.conf not found

[31m###
### Test 0001-multiobj.test in bare mode FAILED!
### [0m

make[1]: **\* [all] Error 1
make: **\* [tests] Error 2
bash-4.2$ make install
if [ "/usr/local" != "/usr/local" ]; then \
        DESTDIR="/usr/local/usr"; \
    else \
        DESTDIR="/usr/local" ; \
    fi ; \
    install -d $DESTDIR/include/librdkafka $DESTDIR/lib ; \
    install rdkafka.h $DESTDIR/include/librdkafka ; \
    install librdkafka.a $DESTDIR/lib ; \
    install librdkafka.so.1 $DESTDIR/lib ; \
    (cd $DESTDIR/lib && ln -sf librdkafka.so.1 librdkafka.so)
bash-4.2$ echo "sorry my VPN wonky right now. no kafka broker available. I'll [K[K[K[K can try tomorrow, but [K[K[K[K[K[K"
sorry my VPN wonky right now. no kafka broker available. I can try tomorrow
bash-4.2$ sudo make install
Password:
if [ "/usr/local" != "/usr/local" ]; then \
        DESTDIR="/usr/local/usr"; \
    else \
        DESTDIR="/usr/local" ; \
    fi ; \
    install -d $DESTDIR/include/librdkafka $DESTDIR/lib ; \
    install rdkafka.h $DESTDIR/include/librdkafka ; \
    install librdkafka.a $DESTDIR/lib ; \
    install librdkafka.so.1 $DESTDIR/lib ; \
    (cd $DESTDIR/lib && ln -sf librdkafka.so.1 librdkafka.so)
bash-4.2$ exit

Script done on Fri Jan 17 00:35:24 2014
