### PR TITLE
Support certificate chains for TLS client authentication

### DIFF
--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -696,9 +696,8 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 			     "Loading certificate from file %s",
 			     rk->rk_conf.ssl.cert_location);
 
-		r = SSL_CTX_use_certificate_file(ctx,
-						 rk->rk_conf.ssl.cert_location,
-						 SSL_FILETYPE_PEM);
+		r = SSL_CTX_use_certificate_chain_file(ctx,
+						       rk->rk_conf.ssl.cert_location);
 
 		if (r != 1)
 			goto fail;


### PR DESCRIPTION
Use SSL_CTX_use_certificate_chain_file() instead of SSL_CTX_use_certificate_file() to allow the use of complete certificate chains for TLS client authentication.