### PR TITLE
Don't busy loop in rd_kafka_timers_run

### DIFF
--- a/src/rdkafka_timer.c
+++ b/src/rdkafka_timer.c
@@ -228,6 +228,11 @@ void rd_kafka_timers_run (rd_kafka_timers_t *rkts, int timeout_us) {
 			    !rd_kafka_timer_scheduled(rtmr))
 				rd_kafka_timer_schedule(rkts, rtmr, 0);
 		}
+
+		if (timeout_us == RD_POLL_NOWAIT) {
+			/* Only iterate once, even if rd_clock doesn't change */
+			break;
+		}
 	}
 
 	rd_kafka_timers_unlock(rkts);


### PR DESCRIPTION
Idle consumers on Win used ~3-4% CPU without doing anything. Turns out they spent their time in a loop in rd_kafka_timers_run, because rd_clock only updates every now and then.

So make it only loop once if called with RD_POLL_NOWAIT, even if rd_clock doesn't change.

This brings idle CPU usage down to practically nothing. The same issue affects osx, but there the effect was smaller, I suspect linux is similar.