### PR TITLE
added virtual destructors to all classes that have a virtual function

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -115,7 +115,7 @@ std::string get_debug_contexts();
  *
  * @returns 0 if all kafka objects are now destroyed, or -1 if the
  * timeout was reached.
- * Since RdKafka handle deletion is an asynch operation the 
+ * Since RdKafka handle deletion is an asynch operation the
  * \p wait_destroyed() function can be used for applications where
  * a clean shutdown is required.
  */
@@ -331,7 +331,7 @@ class KafkaConsumer;
  * The delivery report callback will be called once for each message
  * accepted by RdKafka::Producer::produce() (et.al) with
  * RdKafka::Message::err() set to indicate the result of the produce request.
- * 
+ *
  * The callback is called when a message is succesfully produced or
  * if librdkafka encountered a permanent failure, or the retry counter for
  * temporary errors has been exhausted.
@@ -346,6 +346,8 @@ class RD_EXPORT DeliveryReportCb {
    * @brief Delivery report callback.
    */
   virtual void dr_cb (Message &message) = 0;
+
+  virtual ~DeliveryReportCb() { }
 };
 
 
@@ -378,6 +380,8 @@ class RD_EXPORT PartitionerCb {
                                   const std::string *key,
                                   int32_t partition_cnt,
                                   void *msg_opaque) = 0;
+
+  virtual ~PartitionerCb() { }
 };
 
 /**
@@ -399,6 +403,8 @@ class PartitionerKeyPointerCb {
                                   size_t key_len,
                                   int32_t partition_cnt,
                                   void *msg_opaque) = 0;
+
+  virtual ~PartitionerKeyPointerCb() { }
 };
 
 
@@ -419,6 +425,8 @@ class RD_EXPORT EventCb {
    * @sa RdKafka::Event
    */
   virtual void event_cb (Event &event) = 0;
+
+  virtual ~EventCb() { }
 };
 
 
@@ -447,7 +455,7 @@ class RD_EXPORT Event {
     EVENT_SEVERITY_DEBUG = 7
   };
 
-  ~Event () {};
+  virtual ~Event () { }
 
   /*
    * Event Accessor methods
@@ -517,6 +525,8 @@ class RD_EXPORT ConsumeCb {
    * The callback interface is optional but provides increased performance.
    */
   virtual void consume_cb (Message &message, void *opaque) = 0;
+
+  virtual ~ConsumeCb() { }
 };
 
 
@@ -577,6 +587,8 @@ public:
  virtual void rebalance_cb (RdKafka::KafkaConsumer *consumer,
 			    RdKafka::ErrorCode err,
                             std::vector<TopicPartition*>&partitions) = 0;
+
+ virtual ~RebalanceCb() { }
 };
 
 
@@ -602,6 +614,8 @@ public:
    */
   virtual void offset_commit_cb(RdKafka::ErrorCode err,
                                 std::vector<TopicPartition*>&offsets) = 0;
+
+  virtual ~OffsetCommitCb() { }
 };
 
 
@@ -626,6 +640,8 @@ class RD_EXPORT SocketCb {
    * @returns The socket file descriptor or -1 on error (\c errno must be set)
    */
   virtual int socket_cb (int domain, int type, int protocol) = 0;
+
+  virtual ~SocketCb() { }
 };
 
 
@@ -647,6 +663,8 @@ class RD_EXPORT OpenCb {
    * @remark Not currently available on native Win32
    */
   virtual int open_cb (const std::string &path, int flags, int mode) = 0;
+
+  virtual ~OpenCb() { }
 };
 
 
@@ -698,7 +716,7 @@ class RD_EXPORT Conf {
    */
   static Conf *create (ConfType type);
 
-  virtual ~Conf () { };
+  virtual ~Conf () { }
 
   /**
    * @brief Set configuration property \p name to value \p value.
@@ -783,7 +801,7 @@ class RD_EXPORT Conf {
  */
 class RD_EXPORT Handle {
  public:
-  virtual ~Handle() {};
+  virtual ~Handle() { }
 
   /** @returns the name of the handle */
   virtual const std::string name () const = 0;
@@ -981,7 +999,7 @@ class RD_EXPORT Topic {
   /**
    * @brief Creates a new topic handle for topic named \p topic_str
    *
-   * \p conf is an optional configuration for the topic  that will be used 
+   * \p conf is an optional configuration for the topic  that will be used
    * instead of the default topic configuration.
    * The \p conf object is reusable after this call.
    *
@@ -1030,7 +1048,7 @@ class RD_EXPORT Topic {
 
 /**
  * @brief Message object
- * 
+ *
  * This object represents either a single consumed or produced message,
  * or an event (\p err() is set).
  *
@@ -1235,7 +1253,7 @@ public:
   /**
    * @brief Commit offsets for the current assignment.
    *
-   * @remark This is the synchronous variant that blocks until offsets 
+   * @remark This is the synchronous variant that blocks until offsets
    *         are committed or the commit fails (see return value).
    *
    * @remark If a RdKafka::OffsetCommitCb callback is registered it will


### PR DESCRIPTION
This ensures that the objects are properly cleaned up and also solves compilation issue when flag -Werror=non-virtual-dtor is present.