### PR TITLE
Limit producer queue size to a specified number of payload bytes.

### DIFF
--- a/src/rdkafka_defaultconf.c
+++ b/src/rdkafka_defaultconf.c
@@ -264,7 +264,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	{ _RK_GLOBAL|_RK_PRODUCER, "queue.buffering.max.bytes", _RK_C_INT,
 	  _RK(queue_buffering_max_bytes),
 	  "Maximum number of bytes allowed on the producer queue.",
-	  1, 1000000000, 10000000 },
+	  1, 2147483648, 10000000 },
 	{ _RK_GLOBAL|_RK_PRODUCER, "queue.buffering.max.ms", _RK_C_INT,
 	  _RK(buffering_max_ms),
 	  "Maximum time, in milliseconds, for buffering data "

--- a/src/rdkafka_defaultconf.c
+++ b/src/rdkafka_defaultconf.c
@@ -261,6 +261,10 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	  _RK(queue_buffering_max_msgs),
 	  "Maximum number of messages allowed on the producer queue.",
 	  1, 10000000, 100000 },
+	{ _RK_GLOBAL|_RK_PRODUCER, "queue.buffering.max.bytes", _RK_C_INT,
+	  _RK(queue_buffering_max_bytes),
+	  "Maximum number of bytes allowed on the producer queue.",
+	  1, 1000000000, 10000000 },
 	{ _RK_GLOBAL|_RK_PRODUCER, "queue.buffering.max.ms", _RK_C_INT,
 	  _RK(buffering_max_ms),
 	  "Maximum time, in milliseconds, for buffering data "

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -160,6 +160,7 @@ struct rd_kafka_conf_s {
 	 * Producer configuration
 	 */
 	int    queue_buffering_max_msgs;
+	int    queue_buffering_max_bytes;
 	int    buffering_max_ms;
 	int    max_retries;
 	int    retry_backoff_ms;
@@ -771,7 +772,8 @@ struct rd_kafka_s {
 			uint64_t app_offset;
 		} consumer;
 		struct {
-			int msg_cnt;  /* current message count */
+			int msg_cnt;   /* current message count */
+			int msg_bytes; /* current message bytes */
 		} producer;
 	} rk_u;
 #define rk_consumer rk_u.consumer


### PR DESCRIPTION
Add queue.buffering.max.bytes to producer configuration, which sets a maximum on the number of payload bytes that can be queued on the producer.

Limiting by total size is helpful as the count and time-baesd limits do not give good control over how much space will be used for buffering, which means you're likely to either overbuffer and run out of memory, or underbuffer and lose messages.