### PR TITLE
Partition count should be per topic in offset request buffer

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -289,6 +289,8 @@ void rd_kafka_OffsetRequest (rd_kafka_broker_t *rkb,
                         rd_kafka_buf_write_str(rkbuf, rktpar->topic, -1);
                         topic_cnt++;
                         last_topic = rktpar->topic;
+                        /* New topic so reset partition count */
+                        part_cnt = 0;
 
                         /* PartitionArrayCnt: updated later */
                         of_PartArrayCnt = rd_kafka_buf_write_i32(rkbuf, 0);


### PR DESCRIPTION
Fixes #1190 

`offsetsForTimes()` is failing when requesting offset for multiple partitions, which span multiple topics, on a single broker. This is because the number of partitions in the request was accumulated for all partitions, but should be per topic.

Note, there is no regression test in place yet, may want this before merging.