### PR TITLE
rd_kafka_msg_new() should never free the payload on failure if

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -597,6 +597,10 @@ class Producer : public virtual Handle {
    *
    *  NOTE: RK_MSG_FREE and RK_MSG_COPY are mutually exclusive.
    *
+   *  If the function returns -1 and RK_MSG_FREE was specified, then
+   *  the memory associated with the payload is still the caller's
+   *  responsibility.
+   *
    * 'payload' is the message payload of size 'len' bytes.
    *
    * 'key' is an optional message key, if non-NULL it

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -914,6 +914,10 @@ rd_kafka_resp_err_t rd_kafka_offset_store (rd_kafka_topic_t *rkt,
  *
  *    .._F_FREE and .._F_COPY are mutually exclusive.
  *
+ *    If the function returns -1 and RD_KAFKA_MSG_F_FREE was specified, then
+ *    the memory associated with the payload is still the caller's
+ *    responsibility.
+ *
  * 'payload' is the message payload of size 'len' bytes.
  *
  * 'key' is an optional message key of size 'keylen' bytes, if non-NULL it

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -116,6 +116,10 @@ static rd_kafka_msg_t *rd_kafka_msg_new0 (rd_kafka_topic_t *rkt,
  *          into on the selected partition.
  *
  * Returns 0 on success or -1 on error.
+ *
+ * If the function returns -1 and RD_KAFKA_MSG_F_FREE was specified, then
+ * the memory associated with the payload is still the caller's
+ * responsibility.
  */
 int rd_kafka_msg_new (rd_kafka_topic_t *rkt, int32_t force_partition,
 		      int msgflags,
@@ -150,8 +154,11 @@ int rd_kafka_msg_new (rd_kafka_topic_t *rkt, int32_t force_partition,
 
 	/* Handle partitioner failures: it only fails when the application
 	 * attempts to force a destination partition that does not exist
-	 * in the cluster. */
+	 * in the cluster.  Note we must clear the RD_KAFKA_MSG_F_FREE
+	 * flag since our contract says we don't free the payload on
+	 * failure. */
 
+	rkm->rkm_flags &= ~RD_KAFKA_MSG_F_FREE;
 	rd_kafka_msg_destroy(rkt->rkt_rk, rkm);
 
 	/* Translate error codes to errnos. */


### PR DESCRIPTION
RD_KAFKA_MSG_F_FREE was specified.  (Issue #298)