### PR TITLE
Ignore supplied key or payload length if the pointer is null

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -67,6 +67,9 @@ static rd_kafka_msg_t *rd_kafka_msg_new0 (rd_kafka_topic_t *rkt,
 	rd_kafka_msg_t *rkm;
 	size_t mlen = sizeof(*rkm);
 
+	if (!payload) len = 0;
+	if (!key) keylen = 0;
+
 	if (unlikely(len + keylen > rkt->rkt_rk->rk_conf.max_msg_size)) {
                 *errp = RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE;
                 errno = EMSGSIZE;


### PR DESCRIPTION
Minor API usability tweak. I was producing messages with a NULL payload, but a non-zero payload length. This causes an invalid produce request to be sent to the Kafka broker, and the broker responds by logging an exception (java.nio.BufferUnderflowException) and closing the connection.

Test case: https://gist.github.com/ept/a7d6edc2e46f896b03a6

This is really my mistake for passing invalid parameters to rd_kafka_produce. However, it might be nicer if the length parameters are ignored if NULL data is passed in, rather than creating an invalid produce request. This simple patch forces the length to be zero in that case.