### PR TITLE
C++ Queue Wrapping

### DIFF
--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -4,7 +4,7 @@ LIBVER=		1
 
 CXXSRCS=	RdKafka.cpp ConfImpl.cpp HandleImpl.cpp \
 		ConsumerImpl.cpp ProducerImpl.cpp \
-		TopicImpl.cpp MessageImpl.cpp
+		TopicImpl.cpp MessageImpl.cpp QueueImpl.cpp
 
 HDRS=		rdkafkacpp.h
 

--- a/src-cpp/QueueImpl.cpp
+++ b/src-cpp/QueueImpl.cpp
@@ -1,0 +1,118 @@
+/*
+ * librdkafka - Apache Kafka C/C++ library
+ *
+ * Copyright (c) 2015 Samuele Maci
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <string>
+#include <list>
+#include <cerrno>
+
+#include "rdkafkacpp_int.h"
+
+RdKafka::Queue::~Queue() {
+}
+
+RdKafka::Queue *RdKafka::Queue::create(Consumer *consumer) {
+  RdKafka::ConsumerImpl *consumer_impl =
+      dynamic_cast<RdKafka::ConsumerImpl *>(consumer);
+  RdKafka::QueueImpl *queue_impl = new RdKafka::QueueImpl();
+  queue_impl->rkqu = rd_kafka_queue_new(consumer_impl->rk_);
+  return queue_impl;
+}
+
+
+RdKafka::ErrorCode RdKafka::QueueImpl::start(Topic *topic, int32_t partition,
+    int64_t offset) {
+  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+
+  if (rd_kafka_consume_start_queue(topicimpl->rkt_, partition, offset, rkqu) == -1)
+    return static_cast<RdKafka::ErrorCode>(rd_kafka_errno2err(errno));
+
+  return RdKafka::ERR_NO_ERROR;
+}
+
+RdKafka::ErrorCode RdKafka::QueueImpl::stop(Topic *topic, int32_t partition) {
+  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+
+  if (rd_kafka_consume_stop(topicimpl->rkt_, partition) == -1)
+    return static_cast<RdKafka::ErrorCode>(rd_kafka_errno2err(errno));
+
+  return RdKafka::ERR_NO_ERROR;
+}
+
+void setTopic(rd_kafka_message_t *rkmessage, RdKafka::TopicImpl* topic) {
+  topic->rkt_ = rkmessage->rkt;
+  topic->partitioner_cb_ = NULL;
+  topic->partitioner_kp_cb_ = NULL;
+}
+
+RdKafka::Message *RdKafka::QueueImpl::consume(int timeout_ms) {
+  //TODO: check if could be correct
+  RdKafka::TopicImpl *topicimpl = new RdKafka::TopicImpl();
+  rd_kafka_message_t *rkmessage;
+
+  rkmessage = rd_kafka_consume_queue(rkqu, timeout_ms);
+  if (!rkmessage) {
+    return new RdKafka::MessageImpl(topicimpl,
+        static_cast<RdKafka::ErrorCode>(rd_kafka_errno2err(errno)));
+  }
+  setTopic(rkmessage, topicimpl);
+  return new RdKafka::MessageImpl(topicimpl, rkmessage);
+}
+
+namespace {
+/* Helper struct for `consume_callback'.
+ * Encapsulates the values we need in order to call `rd_kafka_consume_callback_queue'
+ * and keep track of the C++ callback function and `opaque' value.
+ */
+struct QueueImplCallback {
+  QueueImplCallback(RdKafka::ConsumeCb* cb, void* data) :
+      cb_cls(cb), cb_data(data) {
+  }
+  /* This function is the one we give to `rd_kafka_consume_callback', with
+   * the `opaque' pointer pointing to an instance of this struct, in which
+   * we can find the C++ callback and `cb_data'.
+   */
+  static void consume_cb_trampoline(rd_kafka_message_t *msg, void *opaque) {
+    QueueImplCallback *instance = static_cast<QueueImplCallback*>(opaque);
+    RdKafka::TopicImpl *topicimpl = new RdKafka::TopicImpl();
+    setTopic(msg, topicimpl);
+    RdKafka::MessageImpl message(topicimpl, msg, false /*don't free*/);
+    instance->cb_cls->consume_cb(message, instance->cb_data);
+  }
+  RdKafka::ConsumeCb *cb_cls;
+  void *cb_data;
+};
+}
+
+int RdKafka::QueueImpl::consume_callback(int timeout_ms,
+                                          RdKafka::ConsumeCb *consume_cb,
+                                          void *opaque) {
+  QueueImplCallback context(consume_cb, NULL);
+  return rd_kafka_consume_callback_queue(rkqu, timeout_ms,
+      &QueueImplCallback::consume_cb_trampoline, &context);
+}

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -139,7 +139,7 @@ std::string  err2str (RdKafka::ErrorCode err);
  * Wait for all rd_kafka_t objects to be destroyed.
  * Returns 0 if all kafka objects are now destroyed, or -1 if the
  * timeout was reached.
- * Since RdKafka handle deletion is an asynch opration the 
+ * Since RdKafka handle deletion is an asynch opration the
  * `wait_destroyed()` function can be used for applications where
  * a clean shutdown is required.
  */
@@ -392,7 +392,7 @@ class Topic {
   /**
    * Creates a new topic handle for topic named 'topic_str'.
    *
-   * 'conf' is an optional configuration for the topic  that will be used 
+   * 'conf' is an optional configuration for the topic  that will be used
    * instead of the default topic configuration.
    * The 'conf' object is reusable after this call.
    *
@@ -649,6 +649,7 @@ class Queue {
  public:
   /**
    * Creates a new Kafka queue (C++ wrapping of rd_kafka_queue_t).
+   * NOTE: the consumer will not released at the queue destruction.
    */
   static Queue *create (Consumer *consumer);
 
@@ -665,7 +666,7 @@ class Queue {
    * messages in the local queue by repeatedly fetching batches of messages
    * from the broker until the threshold is reached.
    *
-   * The application shall use one of the `..->consume*()` functions
+   * The application shall use one of the `..->consume()` method
    * to consume messages from the local queue, each kafka message being
    * represented as a `RdKafka::Message *` object.
    *
@@ -690,11 +691,11 @@ class Queue {
 
 
   /**
-   * Consume a single message from topic and 'partition' bound by the queue.
+   * Consume a single message from the queue.
    *
    * 'timeout_ms' is maximum amount of time to wait for a message to be
    * received.
-   * Consumer must have been previously started with `..->start()`.
+   * Queue must have been previously started with `..->start()`.
    *
    * Returns a Message object, the application needs to check if message
    * is an error or a proper message `Message->err()` and checking for
@@ -705,11 +706,14 @@ class Queue {
    * Errors (in Message->err()):
    *   ERR__TIMED_OUT - 'timeout_ms' was reached with no new messages fetched.
    *   ERR__PARTITION_EOF - End of partition reached, not an error.
+   *
+   * NOTE: Message ordering is guaranteed within a topic+partition that is re-routed
+   * to the queue, but there is no definition of ordering between topic+partitions.
    */
   virtual Message *consume (int timeout_ms) = 0;
 
   /**
-   * Consumes messages from 'topic' and 'partition', calling
+   * Consumes messages from the queue, calling
    * the provided callback for each consumed messsage.
    *
    * `consume_callback()` provides higher throughput performance

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -379,5 +379,19 @@ class ProducerImpl : virtual public Producer, virtual public HandleImpl {
 };
 
 
+class QueueImpl : virtual public Queue {
+ public:
+  rd_kafka_queue_t *rkqu;
+
+  ~QueueImpl () {
+    rd_kafka_queue_destroy(rkqu);
+  }
+  static Queue *create (Consumer *consumer);
+
+  ErrorCode start (Topic *topic, int32_t partition, int64_t offset);
+  ErrorCode stop (Topic *topic, int32_t partition);
+  Message *consume (int timeout_ms);
+  int consume_callback (int timeout_ms, ConsumeCb *cb, void *opaque);
+};
 
 };


### PR DESCRIPTION
The implemetation of the Queue tries to respect the 1:1 matching with the underlining C functions. The goal of this wrapping is to simplify the consuming of multiple topic+partitions in a single thread.
May be it will be required the update of the wiki page related to it ([wiki page](https://github.com/edenhill/librdkafka/wiki/Consuming-from-multiple-topics-partitions-from-a-single-thread))
Issue: https://github.com/edenhill/librdkafka/issues/383
