### PR TITLE
Enrichment of Conf getter for callbacks.

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -784,7 +784,6 @@ class RD_EXPORT Conf {
   /** @brief Query single configuration value
    *
    * Do not use this method to get callbacks registered by the configuration file.
-   * This returns a CONF_INVALID.
    * Instead use the specific get() methods with the specific callback parameter in the signature.
    *
    *  @returns CONF_OK if the property was set previously set and
@@ -795,50 +794,42 @@ class RD_EXPORT Conf {
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p dr_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-			       DeliveryReportCb *&dr_cb) const = 0;
+  virtual Conf::ConfResult get(DeliveryReportCb *&dr_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p event_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 EventCb *&event_cb) const = 0;
+  virtual Conf::ConfResult get(EventCb *&event_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p partitioner_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 PartitionerCb *&partitioner_cb) const = 0;
+  virtual Conf::ConfResult get(PartitionerCb *&partitioner_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p partitioner_kp_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 PartitionerKeyPointerCb *&partitioner_kp_cb) const = 0;
+  virtual Conf::ConfResult get(PartitionerKeyPointerCb *&partitioner_kp_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p socket_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 SocketCb *&socket_cb) const = 0;
+  virtual Conf::ConfResult get(SocketCb *&socket_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p open_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 OpenCb *&open_cb) const = 0;
+  virtual Conf::ConfResult get(OpenCb *&open_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p rebalance_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 RebalanceCb *&rebalance_cb) const = 0;
+  virtual Conf::ConfResult get(RebalanceCb *&rebalance_cb) const = 0;
 
   /** @brief Query single configuration value
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p offset_commit_cb. */
-  virtual Conf::ConfResult get(const std::string &name,
-				 OffsetCommitCb *&offset_commit_cb) const = 0;
+  virtual Conf::ConfResult get(OffsetCommitCb *&offset_commit_cb) const = 0;
 
   /** @brief Dump configuration names and values to list containing
    *         name,value tuples */

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -782,10 +782,63 @@ class RD_EXPORT Conf {
                                 std::string &errstr) = 0;
 
   /** @brief Query single configuration value
+   *
+   * Do not use this method to get callbacks registered by the configuration file.
+   * This returns a CONF_INVALID.
+   * Instead use the specific get() methods with the specific callback parameter in the signature.
+   *
    *  @returns CONF_OK if the property was set previously set and
    *           returns the value in \p value. */
   virtual Conf::ConfResult get(const std::string &name,
 	  std::string &value) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p dr_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+			       DeliveryReportCb *&dr_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p event_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 EventCb *&event_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p partitioner_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 PartitionerCb *&partitioner_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p partitioner_kp_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 PartitionerKeyPointerCb *&partitioner_kp_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p socket_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 SocketCb *&socket_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p open_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 OpenCb *&open_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p rebalance_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 RebalanceCb *&rebalance_cb) const = 0;
+
+  /** @brief Query single configuration value
+   *  @returns CONF_OK if the property was set previously set and
+   *           returns the value in \p offset_commit_cb. */
+  virtual Conf::ConfResult get(const std::string &name,
+				 OffsetCommitCb *&offset_commit_cb) const = 0;
 
   /** @brief Dump configuration names and values to list containing
    *         name,value tuples */

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -408,19 +408,25 @@ class ConfImpl : public Conf {
 			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 
-		  value.resize(size);
-		  if ((res = rd_kafka_conf_get(rk_conf_, name.c_str(),
-			  (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
-			  return static_cast<Conf::ConfResult>(res);
+		  char valueCharArray[size];
+		  res = rd_kafka_conf_get(rk_conf_, name.c_str(),
+				      (char *) valueCharArray, &size);
+		  value.assign(valueCharArray);
+		  if (res != RD_KAFKA_CONF_OK) {
+		      return static_cast<Conf::ConfResult>(res);
+		  }
+
 	  }
 	  else if (rkt_conf_) {
 		  if ((res = rd_kafka_topic_conf_get(rkt_conf_,
 			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 
-		  value.resize(size);
-		  if ((res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
-			  (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
+		  char valueCharArray[size];
+		  res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
+					    (char *)value.c_str(), &size);
+		  value.assign(valueCharArray);
+		  if (res != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 	  }
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -403,7 +403,7 @@ class ConfImpl : public Conf {
       }
       size_t size;
       rd_kafka_conf_res_t res = RD_KAFKA_CONF_OK;
-      char* tmpValue = NULL;
+      char *tmpValue = NULL;
       if (rk_conf_) {
 	  if ((res = rd_kafka_conf_get(rk_conf_,
 				       name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
@@ -425,9 +425,12 @@ class ConfImpl : public Conf {
 	      return static_cast<Conf::ConfResult>(res);
       }
 
-      value.assign(tmpValue);
-      if (tmpValue != NULL)
-          delete tmpValue;
+      if (tmpValue != NULL) {
+	  value.assign(tmpValue);
+	  delete tmpValue;
+      }
+      else
+      	  value = "";
       return Conf::CONF_OK;
 
   }

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -403,14 +403,15 @@ class ConfImpl : public Conf {
       }
       size_t size;
       rd_kafka_conf_res_t res = RD_KAFKA_CONF_OK;
+      char* tmpValue = NULL;
       if (rk_conf_) {
 	  if ((res = rd_kafka_conf_get(rk_conf_,
 				       name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 	      return static_cast<Conf::ConfResult>(res);
 
-	  value.resize(size);
+	  tmpValue = new char[size];
 	  if ((res = rd_kafka_conf_get(rk_conf_, name.c_str(),
-				       (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
+				       tmpValue, &size)) != RD_KAFKA_CONF_OK)
 	      return static_cast<Conf::ConfResult>(res);
       }
       else if (rkt_conf_) {
@@ -418,13 +419,15 @@ class ConfImpl : public Conf {
 					     name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 	      return static_cast<Conf::ConfResult>(res);
 
-	  value.resize(size);
+	  tmpValue = new char[size];
 	  if ((res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
-					     (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
+					     tmpValue, &size)) != RD_KAFKA_CONF_OK)
 	      return static_cast<Conf::ConfResult>(res);
       }
 
-      value.assign(value.c_str());
+      value.assign(tmpValue);
+      if (tmpValue != NULL)
+          delete tmpValue;
       return Conf::CONF_OK;
 
   }

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -391,142 +391,98 @@ class ConfImpl : public Conf {
   }
 
   Conf::ConfResult get(const std::string &name, std::string &value) const {
-	  if (name.compare("dr_cb") == 0 ||
-	      name.compare("event_cb") == 0 ||
-	      name.compare("partitioner_cb") == 0 ||
-	      name.compare("partitioner_key_pointer_cb") == 0 ||
-	      name.compare("socket_cb") == 0 ||
-	      name.compare("open_cb") == 0 ||
-	      name.compare("rebalance_cb") == 0 ||
-	      name.compare("offset_commit_cb") == 0 ) {
-	      return Conf::CONF_INVALID;
-	  }
-	  size_t size;
-	  rd_kafka_conf_res_t res = RD_KAFKA_CONF_OK;
-	  if (rk_conf_) {
-		  if ((res = rd_kafka_conf_get(rk_conf_,
-			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
-			  return static_cast<Conf::ConfResult>(res);
+      if (name.compare("dr_cb") == 0 ||
+	  name.compare("event_cb") == 0 ||
+	  name.compare("partitioner_cb") == 0 ||
+	  name.compare("partitioner_key_pointer_cb") == 0 ||
+	  name.compare("socket_cb") == 0 ||
+	  name.compare("open_cb") == 0 ||
+	  name.compare("rebalance_cb") == 0 ||
+	  name.compare("offset_commit_cb") == 0 ) {
+	  return Conf::CONF_INVALID;
+      }
+      size_t size;
+      rd_kafka_conf_res_t res = RD_KAFKA_CONF_OK;
+      if (rk_conf_) {
+	  if ((res = rd_kafka_conf_get(rk_conf_,
+				       name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
+	      return static_cast<Conf::ConfResult>(res);
 
-		  char valueCharArray[1000];
-		  res = rd_kafka_conf_get(rk_conf_, name.c_str(),
-				      (char *) valueCharArray, &size);
-		  value.assign(valueCharArray);
-		  if (res != RD_KAFKA_CONF_OK) {
-		      return static_cast<Conf::ConfResult>(res);
-		  }
+	  value.resize(size);
+	  if ((res = rd_kafka_conf_get(rk_conf_, name.c_str(),
+				       (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
+	      return static_cast<Conf::ConfResult>(res);
+      }
+      else if (rkt_conf_) {
+	  if ((res = rd_kafka_topic_conf_get(rkt_conf_,
+					     name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
+	      return static_cast<Conf::ConfResult>(res);
 
-	  }
-	  else if (rkt_conf_) {
-		  if ((res = rd_kafka_topic_conf_get(rkt_conf_,
-			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
-			  return static_cast<Conf::ConfResult>(res);
+	  value.resize(size);
+	  if ((res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
+					     (char *)value.c_str(), &size)) != RD_KAFKA_CONF_OK)
+	      return static_cast<Conf::ConfResult>(res);
+      }
 
-		  char valueCharArray[1000];
-		  res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
-					    (char *) valueCharArray, &size);
-		  value.assign(valueCharArray);
-		  if (res != RD_KAFKA_CONF_OK)
-			  return static_cast<Conf::ConfResult>(res);
-	  }
+      value.assign(value.c_str());
+      return Conf::CONF_OK;
 
-	  return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, DeliveryReportCb *&dr_cb) const {
-      if (name != "dr_cb") {
+  Conf::ConfResult get(DeliveryReportCb *&dr_cb) const {
+      if (!rk_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rk_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       dr_cb = this->dr_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, EventCb *&event_cb) const {
-      if (name != "event_cb") {
+  Conf::ConfResult get(EventCb *&event_cb) const {
+      if (!rk_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rk_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       event_cb = this->event_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, PartitionerCb *&partitioner_cb) const {
-      if (name != "partitioner_cb") {
+  Conf::ConfResult get(PartitionerCb *&partitioner_cb) const {
+      if (!rkt_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rkt_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       partitioner_cb = this->partitioner_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, PartitionerKeyPointerCb *&partitioner_kp_cb) const {
-      if (name != "partitioner_key_pointer_cb") {
+  Conf::ConfResult get(PartitionerKeyPointerCb *&partitioner_kp_cb) const {
+      if (!rkt_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rkt_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       partitioner_kp_cb = this->partitioner_kp_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, SocketCb *&socket_cb) const {
-      if (name != "socket_cb") {
+  Conf::ConfResult get(SocketCb *&socket_cb) const {
+      if (!rk_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rk_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       socket_cb = this->socket_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, OpenCb *&open_cb) const {
-      if (name != "open_cb") {
+  Conf::ConfResult get(OpenCb *&open_cb) const {
+      if (!rk_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rk_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       open_cb = this->open_cb_;
       return Conf::CONF_OK;
   }
 
-  Conf::ConfResult get(const std::string &name, RebalanceCb *&rebalance_cb) const {
-      if (name != "rebalance_cb") {
+  Conf::ConfResult get(RebalanceCb *&rebalance_cb) const {
+      if (!rk_conf_)
 	  return Conf::CONF_INVALID;
-      }
-
-      if (!rk_conf_) {
-	  return Conf::CONF_INVALID;
-      }
       rebalance_cb = this->rebalance_cb_;
       return Conf::CONF_OK;
   }
 
-    Conf::ConfResult get(const std::string &name, OffsetCommitCb *&offset_commit_cb) const {
-	if (name != "offset_commit_cb") {
-	    return Conf::CONF_INVALID;
-	}
-
-	if (!rk_conf_) {
-	    return Conf::CONF_INVALID;
-	}
-	offset_commit_cb = this->offset_commit_cb_;
-	return Conf::CONF_OK;
+  Conf::ConfResult get(OffsetCommitCb *&offset_commit_cb) const {
+      if (!rk_conf_)
+	  return Conf::CONF_INVALID;
+      offset_commit_cb = this->offset_commit_cb_;
+      return Conf::CONF_OK;
     }
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -391,6 +391,16 @@ class ConfImpl : public Conf {
   }
 
   Conf::ConfResult get(const std::string &name, std::string &value) const {
+	  if (name.compare("dr_cb") == 0 ||
+	      name.compare("event_cb") == 0 ||
+	      name.compare("partitioner_cb") == 0 ||
+	      name.compare("partitioner_key_pointer_cb") == 0 ||
+	      name.compare("socket_cb") == 0 ||
+	      name.compare("open_cb") == 0 ||
+	      name.compare("rebalance_cb") == 0 ||
+	      name.compare("offset_commit_cb") == 0 ) {
+	      return Conf::CONF_INVALID;
+	  }
 	  size_t size;
 	  rd_kafka_conf_res_t res = RD_KAFKA_CONF_OK;
 	  if (rk_conf_) {
@@ -416,6 +426,102 @@ class ConfImpl : public Conf {
 
 	  return Conf::CONF_OK;
   }
+
+  Conf::ConfResult get(const std::string &name, DeliveryReportCb *&dr_cb) const {
+      if (name != "dr_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      dr_cb = this->dr_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, EventCb *&event_cb) const {
+      if (name != "event_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      event_cb = this->event_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, PartitionerCb *&partitioner_cb) const {
+      if (name != "partitioner_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rkt_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      partitioner_cb = this->partitioner_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, PartitionerKeyPointerCb *&partitioner_kp_cb) const {
+      if (name != "partitioner_key_pointer_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rkt_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      partitioner_kp_cb = this->partitioner_kp_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, SocketCb *&socket_cb) const {
+      if (name != "socket_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      socket_cb = this->socket_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, OpenCb *&open_cb) const {
+      if (name != "open_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      open_cb = this->open_cb_;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult get(const std::string &name, RebalanceCb *&rebalance_cb) const {
+      if (name != "rebalance_cb") {
+	  return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+	  return Conf::CONF_INVALID;
+      }
+      rebalance_cb = this->rebalance_cb_;
+      return Conf::CONF_OK;
+  }
+
+    Conf::ConfResult get(const std::string &name, OffsetCommitCb *&offset_commit_cb) const {
+	if (name != "offset_commit_cb") {
+	    return Conf::CONF_INVALID;
+	}
+
+	if (!rk_conf_) {
+	    return Conf::CONF_INVALID;
+	}
+	offset_commit_cb = this->offset_commit_cb_;
+	return Conf::CONF_OK;
+    }
 
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -408,7 +408,7 @@ class ConfImpl : public Conf {
 			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 
-		  char valueCharArray[size+1];
+		  char valueCharArray[1000];
 		  res = rd_kafka_conf_get(rk_conf_, name.c_str(),
 				      (char *) valueCharArray, &size);
 		  value.assign(valueCharArray);
@@ -422,7 +422,7 @@ class ConfImpl : public Conf {
 			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 
-		  char valueCharArray[size];
+		  char valueCharArray[1000];
 		  res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
 					    (char *) valueCharArray, &size);
 		  value.assign(valueCharArray);

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -408,7 +408,7 @@ class ConfImpl : public Conf {
 			  name.c_str(), NULL, &size)) != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);
 
-		  char valueCharArray[size];
+		  char valueCharArray[size+1];
 		  res = rd_kafka_conf_get(rk_conf_, name.c_str(),
 				      (char *) valueCharArray, &size);
 		  value.assign(valueCharArray);
@@ -424,7 +424,7 @@ class ConfImpl : public Conf {
 
 		  char valueCharArray[size];
 		  res = rd_kafka_topic_conf_get(rkt_conf_, name.c_str(),
-					    (char *)value.c_str(), &size);
+					    (char *) valueCharArray, &size);
 		  value.assign(valueCharArray);
 		  if (res != RD_KAFKA_CONF_OK)
 			  return static_cast<Conf::ConfResult>(res);


### PR DESCRIPTION
for issue #878
As the (C++) Conf setters do not forward callbacks in the C struct like with other parameters, special getter should be used to read the callbacks from the Conf.
This update also blocks the original Getter(String&, String&) to get the callbacks from the C struct.