### PR TITLE
test-suite-fix: tests that expect more than one partition now create topic ahead-of-time

### DIFF
--- a/tests/0012-produce_consume.c
+++ b/tests/0012-produce_consume.c
@@ -495,6 +495,8 @@ static void test_produce_consume (void) {
 
 	TEST_SAY("Topic %s, testid %"PRIu64"\n", topic, testid);
 
+	test_create_topic(topic, partition_cnt, 1);
+
 	/* Produce messages */
 	produce_messages(testid, topic, partition_cnt, msgcnt);
 

--- a/tests/0018-cgrp_term.c
+++ b/tests/0018-cgrp_term.c
@@ -142,6 +142,8 @@ int main_0018_cgrp_term (int argc, char **argv) {
 
 	testid = test_id_generate();
 
+	test_create_topic(topic, partition_cnt, 1);
+
 	/* Produce messages */
 	rk_p = test_create_producer();
 	rkt_p = test_create_producer_topic(rk_p, topic, NULL);

--- a/tests/0022-consume_batch.c
+++ b/tests/0022-consume_batch.c
@@ -58,6 +58,7 @@ static int do_test_consume_batch (void) {
         /* Produce messages */
         for (i = 0 ; i < topic_cnt ; i++) {
                 topics[i] = rd_strdup(test_mk_topic_name(__FUNCTION__, 1));
+                test_create_topic(topics[i], partition_cnt, 1);
                 for (p = 0 ; p < partition_cnt ; p++)
                         test_produce_msgs_easy(topics[i], testid, p,
                                                msgcnt / topic_cnt /

--- a/tests/0029-assign_offset.c
+++ b/tests/0029-assign_offset.c
@@ -112,6 +112,8 @@ int main_0029_assign_offset (int argc, char **argv) {
 	test_conf_init(NULL, &tconf, 20 + (test_session_timeout_ms * 3 / 1000));
 	test_topic_conf_set(tconf, "auto.offset.reset", "smallest");
 
+    test_create_topic(topic, partitions, 1);
+
 	/* Produce X messages to Y partitions so we get a 
 	 * nice seekable 0..X offset one each partition. */
         /* Produce messages */


### PR DESCRIPTION
These tests were failing because they were trying to publish to partitions that didn't exist (topics were being created with 1 partition (default)).