### PR TITLE
use topic level group_id for rkbuf sizing

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3373,8 +3373,8 @@ static void rd_kafka_toppar_offsetcommit_request (rd_kafka_broker_t *rkb,
                                  /* static fields */
                                  4 + 4 + 4 + 8 +
                                  /* dynamic fields */
-                                 RD_KAFKAP_STR_SIZE(rktp->rktp_rkt->rkt_rk->
-                                                    rk_conf.group_id) +
+                                 RD_KAFKAP_STR_SIZE(rktp->rktp_rkt->
+                                                    rkt_conf.group_id) +
                                  RD_KAFKAP_STR_SIZE(rktp->rktp_rkt->rkt_topic) +
                                  RD_KAFKAP_STR_SIZE(&metadata));
 


### PR DESCRIPTION
rd_kafka_toppar_offsetcommit_request writes topic-level rkt_conf.group_id into the request, but uses the global-level rk_conf.group_id for buffer sizing.  