### PR TITLE
Added hw-kafka to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
   * D (C-like): [librdkafka](https://github.com/DlangApache/librdkafka/)
   * D (C++-like): [librdkafkad](https://github.com/tamediadigital/librdkafka-d)
   * Go: [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go)
+  * Haskell (kafka, conduit, avro, schema registry): [hw-kafka](https://github.com/haskell-works/hw-kafka)
   * Haskell: [haskakafka](https://github.com/cosbynator/haskakafka)
   * Haskell: [haskell-kafka](https://github.com/yanatan16/haskell-kafka)
   * Lua: [luardkafka](https://github.com/mistsv/luardkafka)


### PR DESCRIPTION
## Changes

- Updated `README` to include Haskell "Kafka ecosystem" based on `librdkafka` 