### PR TITLE
Add pkg-config files to -devel RPM spec

### DIFF
--- a/rpm/librdkafka.spec
+++ b/rpm/librdkafka.spec
@@ -75,6 +75,8 @@ rm -rf %{buildroot}
 %{_libdir}/librdkafka.so
 %{_libdir}/librdkafka++.a
 %{_libdir}/librdkafka++.so
+%{_libdir}/pkgconfig/rdkafka++.pc
+%{_libdir}/pkgconfig/rdkafka.pc
 
 
 %changelog


### PR DESCRIPTION
Pkgconfig files were missing from -devel package RPM spec, failing 'make rpm' with unpackaged files.