### PR TITLE
Fix for async offset commit issue on AIX

### DIFF
--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -380,7 +380,11 @@ uint64_t rd_kafka_q_size (rd_kafka_q_t *rkq) {
 #endif
 
 /* Construct temporary on-stack replyq for indicating no replyq. */
-#define RD_KAFKA_NO_REPLYQ  (rd_kafka_replyq_t){NULL, 0}
+#if ENABLE_DEVEL
+#define RD_KAFKA_NO_REPLYQ (rd_kafka_replyq_t){NULL, 0, rd_strdup(__FUNCTION__)}
+#else
+#define RD_KAFKA_NO_REPLYQ (rd_kafka_replyq_t){NULL, 0}
+#endif
 
 /**
  * Set up replyq.


### PR DESCRIPTION
While running tests on IBM-AIX, I experienced a crash while running 0030-offset_commit for  manual async commit. What's happening is that, it is evaluating both expressions and repq being NULL for async case, wreaks havoc when NULL is being passed to rd_kafka_q_keep().
