### PR TITLE
Fix 0025 test to run as RD_KAFKA_PRODUCER

### DIFF
--- a/tests/0025-timers.c
+++ b/tests/0025-timers.c
@@ -99,7 +99,7 @@ static void do_test_stats_timer (void) {
 
 
         TIMING_START(&t_new, "rd_kafka_new()");
-        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
         TIMING_STOP(&t_new);
         if (!rk)
                 TEST_FAIL("Failed to create instance: %s\n", errstr);


### PR DESCRIPTION
Running test 0025-timers.c as RD_KAFKA_CONSUMER causes the rk_curr_msgs.lock to not be initialised in rd_kafka_new before an attempt is made to lock it in rd_kafka_curr_msgs_get, while running the test as RD_KAFKA_PRODUCER does initialise the lock and the test succeeds.

While this bugfix does fix the symptom, it is not clear that the test should be run as an RD_KAFKA_PRODUCER. Please confirm that this should be the case, and that testing timers on an RD_KAFKA_CONSUMER does not make sense.

This bugfix also begs the question as to why the tests are succeeding on Linux.