### PR TITLE
Updated README: Added php-rdkafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
   * Lua: [in progress](https://github.com/edenhill/librdkafka/issues/196)
   * OCaml: [ocaml-kafka](https://github.com/didier-wenzek/ocaml-kafka)
   * PHP: [phpkafka](https://github.com/EVODelavega/phpkafka)
+  * PHP: [php-rdkafka](https://github.com/arnaud-lb/php-rdkafka)
   * Python: [python-librdkafka](https://bitbucket.org/yungchin/python-librdkafka)
   * Python: [PyKafka](https://github.com/Parsely/pykafka)
   * Ruby: [Hermann](https://github.com/stancampbell3/Hermann)


### PR DESCRIPTION
php-rdkafka is a thin PHP binding for librdkafka. Although it uses classes, it attempts to not deviate from librdkafka's API.