### PR TITLE
Change default partitioner to consistent-random (closes #546)

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1153,7 +1153,6 @@ int rd_kafka_topic_partition_available(const rd_kafka_topic_t *rkt,
 /**
  * @brief Random partitioner.
  *
- * This is the default partitioner.
  * Will try not to return unavailable partitions.
  *
  * @returns a random partition between 0 and \p partition_cnt - 1.
@@ -1179,6 +1178,21 @@ int32_t rd_kafka_msg_partitioner_consistent (const rd_kafka_topic_t *rkt,
 					 int32_t partition_cnt,
 					 void *opaque, void *msg_opaque);
 
+/**
+ * Consistent-Random partitioner.
+ *
+ * This is the default partitioner.
+ * Uses consistent hashing to map identical keys onto identical partitions, and
+ * messages without keys will be assigned via the random partitioner.
+ *
+ * @returns a \"random\" partition between 0 and partition_cnt - 1 based on
+ *          the CRC value of the key (if provided)
+ */
+RD_EXPORT
+int32_t rd_kafka_msg_partitioner_consistent_random (const rd_kafka_topic_t *rkt,
+           const void *key, size_t keylen,
+           int32_t partition_cnt,
+           void *opaque, void *msg_opaque);
 
 
 /**@}*/

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -340,6 +340,27 @@ int32_t rd_kafka_msg_partitioner_consistent (const rd_kafka_topic_t *rkt,
     return rd_crc32(key, keylen) % partition_cnt;
 }
 
+int32_t rd_kafka_msg_partitioner_consistent_random (const rd_kafka_topic_t *rkt,
+                                             const void *key, size_t keylen,
+                                             int32_t partition_cnt,
+                                             void *rkt_opaque,
+                                             void *msg_opaque) {
+    if (keylen == 0)
+      return rd_kafka_msg_partitioner_random(rkt,
+                                             key,
+                                             keylen,
+                                             partition_cnt,
+                                             rkt_opaque,
+                                             msg_opaque);
+    else
+      return rd_kafka_msg_partitioner_consistent(rkt,
+                                                 key,
+                                                 keylen,
+                                                 partition_cnt,
+                                                 rkt_opaque,
+                                                 msg_opaque);
+}
+
 
 /**
  * Assigns a message to a topic partition using a partitioner.

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -192,9 +192,9 @@ shptr_rd_kafka_itopic_t *rd_kafka_topic_new0 (rd_kafka_t *rk,
                         * just the placeholder. The internal members
                         * were copied on the line above. */
 
-	/* Default partitioner: random */
+	/* Default partitioner: consistent_random */
 	if (!rkt->rkt_conf.partitioner)
-		rkt->rkt_conf.partitioner = rd_kafka_msg_partitioner_random;
+		rkt->rkt_conf.partitioner = rd_kafka_msg_partitioner_consistent_random;
 
 	if (rkt->rkt_conf.compression_codec == RD_KAFKA_COMPRESSION_INHERIT)
 		rkt->rkt_conf.compression_codec = rk->rk_conf.compression_codec;

--- a/tests/0006-symbols.c
+++ b/tests/0006-symbols.c
@@ -83,6 +83,8 @@ int main_0006_symbols (int argc, char **argv) {
                 rd_kafka_topic_partition_available(NULL, 0);
 		rd_kafka_topic_opaque(NULL);
                 rd_kafka_msg_partitioner_random(NULL, NULL, 0, 0, NULL, NULL);
+                rd_kafka_msg_partitioner_consistent(NULL, NULL, 0, 0, NULL, NULL);
+                rd_kafka_msg_partitioner_consistent_random(NULL, NULL, 0, 0, NULL, NULL);
                 rd_kafka_new(0, NULL, NULL, 0);
                 rd_kafka_destroy(NULL);
                 rd_kafka_name(NULL);


### PR DESCRIPTION
Set default partitioner to _consistent_ (rather than _random_) to behave more like Java/Scala implementations. Closes Issue #546