### PR TITLE
Call on_acknowledgement() interceptor from internal thread

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1790,7 +1790,6 @@ void *rd_kafka_topic_opaque (const rd_kafka_topic_t *rkt);
  *   - error callbacks (rd_kafka_conf_set_error_cb()) [all]
  *   - stats callbacks (rd_kafka_conf_set_stats_cb()) [all]
  *   - throttle callbacks (rd_kafka_conf_set_throttle_cb()) [all]
- *   - on_acknowledgement() interceptors
  *
  * @returns the number of events served.
  */
@@ -3167,7 +3166,7 @@ void rd_kafka_event_destroy (rd_kafka_event_t *rkev);
  * @remark The returned message(s) MUST NOT be
  *         freed with rd_kafka_message_destroy().
  *
- * @remark on_consume() and on_acknowledgement() interceptors may be called
+ * @remark on_consume() interceptor may be called
  *         from this function prior to passing message to application.
  */
 RD_EXPORT
@@ -3184,7 +3183,7 @@ const rd_kafka_message_t *rd_kafka_event_message_next (rd_kafka_event_t *rkev);
  *
  * @returns the number of messages extracted.
  *
- * @remark on_consume() and on_acknowledgement() interceptors may be called
+ * @remark on_consume() interceptor may be called
  *         from this function prior to passing message to application.
  */
 RD_EXPORT
@@ -3520,10 +3519,8 @@ typedef rd_kafka_resp_err_t
 /**
  * @brief on_acknowledgement() is called to inform interceptors that a message
  *        was succesfully delivered or permanently failed delivery.
- *        The interceptor chain is called from rd_kafka_poll(), the event
- *        interface, internal librdkafka threads (if no dr_cb/dr_msg_cb or
- *        RD_KAFKA_EVENT_DR has been registered), or rd_kafka_produce*() if
- *        the partitioner failed.
+ *        The interceptor chain is called from internal librdkafka background
+ *        threads, or rd_kafka_produce*() if the partitioner failed.
  *
  * @param rk The client instance.
  * @param rkmessage The message being produced. Immutable.
@@ -3534,8 +3531,7 @@ typedef rd_kafka_resp_err_t
  * @remark The \p rkmessage object is NOT mutable and MUST NOT be modified
  *         by the interceptor.
  *
- * @warning If no delivery report callback or event has been configured
- *         the on_acknowledgement() method may be called from internal
+ * @warning The on_acknowledgement() method may be called from internal
  *         librdkafka threads. An on_acknowledgement() interceptor MUST NOT
  *         call any librdkafka API's associated with the \p rk, or perform
  *         any blocking or prolonged work.

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -1784,6 +1784,9 @@ void rd_kafka_dr_msgq (rd_kafka_itopic_t *rkt,
 	if (unlikely(rd_kafka_msgq_len(rkmq) == 0))
 	    return;
 
+        /* Call on_acknowledgement() interceptors */
+        rd_kafka_interceptors_on_acknowledgement_queue(rk, rkmq);
+
         if ((rk->rk_conf.enabled_events & RD_KAFKA_EVENT_DR) &&
 	    (!rk->rk_conf.dr_err_only || err)) {
 		/* Pass all messages to application thread in one op. */
@@ -1801,9 +1804,6 @@ void rd_kafka_dr_msgq (rd_kafka_itopic_t *rkt,
 
 	} else {
 		/* No delivery report callback. */
-
-                /* Call on_acknowledgement() interceptors */
-                rd_kafka_interceptors_on_acknowledgement_queue(rk, rkmq);
 
                 /* Destroy the messages right away. */
                 rd_kafka_msgq_purge(rk, rkmq);

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -675,8 +675,7 @@ rd_kafka_message_t *rd_kafka_message_new (void) {
 
 /**
  * @brief Set up a rkmessage from an rko for passing to the application.
- * @remark Will trigger on_consume() or on_acknowledgement() interceptors,
- *         if any.
+ * @remark Will trigger on_consume() interceptors if any.
  */
 static rd_kafka_message_t *
 rd_kafka_message_setup (rd_kafka_op_t *rko, rd_kafka_message_t *rkmessage) {
@@ -705,13 +704,9 @@ rd_kafka_message_setup (rd_kafka_op_t *rko, rd_kafka_message_t *rkmessage) {
         if (!rkmessage->err)
                 rkmessage->err = rko->rko_err;
 
-        /* Call on_acknowledgement and on_consume interceptors */
+        /* Call on_consume interceptors */
         switch (rko->rko_type)
         {
-        case RD_KAFKA_OP_DR:
-                rd_kafka_interceptors_on_acknowledgement(rkt->rkt_rk,
-                                                         rkmessage);
-                break;
         case RD_KAFKA_OP_FETCH:
                 if (!rkmessage->err && rkt)
                         rd_kafka_interceptors_on_consume(rkt->rkt_rk,
@@ -730,7 +725,6 @@ rd_kafka_message_setup (rd_kafka_op_t *rko, rd_kafka_message_t *rkmessage) {
 /**
  * @brief Get rkmessage from rkm (for EVENT_DR)
  * @remark Must only be called just prior to passing a dr to the application.
- * @remark Will trigger on_acknowledgement() interceptors, if any.
  */
 rd_kafka_message_t *rd_kafka_message_get_from_rkm (rd_kafka_op_t *rko,
                                                    rd_kafka_msg_t *rkm) {


### PR DESCRIPTION
To avoid the case where a buggy application does not call poll()
and thus not serving delivery reports, the on_ack..() interceptor
is now called immediately from the broker thread when the
final delivery result is known.