### PR TITLE
changes after checking with cppcheck 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gmon.out
 *.rpm
 staging-docs
 tmp
+win32/librdkafka.VC.db

--- a/README.win32
+++ b/README.win32
@@ -24,3 +24,11 @@ Artifacts:
   - remaining tools (rdkafka_performance, etc)
   - SASL support (no official Cyrus libsasl2 DLLs available)
   - LZ4 support
+
+Configuration:
+ - You can disable/enable SSL using the definition WITH_SSL=0
+   0: disable
+   1: enable (by default)
+ - You can disable/enable ZLIB using the definition WITH_ZLIB=0
+   0: disable
+   1: enable (by default)

--- a/examples/kafkatest_verifiable_client.cpp
+++ b/examples/kafkatest_verifiable_client.cpp
@@ -77,8 +77,7 @@ public:
                 minOffset(-1), maxOffset(0) {
     printf("Created assignment\n");
   }
-  Assignment(const Assignment &a) {
-    topic = a.topic;
+  Assignment(const Assignment &a) : topic(a.topic){
     partition = a.partition;
     consumedMessages = a.consumedMessages;
     minOffset = a.minOffset;
@@ -348,7 +347,7 @@ static void report_records_consumed (int immediate) {
     "\"partitions\": [ ";
 
   for (std::map<std::string,Assignment>::iterator ii = assignments->begin() ;
-       ii != assignments->end() ; ii++) {
+       ii != assignments->end() ; ++ii) {
     Assignment *a = &(*ii).second;
     assert(!a->topic.empty());
     std::cout << (ii == assignments->begin() ? "": ", ") << " { " <<
@@ -746,9 +745,9 @@ int main (int argc, char **argv) {
       for (std::list<std::string>::iterator it = dump->begin();
            it != dump->end(); ) {
         std::cerr << *it << " = ";
-        it++;
+        ++it;
         std::cerr << *it << std::endl;
-        it++;
+        ++it;
       }
       std::cerr << std::endl;
     }

--- a/examples/rdkafka_consumer_example.c
+++ b/examples/rdkafka_consumer_example.c
@@ -71,7 +71,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 
 
 	if (name)
-		fprintf(fp, "%s hexdump (%"PRIusz" bytes):\n", name, len);
+		fprintf(fp, "%s hexdump (%zd bytes):\n", name, len);
 
 	for (of = 0 ; of < len ; of += 16) {
 		char hexen[16*3+1];

--- a/examples/rdkafka_consumer_example.c
+++ b/examples/rdkafka_consumer_example.c
@@ -71,7 +71,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 
 
 	if (name)
-		fprintf(fp, "%s hexdump (%zd bytes):\n", name, len);
+		fprintf(fp, "%s hexdump (%"PRIusz" bytes):\n", name, len);
 
 	for (of = 0 ; of < len ; of += 16) {
 		char hexen[16*3+1];
@@ -98,7 +98,7 @@ static void logger (const rd_kafka_t *rk, int level,
 		    const char *fac, const char *buf) {
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-	fprintf(stdout, "%u.%03u RDKAFKA-%i-%s: %s: %s\n",
+	fprintf(stdout, "%d.%03d RDKAFKA-%i-%s: %s: %s\n",
 		(int)tv.tv_sec, (int)(tv.tv_usec / 1000),
 		level, fac, rd_kafka_name(rk), buf);
 }

--- a/examples/rdkafka_consumer_example.cpp
+++ b/examples/rdkafka_consumer_example.cpp
@@ -401,9 +401,9 @@ int main (int argc, char **argv) {
       for (std::list<std::string>::iterator it = dump->begin();
            it != dump->end(); ) {
         std::cout << *it << " = ";
-        it++;
+        ++it;
         std::cout << *it << std::endl;
-        it++;
+        ++it;
       }
       std::cout << std::endl;
     }

--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -68,7 +68,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 
 
 	if (name)
-		fprintf(fp, "%s hexdump (%zd bytes):\n", name, len);
+		fprintf(fp, "%s hexdump (%"PRIusz" bytes):\n", name, len);
 
 	for (of = 0 ; of < len ; of += 16) {
 		char hexen[16*3+1];
@@ -95,7 +95,7 @@ static void logger (const rd_kafka_t *rk, int level,
 		    const char *fac, const char *buf) {
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-	fprintf(stderr, "%u.%03u RDKAFKA-%i-%s: %s: %s\n",
+	fprintf(stderr, "%d.%03d RDKAFKA-%i-%s: %s: %s\n",
 		(int)tv.tv_sec, (int)(tv.tv_usec / 1000),
 		level, fac, rk ? rd_kafka_name(rk) : NULL, buf);
 }
@@ -114,7 +114,7 @@ static void msg_delivered (rd_kafka_t *rk,
 		fprintf(stderr, "%% Message delivery failed: %s\n",
 			rd_kafka_err2str(error_code));
 	else if (!quiet)
-		fprintf(stderr, "%% Message delivered (%zd bytes): %.*s\n", len,
+		fprintf(stderr, "%% Message delivered (%"PRIusz" bytes): %.*s\n", len,
 			(int)len, (const char *)payload);
 }
 
@@ -608,7 +608,7 @@ int main (int argc, char **argv) {
 			}
 
 			if (!quiet)
-				fprintf(stderr, "%% Sent %zd bytes to topic "
+				fprintf(stderr, "%% Sent %"PRIusz" bytes to topic "
 					"%s partition %i\n",
 				len, rd_kafka_topic_name(rkt), partition);
 			sendcnt++;

--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -68,7 +68,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 
 
 	if (name)
-		fprintf(fp, "%s hexdump (%"PRIusz" bytes):\n", name, len);
+		fprintf(fp, "%s hexdump (%zd bytes):\n", name, len);
 
 	for (of = 0 ; of < len ; of += 16) {
 		char hexen[16*3+1];
@@ -114,7 +114,7 @@ static void msg_delivered (rd_kafka_t *rk,
 		fprintf(stderr, "%% Message delivery failed: %s\n",
 			rd_kafka_err2str(error_code));
 	else if (!quiet)
-		fprintf(stderr, "%% Message delivered (%"PRIusz" bytes): %.*s\n", len,
+		fprintf(stderr, "%% Message delivered (%zd bytes): %.*s\n", len,
 			(int)len, (const char *)payload);
 }
 
@@ -608,7 +608,7 @@ int main (int argc, char **argv) {
 			}
 
 			if (!quiet)
-				fprintf(stderr, "%% Sent %"PRIusz" bytes to topic "
+				fprintf(stderr, "%% Sent %zd bytes to topic "
 					"%s partition %i\n",
 				len, rd_kafka_topic_name(rkt), partition);
 			sendcnt++;

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -619,18 +619,22 @@ int main (int argc, char **argv) {
       if (err != RdKafka::ERR_NO_ERROR) {
         std::cerr << "%% Failed to acquire metadata: " 
                   << RdKafka::err2str(err) << std::endl;
-              run = 0;
+              run = false;
               break;
       }
 
       metadata_print(topic_str, metadata);
 
       delete metadata;
-      run = 0;
+      run = false;
     }
 
   }
 
+  if (conf) delete conf;
+  conf = NULL;
+  if (tconf) delete tconf;
+  tconf = NULL;
 
   /*
    * Wait for RdKafka to decommission.

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -435,9 +435,9 @@ int main (int argc, char **argv) {
       for (std::list<std::string>::iterator it = dump->begin();
            it != dump->end(); ) {
         std::cout << *it << " = ";
-        it++;
+        ++it;
         std::cout << *it << std::endl;
-        it++;
+        ++it;
       }
       std::cout << std::endl;
     }

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -578,7 +578,7 @@ static void print_stats (rd_kafka_t *rk,
                                "%s\n",
                                i_msgs, i_bytes,
                                i_time / 1000,
-                               ((i_msgs * 1000000) / i_time),
+                               i_time!=0?((i_msgs * 1000000) / i_time):-1,
                                (float)((i_bytes) / (float)i_time),
                                extra);
 

--- a/examples/rdkafka_zookeeper_example.c
+++ b/examples/rdkafka_zookeeper_example.c
@@ -72,7 +72,7 @@ static void hexdump (FILE *fp, const char *name, const void *ptr, size_t len) {
 
 
 	if (name)
-		fprintf(fp, "%s hexdump (%zd bytes):\n", name, len);
+		fprintf(fp, "%s hexdump (%"PRIusz" bytes):\n", name, len);
 
 	for (of = 0 ; of < len ; of += 16) {
 		char hexen[16*3+1];
@@ -99,7 +99,7 @@ static void logger (const rd_kafka_t *rk, int level,
 		    const char *fac, const char *buf) {
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
-	fprintf(stderr, "%u.%03u RDKAFKA-%i-%s: %s: %s\n",
+	fprintf(stderr, "%d.%03d RDKAFKA-%i-%s: %s: %s\n",
 		(int)tv.tv_sec, (int)(tv.tv_usec / 1000),
 		level, fac, rd_kafka_name(rk), buf);
 }
@@ -118,7 +118,7 @@ static void msg_delivered (rd_kafka_t *rk,
 		fprintf(stderr, "%% Message delivery failed: %s\n",
 			rd_kafka_err2str(error_code));
 	else if (!quiet)
-		fprintf(stderr, "%% Message delivered (%zd bytes)\n", len);
+		fprintf(stderr, "%% Message delivered (%"PRIusz" bytes)\n", len);
 }
 
 
@@ -608,7 +608,7 @@ int main (int argc, char **argv) {
 			}
 
 			if (!quiet)
-				fprintf(stderr, "%% Sent %zd bytes to topic "
+				fprintf(stderr, "%% Sent %"PRIusz" bytes to topic "
 					"%s partition %i\n",
 				len, rd_kafka_topic_name(rkt), partition);
 			sendcnt++;

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -535,11 +535,10 @@ public:
   topic_(topic), partition_(partition), offset_(RdKafka::Topic::OFFSET_INVALID),
       err_(ERR_NO_ERROR) {}
 
-  TopicPartitionImpl (const rd_kafka_topic_partition_t *c_part) {
-    topic_ = std::string(c_part->topic);
+  TopicPartitionImpl (const rd_kafka_topic_partition_t *c_part) : topic_(std::string(c_part->topic)),
+     err_(static_cast<ErrorCode>(c_part->err)) {
     partition_ = c_part->partition;
     offset_ = c_part->offset;
-    err_ = static_cast<ErrorCode>(c_part->err);
     // FIXME: metadata
   }
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1110,22 +1110,14 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
         use_conf = (conf ? rd_kafka_conf_dup(conf) : rd_kafka_conf_new());
 
         /* Verify mandatory configuration */
-<<<<<<< HEAD
-        if (!conf || !conf->socket_cb) {
-=======
         if (!use_conf->socket_cb) {
->>>>>>> refs/remotes/edenhill/master
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'socket_cb' not set");
                 rd_kafka_conf_destroy(use_conf);
                 return NULL;
         }
 
-<<<<<<< HEAD
-        if (!conf || !conf->open_cb) {
-=======
         if (!use_conf->open_cb) {
->>>>>>> refs/remotes/edenhill/master
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'open_cb' not set");
                 rd_kafka_conf_destroy(use_conf);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -229,7 +229,7 @@ void rd_kafka_log_print(const rd_kafka_t *rk, int level,
 	rd_gettimeofday(&tv, NULL);
 	secs = (int)tv.tv_sec;
 	msecs = (int)(tv.tv_usec / 1000);
-	fprintf(stderr, "%%%i|%u.%03u|%s|%s| %s\n",
+	fprintf(stderr, "%%%i|%d.%03d|%s|%s| %s\n",
 		level, secs, msecs,
 		fac, rk ? rk->rk_name : "", buf);
 }
@@ -1110,14 +1110,14 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *conf,
         use_conf = (conf ? rd_kafka_conf_dup(conf) : rd_kafka_conf_new());
 
         /* Verify mandatory configuration */
-        if (!conf->socket_cb) {
+        if (!conf || !conf->socket_cb) {
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'socket_cb' not set");
                 rd_kafka_conf_destroy(use_conf);
                 return NULL;
         }
 
-        if (!conf->open_cb) {
+        if (!conf || !conf->open_cb) {
                 rd_snprintf(errstr, errstr_size,
                          "Mandatory config property 'open_cb' not set");
                 rd_kafka_conf_destroy(use_conf);
@@ -2362,7 +2362,7 @@ static void rd_kafka_dump0 (FILE *fp, rd_kafka_t *rk, int locks) {
         fprintf(fp, "rd_kafka_op_cnt: %d\n", rd_atomic32_get(&rd_kafka_op_cnt));
 	fprintf(fp, "rd_kafka_t %p: %s\n", rk, rk->rk_name);
 
-	fprintf(fp, " producer.msg_cnt %u (%"PRIdsz" bytes)\n",
+	fprintf(fp, " producer.msg_cnt %u (%"PRIusz" bytes)\n",
 		tot_cnt, tot_size);
 	fprintf(fp, " rk_rep reply queue: %i ops\n",
 		rd_kafka_q_len(rk->rk_rep));

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -96,7 +96,7 @@ const char *rd_kafka_secproto_names[] = {
 static void iov_print (rd_kafka_t *rk,
 		       const char *what, int iov_idx, const struct iovec *iov,
 		       int hexdump) {
-	printf("%s:  iov #%i: %"PRIdsz"\n", what, iov_idx,
+	printf("%s:  iov #%i: %"PRIusz"\n", what, iov_idx,
 	       (size_t)iov->iov_len);
 	if (hexdump)
 		rd_hexdump(stdout, what, iov->iov_base, iov->iov_len);
@@ -109,13 +109,13 @@ void msghdr_print (rd_kafka_t *rk,
 	int i;
 	size_t len = 0;
 
-	printf("%s: iovlen %"PRIdsz"\n", what, (size_t)msg->msg_iovlen);
+	printf("%s: iovlen %"PRIusz"\n", what, (size_t)msg->msg_iovlen);
 
 	for (i = 0 ; i < (int)msg->msg_iovlen ; i++) {
 		iov_print(rk, what, i, &msg->msg_iov[i], hexdump);
 		len += msg->msg_iov[i].iov_len;
 	}
-	printf("%s: ^ message was %"PRIdsz" bytes in total\n", what, len);
+	printf("%s: ^ message was %"PRIusz" bytes in total\n", what, len);
 }
 
 

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -96,7 +96,7 @@ rd_tmpabuf_alloc0 (const char *func, int line, rd_tmpabuf_t *tab, size_t size) {
 	if (unlikely(tab->of + size > tab->size)) {
 		if (tab->assert_on_fail) {
 			fprintf(stderr,
-				"%s: %s:%d: requested size %zd + %zd > %zd\n",
+				"%s: %s:%d: requested size %"PRIusz" + %"PRIusz" > %"PRIusz"\n",
 				__FUNCTION__, func, line, tab->of, size,
 				tab->size);
 			assert(!*"rd_tmpabuf_alloc: not enough size in buffer");

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1295,7 +1295,8 @@ void rd_kafka_toppar_fetch_stopped (rd_kafka_toppar_t *rktp,
  */
 void rd_kafka_toppar_fetch_stop (rd_kafka_toppar_t *rktp,
 				 rd_kafka_op_t *rko_orig) {
-        int32_t version = rko_orig->rko_version;
+        int32_t version = -1;
+        if(rko_orig) version = rko_orig->rko_version;
 
 	rd_kafka_toppar_lock(rktp);
 

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -71,6 +71,7 @@ void rd_kafka_q_destroy_final (rd_kafka_q_t *rkq);
 
 static RD_INLINE RD_UNUSED
 rd_kafka_q_t *rd_kafka_q_keep (rd_kafka_q_t *rkq) {
+   if (!rkq) return NULL;
         mtx_lock(&rkq->rkq_lock);
         rkq->rkq_refcnt++;
         mtx_unlock(&rkq->rkq_lock);

--- a/src/rdstring.c
+++ b/src/rdstring.c
@@ -94,9 +94,9 @@ char *rd_string_render (const char *template,
 			 *               ^ */
 			te = strchr(t+2, '}');
 			if (!te) {
-				rd_snprintf(errstr, errstr_size,
+            rd_snprintf(errstr, errstr_size,
 					    "Missing close-brace } for "
-					    "%.*s at %"PRIdsz,
+					    "%.*s at %"PRIusz"",
 					    15, t, tof);
 				rd_free(buf);
 				return NULL;

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -98,11 +98,7 @@ struct msghdr {
 
 /* size_t and ssize_t format strings */
 #define PRIusz  "Iu"
-#if defined _MSC_VER
-#  define PRIdsz  "ll"
-#else
-#  define PRIdsz  "Id"
-#endif
+#define PRIdsz  "Id"
 
 #define RD_FORMAT(...)
 

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -98,7 +98,11 @@ struct msghdr {
 
 /* size_t and ssize_t format strings */
 #define PRIusz  "Iu"
-#define PRIdsz  "Id"
+#if defined _MSC_VER
+#  define PRIdsz  "ll"
+#else
+#  define PRIdsz  "Id"
+#endif
 
 #define RD_FORMAT(...)
 

--- a/src/win32_config.h
+++ b/src/win32_config.h
@@ -31,8 +31,17 @@
  */
 #pragma once
 
-#define WITH_SSL 1
-#define WITH_ZLIB 1
+#if !defined WITH_SSL
+#  define WITH_SSL 1
+#endif
+#if !defined WITH_ZLIB
+#  define WITH_ZLIB 1
+#endif
 #define WITH_SNAPPY 1
 
 #define ENABLE_DEVEL 0
+
+#if WITH_SSL
+#pragma comment(lib, "libeay32MT.lib")
+#pragma comment(lib, "ssleay32MT.lib")
+#endif

--- a/tests/0004-conf.c
+++ b/tests/0004-conf.c
@@ -90,7 +90,7 @@ static void conf_cmp (const char *desc,
 	int i;
 
 	if (acnt != bcnt)
-		TEST_FAIL("%s config compare: count %zd != %zd mismatch",
+		TEST_FAIL("%s config compare: count %"PRIusz" != %"PRIusz" mismatch",
 			  desc, acnt, bcnt);
 
 	for (i = 0 ; i < (int)acnt ; i += 2) {

--- a/tests/0022-consume_batch.c
+++ b/tests/0022-consume_batch.c
@@ -106,8 +106,8 @@ static int do_test_consume_batch (void) {
                 r = rd_kafka_consume_batch_queue(rkq, 1000, rkmessage, 1000);
                 TIMING_STOP(&t_batch);
 
-                TEST_SAY("Batch consume iteration #%d: Consumed %"PRIdsz
-                         "/1000 messages\n", batch_cnt, r);
+                TEST_SAY("Batch consume iteration #%d: Consumed %"PRIdsz""\
+                         "1000 messages\n", batch_cnt, r);
 
                 if (r == -1)
                         TEST_FAIL("Failed to consume messages: %s\n",

--- a/tests/test.c
+++ b/tests/test.c
@@ -1977,7 +1977,7 @@ static int test_mv_mvec_verify_dup (test_msgver_t *mv, int flags,
 		_P_MSGID
 	} pass;
 
-	for (pass = _P_OFFSET ; pass <= _P_MSGID ; pass++) {
+	for (pass = _P_OFFSET ; pass <= _P_MSGID ; ++pass) {
 
 		if (pass == _P_OFFSET) {
 			if (!(flags & TEST_MSGVER_BY_OFFSET))

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -28,26 +28,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -93,7 +97,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -102,14 +106,14 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -118,7 +122,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -129,14 +133,14 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -147,14 +151,14 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -97,7 +97,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -113,7 +113,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -133,7 +133,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -151,7 +151,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;LIBRDKAFKA_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/win32/librdkafkacpp/librdkafkacpp.vcxproj
+++ b/win32/librdkafkacpp/librdkafkacpp.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -29,26 +29,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/win32/rdkafka_consumer_example_cpp/rdkafka_consumer_example_cpp.vcxproj
+++ b/win32/rdkafka_consumer_example_cpp/rdkafka_consumer_example_cpp.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -28,26 +28,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/win32/rdkafka_example/rdkafka_example.vcxproj
+++ b/win32/rdkafka_example/rdkafka_example.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -28,26 +28,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -90,7 +90,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
       <ShowIncludes>false</ShowIncludes>
@@ -110,7 +110,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
       <ShowIncludes>false</ShowIncludes>
@@ -132,7 +132,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
     </ClCompile>
@@ -153,7 +153,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
     </ClCompile>

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -27,26 +27,30 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -86,7 +90,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
       <ShowIncludes>false</ShowIncludes>
@@ -106,7 +110,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;_DEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
       <ShowIncludes>false</ShowIncludes>
@@ -128,7 +132,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
     </ClCompile>
@@ -149,7 +153,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WITH_SSL=0;WITH_ZLIB=0;NDEBUG;_CONSOLE;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)\..\src;$(SolutionDir)\..\src-cpp</AdditionalIncludeDirectories>
     </ClCompile>

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -74,15 +74,19 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <LibraryPath>$(LibraryPath);C:\OpenSSL-Win32\lib\VC</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;C:\OpenSSL-Win32\lib\VC</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <LibraryPath>$(LibraryPath);C:\OpenSSL-Win32\lib\VC</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;C:\OpenSSL-Win32\lib\VC</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
A tool for static C/C++ code analysis: more info here
(http://cppcheck.sourceforge.net/)
---

Summary: Prefer prefix ++/-- operators for non-primitive types.
Message: Prefix ++/-- operators should be preferred for non-primitive
types. Pre-increment/decrement can be more efficient than
post-increment/decrement. Post-increment/decrement usually involves
keeping a copy of the previous value around and adds a little extra
code.
---

Summary: Variable 'topic_' is assigned in constructor body. Consider
performing initialization in initialization list.
Message: When an object of a class is created, the constructors of all
member variables are called consecutively in the order the variables are
declared, even if you don't explicitly write them to the initialization
list. You could avoid assigning 'topic_' a value by passing the value to
the constructor in the initialization list.

First included by: src-cpp\ConfImpl.cpp
---

Summary: %zd in format string (no. 2) requires 'ssize_t' but the
argument type is 'size_t {aka unsigned long long}'.
Message: %zd in format string (no. 2) requires 'ssize_t' but the
argument type is 'size_t {aka unsigned long long}'.
---

Summary: Either the condition 'if(rko_orig)' is redundant or there is
possible null pointer dereference: rko_orig.
Message: Either the condition 'if(rko_orig)' is redundant or there is
possible null pointer dereference: rko_orig.
---

there are advise/errors but I don´t know if it is an error or not... I
am noob with kafka

1)
file rdkafka_broker.c

Summary: Dead pointer usage. Pointer 'msg' is dead if it has been
assigned '&msg2' at line 1760.
Message: Dead pointer usage. Pointer 'msg' is dead if it has been
assigned '&msg2' at line 1760.

2)
file
rdkafka_cgrp.c

Summary: Conversion of string literal "RD_KAFKA_OP_OFFSET_COMMIT" to
bool always evaluates to true.
Message: Conversion of string literal "RD_KAFKA_OP_OFFSET_COMMIT" to
bool always evaluates to true.

3)
file
rdrand.c

Summary: Obsolete function 'alloca' called. In C99 and later it is
recommended to use a variable length array instead.
Message: The obsolete function 'alloca' is called. In C99 and later it
is recommended to use a variable length array or a dynamically allocated
array instead. The function 'alloca' is dangerous for many reasons
(http://stackoverflow.com/questions/1018853/why-is-alloca-not-considered-good-practice
and http://linux.die.net/man/3/alloca).
