### PR TITLE
In case of error in rd_kafka_produce_batch, memory can leak.

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -974,7 +974,7 @@ int rd_kafka_produce (rd_kafka_topic_t *rkt, int32_t partitition,
  *   _private        - Message opaque pointer (msg_opaque)
  *   err             - Will be set according to success or failure.
  *                     Application only needs to check for errors if
- *                     return value != `message_cnt`. In case of error and it
+ *                     return value != `message_cnt`. In case of error and if
  *                     the payload pointer is not set to 0, the caller is
  *                     responsible for freeing the memory if
  *                     RD_KAFKA_MSG_F_FREE is given.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -974,7 +974,10 @@ int rd_kafka_produce (rd_kafka_topic_t *rkt, int32_t partitition,
  *   _private        - Message opaque pointer (msg_opaque)
  *   err             - Will be set according to success or failure.
  *                     Application only needs to check for errors if
- *                     return value != `message_cnt`.
+ *                     return value != `message_cnt`. In case of error and it
+ *                     the payload pointer is not set to 0, the caller is
+ *                     responsible for freeing the memory if
+ *                     RD_KAFKA_MSG_F_FREE is given.
  *
  * Returns the number of messages succesfully enqueued for producing.
  */

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -229,8 +229,12 @@ int rd_kafka_produce_batch (rd_kafka_topic_t *rkt, int32_t partition,
                                         rkmessages[i]._private,
                                         &rkmessages[i].err,
                                         now);
-                if (!rkm)
+                if (unlikely(!rkm)) {
+                        rkmessages[i].err = RD_KAFKA_RESP_ERR__CRIT_SYS_RESOURCE;
                         continue;
+                } else {
+                    rkmessages[i].payload = 0; // owned by rkm
+                }
 
                 /* Two cases here:
                  *  partition==UA:     run the partitioner (slow)


### PR DESCRIPTION
The payload pointer will be set to 0 when the caller needs to clean up
the memory.