### PR TITLE
Make configure script work under FreeBSD

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 MKL_CONFIGURE_ARGS="$0 $*"


### PR DESCRIPTION
When executing the configure file, I get an error on FreeBSD 10.1:

    > ./configure
    -bash: ./configure: /bin/bash: bad interpreter: No such file or directory

The reason being that bash is at /usr/local/bin/bash but the configure script uses /bin/bash which is not available by default. A portable way is to use env to get the correct path.
See http://stackoverflow.com/questions/5159711/what-is-the-proper-way-to-make-a-bash-script-portable-between-linux-and-freebsd
Tested on Mac Yosemite, Ubuntu Trusty and FreeBSD 10.1. 