### PR TITLE
Release thread attr handles and block default route on compression

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1039,12 +1039,13 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
 				 "Failed to create thread: %s", strerror(err));
 		rd_kafka_destroy0(rk); /* handler thread */
 		rd_kafka_destroy0(rk); /* application refcnt */
-                /* Restore sigmask of caller */
-                pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+		/* Restore sigmask of caller */
+		pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+		/* Release thread attribute storage */
+		pthread_attr_destroy(&attr);
 		errno = err;
 		return NULL;
 	}
-
 
 	/* Add initial list of brokers from configuration */
 	if (rk->rk_conf.brokerlist)
@@ -1052,8 +1053,11 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
 
 	(void)rd_atomic_add(&rd_kafka_handle_cnt_curr, 1);
 
-        /* Restore sigmask of caller */
-        pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+	/* Restore sigmask of caller */
+	pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+
+	/* Release thread attribute storage */
+	pthread_attr_destroy(&attr);
 
 	return rk;
 }

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2210,6 +2210,11 @@ static int rd_kafka_broker_produce_toppar (rd_kafka_broker_t *rkb,
 
 			/* Free snappy environment */
 			snappy_free_env(&senv);
+			break;
+
+		default:
+			rd_kafka_assert(rkb->rkb_rk, !*"notreached: compression.codec");
+			break;
 
 		}
 
@@ -4000,8 +4005,13 @@ static rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 
 		free(rkb);
 		rd_kafka_destroy(rk);
-                /* Restore sigmask of caller */
-                pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+
+		/* Restore sigmask of caller */
+		pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+
+		/* Release thread attribute storage */
+		pthread_attr_destroy(&attr);
+
 		return NULL;
 	}
 
@@ -4012,8 +4022,11 @@ static rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 		   "Added new broker with NodeId %"PRId32,
 		   rkb->rkb_nodeid);
 
-        /* Restore sigmask of caller */
-        pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+	/* Restore sigmask of caller */
+	pthread_sigmask(SIG_SETMASK, &oldset, NULL);
+
+	/* Release thread attribute storage */
+	pthread_attr_destroy(&attr);
 
 	return rkb;
 }


### PR DESCRIPTION
Release the thread attributes where were created with pthread_attr_init. According to the manual: "When a thread attributes object is no longer required, it should be destroyed using the pthread_attr_destroy() function. Destroying a thread attributes object has no effect on threads that were created using that object.". For the configuration of the compression add the default switch to block accidental invalid configuration settings since this would use an uninitialized variable.
