### PR TITLE
silence warning about hidden constructor

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -2243,7 +2243,7 @@ RD_EXPORT
 rd_kafka_resp_err_t
 rd_kafka_metadata (rd_kafka_t *rk, int all_topics,
                    rd_kafka_topic_t *only_rkt,
-                   const struct rd_kafka_metadata **metadatap,
+                   const rd_kafka_metadata_t **metadatap,
                    int timeout_ms);
 
 /**


### PR DESCRIPTION
Compiling with the rdkafka.h header in my environment gives the following warning:

/rdkafka.h:2247:34: warning: ‘rd_kafka_resp_err_t rd_kafka_metadata(rd_kafka_t*, int, rd_kafka_topic_t*, const rd_kafka_metadata**, int)’ hides constructor for ‘struct rd_kafka_metadata’ [-Wshadow]
                    int timeout_ms);

The struct in question is typedef'd directly above this, so we should be able to safely use it's type, rd_kafka_metadata_t, instead.