### PR TITLE
Fix for AIX-- exclude endian.h on AIX

### DIFF
--- a/src/snappy_compat.h
+++ b/src/snappy_compat.h
@@ -19,7 +19,7 @@
 #endif
 
 
-#elif !defined(__WIN32__) && !defined(_MSC_VER) && !defined(sun)
+#elif !defined(__WIN32__) && !defined(_MSC_VER) && !defined(sun) && !defined(_AIX)
 #  include <endian.h>
 #endif
 


### PR DESCRIPTION
A few more changes for AIX:
1. malloc/calloc return NULL for 0 size memory request.
2. As described in issue  #837, need to use mutexes for atomic ops.