### PR TITLE
fix crash in rd_kafka_new() when conf is NULL

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1110,14 +1110,14 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
         use_conf = (conf ? rd_kafka_conf_dup(conf) : rd_kafka_conf_new());
 
         /* Verify mandatory configuration */
-        if (!conf->socket_cb) {
+        if (conf && !conf->socket_cb) {
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'socket_cb' not set");
                 rd_kafka_conf_destroy(use_conf);
                 return NULL;
         }
 
-        if (!conf->open_cb) {
+        if (conf && !conf->open_cb) {
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'open_cb' not set");
                 rd_kafka_conf_destroy(use_conf);


### PR DESCRIPTION
when we use the latest code of https://github.com/edenhill/librdkafka and https://pecl.php.net/package/rdkafka, the php core dumped, so i fixed it.

please review if it's ok, thanks:)

the php code:
```php
$rk = new RdKafka\Producer();
$rk->setLogLevel(LOG_DEBUG);
```

the core dump backtrace:
```
Program received signal SIGSEGV, Segmentation fault.
rd_kafka_new (type=RD_KAFKA_CONSUMER, conf=0x0, errstr=0x7fffffffa9a0 "\316\006", errstr_size=512) at rdkafka.c:1113
1113	        if (!conf->socket_cb) {
Missing separate debuginfos, use: debuginfo-install audit-libs-2.3.7-5.el6.x86_64 cyrus-sasl-lib-2.1.23-15.el6_6.2.x86_64 freetype-2.3.11-15.el6_6.1.x86_64 glibc-2.12-1.149.el6_6.9.x86_64 keyutils-libs-1.4-5.el6.x86_64 krb5-libs-1.10.3-37.el6_6.x86_64 libcom_err-1.41.12-21.el6.x86_64 libcurl-7.19.7-46.el6.x86_64 libgcc-4.4.7-11.el6.x86_64 libgomp-4.4.7-11.el6.x86_64 libidn-1.18-2.el6.x86_64 libjpeg-turbo-1.2.1-3.el6_5.x86_64 libselinux-2.0.94-5.8.el6.x86_64 libssh2-1.4.2-1.el6_6.1.x86_64 libxml2-2.7.6-17.el6_6.1.x86_64 libyaml-0.1.6-1.el6.x86_64 nspr-4.10.8-1.el6_6.x86_64 nss-3.19.1-3.el6_6.x86_64 nss-softokn-freebl-3.14.3-22.el6_6.x86_64 nss-util-3.19.1-1.el6_6.x86_64 openldap-2.4.39-8.el6.x86_64 openssl-1.0.1e-42.el6.x86_64 pam-1.1.1-20.el6.x86_64 postgresql-libs-8.4.20-3.el6_6.x86_64 sqlite-3.6.20-1.el6.x86_64 zlib-1.2.3-29.el6.x86_64
(gdb) backtrace
#0  rd_kafka_new (type=RD_KAFKA_CONSUMER, conf=0x0, errstr=0x7fffffffa9a0 "\316\006", errstr_size=512) at rdkafka.c:1113
#1  0x00007fffe802ab6d in kafka_init (this_ptr=0x7ffff1e130f0, type=RD_KAFKA_CONSUMER, zconf=<value optimized out>)
    at /tmp/source/rdkafka-2.0.0/rdkafka.c:98
#2  0x00007fffe802acbc in zim_RdKafka__Consumer___construct (execute_data=0x7ffff1e130d0, return_value=<value optimized out>)
    at /tmp/source/rdkafka-2.0.0/rdkafka.c:169
#3  0x0000000000785628 in ZEND_DO_FCALL_SPEC_HANDLER (execute_data=0x7ffff1e13030)
    at /tmp/opdir/php-7.0.11/Zend/zend_vm_execute.h:842
#4  0x000000000074d420 in execute_ex (ex=<value optimized out>) at /tmp/opdir/php-7.0.11/Zend/zend_vm_execute.h:417
#5  0x00000000007a06cb in zend_execute (op_array=0x7ffff1e7e000, return_value=<value optimized out>)
    at /tmp/opdir/php-7.0.11/Zend/zend_vm_execute.h:458
#6  0x000000000070dde3 in zend_execute_scripts (type=8, retval=0x0, file_count=3)
    at /tmp/opdir/php-7.0.11/Zend/zend.c:1427
#7  0x00000000006b0290 in php_execute_script (primary_file=0x7fffffffe120) at /tmp/opdir/php-7.0.11/main/main.c:2494
#8  0x00000000007a49fa in do_cli (argc=2, argv=0xd31be0) at /tmp/opdir/php-7.0.11/sapi/cli/php_cli.c:974
#9  0x00000000007a51fa in main (argc=2, argv=0xd31be0) at /tmp/opdir/php-7.0.11/sapi/cli/php_cli.c:1344
```