### PR TITLE
Off-by-one error when calculating tv_nsec.

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -101,7 +101,7 @@ int pthread_cond_timedwait_ms (pthread_cond_t *cond,
 	ts.tv_sec  += timeout_ms / 1000;
 	ts.tv_nsec += (timeout_ms % 1000) * 1000000;
 
-	if (ts.tv_nsec > 1000000000) {
+	if (ts.tv_nsec >= 1000000000) {
 		ts.tv_sec++;
 		ts.tv_nsec -= 1000000000;
 	}
@@ -530,7 +530,7 @@ static int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
 	TIMEVAL_TO_TIMESPEC(&tv, &ts);
 	ts.tv_sec  += timeout_ms / 1000;
 	ts.tv_nsec += (timeout_ms % 1000) * 1000000;
-	if (ts.tv_nsec > 1000000000) {
+	if (ts.tv_nsec >= 1000000000) {
 		ts.tv_sec++;
 		ts.tv_nsec -= 1000000000;
 	}

--- a/src/rdthread.h
+++ b/src/rdthread.h
@@ -227,7 +227,7 @@ static int rd_cond_timedwait_ms (rd_cond_t *cond,
 	ts.tv_sec  += timeout_ms / 1000;
 	ts.tv_nsec += (timeout_ms % 1000) * 1000000;
 
-	if (ts.tv_nsec > 1000000000) {
+	if (ts.tv_nsec >= 1000000000) {
 		ts.tv_sec++;
 		ts.tv_nsec -= 1000000000;
 	}

--- a/src/rdtime.h
+++ b/src/rdtime.h
@@ -47,7 +47,7 @@
 #define TS_TO_TIMESPEC(ts,tsx) do {			\
 	(ts)->tv_sec  = (tsx) / 1000000;		\
         (ts)->tv_nsec = ((tsx) % 1000000) * 1000;	\
-	if ((ts)->tv_nsec > 1000000000LLU) {		\
+	if ((ts)->tv_nsec >= 1000000000LLU) {		\
 	   (ts)->tv_sec++;				\
 	   (ts)->tv_nsec -= 1000000000LLU;		\
 	}						\


### PR DESCRIPTION
When calling pthread_cond_timedwait, tv_nsec must not equal or exceed
10e9, as this will immediately make pthread_cond_timedwait return
EINVAL. Several of the conditional wait loops check for ETIMEDOUT but
not EINVAL, which means that this causes infinite loops in some rare
cases.

Basically, this happens in only one in a billion cases, but over the
past few days I've had it happen quite a few times.

I believe I've corrected all cases where this happens in this patch.

Best regards, Lasse
