### PR TITLE
Fix endianism issues that were causing snappy to compress incorrectly on SPARC

### DIFF
--- a/src/rdendian.h
+++ b/src/rdendian.h
@@ -63,14 +63,30 @@
 #elif defined sun
   #include <sys/byteorder.h>
   #include <sys/isa_defs.h>
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
 #ifdef _BIG_ENDIAN
+#define __BYTE_ORDER __BIG_ENDIAN
 #define be64toh(x) (x)
 #define be32toh(x) (x)
 #define be16toh(x) (x)
+#define le16toh(x) ((uint16_t)BSWAP_16(x))
+#define le32toh(x) BSWAP_32(x)
+#define le64toh(x) BSWAP_64(x)
+#define htole16(x) ((uint16_t)BSWAP_16(x))
+#define htole32(x) BSWAP_32(x)
+#define htole64(x) BSWAP_64(x)
 # else
+#define __BYTE_ORDER __LITTLE_ENDIAN
 #define be64toh(x) BSWAP_64(x)
 #define be32toh(x) ntohl(x)
 #define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+#define le32toh(x) (x)
+#define le64toh(x) (x)
+#define htole16(x) (x)
+#define htole32(x) (x)
+#define htole64(x) (x)
 #endif /* sun */
 
 #elif defined __APPLE__


### PR DESCRIPTION
See [Issue #1156] for more info.

The two key things are:

1) getting __LITTLE_ENDIAN, __BIG_ENDIAN, and __BYTE_ORDER defined
   properly

2) the (uint16_t) part of the

   #define htole16(x) ((uint16_t)BSWAP_16(x))

line.

The cast is essential as otherwise in this part of a
macro in snappy_compat.h

    typeof((v)) _v = (v); \
    memcpy((x), &_v, sizeof(*(x))); })

the value of 'v' has typeof int, not uint16_t, and it takes the 32-bit
extended value and copies the first two bytes, which being big endian,
are zero and not the correct swapped value.