### PR TITLE
Added Consumer::consume_callback as front-end of rd_kafka_consume_callback

### DIFF
--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -126,9 +126,9 @@ void msg_consume(RdKafka::Message* message, void* opaque) {
 
     case RdKafka::ERR_NO_ERROR:
       /* Real message */
-      std::cerr << "Read msg at offset " << message->offset() << std::endl;
+      std::cout << "Read msg at offset " << message->offset() << std::endl;
       if (message->key()) {
-        std::cerr << "Key: " << *message->key() << std::endl;
+        std::cout << "Key: " << *message->key() << std::endl;
       }
       printf("%.*s\n",
         static_cast<int>(message->len()),
@@ -147,8 +147,6 @@ void msg_consume(RdKafka::Message* message, void* opaque) {
       std::cerr << "Consume failed: " << message->errstr() << std::endl;
       run = false;
   }
-
-  delete message;
 }
 
 
@@ -463,15 +461,13 @@ int main (int argc, char **argv) {
     while (run) {
       RdKafka::Message *msg = consumer->consume(topic, partition, 1000);
       msg_consume(msg, NULL);
-      consumer->poll(0);
+      delete msg;
     }
 
     /*
      * Stop consumer
      */
     consumer->stop(topic, partition);
-
-    consumer->poll(1000);
 
     delete topic;
     delete consumer;

--- a/src-cpp/ConsumerImpl.cpp
+++ b/src-cpp/ConsumerImpl.cpp
@@ -117,20 +117,20 @@ namespace {
    * and keep track of the C++ callback function and `opaque' value.
    */
   struct ConsumerImplCallback {
-    ConsumerImplCallback(RdKafka::Topic* topic, void (*cb)(RdKafka::Message*, void*), void* data)
-      : topic(topic), cxx_cb_func(cb), cb_data(data) {
+    ConsumerImplCallback(RdKafka::Topic* topic, RdKafka::ConsumeCb* cb, void* data)
+      : topic(topic), cb_cls(cb), cb_data(data) {
     }
     /* This function is the one we give to `rd_kafka_consume_callback', with
      * the `opaque' pointer pointing to an instance of this struct, in which
      * we can find the C++ callback and `cb_data'.
      */
-    static void cb_from_c(rd_kafka_message_t *msg, void *opaque) {
+    static void consume_cb_trampoline(rd_kafka_message_t *msg, void *opaque) {
       ConsumerImplCallback *instance = static_cast<ConsumerImplCallback*>(opaque);
       RdKafka::MessageImpl message(instance->topic, msg, false /*don't free*/);
-      instance->cxx_cb_func(&message, instance->cb_data);
+      instance->cb_cls->consume_cb(message, instance->cb_data);
     }
     RdKafka::Topic *topic;
-    void (*cxx_cb_func)(RdKafka::Message*, void*);
+    RdKafka::ConsumeCb *cb_cls;
     void *cb_data;
   };
 }
@@ -138,9 +138,10 @@ namespace {
 int RdKafka::ConsumerImpl::consume_callback (RdKafka::Topic* topic,
                                              int32_t partition,
                                              int timeout_ms,
-                                             void (*consume_cb)(RdKafka::Message*, void*),
-                                             void* opaque) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
-  ConsumerImplCallback context(topic, consume_cb, opaque);
-  return rd_kafka_consume_callback(topicimpl->rkt_, partition, timeout_ms, ConsumerImplCallback::cb_from_c, &context);
+                                             RdKafka::ConsumeCb *consume_cb,
+                                             void *opaque) {
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
+  ConsumerImplCallback context(topic, consume_cb, NULL);
+  return rd_kafka_consume_callback(topicimpl->rkt_, partition, timeout_ms,
+                                   &ConsumerImplCallback::consume_cb_trampoline, &context);
 }

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -514,6 +514,28 @@ class Consumer : public virtual Handle {
   virtual Message *consume (Topic *topic, int32_t partition,
                             int timeout_ms) = 0;
 
+  /**
+   * Consumes messages from 'topic' and 'partition', calling
+   * the provided callback for each consumed messsage.
+   *
+   * `consume_callback()` provides higher throughput performance
+   * than `consume()`.
+   *
+   * 'timeout_ms' is the maximum amount of time to wait for one or more messages
+   * to arrive.
+   *
+   * The provided 'consume_cb' function is called for each message,
+   * the application must not delete the provided 'message'.
+   *
+   * The 'opaque' argument is passed to the 'consume_cb' as 'opaque'.
+   *
+   * Returns the number of messages processed or -1 on error.
+   */
+  virtual int consume_callback (Topic *topic, int32_t partition,
+                                int timeout_ms,
+                                void (*consume_cb) (Message* message, void *opaque),
+                                void *opaque) = 0;
+
 };
 
 

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -215,6 +215,15 @@ class EventCb {
 
 
 /**
+ * Consume callback class
+ */
+class ConsumeCb {
+ public:
+  virtual void consume_cb (Message &message, void *opaque) = 0;
+};
+
+
+/**
  * Event class as provided to the EventCb callback.
  */
 class Event {
@@ -524,8 +533,8 @@ class Consumer : public virtual Handle {
    * 'timeout_ms' is the maximum amount of time to wait for one or more messages
    * to arrive.
    *
-   * The provided 'consume_cb' function is called for each message,
-   * the application must not delete the provided 'message'.
+   * The provided 'consume_cb' instance has its 'consume_cb' function
+   * called for every message received.
    *
    * The 'opaque' argument is passed to the 'consume_cb' as 'opaque'.
    *
@@ -533,9 +542,8 @@ class Consumer : public virtual Handle {
    */
   virtual int consume_callback (Topic *topic, int32_t partition,
                                 int timeout_ms,
-                                void (*consume_cb) (Message* message, void *opaque),
+                                ConsumeCb *consume_cb,
                                 void *opaque) = 0;
-
 };
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -351,7 +351,8 @@ class ConsumerImpl : virtual public Consumer, virtual public HandleImpl {
   ErrorCode start (Topic *topic, int32_t partition, int64_t offset);
   ErrorCode stop (Topic *topic, int32_t partition);
   Message *consume (Topic *topic, int32_t partition, int timeout_ms);
-  int consume_callback(Topic* topic, int32_t partition, int timeout_ms, void (*consume_cb)(Message*, void*), void* opaque);
+  int consume_callback (Topic *topic, int32_t partition, int timeout_ms,
+                        ConsumeCb *cb, void *opaque);
 };
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -351,7 +351,7 @@ class ConsumerImpl : virtual public Consumer, virtual public HandleImpl {
   ErrorCode start (Topic *topic, int32_t partition, int64_t offset);
   ErrorCode stop (Topic *topic, int32_t partition);
   Message *consume (Topic *topic, int32_t partition, int timeout_ms);
-
+  int consume_callback(Topic* topic, int32_t partition, int timeout_ms, void (*consume_cb)(Message*, void*), void* opaque);
 };
 
 


### PR DESCRIPTION
Implements #168 / #245. Lets the example program use it when called with -e option.

This is one way of doing it, kept reasonably close to the C function. Another would be to define a callback base class (like e.g. EventCb) and use a instance of one of those as argument to consume_callback. If you'd rather see that instead, I can draft it tomorrow or the next day?