### PR TITLE
Add cppkafka to language bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
 # Language bindings #
 
   * C#/.NET: [confluent-kafka-dotnet](https://github.com/confluentinc/confluent-kafka-dotnet) (based on [rdkafka-dotnet](https://github.com/ah-/rdkafka-dotnet))
+  * C++: [cppkafka](https://github.com/mfontanini/cppkafka)
   * D (C-like): [librdkafka](https://github.com/DlangApache/librdkafka/)
   * D (C++-like): [librdkafkad](https://github.com/tamediadigital/librdkafka-d)
   * Go: [confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go)


### PR DESCRIPTION
I finally released cppkafka, my C++11 rdkafka wrapper, so I think it's a good idea to add it here.