### PR TITLE
adds check of defined LIBRDKAFKA_STATICLIB to enable static library

### DIFF
--- a/README.win32
+++ b/README.win32
@@ -24,3 +24,7 @@ Artifacts:
   - remaining tools (rdkafka_performance, etc)
   - SASL support (no official Cyrus libsasl2 DLLs available)
   - LZ4 support
+
+If you build librdkafka with an external tool (ie CMake) you can get rid of the 
+__declspec(dllexport) / __declspec(dllimport) decorations by adding a define
+-DLIBRDKAFKA_STATICLIB to your CFLAGS

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -54,10 +54,14 @@
 
 #ifdef _MSC_VER
 #undef RD_EXPORT
+#ifdef LIBRDKAFKA_STATICLIB
+#define RD_EXPORT
+#else
 #ifdef LIBRDKAFKACPP_EXPORTS
 #define RD_EXPORT __declspec(dllexport)
 #else
 #define RD_EXPORT __declspec(dllimport)
+#endif
 #endif
 #else
 #define RD_EXPORT

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -65,10 +65,14 @@ typedef SSIZE_T ssize_t;
 #define RD_INLINE __inline
 #define RD_DEPRECATED
 #undef RD_EXPORT
+#ifdef LIBRDKAFKA_STATICLIB
+#define RD_EXPORT
+#else
 #ifdef LIBRDKAFKA_EXPORTS
 #define RD_EXPORT __declspec(dllexport)
 #else
 #define RD_EXPORT __declspec(dllimport)
+#endif
 #endif
 
 #else


### PR DESCRIPTION
I currently build librdkafka out of source with cmake but it would be convenient to make it possible to build static libs. This pull request only enables that - it does not change anything for existing builds.