### PR TITLE
Use compiler specific atomic ops for sun studio compiler

### DIFF
--- a/src/rdatomic.h
+++ b/src/rdatomic.h
@@ -26,7 +26,9 @@ static RD_INLINE RD_UNUSED void rd_atomic32_init (rd_atomic32_t *ra, int32_t v) 
 
 
 static RD_INLINE int32_t RD_UNUSED rd_atomic32_add (rd_atomic32_t *ra, int32_t v) {
-#ifdef _MSC_VER
+#ifdef __SUNPRO_C
+	return atomic_add_32_nv(&ra->val, v);
+#elif defined(_MSC_VER)
 	return InterlockedAdd(&ra->val, v);
 #elif !defined(HAVE_ATOMICS_32)
 	int32_t r;
@@ -41,7 +43,9 @@ static RD_INLINE int32_t RD_UNUSED rd_atomic32_add (rd_atomic32_t *ra, int32_t v
 }
 
 static RD_INLINE int32_t RD_UNUSED rd_atomic32_sub(rd_atomic32_t *ra, int32_t v) {
-#ifdef _MSC_VER
+#ifdef __SUNPRO_C
+	return atomic_add_32_nv(&ra->val, -v);
+#elif defined(_MSC_VER)
 	return InterlockedAdd(&ra->val, -v);
 #elif !defined(HAVE_ATOMICS_32)
 	int32_t r;
@@ -56,7 +60,7 @@ static RD_INLINE int32_t RD_UNUSED rd_atomic32_sub(rd_atomic32_t *ra, int32_t v)
 }
 
 static RD_INLINE int32_t RD_UNUSED rd_atomic32_get(rd_atomic32_t *ra) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__SUNPRO_C)
 	return ra->val;
 #elif !defined(HAVE_ATOMICS_32)
 	int32_t r;
@@ -93,7 +97,9 @@ static RD_INLINE RD_UNUSED void rd_atomic64_init (rd_atomic64_t *ra, int64_t v) 
 }
 
 static RD_INLINE int64_t RD_UNUSED rd_atomic64_add (rd_atomic64_t *ra, int64_t v) {
-#ifdef _MSC_VER
+#ifdef __SUNPRO_C
+	return atomic_add_64_nv(&ra->val, v);
+#elif defined(_MSC_VER)
 	return InterlockedAdd64(&ra->val, v);
 #elif !defined(HAVE_ATOMICS_64)
 	int64_t r;
@@ -108,7 +114,9 @@ static RD_INLINE int64_t RD_UNUSED rd_atomic64_add (rd_atomic64_t *ra, int64_t v
 }
 
 static RD_INLINE int64_t RD_UNUSED rd_atomic64_sub(rd_atomic64_t *ra, int64_t v) {
-#ifdef _MSC_VER
+#ifdef __SUNPRO_C
+	return atomic_add_64_nv(&ra->val, -v);
+#elif defined(_MSC_VER)
 	return InterlockedAdd64(&ra->val, -v);
 #elif !defined(HAVE_ATOMICS_64)
 	int64_t r;
@@ -123,7 +131,7 @@ static RD_INLINE int64_t RD_UNUSED rd_atomic64_sub(rd_atomic64_t *ra, int64_t v)
 }
 
 static RD_INLINE int64_t RD_UNUSED rd_atomic64_get(rd_atomic64_t *ra) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__SUNPRO_C)
 	return ra->val;
 #elif !defined(HAVE_ATOMICS_64)
 	int64_t r;


### PR DESCRIPTION
This is to make atomic functions work  using native sun solaris compiler. I could not find any good way to do it thru config.