### PR TITLE
remove unused variable r

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -1536,7 +1536,6 @@ static int rd_kafka_compress_MessageSet_buf (rd_kafka_broker_t *rkb,
 	int32_t MessageSetSize = *MessageSetSizep;
 	size_t coutlen = 0;
 	int    outlen;
-	int r;
 #if WITH_SNAPPY
 	int    siovlen = 1;
 	struct snappy_env senv;


### PR DESCRIPTION
gcc warned about unused variable:
gcc -MD -MP -D_FORTIFY_SOURCE=2 -D_FORTIFY_SOURCE=2 -g -O2 -fPIC -Wall -Wsign-compare
              -Wfloat-equal -Wpointer-arith -D_FORTIFY_SOURCE=2 -g -O2 -fPIC -Wall -Wsign-compare
              -Wfloat-equal -Wpointer-arith -D_FORTIFY_SOURCE=2 -g -O2 -fPIC -Wall -Wsign-compare
              -Wfloat-equal -Wpointer-arith -g -O2 -fstack-protector-strong -Wformat
              -Werror=format-security -g -O2 -fstack-protector-strong -Wformat -Werror=format-security
              -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -g -O2
              -fstack-protector-strong -Wformat -Werror=format-security -c rdkafka_broker.c -o
              rdkafka_broker.o
Putting child 0xe44800 (rdkafka_broker.o) PID 13848 on the chain.
Live child 0xe44800 (rdkafka_broker.o) PID 13848
rdkafka_broker.c: In function ‘rd_kafka_compress_MessageSet_buf’:
rdkafka_broker.c:1539:6: warning: unused variable ‘r’ [-Wunused-variable]
  int r;
      ^
 it builds just fine without r and warning is gone