### PR TITLE
rd_kafka_new: delete conf only on success

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1346,8 +1346,8 @@ int32_t rd_kafka_msg_partitioner_consistent_random (const rd_kafka_topic_t *rkt,
  *
  * \p conf is an optional struct created with `rd_kafka_conf_new()` that will
  * be used instead of the default configuration.
- * The \p conf object is freed by this function and must not be used or
- * destroyed by the application sub-sequently.
+ * The \p conf object is freed by this function on success and must not be used
+ * or destroyed by the application sub-sequently.
  * See `rd_kafka_conf_set()` et.al for more information.
  *
  * \p errstr must be a pointer to memory of at least size \p errstr_size where


### PR DESCRIPTION
This patch allows the user to be sure the rd_kafka_conf_t* is only deleted on success when calling rd_kafka_new.

It works by first duplicating the user conf if supplied, or creating a new conf. This means that this duplicate conf may be deleted from the same places in rd_kafka_new as before.

At the end of rd_kafka_new: delete the user supplied conf to keep current behavior.

If we were to change behavior and have user create and delete conf, it's as easy as just deleting the last lines of function rd_kafka_new.
