### PR TITLE
Documented hard exit flag for rdkafka_performance

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1037,6 +1037,7 @@ int main (int argc, char **argv) {
 			"  -s <size>    Message size (producer)\n"
 			"  -k <key>     Message key (producer)\n"
 			"  -c <cnt>     Messages to transmit/receive\n"
+			"  -x <cnt>     Hard exit after transmitting <cnt> messages (producer)\n"
 			"  -D           Copy/Duplicate data buffer (producer)\n"
 			"  -i <ms>      Display interval\n"
 			"  -m <msg>     Message payload pattern\n"


### PR DESCRIPTION
`rdkafka_performance` had the undocumented flag `-x` which causes the tool to hard exit after sending <cnt> messages. I documented this flag in the tool's help message.