### PR TITLE
Allow message payload to be NULL.

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -93,6 +93,13 @@ static rd_kafka_msg_t *rd_kafka_msg_new0 (rd_kafka_topic_t *rkt,
 			rkt->rkt_conf.message_timeout_ms * 1000;
 	}
 
+        /* Check for a NULL payload */
+        if (payload == NULL) {
+            rkm->rkm_payload = NULL;
+            rkm->rkm_len = 0;
+            return rkm;
+        }
+
 	if (msgflags & RD_KAFKA_MSG_F_COPY) {
 		/* Copy payload to space following the ..msg_t */
 		rkm->rkm_payload = (void *)(rkm+1);


### PR DESCRIPTION
NULL message payloads are used with compaction topics introduced in 0.8.1
which use the NULL payload to indicate the corresponding key should be deleted.

(see [Log Compaction](https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction#LogCompaction-Theanatomyofalog) for more details)

The [Kafka protocol guide](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Messagesets) also notes that the Value (payload) may be NULL. 

This commit makes these changes:

- prevents NULL payloads from being copied when `RD_KAFKA_MSG_F_COPY` is set.
- prevents payload bytes being copied into `rkbuf` when NULL.
- sets `rkm_len` to `-1` when payload is NULL (just like key).
- Allows NULL payloads to be received in a fetch.

C is not my strong point so I'm sure there are things missed. If you can point me in the right direction I'd be happy make any changes, or if you'd rather clean things yourself that works for me too :)

Thanks!