### PR TITLE
Make rwlocks prefer writer

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1257,7 +1257,11 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
 
 	rd_kafka_keep(rk); /* application refcnt */
 
-	pthread_rwlock_init(&rk->rk_lock, NULL);
+	pthread_rwlockattr_t rwattr;
+	pthread_rwlockattr_init(&rwattr);
+	pthread_rwlockattr_setkind_np(&rwattr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+	pthread_rwlock_init(&rk->rk_lock, &rwattr);
+	pthread_rwlockattr_destroy(&rwattr);
 
 	rd_kafka_q_init(&rk->rk_rep);
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4310,7 +4310,12 @@ static rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 
 	rkb->rkb_s = -1;
 	pthread_mutex_init(&rkb->rkb_lock, NULL);
-	pthread_rwlock_init(&rkb->rkb_toppar_lock, NULL);
+
+	pthread_rwlockattr_t rwattr;
+	pthread_rwlockattr_init(&rwattr);
+	pthread_rwlockattr_setkind_np(&rwattr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+	pthread_rwlock_init(&rkb->rkb_toppar_lock, &rwattr);
+	pthread_rwlockattr_destroy(&rwattr);
 	TAILQ_INIT(&rkb->rkb_toppars);
 	rd_kafka_bufq_init(&rkb->rkb_outbufs);
 	rd_kafka_bufq_init(&rkb->rkb_waitresps);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -537,7 +537,11 @@ rd_kafka_topic_t *rd_kafka_topic_new (rd_kafka_t *rk, const char *topic,
 	rd_kafka_topic_keep(rkt);
 	rd_kafka_keep(rk);
 
-	pthread_rwlock_init(&rkt->rkt_lock, NULL);
+	pthread_rwlockattr_t rwattr;
+	pthread_rwlockattr_init(&rwattr);
+	pthread_rwlockattr_setkind_np(&rwattr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+	pthread_rwlock_init(&rkt->rkt_lock, &rwattr);
+	pthread_rwlockattr_destroy(&rwattr);
 
 	/* Create unassigned partition */
 	rkt->rkt_ua = rd_kafka_toppar_new(rkt, RD_KAFKA_PARTITION_UA);


### PR DESCRIPTION
The particular issue that inspired this change was that when consuming at a high volume metadata updates would get stuck indefinitely behind consumers that weren't making any progress. Since rdkafka doesn't use rwlocks recursively anywhere and other than that the restriction there's pretty minimal overhead, just converted all rwlocks to prefer writer.

First time contributing to rdkafka, so just let me know if you'd like me to pull out this stanza to a common library or add any particular testing.