### PR TITLE
Update rdkafka_msg.c

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -134,7 +134,7 @@ int rd_kafka_msg_new (rd_kafka_topic_t *rkt, int32_t force_partition,
                                 rd_clock());
         if (unlikely(!rkm)) {
                 /* errno is already set by msg_new() */
-                rd_atomic_sub(&rkt->rkt_rk->rk_producer.msg_cnt, 1);
+                (void)rd_atomic_sub(&rkt->rkt_rk->rk_producer.msg_cnt, 1);
                 return -1;
         }
 


### PR DESCRIPTION
gcc version 4.1.2 20080704 (Red Hat 4.1.2-44)

$[home/kafka/librdkafka-master] make all
gcc -MD -MP -g -O2 -fPIC -Wall -Werror -Wfloat-equal -Wpointer-arith  -c rdkafka_msg.c -o rdkafka_msg.o
cc1: warnings being treated as errors
rdkafka_msg.c: In function 'rd_kafka_msg_new':
rdkafka_msg.c:137: warning: value computed is not used
make: **\* [rdkafka_msg.o] Error 1

rdkafka_msg.c:137 : 'rd_atomic_sub(&rkt->rkt_rk->rk_producer.msg_cnt, 1);' and '(void)'
