### PR TITLE
Added target dependencies for "make -j".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,14 @@ CONFIGURATION.md: src/rdkafka.h examples
 		mv CONFIGURATION.md.tmp CONFIGURATION.md; \
 	rm -f CONFIGURATION.md.tmp)
 
+file-check: CONFIGURATION.md examples
 check: file-check
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d $@ || exit $?; done)
 
 install:
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d $@ || exit $?; done)
 
-examples tests: .PHONY
+examples tests: .PHONY libs
 	$(MAKE) -C $@
 
 clean:

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -37,6 +37,7 @@ LIBS += -lstdc++
 CHECK_FILES+= $(LIBFILENAME) $(LIBNAME).a
 
 
+file-check: lib
 check: file-check
 
 install: lib-install

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,7 @@ include ../mklove/Makefile.base
 
 CHECK_FILES+= $(LIBFILENAME) $(LIBNAME).a
 
+file-check: lib
 check: file-check
 	@(printf "%-30s " "Symbol visibility" ; \
 	(($(SYMDUMPER) $(LIBFILENAME) | grep -q rd_kafka_new) && \


### PR DESCRIPTION
Mainly a case of defining "file-check" to depend on the recipes that build the files that file-check will check.
This fixes #179 for me, but one is never quite sure with "make -j" :-P