### PR TITLE
NULL conf pointer after free

### DIFF
--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -508,6 +508,7 @@ rd_kafka_topic_t *rd_kafka_topic_new (rd_kafka_t *rk, const char *topic,
 		conf = rd_kafka_topic_conf_new();
 	rkt->rkt_conf = *conf;
 	free(conf);
+	conf = NULL;
 
 	/* Default partitioner: random */
 	if (!rkt->rkt_conf.partitioner)


### PR DESCRIPTION
Fixes an issue where if we have already seen the topic we may have created a new rd_kafka_topic_conf_t object that will leak memory. If we have already seen the topic, we can check that the rd_kafka_topic_conf_t
pointer is not NULL and free it ourselves, otherwise if it is NULL we know that the internals have already
deallocated conf. This commit mainly prevents a double-free error.
