### PR TITLE
add build instruction for osx users

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,17 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
 
 ## Instructions
 
-### Building
+### Building(Linux)
 
       ./configure
       make
       sudo make install
 
+### Building(OSX)
+
+      CC=clang CXX=clang ./configure
+      make
+      sudo make install
 
 ### Usage in code
 


### PR DESCRIPTION
The former build instruction is confusing OSX users because it will fail on OSX now.
(OSX users should use clang instead of gcc)

How about adding an build instruction for OSX users?