### PR TITLE
Initialize rktp_stored_offset after loading from a file.

### DIFF
--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -830,6 +830,7 @@ static void rd_kafka_offset_file_init (rd_kafka_toppar_t *rktp) {
 
 	if (offset != RD_KAFKA_OFFSET_INVALID) {
 		/* Start fetching from offset */
+		rktp->rktp_stored_offset = offset;
 		rktp->rktp_committed_offset = offset;
                 rd_kafka_toppar_next_offset_handle(rktp, offset);
 


### PR DESCRIPTION
This seemed to be needed, but alas I don't have good notes on the exact problem that not doing it caused.  (I'm trying to catch you up on outstanding patches I have that might be of general use.)