### PR TITLE
Memleak in rd_kafka_broker_metadata_req()

### DIFF
--- a/rdkafka_broker.c
+++ b/rdkafka_broker.c
@@ -986,6 +986,8 @@ static void rd_kafka_broker_metadata_req (rd_kafka_broker_t *rkb,
 				buf, of,
 				RD_KAFKA_OP_F_FREE|RD_KAFKA_OP_F_FLASH,
 				rd_kafka_broker_metadata_reply, only_rkt);
+
+	free(buf);
 }
 
 


### PR DESCRIPTION
"buf" is allocated here locally, then passed to
rd_kafka_broker_buf_enq(), which does not free it due to
the RD_KAFKA_OP_F_FREE ...
