### PR TITLE
Fix mismatches in broker_keep and broker_destroy that cause brokers to l...

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1147,6 +1147,8 @@ static void rd_kafka_metadata_refresh_cb (rd_kafka_t *rk, void *arg) {
         else
                 rd_kafka_broker_metadata_req(rkb, 1 /* all topics */, NULL,
                                              NULL, "periodic refresh");
+
+		rd_kafka_broker_destroy(rkb);
 }
 
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4321,6 +4321,7 @@ rd_kafka_broker_t *rd_kafka_broker_find_by_nodeid (rd_kafka_t *rk,
 
 /**
  * Locks: rd_kafka_rdlock(rk) must be held
+ * NOTE: caller must release rkb reference by rd_kafka_broker_destroy()
  */
 static rd_kafka_broker_t *rd_kafka_broker_find (rd_kafka_t *rk,
 						const char *name,
@@ -4391,6 +4392,11 @@ int rd_kafka_brokers_add (rd_kafka_t *rk, const char *brokerlist) {
 		} else if (rd_kafka_broker_add(rk, RD_KAFKA_CONFIGURED, s, port,
 					       RD_KAFKA_NODEID_UA) != NULL)
 			cnt++;
+
+		/* If rd_kafka_broker_find returned a broker its reference needs to be released 
+		 * See issue #193 */
+		if (rkb)
+			rd_kafka_broker_destroy(rkb);
 
 		rd_kafka_unlock(rk);
 


### PR DESCRIPTION
The fix on brokers_add is not too sexy, but it's not enough to only call broker_destroy on line 4389 (after cnt++) because this will leak when `rkb->rkb_source != RD_KAFKA_CONFIGURED` (#193)