### PR TITLE
Makefile: add enable/disable lz4 builds

### DIFF
--- a/configure.librdkafka
+++ b/configure.librdkafka
@@ -42,7 +42,10 @@ function checks {
     # optional libs
     mkl_lib_check "zlib" "WITH_ZLIB" disable CC "-lz"
     mkl_lib_check "libcrypto" "" disable CC "-lcrypto"
-    mkl_lib_check "liblz4" "WITH_LZ4" disable CC "-llz4"
+
+    if mkl_compile_check "llz4" "WITH_LZ4" disable CC "#include <lz4frame.h>"; then
+        mkl_lib_check "llz4" "" disable CC "-llz4"
+    fi
 
     # Snappy support is built-in
     mkl_allvar_set WITH_SNAPPY WITH_SNAPPY y
@@ -117,4 +120,3 @@ int foo (void) {
 			  "#include <valgrind/memcheck.h>"
     fi
 }
-

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -1685,8 +1685,3 @@ function mkl_toggle_option_lib {
     eval "function _tmp_func { mkl_lib_check \"$2\" \"$3\" \"$4\" CC \"$7\"; }"
     mkl_func_push MKL_CHECKS "$MKL_MODULE" _tmp_func
 }
-
-
-
-
-


### PR DESCRIPTION
Added ability to add or remove -llz4 builds.

* This is to get it to compile on ubuntu 14.04 which doesn't support the latest lz4 lib avail on 16.04
* The header lz4frame.h is missing on liblz4-dev
* Style is compatible with the other enable/disable makefile flags.

Signed-off-by: Alexander Gallego <gallego.alexx@gmail.com>