### PR TITLE
Update readme: PHP extension is not being developed by salebab anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
   * Node.js: [node-kafka](https://github.com/sutoiku/node-kafka)
   * Lua: [in progress](https://github.com/edenhill/librdkafka/issues/196)
   * OCaml: [ocaml-kafka](https://github.com/didier-wenzek/ocaml-kafka)
-  * PHP: [phpkafka](https://github.com/salebab/phpkafka)
+  * PHP: [phpkafka](https://github.com/EVODelavega/phpkafka)
   * Python: [python-librdkafka](https://bitbucket.org/yungchin/python-librdkafka)
   * Python: [PyKafka](https://github.com/Parsely/pykafka)
   * Ruby: [Hermann](https://github.com/stancampbell3/Hermann)


### PR DESCRIPTION
The linked PHP extension repo is no longer being developed. I've changed the link to the only fork that is being developed ATM. I'm trying to advertise the fact that PHP-Kafka integration is being worked on, hoping to get some feedback, and possibly contributions to get a usable extension out there ASAP.

Cheers