### PR TITLE
Fix a potential signed integer overflow that gcc 5.1 complains about

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -63,7 +63,7 @@ static void stop (int sig) {
 
 static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 	const char *p = (const char *)ptr;
-	unsigned int of = 0;
+	size_t of = 0;
 
 
 	if (name)
@@ -82,7 +82,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 			cof += sprintf(charen+cof, "%c",
 				       isprint((int)p[i]) ? p[i] : '.');
 		}
-		fprintf(fp, "%08x: %-48s %-16s\n",
+		fprintf(fp, "%08zx: %-48s %-16s\n",
 			of, hexen, charen);
 	}
 }

--- a/src/rdlog.c
+++ b/src/rdlog.c
@@ -38,7 +38,7 @@
 
 void rd_hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 	const char *p = (const char *)ptr;
-	unsigned int of = 0;
+	size_t of = 0;
 
 
 	if (name)
@@ -59,7 +59,7 @@ void rd_hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 			cof += rd_snprintf(charen+cof, sizeof(charen)-cof, "%c",
 					   isprint((int)p[i]) ? p[i] : '.');
 		}
-		fprintf(fp, "%08x: %-48s %-16s\n",
+		fprintf(fp, "%08zx: %-48s %-16s\n",
 			of, hexen, charen);
 	}
 }


### PR DESCRIPTION
gcc 5.1 complains 
 rdlog.c:39:6: error: assuming signed overflow does not occur when
  assuming that (X + c) >= X is always true [-Werror=strict-overflow]