### PR TITLE
Implement Message::key() in C++ interface

### DIFF
--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -440,6 +440,9 @@ int main (int argc, char **argv) {
         case RdKafka::ERR_NO_ERROR:
 	  /* Real message */
 	  std::cerr << "Read msg at offset " << msg->offset() << std::endl;
+	  if (msg->key()) {
+		  std::cerr << "Key: " << *msg->key() << std::endl;
+	  }
           printf("%.*s\n",
                  static_cast<int>(msg->len()),
                  static_cast<const char *>(msg->payload()));

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -81,24 +81,22 @@ class MessageImpl : public Message {
   ~MessageImpl () {
     if (free_rkmessage_)
       rd_kafka_message_destroy(const_cast<rd_kafka_message_t *>(rkmessage_));
+    delete key_;
   };
 
   MessageImpl (RdKafka::Topic *topic, rd_kafka_message_t *rkmessage):
-      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(true),
-      key_(static_cast<char const*>(rkmessage->key), rkmessage->key_len) { }
+      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(true), key_(NULL) { }
 
   MessageImpl (RdKafka::Topic *topic, rd_kafka_message_t *rkmessage,
                bool dofree):
-      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(dofree),
-      key_(static_cast<char const*>(rkmessage->key), rkmessage->key_len) { }
+      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(dofree), key_(NULL) { }
 
   MessageImpl (RdKafka::Topic *topic, const rd_kafka_message_t *rkmessage):
-      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(false),
-      key_(static_cast<char const*>(rkmessage->key), rkmessage->key_len) { }
+      topic_(topic), rkmessage_(rkmessage), free_rkmessage_(false), key_(NULL) { }
 
   /* Create errored message */
   MessageImpl (RdKafka::Topic *topic, RdKafka::ErrorCode err):
-      topic_(topic), free_rkmessage_(false), key_() {
+      topic_(topic), free_rkmessage_(false), key_(NULL) {
     rkmessage_ = &rkmessage_err_;
     memset(&rkmessage_err_, 0, sizeof(rkmessage_err_));
     rkmessage_err_.err = static_cast<rd_kafka_resp_err_t>(err);
@@ -122,7 +120,15 @@ class MessageImpl : public Message {
   int32_t             partition () const { return rkmessage_->partition; }
   void               *payload () const { return rkmessage_->payload; }
   size_t              len () const { return rkmessage_->len; }
-  const std::string  *key () const { return key_.empty() ? NULL : &key_; }
+  const std::string  *key () const {
+    if (key_) {
+      return key_;
+    } else if (rkmessage_->key) {
+      key_ = new std::string(static_cast<char const*>(rkmessage_->key), rkmessage_->key_len);
+      return key_;
+    }
+    return NULL;
+  }
   int64_t             offset () const { return rkmessage_->offset; }
   void               *msg_opaque () const { return rkmessage_->_private; };
 
@@ -132,7 +138,12 @@ class MessageImpl : public Message {
   /* For error signalling by the C++ layer the .._err_ message is
    * used as a place holder and rkmessage_ is set to point to it. */
   rd_kafka_message_t rkmessage_err_;
-  std::string key_;
+  mutable std::string* key_; /* mutable because it's a cached value */
+
+private:
+  /* "delete" copy ctor + copy assignment, for safety of key_ */
+  MessageImpl(MessageImpl const&) /*= delete*/;
+  MessageImpl& operator=(MessageImpl const&) /*= delete*/;
 };
 
 


### PR DESCRIPTION
This should fix #187 by adding a key_ member to the message implementation and returning that as key (or NULL if they key is empty/unset).
The C++ example prints the key if present, like the C example does. None of the examples actually produce keys (so this code was tested with a temporary example code).