### PR TITLE
Examples require getopt header file to avoid 'optind' undeclared error

### DIFF
--- a/examples/rdkafka_consumer_example.c
+++ b/examples/rdkafka_consumer_example.c
@@ -40,6 +40,7 @@
 #include <syslog.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <getopt.h>
 
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is builtin from within the librdkafka source tree and thus differs. */

--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -40,6 +40,7 @@
 #include <syslog.h>
 #include <time.h>
 #include <sys/time.h>
+#include <getopt.h>
 
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is builtin from within the librdkafka source tree and thus differs. */


### PR DESCRIPTION
Configuration on Linux 3.19.0-49-generic #55~14.04.1-Ubuntu x86_64 fails on C files in the examples directory because of missing getopt.h include.

```
CFLAGS="--std=c99 -g -O2" CXXFLAGS="--std=c++11 -g -O2" ./configure --no-download --disable-ssl --disable-sasl --prefix=/usr/local
(...)
make[1]: Entering directory `/home/julien/dev/github/librdkafka/examples'
gcc -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith --std=c99 -g -O2     -I../src rdkafka_example.c -o rdkafka_example  \
                ../src/librdkafka.a -lpthread -lz   -lcrypto   -lrt
rdkafka_example.c: In function ‘main’:
rdkafka_example.c:303:2: warning: implicit declaration of function ‘getopt’ [-Wimplicit-function-declaration]
  while ((opt = getopt(argc, argv, "PCLt:p:b:z:qd:o:eX:As:")) != -1) {
  ^
rdkafka_example.c:311:12: error: ‘optarg’ undeclared (first use in this function)
    topic = optarg;
            ^
rdkafka_example.c:311:12: note: each undeclared identifier is reported only once for each function it appears in
rdkafka_example.c:478:6: error: ‘optind’ undeclared (first use in this function)
  if (optind != argc || (mode != 'L' && !topic)) {
      ^
make[1]: *** [rdkafka_example] Error 1

```