### PR TITLE
Add ability to specify a CRL for checking remote certificates

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -48,6 +48,7 @@ ssl.key.location                         |  *  |                 |              
 ssl.key.password                         |  *  |                 |               | Private key passphrase <br>*Type: string*
 ssl.certificate.location                 |  *  |                 |               | Path to client's public key (PEM) used for authentication. <br>*Type: string*
 ssl.ca.location                          |  *  |                 |               | File or directory path to CA certificate(s) for verifying the broker's key. <br>*Type: string*
+ssl.crl.location                         |  *  |                 |               | Path to CRL for verifying broker's certificate validity. <br>*Type: string*
 sasl.mechanisms                          |  *  | GSSAPI, PLAIN   |        GSSAPI | SASL mechanism to use for authentication. Supported: GSSAPI, PLAIN. **NOTE**: Despite the name only one mechanism must be configured. <br>*Type: string*
 sasl.kerberos.service.name               |  *  |                 |         kafka | Kerberos principal name that Kafka runs as. <br>*Type: string*
 sasl.kerberos.principal                  |  *  |                 |   kafkaclient | This client's Kerberos principal name. <br>*Type: string*

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -388,6 +388,10 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	  "File or directory path to CA certificate(s) for verifying "
 	  "the broker's key."
 	},
+	{ _RK_GLOBAL, "ssl.crl.location", _RK_C_STR,
+	  _RK(ssl.crl_location),
+	  "Path to CRL for verifying broker's certificate validity."
+	},
 #endif /* WITH_SSL */
 
 #if WITH_SASL

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -92,6 +92,7 @@ struct rd_kafka_conf_s {
 		char *key_password;
 		char *cert_location;
 		char *ca_location;
+		char *crl_location;
 	} ssl;
 #endif
 

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -665,6 +665,26 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 			goto fail;
 	}
 
+	if (rk->rk_conf.ssl.crl_location) {
+		rd_kafka_dbg(rk, SECURITY, "SSL",
+			     "Loading CRL from file %s",
+			     rk->rk_conf.ssl.crl_location);
+
+		r = SSL_CTX_load_verify_locations(ctx,
+						  rk->rk_conf.ssl.crl_location,
+						  NULL);
+
+		if (r != 1)
+			goto fail;
+
+
+		rd_kafka_dbg(rk, SECURITY, "SSL",
+			     "Enabling CRL checks");
+
+		X509_STORE_set_flags(SSL_CTX_get_cert_store(ctx),
+				     X509_V_FLAG_CRL_CHECK);
+	}
+
 	if (rk->rk_conf.ssl.cert_location) {
 		rd_kafka_dbg(rk, SECURITY, "SSL",
 			     "Loading certificate from file %s",


### PR DESCRIPTION
By default, OpenSSL will ignore any CRL provided in the CA. With this
option, a user can provide a specific CRL file and, in this case, we
also instruct OpenSSL to do a CRL check when verifying a remote
certificate. If a user wants OpenSSL to check the CRL embedded in a CA,
they can just provide the CA instead of the CRL.