### PR TITLE
Compile cleanly / sort out sizeof(size_t) != sizeof(int)

### DIFF
--- a/src/rdaddr.c
+++ b/src/rdaddr.c
@@ -72,7 +72,7 @@ const char *rd_sockaddr2str (const void *addr, int flags) {
 
 		
 		if (flags & RD_SOCKADDR2STR_F_PORT) {
-			int len = strlen(ret[reti]);
+			size_t len = strlen(ret[reti]);
 			rd_snprintf(ret[reti]+len, sizeof(ret[reti])-len,
 				 "%s:%s",
 				 a->sinx_family == AF_INET6 ? "]" : "",
@@ -97,7 +97,7 @@ const char *rd_addrinfo_prepare (const char *nodesvc,
 	static RD_TLS char ssvc[64];
 	const char *t;
 	const char *svct = NULL;
-	int nodelen = 0;
+	size_t nodelen = 0;
 
 	*snode = '\0';
 	*ssvc = '\0';
@@ -107,7 +107,7 @@ const char *rd_addrinfo_prepare (const char *nodesvc,
 		if  (!(t = strchr(nodesvc, ']')))
 			return "Missing close-']'";
 		nodesvc++;
-		nodelen = (int)(t-nodesvc);
+		nodelen = t-nodesvc;
 		svct = t+1;
 
 	} else if (*nodesvc == ':' && *(nodesvc+1) != ':') {
@@ -123,7 +123,7 @@ const char *rd_addrinfo_prepare (const char *nodesvc,
 			return "Service name too long";
 		strcpy(ssvc, svct);
 		if (!nodelen)
-			nodelen = (int)(svct - nodesvc)-1;
+			nodelen = svct - nodesvc - 1;
 
 	} else if (!nodelen)
 		nodelen = strlen(nodesvc);

--- a/src/rdcrc32.h
+++ b/src/rdcrc32.h
@@ -98,7 +98,8 @@ static __inline RD_UNUSED
 rd_crc32_t rd_crc32_update(rd_crc32_t crc, const unsigned char *data, size_t data_len)
 {
 #if WITH_ZLIB
-        return crc32(crc, data, data_len);
+        rd_assert(data_len <= UINT_MAX);
+        return crc32(crc, data, (uInt) data_len);
 #else
     unsigned int tbl_idx;
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -578,12 +578,12 @@ static void rd_kafka_destroy_internal (rd_kafka_t *rk) {
  * Emit stats for toppar
  */
 static __inline void rd_kafka_stats_emit_toppar (char **bufp, size_t *sizep,
-					       int *ofp,
+					       size_t *ofp,
 					       rd_kafka_toppar_t *rktp,
 					       int first) {
 	char *buf = *bufp;
 	size_t size = *sizep;
-	int of = *ofp;
+	size_t of = *ofp;
         int64_t consumer_lag = -1;
         struct offset_stats offs;
 
@@ -665,7 +665,7 @@ static __inline void rd_kafka_stats_emit_toppar (char **bufp, size_t *sizep,
 static void rd_kafka_stats_emit_all (rd_kafka_t *rk) {
 	char  *buf;
 	size_t size = 1024*10;
-	int    of = 0;
+	size_t of = 0;
 	rd_kafka_broker_t *rkb;
 	rd_kafka_itopic_t *rkt;
 	shptr_rd_kafka_toppar_t *s_rktp;

--- a/src/rdkafka_assignor.c
+++ b/src/rdkafka_assignor.c
@@ -205,7 +205,7 @@ rd_kafka_member_subscriptions_map (rd_kafka_cgrp_t *rkcg,
                                    rd_list_t *eligible_topics,
                                    const rd_kafka_metadata_t *metadata,
                                    rd_kafka_group_member_t *members,
-                                   size_t member_cnt) {
+                                   int member_cnt) {
         int ti;
         rd_kafka_assignor_topic_t *eligible_topic = NULL;
 
@@ -215,7 +215,7 @@ rd_kafka_member_subscriptions_map (rd_kafka_cgrp_t *rkcg,
          * to find matching subscriptions. */
         for (ti = 0 ; ti < metadata->topic_cnt ; ti++) {
                 int complete_cnt = 0;
-                unsigned int i;
+                int i;
 
                 /* Ignore topics in blacklist */
                 if (rd_kafka_pattern_match(&rkcg->rkcg_rk->rk_conf.
@@ -280,12 +280,12 @@ rd_kafka_assignor_run (rd_kafka_cgrp_t *rkcg,
                        const char *protocol_name,
                        rd_kafka_metadata_t *metadata,
                        rd_kafka_group_member_t *members,
-                       size_t member_cnt,
+                       int member_cnt,
                        char *errstr, size_t errstr_size) {
         rd_kafka_resp_err_t err;
         rd_kafka_assignor_t *rkas;
         rd_ts_t ts_start = rd_clock();
-        unsigned int i;
+        int i;
         rd_list_t eligible_topics;
         int j;
 
@@ -307,7 +307,7 @@ rd_kafka_assignor_run (rd_kafka_cgrp_t *rkcg,
                              "Group \"%s\" running %s assignment for "
                              "%d member(s):",
                              rkcg->rkcg_group_id->str, protocol_name,
-                             (int)member_cnt);
+                             member_cnt);
 
                 for (i = 0 ; i < member_cnt ; i++) {
                         const rd_kafka_group_member_t *member = &members[i];
@@ -478,7 +478,7 @@ static void rtrim (char *s) {
 /**
  * Initialize assignor list based on configuration.
  */
-int rd_kafka_assignors_init (rd_kafka_t *rk, char *errstr, int errstr_size) {
+int rd_kafka_assignors_init (rd_kafka_t *rk, char *errstr, size_t errstr_size) {
 	char *wanted;
 	char *s;
 

--- a/src/rdkafka_assignor.h
+++ b/src/rdkafka_assignor.h
@@ -131,13 +131,13 @@ rd_kafka_resp_err_t
 rd_kafka_assignor_run (struct rd_kafka_cgrp_s *rkcg,
                        const char *protocol_name,
                        rd_kafka_metadata_t *metadata,
-                       rd_kafka_group_member_t *members, size_t member_cnt,
+                       rd_kafka_group_member_t *members, int member_cnt,
                        char *errstr, size_t errstr_size);
 
 rd_kafka_assignor_t *
 rd_kafka_assignor_find (rd_kafka_t *rk, const char *protocol);
 
-int rd_kafka_assignors_init (rd_kafka_t *rk, char *errstr, int errstr_size);
+int rd_kafka_assignors_init (rd_kafka_t *rk, char *errstr, size_t errstr_size);
 void rd_kafka_assignors_term (rd_kafka_t *rk);
 
 

--- a/src/rdkafka_buf.c
+++ b/src/rdkafka_buf.c
@@ -77,8 +77,8 @@ void rd_kafka_buf_alloc_recvbuf (rd_kafka_buf_t *rkbuf, size_t size) {
 /**
  * Rewind write offset pointer and iovec poiner to a previous stored value.
  */
-void rd_kafka_buf_rewind (rd_kafka_buf_t *rkbuf, int iovindex, int new_of,
-	int new_of_init) {
+void rd_kafka_buf_rewind (rd_kafka_buf_t *rkbuf, int iovindex, size_t new_of,
+	size_t new_of_init) {
 	rkbuf->rkbuf_msg.msg_iovlen = iovindex;
 	rkbuf->rkbuf_wof = new_of;
 	rkbuf->rkbuf_wof_init = new_of_init;
@@ -303,15 +303,15 @@ void rd_kafka_bufq_purge (rd_kafka_broker_t *rkb,
 
 
 
-int rd_kafka_buf_write_Message (rd_kafka_buf_t *rkbuf,
-				int64_t Offset, int8_t MagicByte,
-				int8_t Attributes,
-				const rd_kafkap_bytes_t *key,
-				const void *payload, int len,
-				int *outlenp) {
+size_t rd_kafka_buf_write_Message (rd_kafka_buf_t *rkbuf,
+				   int64_t Offset, int8_t MagicByte,
+				   int8_t Attributes,
+				   const rd_kafkap_bytes_t *key,
+				   const void *payload, int32_t len,
+				   int *outlenp) {
 	int32_t MessageSize;
-	int begin_of;
-	int of_Crc;
+	size_t begin_of;
+	size_t of_Crc;
 
 	/*
 	 * MessageSet's per-Message header.
@@ -478,7 +478,8 @@ void rd_kafka_buf_callback (rd_kafka_broker_t *rkb, rd_kafka_resp_err_t err,
  */
 rd_kafkap_bytes_t *rd_kafkap_bytes_from_buf (const rd_kafka_buf_t *rkbuf) {
         rd_kafka_assert(NULL, rkbuf->rkbuf_msg.msg_iovlen == 1);
-        return rd_kafkap_bytes_new(rkbuf->rkbuf_wbuf, rkbuf->rkbuf_wof);
+        rd_kafka_assert(NULL, rkbuf->rkbuf_wof < INT32_MAX);
+        return rd_kafkap_bytes_new(rkbuf->rkbuf_wbuf, (int32_t) rkbuf->rkbuf_wof);
 }
 
 

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -657,7 +657,7 @@ static rd_kafka_conf_res_t
 rd_kafka_anyconf_set_prop0 (int scope, void *conf,
 			    const struct rd_kafka_property *prop,
 			    const char *istr, int ival,
-                            char *errstr, int errstr_size) {
+                            char *errstr, size_t errstr_size) {
 #define _RK_PTR(TYPE,BASE,OFFSET)  (TYPE)(((char *)(BASE))+(OFFSET))
 	switch (prop->type)
 	{
@@ -1322,7 +1322,7 @@ rd_kafka_anyconf_get0 (const void *conf, const struct rd_kafka_property *prop,
         {
                 const int ival = *_RK_PTR(const int *, conf, prop->offset);
                 int phase = 0;
-                int of = 0;
+                size_t of = 0;
 
                 /* Phase 1: scan for set flags, accumulate needed size.
                  * Phase 2: write to dest */
@@ -1376,7 +1376,7 @@ rd_kafka_anyconf_get0 (const void *conf, const struct rd_kafka_property *prop,
         val_len = strlen(val);
 
         if (dest) {
-                int use_len = RD_MIN(val_len, (*dest_size)-1);
+                size_t use_len = RD_MIN(val_len, (*dest_size)-1);
                 memcpy(dest, val, use_len);
                 dest[use_len] = '\0';
         }

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -73,7 +73,8 @@ static rd_kafka_msg_t *rd_kafka_msg_new0 (rd_kafka_itopic_t *rkt,
 	if (!key)
 		keylen = 0;
 
-	if (unlikely(len + keylen > (size_t)rkt->rkt_rk->rk_conf.max_msg_size)){
+	if (unlikely(len + keylen > (size_t)rkt->rkt_rk->rk_conf.max_msg_size ||
+		     keylen > INT32_MAX)){
 		*errp = RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE;
                 errno = EMSGSIZE;
 		return NULL;
@@ -91,7 +92,7 @@ static rd_kafka_msg_t *rd_kafka_msg_new0 (rd_kafka_itopic_t *rkt,
 	rkm->rkm_len        = len;
 	rkm->rkm_flags      = msgflags;
 	rkm->rkm_opaque     = msg_opaque;
-	rkm->rkm_key        = rd_kafkap_bytes_new(key, keylen);
+	rkm->rkm_key        = rd_kafkap_bytes_new(key, (int32_t) keylen);
 	rkm->rkm_partition  = force_partition;
         rkm->rkm_offset     = 0;
 	if (rkt->rkt_conf.message_timeout_ms == 0) {

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -173,7 +173,7 @@ static int64_t rd_kafka_offset_file_read (rd_kafka_toppar_t *rktp) {
 	char buf[22];
 	char *end;
 	int64_t offset;
-	int r;
+	size_t r;
 
 	if (fseek(rktp->rktp_offset_fp, 0, SEEK_SET) == -1) {
 		rd_kafka_op_err(rktp->rktp_rkt->rkt_rk,
@@ -188,18 +188,7 @@ static int64_t rd_kafka_offset_file_read (rd_kafka_toppar_t *rktp) {
 		return -1;
 	}
 
-	if ((r = fread(buf, 1, sizeof(buf)-1, rktp->rktp_offset_fp)) == -1) {
-		rd_kafka_op_err(rktp->rktp_rkt->rkt_rk,
-				RD_KAFKA_RESP_ERR__FS,
-				"%s [%"PRId32"]: "
-				"Failed to read offset file %s: %s",
-				rktp->rktp_rkt->rkt_topic->str,
-				rktp->rktp_partition,
-				rktp->rktp_offset_path, rd_strerror(errno));
-		rd_kafka_offset_file_close(rktp);
-		return -1;
-	}
-
+	r = fread(buf, 1, sizeof(buf) - 1, rktp->rktp_offset_fp);
 	if (r == 0) {
 		rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "OFFSET",
 			     "%s [%"PRId32"]: offset file (%s) is empty",
@@ -747,7 +736,7 @@ static char *mk_esc_filename (const char *in, char *out, size_t out_size) {
 
         while (*s) {
                 const char *esc;
-                int esclen;
+                size_t esclen;
 
                 switch (*s)
                 {

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -136,7 +136,7 @@ void rd_kafka_op_app_reply (rd_kafka_q_t *rkq,
                             rd_kafka_op_type_t type,
                             rd_kafka_resp_err_t err,
                             int32_t version,
-                            void *payload, int len) {
+                            void *payload, size_t len) {
 	rd_kafka_op_t *rko;
 
         rko = rd_kafka_op_new(type);
@@ -229,7 +229,7 @@ void rd_kafka_q_op_err (rd_kafka_q_t *rkq, rd_kafka_op_type_t optype,
 void rd_kafka_op_app (rd_kafka_q_t *rkq, rd_kafka_op_type_t type,
                       int op_flags, rd_kafka_toppar_t *rktp,
                       rd_kafka_resp_err_t err,
-                      void *payload, int len,
+                      void *payload, size_t len,
                       void (*free_cb) (void *)) {
         rd_kafka_op_t *rko;
 
@@ -315,7 +315,7 @@ rd_kafka_op_t *rd_kafka_op_new_reply (rd_kafka_op_t *rko_orig) {
  */
 int rd_kafka_op_reply (rd_kafka_op_t *rko_orig,
                        rd_kafka_resp_err_t err,
-                       void *payload, int len, void (*free_cb) (void *)) {
+                       void *payload, size_t len, void (*free_cb) (void *)) {
         rd_kafka_op_t *rko;
 
         if (!rko_orig->rko_replyq)

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -187,11 +187,11 @@ void rd_kafka_op_app_reply (rd_kafka_q_t *rkq,
                             rd_kafka_op_type_t type,
                             rd_kafka_resp_err_t err,
                             int32_t version,
-                            void *payload, int len);
+                            void *payload, size_t len);
 
 int rd_kafka_op_reply (rd_kafka_op_t *orig_rko,
                        rd_kafka_resp_err_t err,
-                       void *payload, int len, void (*free_cb) (void *));
+                       void *payload, size_t len, void (*free_cb) (void *));
 void rd_kafka_op_sprintf (rd_kafka_op_t *rko, const char *fmt, ...);
 
 void rd_kafka_op_err (rd_kafka_t *rk, rd_kafka_resp_err_t err,
@@ -202,7 +202,7 @@ void rd_kafka_q_op_err (rd_kafka_q_t *rkq, rd_kafka_op_type_t optype,
 void rd_kafka_op_app (rd_kafka_q_t *rkq, rd_kafka_op_type_t type,
                       int op_flags, rd_kafka_toppar_t *rktp,
                       rd_kafka_resp_err_t err,
-                      void *payload, int len,
+                      void *payload, size_t len,
                       void (*free_cb) (void *));
 void rd_kafka_op_app_fmt (rd_kafka_q_t *rkq, rd_kafka_op_type_t type,
                           rd_kafka_toppar_t *rktp,

--- a/src/rdkafka_pattern.c
+++ b/src/rdkafka_pattern.c
@@ -114,7 +114,7 @@ int rd_kafka_pattern_list_remove (rd_kafka_pattern_list_t *plist,
  */
 static int rd_kafka_pattern_list_parse (rd_kafka_pattern_list_t *plist,
                                         const char *patternlist,
-                                        char *errstr, int errstr_size) {
+                                        char *errstr, size_t errstr_size) {
 		char *s;
 		rd_strdupa(&s, patternlist);
 
@@ -182,7 +182,7 @@ void rd_kafka_pattern_list_destroy (rd_kafka_pattern_list_t *plist) {
  */
 int rd_kafka_pattern_list_init (rd_kafka_pattern_list_t *plist,
                                 const char *patternlist,
-                                char *errstr, int errstr_size) {
+                                char *errstr, size_t errstr_size) {
         TAILQ_INIT(&plist->rkpl_head);
         if (patternlist) {
                 if (rd_kafka_pattern_list_parse(plist, patternlist,

--- a/src/rdkafka_pattern.h
+++ b/src/rdkafka_pattern.h
@@ -58,7 +58,7 @@ void rd_kafka_pattern_list_clear (rd_kafka_pattern_list_t *plist);
 void rd_kafka_pattern_list_destroy (rd_kafka_pattern_list_t *plist);
 int rd_kafka_pattern_list_init (rd_kafka_pattern_list_t *plist,
                                 const char *patternlist,
-                                char *errstr, int errstr_size);
+                                char *errstr, size_t errstr_size);
 rd_kafka_pattern_list_t *rd_kafka_pattern_list_new (const char *patternlist,
                                                     char *errstr,
                                                     int errstr_size);

--- a/src/rdkafka_proto.h
+++ b/src/rdkafka_proto.h
@@ -223,7 +223,7 @@ static __inline RD_UNUSED int rd_kafkap_str_cmp (const rd_kafkap_str_t *a,
 
 static __inline RD_UNUSED int rd_kafkap_str_cmp_str (const rd_kafkap_str_t *a,
 						     const char *str) {
-	int len = strlen(str);
+	ssize_t len = strlen(str);
 	if (a->len != len)
 		return -1;
 	return memcmp(a->str, str, a->len);
@@ -241,7 +241,7 @@ static __inline RD_UNUSED int rd_kafkap_str_cmp_str (const rd_kafkap_str_t *a,
  */
 typedef struct rd_kafkap_bytes_s {
 	/* convenience header (aligned access, host endian) */
-	int         len;   /* Kafka bytes length (-1=NULL, 0=empty, >0=data) */
+	int32_t     len;   /* Kafka bytes length (-1=NULL, 0=empty, >0=data) */
 	const void *data;  /* points just past the struct, or other memory,
 			    * not NULL-terminated */
 	const char _data[]; /* Bytes following struct when new()ed */
@@ -278,7 +278,7 @@ static RD_UNUSED void rd_kafkap_bytes_destroy (rd_kafkap_bytes_t *kbytes) {
  * Supports Kafka NULL bytes.
  */
 static __inline RD_UNUSED
-rd_kafkap_bytes_t *rd_kafkap_bytes_new (const char *bytes, int len) {
+rd_kafkap_bytes_t *rd_kafkap_bytes_new (const char *bytes, int32_t len) {
 	rd_kafkap_bytes_t *kbytes;
 	int32_t klen;
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -531,9 +531,9 @@ void rd_kafka_OffsetFetchRequest (rd_kafka_broker_t *rkb,
                                   rd_kafka_resp_cb_t *resp_cb,
                                   void *opaque) {
 	rd_kafka_buf_t *rkbuf;
-        int of_TopicCnt;
+        size_t of_TopicCnt;
         int TopicCnt = 0;
-        int of_PartCnt = -1;
+        ssize_t of_PartCnt = -1;
         const char *last_topic = NULL;
         int PartCnt = 0;
         int i;
@@ -683,10 +683,10 @@ void rd_kafka_OffsetCommitRequest (rd_kafka_broker_t *rkb,
                                    rd_kafka_resp_cb_t *resp_cb,
                                    void *opaque) {
 	rd_kafka_buf_t *rkbuf;
-        int of_TopicCnt = -1;
+        ssize_t of_TopicCnt = -1;
         int TopicCnt = 0;
         const char *last_topic = NULL;
-        int of_PartCnt = -1;
+        ssize_t of_PartCnt = -1;
         int PartCnt = 0;
         int i;
 
@@ -782,8 +782,8 @@ static rd_kafkap_bytes_t *rd_kafka_group_MemberState_consumer_write (
         rd_kafka_buf_t *rkbuf;
         int i;
         const char *last_topic = NULL;
-        int of_TopicCnt;
-        int of_PartCnt = -1;
+        size_t of_TopicCnt;
+        ssize_t of_PartCnt = -1;
         int TopicCnt = 0;
         int PartCnt = 0;
         rd_kafkap_bytes_t *MemberState;
@@ -1485,11 +1485,11 @@ rd_kafka_parse_Metadata (rd_kafka_broker_t *rkb,
                          rd_kafka_itopic_t *rkt, rd_kafka_buf_t *rkbuf) {
 	int i, j, k;
 	int req_rkt_seen = 0;
-        char *msh_buf = NULL;
-        int   msh_of  = 0;
-        int   msh_size;
+        char  *msh_buf = NULL;
+        size_t msh_of  = 0;
+        size_t msh_size;
         struct rd_kafka_metadata *md = NULL;
-        int rkb_namelen;
+        size_t rkb_namelen;
         const int log_decode_errors = 1;
 
         rd_kafka_broker_lock(rkb);

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -150,7 +150,7 @@ rd_kafka_transport_socket_sendmsg (rd_kafka_transport_t *rktrans,
 		ssize_t r;
 
 		r = send(rktrans->rktrans_s,
-			 msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len, 0);
+			 msg->msg_iov[i].iov_base, (int) msg->msg_iov[i].iov_len, 0);
 		if (r == SOCKET_ERROR) {
 			if (sum > 0 || WSAGetLastError() == WSAEWOULDBLOCK)
 				return sum;
@@ -201,7 +201,7 @@ rd_kafka_transport_socket_recvmsg (rd_kafka_transport_t *rktrans,
 		ssize_t r;
 
 		r = recv(rktrans->rktrans_s,
-			 msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len, 0);
+			 msg->msg_iov[i].iov_base, (int) msg->msg_iov[i].iov_len, 0);
 		if (r == SOCKET_ERROR) {
 			if (WSAGetLastError() == WSAEWOULDBLOCK)
 				break;
@@ -269,7 +269,7 @@ void rd_kafka_transport_connect_done (rd_kafka_transport_t *rktrans,
  * else it will fall back on global 'rk' debugging.
  */
 static char *rd_kafka_ssl_error (rd_kafka_t *rk, rd_kafka_broker_t *rkb,
-				 char *errstr, int errstr_size) {
+				 char *errstr, size_t errstr_size) {
     unsigned long l;
     const char *file, *data;
     int line, flags;
@@ -360,7 +360,7 @@ static void rd_kafka_transport_ssl_init (void) {
  */
 static __inline int
 rd_kafka_transport_ssl_io_update (rd_kafka_transport_t *rktrans, int ret,
-				  char *errstr, int errstr_size) {
+				  char *errstr, size_t errstr_size) {
 	int serr = SSL_get_error(rktrans->rktrans_ssl, ret);
 	int serr2;
 
@@ -411,7 +411,7 @@ rd_kafka_transport_ssl_sendmsg (rd_kafka_transport_t *rktrans,
 
 		r = SSL_write(rktrans->rktrans_ssl, 
 			      msg->msg_iov[i].iov_base,
-			      msg->msg_iov[i].iov_len);
+			      (int) msg->msg_iov[i].iov_len);
 
 		if (unlikely(r <= 0)) {
 			if (rd_kafka_transport_ssl_io_update(rktrans, r,
@@ -442,7 +442,7 @@ rd_kafka_transport_ssl_recvmsg (rd_kafka_transport_t *rktrans,
 		int r;
 
 		r = SSL_read(rktrans->rktrans_ssl,
-			     msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
+			     msg->msg_iov[i].iov_base, (int) msg->msg_iov[i].iov_len);
 
 		if (unlikely(r <= 0)) {
 			if (rd_kafka_transport_ssl_io_update(rktrans, r,
@@ -487,7 +487,7 @@ static int rd_kafka_transport_ssl_passwd_cb (char *buf, int size, int rwflag,
 	}
 
 
-	pwlen = strlen(rk->rk_conf.ssl.key_password);
+	pwlen = (int) strlen(rk->rk_conf.ssl.key_password);
 	memcpy(buf, rk->rk_conf.ssl.key_password, RD_MIN(pwlen, size));
 
 	return pwlen;
@@ -640,7 +640,7 @@ void rd_kafka_transport_ssl_ctx_term (rd_kafka_t *rk) {
  * NOTE: rd_kafka_wrlock() MUST be held
  */
 int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
-				     char *errstr, int errstr_size) {
+				     char *errstr, size_t errstr_size) {
 	int r;
 	SSL_CTX *ctx;
 
@@ -779,7 +779,7 @@ int rd_kafka_transport_framed_recvmsg (rd_kafka_transport_t *rktrans,
 				       rd_kafka_buf_t **rkbufp,
 				       char *errstr, size_t errstr_size) {
 	rd_kafka_buf_t *rkbuf = rktrans->rktrans_recv_buf;
-	int r;
+	ssize_t r;
 	const int log_decode_errors = 0;
 
 	/* States:

--- a/src/rdkafka_transport.h
+++ b/src/rdkafka_transport.h
@@ -60,7 +60,7 @@ int rd_kafka_transport_poll(rd_kafka_transport_t *rktrans, int tmout);
 #if WITH_SSL
 void rd_kafka_transport_ssl_ctx_term (rd_kafka_t *rk);
 int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
-				     char *errstr, int errstr_size);
+				     char *errstr, size_t errstr_size);
 #endif
 void rd_kafka_transport_term (void);
 void rd_kafka_transport_init(void);

--- a/src/rdrand.c
+++ b/src/rdrand.c
@@ -37,7 +37,7 @@ void rd_array_shuffle (void *base, size_t nmemb, size_t entry_size) {
 
 	/* FIXME: Optimized version for word-sized entries. */
 
-	for (i = nmemb - 1 ; i > 0 ; i--) {
+	for (i = (int) nmemb - 1 ; i > 0 ; i--) {
 		int j = rd_jitter(0, i);
 		if (unlikely(i == j))
 			continue;

--- a/src/trex.h
+++ b/src/trex.h
@@ -56,7 +56,7 @@ typedef struct TRex TRex;
 
 typedef struct {
 	const TRexChar *begin;
-	int len;
+	size_t len;
 } TRexMatch;
 
 TREX_API TRex *trex_compile(const TRexChar *pattern,const TRexChar **error);

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -225,7 +225,9 @@
     <ClCompile Include="..\src\rdlist.c" />
     <ClCompile Include="..\src\rdlog.c" />
     <ClCompile Include="..\src\rdrand.c" />
-    <ClCompile Include="..\src\snappy.c" />
+    <ClCompile Include="..\src\snappy.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\src\tinycthread.c" />
     <ClCompile Include="..\src\trex.c" />
   </ItemGroup>

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -92,7 +92,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -108,7 +108,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -128,7 +128,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -146,7 +146,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
I'm trying to get librdkafka to compile 100% clean with msvc, clang and gcc.

This got longer than expected, so I would appreciate if you had a look.
It's not finished yet, but the remaining warnings are all about rather tricky issues.

Mostly replacing ints with size_t where the int was actually just assigned to the return value of something like strlen or where the value is passed to something like malloc.

Watch out for cases where I might have overlooked things that are now size_ts might actually be negative. I think I got them all now, but best to triple-check.

How would you prefer to continue with this? I think part of this PR should be fairly uncontroversial, another part needs checking by you, and then there's also a bunch of remaining warnings left.

Tests pass on win32/64 and with clang on osx, but haven't run them with valgrind yet.