### PR TITLE
Added Consumer::consume_callback as front-end of rd_kafka_consume_callback

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -215,6 +215,15 @@ class EventCb {
 
 
 /**
+ * Consume callback class
+ */
+class ConsumeCb {
+ public:
+  virtual void consume_cb (Message &message, void *opaque) = 0;
+};
+
+
+/**
  * Event class as provided to the EventCb callback.
  */
 class Event {
@@ -514,6 +523,27 @@ class Consumer : public virtual Handle {
   virtual Message *consume (Topic *topic, int32_t partition,
                             int timeout_ms) = 0;
 
+  /**
+   * Consumes messages from 'topic' and 'partition', calling
+   * the provided callback for each consumed messsage.
+   *
+   * `consume_callback()` provides higher throughput performance
+   * than `consume()`.
+   *
+   * 'timeout_ms' is the maximum amount of time to wait for one or more messages
+   * to arrive.
+   *
+   * The provided 'consume_cb' instance has its 'consume_cb' function
+   * called for every message received.
+   *
+   * The 'opaque' argument is passed to the 'consume_cb' as 'opaque'.
+   *
+   * Returns the number of messages processed or -1 on error.
+   */
+  virtual int consume_callback (Topic *topic, int32_t partition,
+                                int timeout_ms,
+                                ConsumeCb *consume_cb,
+                                void *opaque) = 0;
 };
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -351,7 +351,8 @@ class ConsumerImpl : virtual public Consumer, virtual public HandleImpl {
   ErrorCode start (Topic *topic, int32_t partition, int64_t offset);
   ErrorCode stop (Topic *topic, int32_t partition);
   Message *consume (Topic *topic, int32_t partition, int timeout_ms);
-
+  int consume_callback (Topic *topic, int32_t partition, int timeout_ms,
+                        ConsumeCb *cb, void *opaque);
 };
 
 


### PR DESCRIPTION
* New base class ConsumeCb allows for easy definition of consume_callback classes.
* New function Consumer::consume_callback consumes as many messages as possible, calls ConsumeCb::consume_cb for each message.
* Example C++ code re-organized a little; function msg_consume extracted from loop, prints on cout instead of cerr.

Implements #168, implements #245.