### PR TITLE
fix bug rd_kafka_timer_t microsecond interval overflow.

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -48,7 +48,7 @@
 
 static int run = 1;
 static int forever = 1;
-static int dispintvl = 1000;
+static rd_ts_t dispintvl = 1000;
 static int do_seq = 0;
 static int exit_after = 0;
 static int exit_eof = 0;
@@ -172,7 +172,7 @@ static void msg_delivered (rd_kafka_t *rk,
               !(cnt.msgs_dr_err % (dispintvl / 1000)))) ||
 	    !last || msgs_wait_cnt < 5 ||
 	    !(msgs_wait_cnt % dr_disp_div) || 
-	    (int)(now - last) >= dispintvl * 1000 ||
+	    (now - last) >= dispintvl * 1000 ||
             verbosity >= 3) {
 		if (rkmessage->err && verbosity >= 2)
 			printf("%% Message delivery failed: %s [%"PRId32"]: "
@@ -1000,7 +1000,7 @@ int main (int argc, char **argv) {
         if (!stats_intvlstr) {
                 /* if no user-desired stats, adjust stats interval
                  * to the display interval. */
-                snprintf(tmp, sizeof(tmp), "%i", dispintvl / 1000);
+                snprintf(tmp, sizeof(tmp), "%ld", dispintvl / 1000);
         }
 
         if (rd_kafka_conf_set(conf, "statistics.interval.ms",

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1000,7 +1000,7 @@ int main (int argc, char **argv) {
         if (!stats_intvlstr) {
                 /* if no user-desired stats, adjust stats interval
                  * to the display interval. */
-                snprintf(tmp, sizeof(tmp), "%ld", dispintvl / 1000);
+                snprintf(tmp, sizeof(tmp), "%"PRId64, dispintvl / 1000);
         }
 
         if (rd_kafka_conf_set(conf, "statistics.interval.ms",

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1044,12 +1044,12 @@ static int rd_kafka_thread_main (void *arg) {
 	rd_kafka_timer_start(&rk->rk_timers, &tmr_topic_scan, 1000000,
 			     rd_kafka_topic_scan_tmr_cb, NULL);
 	rd_kafka_timer_start(&rk->rk_timers, &tmr_stats_emit,
-			     rk->rk_conf.stats_interval_ms * 1000,
+			     rk->rk_conf.stats_interval_ms * 1000ll,
 			     rd_kafka_stats_emit_tmr_cb, NULL);
         if (rk->rk_conf.metadata_refresh_interval_ms >= 0)
                 rd_kafka_timer_start(&rk->rk_timers, &tmr_metadata_refresh,
                                      rk->rk_conf.metadata_refresh_interval_ms *
-                                     1000,
+                                     1000ll,
                                      rd_kafka_metadata_refresh_cb, NULL);
 
 	if (rk->rk_cgrp)

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -202,7 +202,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new (rd_kafka_t *rk,
                 rd_kafka_timer_start(&rk->rk_timers,
                                      &rkcg->rkcg_offset_commit_tmr,
                                      rk->rk_conf.
-				     auto_commit_interval_ms * 1000,
+				     auto_commit_interval_ms * 1000ll,
                                      rd_kafka_cgrp_offset_commit_tmr_cb,
                                      rkcg);
 

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -875,7 +875,7 @@ static void rd_kafka_offset_file_init (rd_kafka_toppar_t *rktp) {
 		rd_kafka_timer_start(&rktp->rktp_rkt->rkt_rk->rk_timers,
 				     &rktp->rktp_offset_sync_tmr,
 				     rktp->rktp_rkt->rkt_conf.
-				     offset_store_sync_interval_ms * 1000,
+				     offset_store_sync_interval_ms * 1000ll,
 				     rd_kafka_offset_sync_tmr_cb, rktp);
 
 	if (rd_kafka_offset_file_open(rktp) != -1) {
@@ -1062,7 +1062,7 @@ void rd_kafka_offset_store_init (rd_kafka_toppar_t *rktp) {
 		rd_kafka_timer_start(&rktp->rktp_rkt->rkt_rk->rk_timers,
 				     &rktp->rktp_offset_commit_tmr,
 				     rktp->rktp_rkt->rkt_conf.
-				     auto_commit_interval_ms * 1000,
+				     auto_commit_interval_ms * 1000ll,
 				     rd_kafka_offset_auto_commit_tmr_cb,
 				     rktp);
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -192,7 +192,7 @@ shptr_rd_kafka_toppar_t *rd_kafka_toppar_new0 (rd_kafka_itopic_t *rkt,
                         intvl = 10 * 1000;
 		rd_kafka_timer_start(&rkt->rkt_rk->rk_timers,
 				     &rktp->rktp_consumer_lag_tmr,
-                                     intvl * 1000,
+                                     intvl * 1000ll,
 				     rd_kafka_toppar_consumer_lag_tmr_cb,
 				     rktp);
         }
@@ -1118,7 +1118,7 @@ void rd_kafka_toppar_offset_request (rd_kafka_toppar_t *rktp,
                         rktp, RD_KAFKA_TOPPAR_FETCH_OFFSET_QUERY);
 		rd_kafka_timer_start(&rktp->rktp_rkt->rkt_rk->rk_timers,
 				     &rktp->rktp_offset_query_tmr,
-				     backoff_ms*1000,
+				     backoff_ms*1000ll,
 				     rd_kafka_offset_query_tmr_cb, rktp);
 		return;
         }

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -613,7 +613,7 @@ void rd_kafka_broker_sasl_init (rd_kafka_broker_t *rkb) {
 		return; /* kinit not configured, no need to start timer */
 
 	rd_kafka_timer_start(&rk->rk_timers, &rkb->rkb_sasl_kinit_refresh_tmr,
-			     rk->rk_conf.sasl.relogin_min_time * 1000,
+			     rk->rk_conf.sasl.relogin_min_time * 1000ll,
 			     rd_kafka_sasl_kinit_refresh_tmr_cb, rkb);
 }
 

--- a/src/rdkafka_timer.c
+++ b/src/rdkafka_timer.c
@@ -119,7 +119,7 @@ void rd_kafka_timer_stop (rd_kafka_timers_t *rkts, rd_kafka_timer_t *rtmr,
  * Use rd_kafka_timer_stop() to stop a timer.
  */
 void rd_kafka_timer_start (rd_kafka_timers_t *rkts,
-			   rd_kafka_timer_t *rtmr, int interval,
+			   rd_kafka_timer_t *rtmr, rd_ts_t interval,
 			   void (*callback) (rd_kafka_timers_t *rkts, void *arg),
 			   void *arg) {
 	rd_kafka_timers_lock(rkts);

--- a/src/rdkafka_timer.h
+++ b/src/rdkafka_timer.h
@@ -48,7 +48,7 @@ typedef struct rd_kafka_timer_s {
 	TAILQ_ENTRY(rd_kafka_timer_s)  rtmr_link;
 
 	rd_ts_t rtmr_next;
-	int     rtmr_interval;   /* interval in microseconds */
+	rd_ts_t rtmr_interval;   /* interval in microseconds */
 
 	void  (*rtmr_callback) (rd_kafka_timers_t *rkts, void *arg);
 	void   *rtmr_arg;
@@ -59,7 +59,7 @@ typedef struct rd_kafka_timer_s {
 void rd_kafka_timer_stop (rd_kafka_timers_t *rkts,
                           rd_kafka_timer_t *rtmr, int lock);
 void rd_kafka_timer_start (rd_kafka_timers_t *rkts,
-			   rd_kafka_timer_t *rtmr, int interval,
+			   rd_kafka_timer_t *rtmr, rd_ts_t interval,
 			   void (*callback) (rd_kafka_timers_t *rkts,
                                              void *arg),
 			   void *arg);


### PR DESCRIPTION
./rdkafka_performance -P -b xxxx:xx -t test_topic -i 3600000
% Configuration property "statistics.interval.ms" value -694967 is outside allowed range 0..86400000

statistics.interval.ms 86400000
int rtmr_interval max :  2147483647(2^31)

86400000 * 1000 > 2147483647(2^31)
