### PR TITLE
Add rd_kafka_query_watermark_offsets call to rd_kafka_topic_leader_query

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1911,6 +1911,9 @@ rd_kafka_query_watermark_offsets (rd_kafka_t *rk, const char *topic,
 		return RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION;
 	rktp = rd_kafka_toppar_s2i(s_rktp);
 
+	/* Query for the topic leader (async) */
+	rd_kafka_topic_leader_query(rk, rktp->rktp_rkt);
+
 	/* Get toppar's leader broker. */
 	do {
 		if ((rkb = rd_kafka_toppar_leader(rktp, 1)))


### PR DESCRIPTION
Query watermark offsets uses rd_kafka_toppar_get2 to create a topic which
in turn calls rd_kafka_topic_new0, which unlike rd_kafka_topic_new does
not call rd_kafka_topic_leader_query.

This had the effect that rd_kafka_toppar_leader would return NULL until
rd_kafka_topic_leader_query was called by rd_kafka_topic_scan_tmr_cb,
which is run every 1000ms by a timer. Because of this query watermark
offsets would occasionally take 1000ms longer to finish, or return
WAIT_COORD error if timeout was shorter than that.