### PR TITLE
Add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,41 @@ set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 # * HAVE_STRNDUP
 configure_file(config.h.in "${GENERATED_DIR}/config.h" @ONLY)
 
+# Installation (https://github.com/forexample/package-example) {
+
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+
+# In:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "packaging/cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+install(
+    FILES "${project_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+# }
+
 add_subdirectory(src)
 add_subdirectory(src-cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,9 @@ configure_file(config.h.in "${GENERATED_DIR}/config.h" @ONLY)
 
 # Installation (https://github.com/forexample/package-example) {
 
+include(GNUInstallDirs)
+
 set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ install(
 )
 
 install(
-    FILES LICENSE
+    FILES LICENSES.txt
     DESTINATION "share/licenses/librdkafka"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ install(
     DESTINATION "${config_install_dir}"
 )
 
+install(
+    FILES LICENSE
+    DESTINATION "share/licenses/librdkafka"
+)
+
 # }
 
 add_subdirectory(src)

--- a/packaging/cmake/Config.cmake.in
+++ b/packaging/cmake/Config.cmake.in
@@ -1,0 +1,20 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if(@WITH_ZLIB@)
+  find_dependency(ZLIB)
+endif()
+
+if(@WITH_SSL@)
+  if(@WITH_BUNDLED_SSL@)
+    # TODO: custom SSL library should be installed
+  else()
+    find_dependency(OpenSSL)
+  endif()
+endif()
+
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -21,13 +21,13 @@ target_include_directories(rdkafka++ PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_L
 install(
     TARGETS rdkafka++
     EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 install(
     FILES "rdkafkacpp.h"
-    DESTINATION "${include_install_dir}/librdkafka"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/librdkafka"
 )

--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -17,3 +17,17 @@ target_link_libraries(rdkafka++ PUBLIC rdkafka)
 
 # Support '#include <rdkafcpp.h>'
 target_include_directories(rdkafka++ PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
+
+install(
+    TARGETS rdkafka++
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+install(
+    FILES "rdkafkacpp.h"
+    DESTINATION "${include_install_dir}/librdkafka"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,13 +103,13 @@ endif()
 install(
     TARGETS rdkafka
     EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 install(
     FILES "rdkafka.h"
-    DESTINATION "${include_install_dir}/librdkafka"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/librdkafka"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,3 +99,17 @@ if(WITH_SASL)
   pkg_check_modules(SASL REQUIRED libsasl2)
   target_link_libraries(rdkafka PUBLIC ${SASL_LIBRARIES})
 endif()
+
+install(
+    TARGETS rdkafka
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+install(
+    FILES "rdkafka.h"
+    DESTINATION "${include_install_dir}/librdkafka"
+)


### PR DESCRIPTION
After install package can be found by [find_package](https://cmake.org/cmake/help/latest/command/find_package.html). Example:

```cmake
find_package(RdKafka CONFIG REQUIRED)

add_executable(rdkafka_example rdkafka_example.c)
target_link_libraries(rdkafka_example PUBLIC RdKafka::rdkafka)

add_executable(rdkafka_example_cpp rdkafka_example.cpp)
target_link_libraries(rdkafka_example_cpp PUBLIC RdKafka::rdkafka++)
```