### PR TITLE
Add a built in consistent hashing partitioner

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -541,6 +541,16 @@ int32_t rd_kafka_msg_partitioner_random (const rd_kafka_topic_t *rkt,
 					 int32_t partition_cnt,
 					 void *opaque, void *msg_opaque);
 
+/**
+ * Consistent partitioner
+ * Uses consistent hashing to map identical keys onto identical partitions.
+ *
+ * Returns a 'random' partition between 0 and partition_cnt - 1 based on the crc value of the key
+ */
+int32_t rd_kafka_msg_partitioner_consistent (const rd_kafka_topic_t *rkt,
+					 const void *key, size_t keylen,
+					 int32_t partition_cnt,
+					 void *opaque, void *msg_opaque);
 
 
 

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -30,6 +30,7 @@
 #include "rdkafka_int.h"
 #include "rdkafka_msg.h"
 #include "rdkafka_topic.h"
+#include "rdcrc32.h"
 #include "rdrand.h"
 #include "rdtime.h"
 
@@ -310,6 +311,15 @@ int32_t rd_kafka_msg_partitioner_random (const rd_kafka_topic_t *rkt,
 	else
 		return p;
 }
+
+int32_t rd_kafka_msg_partitioner_consistent (const rd_kafka_topic_t *rkt,
+					 const void *key, size_t keylen,
+					 int32_t partition_cnt,
+					 void *rkt_opaque,
+					 void *msg_opaque) {
+    return rd_crc32(key, keylen) % partition_cnt;
+}
+
 
 /**
  * Assigns a message to a topic partition using a partitioner.


### PR DESCRIPTION
For our particular use case mapping keyed messages on to a consistent partition is important, it's probably important for anyone who wants to use log compaction.  I'm not sure what you'd want in terms of tests so I've done nothing. :trollface: 

Uses rd's crc32 to hash keys ensuring that the same key will map to the same partition.

Similar in spirit to the Scala code's default partitioner:

```scala
def partition(key: Any, numPartitions: Int): Int = {
  Utils.abs(key.hashCode) % numPartitions
}
```

