### PR TITLE
add weiboad/aidp project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
   * [OVH](http://ovh.com) - [AntiDDOS](http://www.slideshare.net/hugfrance/hugfr-6-oct2014ovhantiddos)
   * [otto.de](http://otto.de)'s [trackdrd](https://github.com/otto-de/trackrdrd) - Varnish log reader
   * [Microwish](https://github.com/microwish) has a range of Kafka utilites for log aggregation, HDFS integration, etc.
+  * [aidp](https://github.com/weiboad/aidp) - kafka consumer embedded Lua scripting language in data process framework 
   * large unnamed financial institution
   * *Let [me](mailto:rdkafka@edenhill.se) know if you are using librdkafka*
 


### PR DESCRIPTION
We use librdkafka to develop an embedded Lua script to consume Kafka data process service

Now we have open source it, we hope you add our project

Our project : https://github.com/weiboad/aidp

Thanks