### PR TITLE
Fix offset commit bug

### DIFF
--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -160,9 +160,9 @@ static int rd_kafka_offset_file_open (rd_kafka_toppar_t *rktp) {
 
 	rktp->rktp_offset_fp =
 #ifndef _MSC_VER
-		fdopen(fd, "a+");
+		fdopen(fd, "r+");
 #else
-		_fdopen(fd, "a+");
+		_fdopen(fd, "r+");
 #endif
 
 	return 0;


### PR DESCRIPTION
If a file is opened in `a+` mode, output is always appended to the end of file.
Therefore, in function `rd_kafka_offset_file_commit` ( https://github.com/edenhill/librdkafka/blob/master/src/rdkafka_offset.c#L260-L342 ), `fseek` is ignored and offset file is not updated.