### PR TITLE
Add missing return in rd_kafka_curr_msgs_get if RD_KAFKA_PRODUCER.

### DIFF
--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -253,6 +253,7 @@ rd_kafka_curr_msgs_get (rd_kafka_t *rk, unsigned int *cntp, size_t *sizep) {
 	if (rk->rk_type != RD_KAFKA_PRODUCER) {
 		*cntp = 0;
 		*sizep = 0;
+		return;
 	}
 
 	mtx_lock(&rk->rk_curr_msgs.lock);


### PR DESCRIPTION
There is a pattern in the rd_kafka_curr_msgs_* functions in rdkafka_int.h to avoid referencing the rk_curr_msgs structure if the application is not a RD_KAFKA_PRODUCER.

However, for the rd_kafka_curr_msgs_get function, while there exists a check for RD_KAFKA_PRODUCER and return values are set to 0, there is no subsequent return statement and the function falls through to manipulating the rk_curr_msgs structure even when the application is not a RD_KAFKA_PRODUCER, causing exceptions on trying to lock the structure on WIN32.

This patch adds the missing return statement.