### PR TITLE
Dynamically increase the max fetch size when needed

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -148,6 +148,8 @@ shptr_rd_kafka_toppar_t *rd_kafka_toppar_new (rd_kafka_itopic_t *rkt,
 	rktp->rktp_partition = partition;
 	rktp->rktp_rkt = rkt;
 	rktp->rktp_fetch_state = RD_KAFKA_TOPPAR_FETCH_NONE;
+        rktp->rktp_fetch_msg_max_bytes
+            = rkt->rkt_rk->rk_conf.fetch_msg_max_bytes;
 	rktp->rktp_offset_fp = NULL;
         rd_kafka_offset_stats_reset(&rktp->rktp_offsets);
         rd_kafka_offset_stats_reset(&rktp->rktp_offsets_fin);

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -109,6 +109,10 @@ struct rd_kafka_toppar_s { /* rd_kafka_toppar_t */
 #define RD_KAFKA_TOPPAR_FETCH_IS_STARTED(fetch_state) \
         ((fetch_state) >= RD_KAFKA_TOPPAR_FETCH_OFFSET_QUERY)
 
+	int32_t            rktp_fetch_msg_max_bytes; /* Max number of bytes to
+                                                      * fetch.
+                                                      * Locality: broker thread
+                                                      */
 
 	int64_t            rktp_query_offset;    /* Offset to query broker for*/
 	int64_t            rktp_next_offset;     /* Next offset to start


### PR DESCRIPTION
This patch allows the max fetch size (currently fixed at `fetch.msg.max.bytes`) to be increased dynamically when a larger message has to be consumed.

Motivation: I have an application where a client have to seek around in a topic and consume a small amount of data after each seek. I'd like to set `fetch.msg.max.bytes` to a small value to minimize bandwidth usage. However, currently this has a danger that a consumer may become permanently stuck when there is a message whose size exceeds this value. I'd like a way to use a small transfer sizes while avoiding the danger.

Regarding the implementation, it's possible that I have made mistakes because I'm not very familiar with the code. In particular I'm not sure that I correctly implemented the check to identify a case where the next message is too large to consume.

Related issues: #320 and #482.