### PR TITLE
fix build on SmartOS

### DIFF
--- a/configure.librdkafka
+++ b/configure.librdkafka
@@ -105,6 +105,9 @@ void foo (void) {
     # Required on SunOS
     if [[ $MKL_DISTRO == "SunOS" ]]; then
 	mkl_mkvar_append CPPFLAGS CPPFLAGS "-D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__"
+	# Source defines _POSIX_C_SOURCE to 200809L for Solaris, and this is
+	# incompatible on that platform with compilers < c99.
+	mkl_mkvar_append CFLAGS CFLAGS "-std=c99"
     fi
 
     # Check if strndup() is available (isn't on Solaris 10)

--- a/src/rdendian.h
+++ b/src/rdendian.h
@@ -108,8 +108,11 @@
 
 
 
-
-#ifndef be64toh
+/*
+ * On Solaris, be64toh is a function, not a macro, so there's no need to error
+ * if it's not defined.
+ */
+#if !defined(__sun) && !defined(be64toh)
 #error Missing definition for be64toh
 #endif
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -30,7 +30,12 @@
 
 #ifndef _MSC_VER
 #define _GNU_SOURCE
-#ifndef _AIX    /* AIX defines this and the value needs to be set correctly */
+/*
+ * AIX defines this and the value needs to be set correctly. For Solaris,
+ * src/rd.h defines _POSIX_SOURCE to be 200809L, which corresponds to XPG7,
+ * which itself is not compatible with _XOPEN_SOURCE on that platform.
+ */
+#if !defined(_AIX) && !defined(__sun)
 #define _XOPEN_SOURCE
 #endif
 #include <signal.h>


### PR DESCRIPTION
[SmartOS](https://www.joyent.com/smartos) is a derivative of Illumos, itself a derivative of Solaris. Building librdkafka's master branch on a 15.4 image of SmartOS failed with the following error:

```
[root@e31d952d-043b-4188-e3fa-9ae120820740 /var/tmp/gh-repos/librdkafka]# make -j 6
make[1]: Entering directory '/var/tmp/gh-repos/librdkafka/src'
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka.c -o rdkafka.o
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka_broker.c -o rdkafka_broker.o
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka_msg.c -o rdkafka_msg.o
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka_topic.c -o rdkafka_topic.o
In file included from /usr/include/stdio.h:37:0,
                 from rd.h:43,
                 from rdkafka_msg.c:29:
/usr/include/sys/feature_tests.h:400:2: error: #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications       require the use of c99"
 #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications \
  ^
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka_conf.c -o rdkafka_conf.o
In file included from /usr/include/stdio.h:37:0,
                 from rd.h:43,
                 from rdkafka_topic.c:29:
/usr/include/sys/feature_tests.h:400:2: error: #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications       require the use of c99"
 #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications \
  ^
gcc -MD -MP -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D__EXTENSIONS__ -DLIBRDKAFKA_GIT_VERSION="\"v0.9.4-132-g386516-dirty\""  -c rdkafka_timer.c -o rdkafka_timer.o
../mklove/Makefile.base:77: recipe for target 'rdkafka_msg.o' failed
make[1]: *** [rdkafka_msg.o] Error 1
make[1]: *** Waiting for unfinished jobs....
../mklove/Makefile.base:77: recipe for target 'rdkafka_topic.o' failed
make[1]: *** [rdkafka_topic.o] Error 1
make[1]: Leaving directory '/var/tmp/gh-repos/librdkafka/src'
Makefile:20: recipe for target 'libs' failed
make: *** [libs] Error 2
[root@e31d952d-043b-4188-e3fa-9ae120820740 /var/tmp/gh-repos/librdkafka]#
```

The changes in this PR allows users of SmartOS to build librdkafka without any error.