### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/src/rdaddr.c
+++ b/src/rdaddr.c
@@ -152,6 +152,7 @@ rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
 	struct addrinfo *ais, *ai;
 	char *node, *svc;
 	int r;
+	int check_r;
 	int cnt = 0;
 	rd_sockaddr_list_t *rsal;
 
@@ -165,10 +166,11 @@ rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
 		
 	if ((r = getaddrinfo(node, defsvc, &hints, &ais))) {
 #ifdef EAI_SYSTEM
-		if (r == EAI_SYSTEM)
+		check_r = (r == EAI_SYSTEM);
 #else
-		if (0)
+		check_r = 0;
 #endif
+		if (check_r)
 			*errstr = rd_strerror(errno);
 		else {
 #ifdef _MSC_VER


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.