### PR TITLE
Fixed high level consumer CPU usage issue

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2929,7 +2929,7 @@ void rd_kafka_cgrp_serve (rd_kafka_cgrp_t *rkcg) {
         case RD_KAFKA_CGRP_STATE_UP:
 		/* Move any ops awaiting the coordinator to the ops queue
 		 * for reprocessing. */
-		rd_kafka_q_concat(rkcg->rkcg_ops, rkcg->rkcg_wait_coord_q);
+			rd_kafka_q_concat(rkcg->rkcg_ops, rkcg->rkcg_wait_coord_q);
 
                 /* Relaxed coordinator queries. */
                 if (rd_interval(&rkcg->rkcg_coord_query_intvl,


### PR DESCRIPTION
Fixed an issue that caused the high level consumer to use a lot of CPU due to a queue being continuously signaled while there are no new queue entries available.