### PR TITLE
Stop exporting internal symbols from shared libraries

### DIFF
--- a/lds-gen.py
+++ b/lds-gen.py
@@ -32,4 +32,6 @@ if __name__ == '__main__':
         for f in sorted(funcs):
             print('    %s;' % f)
 
+        print('local:\n    *;')
+
     print('};')


### PR DESCRIPTION
After the change to rewrite the lds-gen script in Python (in 0fdac6aa), internal symbols are exported in the shared libraries. This branch undoes the change.

The extra exported symbols somehow prevented my application from working, but I haven't tracked down how this happened.