### PR TITLE
issue in broker address caching

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -573,7 +573,7 @@ static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb) {
                                              rkb->rkb_nodename, errstr);
 			return -1;
 		}
-	    rkb->rkb_t_rsal_last = time(NULL);
+		rkb->rkb_t_rsal_last = time(NULL);
 	}
 
 	return 0;

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -573,6 +573,7 @@ static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb) {
                                              rkb->rkb_nodename, errstr);
 			return -1;
 		}
+	    rkb->rkb_t_rsal_last = time(NULL);
 	}
 
 	return 0;


### PR DESCRIPTION
When a broker goes down, it seems that rdkafka should keep its address in cache for a little while before retrying.
From what I understand, rkb->rkb_t_rsal_last should contain the last time the cache was updated.
But it is not set.
So, we always have
````C
 rkb->rkb_t_rsal_last + rkb->rkb_rk->rk_conf.broker_addr_ttl == 0 + 300 000 /*ms*/
````
Which is always less than
````C
time(NULL)
````
Which means rkb->rkb_rsal is always set to NULL, and rd_getaddrinfo() is always called.
Do you agree?