### PR TITLE
Plugin fixes

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,7 +65,7 @@ sasl.kerberos.keytab                     |  *  |                 |              
 sasl.kerberos.min.time.before.relogin    |  *  | 1 .. 86400000   |         60000 | Minimum time in milliseconds between key refresh attempts. <br>*Type: integer*
 sasl.username                            |  *  |                 |               | SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms <br>*Type: string*
 sasl.password                            |  *  |                 |               | SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism <br>*Type: string*
-plugin.library.paths                     |  *  |                 |               | List of plugin libaries to load (; separated) <br>*Type: string*
+plugin.library.paths                     |  *  |                 |               | List of plugin libaries to load (; separated). The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the platform-specific extension (such as .dll or .so) will be appended automatically. <br>*Type: string*
 interceptors                             |  *  |                 |               | Interceptors added through rd_kafka_conf_interceptor_add_..() and any configuration handled by interceptors. <br>*Type: *
 group.id                                 |  *  |                 |               | Client group id string. All clients sharing the same group.id belong to the same group. <br>*Type: string*
 partition.assignment.strategy            |  *  |                 | range,roundrobin | Name of partition assignment strategy to use when elected group leader assigns partitions to group members. <br>*Type: string*

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -27,11 +27,9 @@ endif
 
 _UNAME_S := $(shell uname -s)
 ifeq ($(_UNAME_S),Darwin)
-        SOLIB_EXT?=.dylib
 	LIBFILENAME=$(LIBNAME).$(LIBVER)$(SOLIB_EXT)
 	LIBFILENAMELINK=$(LIBNAME)$(SOLIB_EXT)
 else
-        SOLIB_EXT?=.so
 	LIBFILENAME=$(LIBNAME)$(SOLIB_EXT).$(LIBVER)
 	LIBFILENAMELINK=$(LIBNAME)$(SOLIB_EXT)
 endif

--- a/mklove/modules/configure.host
+++ b/mklove/modules/configure.host
@@ -23,6 +23,8 @@ function checks {
     # Try to figure out what OS/distro we are running on.
     mkl_check_begin "distro" "" "no-cache" "OS or distribution"
 
+    solib_ext=.so
+
     # Try lsb_release
     local sys
     sys=$(lsb_release -is 2>/dev/null)
@@ -32,15 +34,19 @@ function checks {
         case $kn in
             Linux)
                 sys=Linux
+                solib_ext=.so
                 ;;
             Darwin)
                 sys=osx
+                solib_ext=.dylib
                 ;;
             CYGWIN*)
                 sys=Cygwin
+                solib_ext=.dll
                 ;;
             *)
                 sys="$kn"
+                solib_ext=.so
                 ;;
         esac
     fi
@@ -50,6 +56,7 @@ function checks {
     else
         mkl_check_done "distro" "" "ignore" "ok" "$sys"
         mkl_mkvar_set "distro" "MKL_DISTRO" "$sys"
+        mkl_allvar_set "distro" "SOLIB_EXT" "$solib_ext"
     fi
 }
 

--- a/src/rddl.c
+++ b/src/rddl.c
@@ -102,7 +102,7 @@ rd_dl_hnd_t *rd_dl_open (const char *path, char *errstr, size_t errstr_size) {
         rd_dl_hnd_t *handle;
         char *extpath;
         size_t pathlen;
-        char *td, *fname;
+        const char *td, *fname;
         const char *solib_ext = SOLIB_EXT;
 
         /* Try original path first. */
@@ -113,9 +113,18 @@ rd_dl_hnd_t *rd_dl_open (const char *path, char *errstr, size_t errstr_size) {
         /* Original path not found, see if we can append the solib_ext
          * filename extension. */
 
-        /* Get filename and filename extension */
-        fname = basename(path);
-        td = rindex(fname, '.');
+        /* Get filename and filename extension.
+         * We can't rely on basename(3) since it is not portable */
+        fname = strrchr(path, '/');
+#ifdef _MSC_VER
+        td = strrchr(path, '\\');
+        if (td > fname)
+                fname = td;
+#endif
+        if (!fname)
+                fname = path;
+
+        td = strrchr(fname, '.');
 
         /* If there is a filename extension ('.' within the last characters)
          * then bail out, we will not append an extension in this case. */

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1333,7 +1333,7 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *app_conf,
                                 * as the rk itself is destroyed. */
 
         /* Call on_new() interceptors */
-        rd_kafka_interceptors_on_new(rk);
+        rd_kafka_interceptors_on_new(rk, &rk->rk_conf);
 
 	rwlock_init(&rk->rk_lock);
         mtx_init(&rk->rk_internal_rkb_lock, mtx_plain);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1035,6 +1035,17 @@ rd_kafka_conf_t *rd_kafka_conf_dup(const rd_kafka_conf_t *conf);
 
 
 /**
+ * @brief Same as rd_kafka_conf_dup() but with an array of property name
+ *        prefixes to filter out (ignore) when copying.
+ */
+RD_EXPORT
+rd_kafka_conf_t *rd_kafka_conf_dup_filter (const rd_kafka_conf_t *conf,
+                                           size_t filter_cnt,
+                                           const char **filter);
+
+
+
+/**
  * @brief Sets a configuration property.
  *
  * \p conf must have been previously created with rd_kafka_conf_new().
@@ -3466,6 +3477,8 @@ typedef rd_kafka_conf_res_t
 typedef rd_kafka_resp_err_t
 (rd_kafka_interceptor_f_on_conf_dup_t) (rd_kafka_conf_t *new_conf,
                                         const rd_kafka_conf_t *old_conf,
+                                        size_t filter_cnt,
+                                        const char **filter,
                                         void *ic_opaque);
 
 

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -503,7 +503,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
         /* Plugins */
         { _RK_GLOBAL, "plugin.library.paths", _RK_C_STR,
           _RK(plugin_paths),
-          "List of plugin libaries to load (; separated)",
+          "List of plugin libaries to load (; separated). "
+          "The library search path is platform dependent (see dlopen(3) for Unix and LoadLibrary() for Windows). If no filename extension is specified the "
+          "platform-specific extension (such as .dll or .so) will be appended automatically.",
           .set = rd_kafka_plugins_conf_set },
 #endif
 

--- a/src/rdkafka_interceptor.c
+++ b/src/rdkafka_interceptor.c
@@ -158,22 +158,6 @@ rd_kafka_interceptor_method_add (rd_list_t *list, const char *ic_name,
 }
 
 /**
- * @brief Copy constructor for method
- */
-static void *rd_kafka_interceptor_method_copy (const void *psrc, void *opaque) {
-        const rd_kafka_interceptor_method_t *src = psrc;
-        rd_list_t *dlist = opaque; /* Destination list */
-
-        rd_kafka_interceptor_method_add(dlist,
-                                        src->ic_name,
-                                        src->u.generic,
-                                        src->ic_opaque);
-
-        return NULL; /* method added by _add() (possibly) */
-}
-
-
-/**
  * @brief Destroy all interceptors
  * @locality application thread calling rd_kafka_conf_destroy() or 
  *           rd_kafka_destroy()

--- a/src/rdkafka_interceptor.h
+++ b/src/rdkafka_interceptor.h
@@ -39,7 +39,7 @@ rd_kafka_interceptors_on_conf_dup (rd_kafka_conf_t *new_conf,
 void
 rd_kafka_interceptors_on_conf_destroy (rd_kafka_conf_t *conf) ;
 void
-rd_kafka_interceptors_on_new (rd_kafka_t *rk);
+rd_kafka_interceptors_on_new (rd_kafka_t *rk, const rd_kafka_conf_t *conf);
 void
 rd_kafka_interceptors_on_destroy (rd_kafka_t *rk);
 void

--- a/src/rdkafka_interceptor.h
+++ b/src/rdkafka_interceptor.h
@@ -35,7 +35,8 @@ rd_kafka_interceptors_on_conf_set (rd_kafka_conf_t *conf,
                                    char *errstr, size_t errstr_size);
 void
 rd_kafka_interceptors_on_conf_dup (rd_kafka_conf_t *new_conf,
-                                   const rd_kafka_conf_t *old_conf);
+                                   const rd_kafka_conf_t *old_conf,
+                                   size_t filter_cnt, const char **filter);
 void
 rd_kafka_interceptors_on_conf_destroy (rd_kafka_conf_t *conf) ;
 void
@@ -62,7 +63,8 @@ rd_kafka_interceptors_on_commit (rd_kafka_t *rk,
 void rd_kafka_conf_interceptor_ctor (int scope, void *pconf);
 void rd_kafka_conf_interceptor_dtor (int scope, void *pconf);
 void rd_kafka_conf_interceptor_copy (int scope, void *pdst, const void *psrc,
-                                     void *dstptr, const void *srcptr);
+                                     void *dstptr, const void *srcptr,
+                                     size_t filter_cnt, const char **filter);
 
 void rd_kafka_interceptors_destroy (rd_kafka_conf_t *conf);
 

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -48,13 +48,16 @@ void rd_list_grow (rd_list_t *rl, size_t size) {
                                   sizeof(*rl->rl_elems) * rl->rl_size);
 }
 
-void rd_list_init (rd_list_t *rl, int initial_size, void (*free_cb) (void *)) {
+rd_list_t *
+rd_list_init (rd_list_t *rl, int initial_size, void (*free_cb) (void *)) {
         memset(rl, 0, sizeof(*rl));
 
 	if (initial_size > 0)
 		rd_list_grow(rl, initial_size);
 
         rl->rl_free_cb = free_cb;
+
+        return rl;
 }
 
 rd_list_t *rd_list_new (int initial_size, void (*free_cb) (void *)) {

--- a/src/rdlist.h
+++ b/src/rdlist.h
@@ -47,14 +47,20 @@ typedef struct rd_list_s {
 				   * When this flag is set bsearch() is used
 				   * by find(), otherwise a linear search. */
 #define RD_LIST_F_FIXED_SIZE 0x4  /* Assert on grow */
+#define RD_LIST_F_UNIQUE     0x8  /* Don't allow duplicates:
+                                   * ONLY ENFORCED BY CALLER. */
 } rd_list_t;
 
 
 /**
- * Initialize a list, preallocate space for 'initial_size' elements (optional).
- * List elements will optionally be freed by \p free_cb.
+ * @brief Initialize a list, preallocate space for 'initial_size' elements
+ *       (optional).
+ *       List elements will optionally be freed by \p free_cb.
+ *
+ * @returns \p rl
  */
-void rd_list_init (rd_list_t *rl, int initial_size, void (*free_cb) (void *));
+rd_list_t *
+rd_list_init (rd_list_t *rl, int initial_size, void (*free_cb) (void *));
 
 
 /**

--- a/src/rdstring.c
+++ b/src/rdstring.c
@@ -154,7 +154,7 @@ rd_strtup_t *rd_strtup_new (const char *name, const char *value) {
 
         strtup = rd_malloc(sizeof(*strtup) +
                            name_sz + value_sz - 1/*name[1]*/);
-        memcpy(strtup->name, name, name_sz+1);
+        memcpy(strtup->name, name, name_sz);
         strtup->value = &strtup->name[name_sz];
         memcpy(strtup->value, value, value_sz);
 

--- a/src/win32_config.h
+++ b/src/win32_config.h
@@ -37,3 +37,4 @@
 #define WITH_SASL_SCRAM 1
 #define ENABLE_DEVEL 0
 #define WITH_PLUGINS 1
+#define SOLIB_EXT ".dll"

--- a/tests/0066-plugins.cpp
+++ b/tests/0066-plugins.cpp
@@ -49,13 +49,14 @@ struct ictest ictest;
 static void do_test_plugin () {
   std::string errstr;
   std::string topic = Test::mk_topic_name("0066_plugins", 1);
-  std::pair<std::string, std::string> config[] = {
-    { "session.timeout.ms", "6000" }, /* Before plugin */
-    { "plugin.library.paths", "interceptor_test/interceptor_test" },
-    { "socket.timeout.ms", "12" }, /* After plugin */
-    { "interceptor_test.config1", "one" },
-    { "interceptor_test.config2", "two" },
-    { "topic.metadata.refresh.interval.ms", "1234" },
+  static const char *config[] = {
+    "session.timeout.ms", "6000", /* Before plugin */
+    "plugin.library.paths", "interceptor_test/interceptor_test",
+    "socket.timeout.ms", "12", /* After plugin */
+    "interceptor_test.config1", "one",
+    "interceptor_test.config2", "two",
+    "topic.metadata.refresh.interval.ms", "1234",
+    NULL,
   };
 
   /* Interceptor back-channel config */
@@ -66,10 +67,10 @@ static void do_test_plugin () {
   /* Config for intercepted client */
   RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
 
-  for (unsigned int i = 0 ; i < sizeof(config) / sizeof(*config) ; i++) {
-    Test::Say("set(" + config[i].first + ", " + config[i].second + ")\n");
-    if (conf->set(config[i].first, config[i].second, errstr))
-      Test::Fail("set(" + config[i].first + ") failed: " + errstr);
+  for (int i = 0 ; config[i] ; i += 2) {
+    Test::Say(tostr() << "set(" << config[i] << ", " << config[i+1] << ")\n");
+    if (conf->set(config[i], config[i+1], errstr))
+      Test::Fail(tostr() << "set(" << config[i] << ") failed: " << errstr);
   }
 
   /* Create producer */

--- a/tests/0066-plugins.cpp
+++ b/tests/0066-plugins.cpp
@@ -1,0 +1,108 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2016, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <cstring>
+#include <cstdlib>
+#include "testcpp.h"
+
+
+extern "C" {
+#include "interceptor_test/interceptor_test.h"
+
+struct ictest ictest;
+};
+
+
+/**
+ * Verify plugin.library.paths and interceptors
+ * using interceptor_test/...
+ *
+ */
+
+
+static void do_test_plugin () {
+  std::string errstr;
+  std::string topic = Test::mk_topic_name("0066_plugins", 1);
+  std::pair<std::string, std::string> config[] = {
+    { "session.timeout.ms", "6000" }, /* Before plugin */
+    { "plugin.library.paths", "interceptor_test/interceptor_test" },
+    { "socket.timeout.ms", "12" }, /* After plugin */
+    { "interceptor_test.config1", "one" },
+    { "interceptor_test.config2", "two" },
+    { "topic.metadata.refresh.interval.ms", "1234" },
+  };
+
+  /* Interceptor back-channel config */
+  ictest_init(&ictest);
+  ictest_cnt_init(&ictest.conf_init, 1, 1000);
+  ictest_cnt_init(&ictest.on_new, 1, 1);
+
+  /* Config for intercepted client */
+  RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+
+  for (unsigned int i = 0 ; i < sizeof(config) / sizeof(*config) ; i++) {
+    Test::Say("set(" + config[i].first + ", " + config[i].second + ")\n");
+    if (conf->set(config[i].first, config[i].second, errstr))
+      Test::Fail("set(" + config[i].first + ") failed: " + errstr);
+  }
+
+  /* Create producer */
+  RdKafka::Producer *p = RdKafka::Producer::create(conf, errstr);
+  if (!p)
+    Test::Fail("Failed to create producer: " + errstr);
+
+  if (ictest.on_new.cnt < ictest.on_new.min ||
+      ictest.on_new.cnt > ictest.on_new.max)
+    Test::Fail(tostr() << "on_new.cnt " << ictest.on_new.cnt <<
+               " not within range " << ictest.on_new.min << ".." <<
+               ictest.on_new.max);
+
+  /* Verification */
+  if (!ictest.config1 || strcmp(ictest.config1, "one"))
+    Test::Fail(tostr() << "config1 was " << ictest.config1);
+  if (!ictest.config2 || strcmp(ictest.config2, "two"))
+    Test::Fail(tostr() << "config2 was " << ictest.config2);
+  if (!ictest.session_timeout_ms || strcmp(ictest.session_timeout_ms, "6000"))
+    Test::Fail(tostr() << "session.timeout.ms was " << ictest.session_timeout_ms);
+  if (!ictest.socket_timeout_ms || strcmp(ictest.socket_timeout_ms, "12"))
+    Test::Fail(tostr() << "socket.timeout.ms was " << ictest.socket_timeout_ms);
+
+  delete conf;
+
+  delete p;
+
+  ictest_free(&ictest);
+}
+
+extern "C" {
+  int main_0066_plugins (int argc, char **argv) {
+    do_test_plugin();
+    return 0;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(
     0063-clusterid.cpp
     0064-interceptors.c
     0065-yield.cpp
+    0066-plugins.cpp
     test.c
     testcpp.cpp
     sockem.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,9 +38,6 @@ run_local: $(BIN)
 
 .PHONY: interceptor_test
 
-interceptor_test:
-	$(MAKE) -C $@
-
 build: $(BIN) interceptor_test
 
 test.o: ../src/librdkafka.a ../src-cpp/librdkafka++.a interceptor_test
@@ -48,6 +45,14 @@ test.o: ../src/librdkafka.a ../src-cpp/librdkafka++.a interceptor_test
 
 
 include ../mklove/Makefile.base
+
+ifeq ($(_UNAME_S),Darwin)
+interceptor_test:
+else
+interceptor_test:
+	$(MAKE) -C $@
+endif
+
 
 tinycthread.o: ../src/tinycthread.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ LIBS	 += -lrdkafka++ -lrdkafka -lstdc++
 OBJS	 += test.o testcpp.o tinycthread.o rdlist.o sockem.o
 CFLAGS += -I../src
 CXXFLAGS += -I../src -I../src-cpp
-LDFLAGS += -L../src -L../src-cpp
+LDFLAGS += -rdynamic -L../src -L../src-cpp
 
 KAFKA_VERSION?=0.10.2.0
 

--- a/tests/interceptor_test/interceptor_test.c
+++ b/tests/interceptor_test/interceptor_test.c
@@ -155,7 +155,7 @@ static rd_kafka_resp_err_t on_new (rd_kafka_t *rk, const rd_kafka_conf_t *conf,
          * configuration. */
         ictest.session_timeout_ms = rd_strdup(test_conf_get(ici->conf, "session.timeout.ms"));
         ictest.socket_timeout_ms  = rd_strdup(test_conf_get(ici->conf, "socket.timeout.ms"));
-        ictest.config1 = srd_trdup(ici->config1);
+        ictest.config1 = rd_strdup(ici->config1);
         ictest.config2 = rd_strdup(ici->config2);
 
         rd_kafka_interceptor_add_on_send(rk, __FILE__, on_send, ici);

--- a/tests/interceptor_test/interceptor_test.c
+++ b/tests/interceptor_test/interceptor_test.c
@@ -153,10 +153,10 @@ static rd_kafka_resp_err_t on_new (rd_kafka_t *rk, const rd_kafka_conf_t *conf,
         TEST_ASSERT(!ictest.socket_timeout_ms);
         /* Extract some well known config properties from the interceptor's
          * configuration. */
-        ictest.session_timeout_ms = strdup(test_conf_get(ici->conf, "session.timeout.ms"));
-        ictest.socket_timeout_ms  = strdup(test_conf_get(ici->conf, "socket.timeout.ms"));
-        ictest.config1 = strdup(ici->config1);
-        ictest.config2 = strdup(ici->config2);
+        ictest.session_timeout_ms = rd_strdup(test_conf_get(ici->conf, "session.timeout.ms"));
+        ictest.socket_timeout_ms  = rd_strdup(test_conf_get(ici->conf, "socket.timeout.ms"));
+        ictest.config1 = srd_trdup(ici->config1);
+        ictest.config2 = rd_strdup(ici->config2);
 
         rd_kafka_interceptor_add_on_send(rk, __FILE__, on_send, ici);
         rd_kafka_interceptor_add_on_acknowledgement(rk, __FILE__,
@@ -200,7 +200,7 @@ static rd_kafka_conf_res_t on_conf_set (rd_kafka_conf_t *conf,
                         ici->config1 = NULL;
                 }
                 if (val)
-                        ici->config1 = strdup(val);
+                        ici->config1 = rd_strdup(val);
                 TEST_SAY("on_conf_set(conf %p, %s, %s): %p\n",
                          conf, name, val, ici);
                 return RD_KAFKA_CONF_OK;
@@ -210,7 +210,7 @@ static rd_kafka_conf_res_t on_conf_set (rd_kafka_conf_t *conf,
                         ici->config2 = NULL;
                 }
                 if (val)
-                        ici->config2 = strdup(val);
+                        ici->config2 = rd_strdup(val);
                 return RD_KAFKA_CONF_OK;
         } else {
                 /* Apply intercepted client's config properties on

--- a/tests/interceptor_test/interceptor_test.c
+++ b/tests/interceptor_test/interceptor_test.c
@@ -39,6 +39,8 @@
 
 #define _CRT_SECURE_NO_WARNINGS /* Silence MSVC nonsense */
 
+#include "../test.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
@@ -46,15 +48,31 @@
 /* typical include path outside tests is <librdkafka/rdkafka.h> */
 #include "rdkafka.h"
 
+#include "interceptor_test.h"
+
 #ifdef _MSC_VER
 #define DLL_EXPORT __declspec(dllexport)
 #else
 #define DLL_EXPORT
 #endif
 
+/**
+ * @brief Interceptor instance.
+ *
+ * An interceptor instance is created for each intercepted configuration
+ * object (triggered through conf_init() which is the plugin loader,
+ * or by conf_dup() which is a copying of a conf previously seen by conf_init())
+ */
+struct ici {
+        rd_kafka_conf_t *conf;  /**< Interceptor config */
+        char *config1;          /**< Interceptor-specific config */
+        char *config2;
+
+        int on_new_cnt;
+        int on_conf_destroy_cnt;
+};
 
 static char *my_interceptor_plug_opaque = "my_interceptor_plug_opaque";
-static char *my_ic_opaque = "my_ic_opaque";
 
 
 
@@ -62,8 +80,8 @@ static char *my_ic_opaque = "my_ic_opaque";
 rd_kafka_resp_err_t on_send (rd_kafka_t *rk,
                              rd_kafka_message_t *rkmessage,
                              void *ic_opaque) {
-        assert(ic_opaque == my_ic_opaque);
-        printf("on_send\n");
+        struct ici *ici = ic_opaque;
+        printf("on_send: %p\n", ici);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
@@ -71,9 +89,9 @@ rd_kafka_resp_err_t on_send (rd_kafka_t *rk,
 rd_kafka_resp_err_t on_acknowledgement (rd_kafka_t *rk,
                                         rd_kafka_message_t *rkmessage,
                                         void *ic_opaque) {
-        assert(ic_opaque == my_ic_opaque);
-        printf("on_acknowledgement: err %d, partition %"PRId32"\n",
-               rkmessage->err, rkmessage->partition);
+        struct ici *ici = ic_opaque;
+        printf("on_acknowledgement: %p: err %d, partition %"PRId32"\n",
+               ici, rkmessage->err, rkmessage->partition);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
@@ -81,36 +99,72 @@ rd_kafka_resp_err_t on_acknowledgement (rd_kafka_t *rk,
 rd_kafka_resp_err_t on_consume (rd_kafka_t *rk,
                                 rd_kafka_message_t *rkmessage,
                                 void *ic_opaque) {
-        assert(ic_opaque == my_ic_opaque);
-        printf("on_consume partition %"PRId32" @ %"PRId64"\n",
-               rkmessage->partition, rkmessage->offset);
+        struct ici *ici = ic_opaque;
+        printf("on_consume: %p: partition %"PRId32" @ %"PRId64"\n",
+               ici, rkmessage->partition, rkmessage->offset);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
 rd_kafka_resp_err_t on_commit (rd_kafka_t *rk,
                                const rd_kafka_topic_partition_list_t *offsets,
                                rd_kafka_resp_err_t err, void *ic_opaque) {
-        assert(ic_opaque == my_ic_opaque);
-        printf("on_commit: err %d\n", err);
+        struct ici *ici = ic_opaque;
+        printf("on_commit: %p: err %d\n", ici, err);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+
+static void ici_destroy (struct ici *ici) {
+        if (ici->conf)
+                rd_kafka_conf_destroy(ici->conf);
+        if (ici->config1)
+                free(ici->config1);
+        if (ici->config2)
+                free(ici->config2);
+        free(ici);
+}
+
+rd_kafka_resp_err_t on_destroy (rd_kafka_t *rk, void *ic_opaque) {
+        struct ici *ici = ic_opaque;
+        printf("on_destroy: %p\n", ici);
+        /* the ici is freed from on_conf_destroy() */
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
 
 
 /**
  * @brief Called from rd_kafka_new(). We use it to set up interceptors.
  */
-static rd_kafka_resp_err_t on_new (rd_kafka_t *rk, void *ic_opaque,
+static rd_kafka_resp_err_t on_new (rd_kafka_t *rk, const rd_kafka_conf_t *conf,
+                                   void *ic_opaque,
                                    char *errstr, size_t errstr_size) {
-        rd_kafka_interceptor_add_on_send(rk, __FILE__, on_send,
-                                         my_ic_opaque);
+        struct ici *ici = ic_opaque;
+
+        ictest.on_new.cnt++;
+        ici->on_new_cnt++;
+
+        TEST_SAY("on_new(rk %p, conf %p, ici->conf %p): %p: #%d\n",
+                 rk, conf, ici->conf, ici, ictest.on_new.cnt);
+
+        ICTEST_CNT_CHECK(on_new);
+        TEST_ASSERT(ici->on_new_cnt == 1);
+
+        TEST_ASSERT(!ictest.session_timeout_ms);
+        TEST_ASSERT(!ictest.socket_timeout_ms);
+        /* Extract some well known config properties from the interceptor's
+         * configuration. */
+        ictest.session_timeout_ms = strdup(test_conf_get(ici->conf, "session.timeout.ms"));
+        ictest.socket_timeout_ms  = strdup(test_conf_get(ici->conf, "socket.timeout.ms"));
+        ictest.config1 = strdup(ici->config1);
+        ictest.config2 = strdup(ici->config2);
+
+        rd_kafka_interceptor_add_on_send(rk, __FILE__, on_send, ici);
         rd_kafka_interceptor_add_on_acknowledgement(rk, __FILE__,
-                                                    on_acknowledgement,
-                                                    my_ic_opaque);
-        rd_kafka_interceptor_add_on_consume(rk, __FILE__, on_consume,
-                                            my_ic_opaque);
-        rd_kafka_interceptor_add_on_commit(rk, __FILE__, on_commit,
-                                           my_ic_opaque);
+                                                    on_acknowledgement, ici);
+        rd_kafka_interceptor_add_on_consume(rk, __FILE__, on_consume, ici);
+        rd_kafka_interceptor_add_on_commit(rk, __FILE__, on_commit, ici);
+        rd_kafka_interceptor_add_on_destroy(rk, __FILE__, on_destroy, ici);
+
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
@@ -122,6 +176,17 @@ static rd_kafka_conf_res_t on_conf_set (rd_kafka_conf_t *conf,
                                         const char *name, const char *val,
                                         char *errstr, size_t errstr_size,
                                         void *ic_opaque) {
+        struct ici *ici = ic_opaque;
+        int level = 3;
+
+        if (!strcmp(name, "session.timeout.ms") ||
+            !strcmp(name, "socket.timeout.ms") ||
+            !strncmp(name, "interceptor_test", strlen("interceptor_test")))
+                level = 2;
+
+        TEST_SAYL(level, "on_conf_set(conf %p, \"%s\", \"%s\"): %p\n",
+                  conf, name, val, ici);
+
         if (!strcmp(name, "interceptor_test.good"))
                 return RD_KAFKA_CONF_OK;
         else if (!strcmp(name, "interceptor_test.bad")) {
@@ -129,6 +194,32 @@ static rd_kafka_conf_res_t on_conf_set (rd_kafka_conf_t *conf,
                         errstr_size-1);
                 errstr[errstr_size-1] = '\0';
                 return RD_KAFKA_CONF_INVALID;
+        } else if (!strcmp(name, "interceptor_test.config1")) {
+                if (ici->config1) {
+                        free(ici->config1);
+                        ici->config1 = NULL;
+                }
+                if (val)
+                        ici->config1 = strdup(val);
+                TEST_SAY("on_conf_set(conf %p, %s, %s): %p\n",
+                         conf, name, val, ici);
+                return RD_KAFKA_CONF_OK;
+        } else if (!strcmp(name, "interceptor_test.config2")) {
+                if (ici->config2) {
+                        free(ici->config2);
+                        ici->config2 = NULL;
+                }
+                if (val)
+                        ici->config2 = strdup(val);
+                return RD_KAFKA_CONF_OK;
+        } else {
+                /* Apply intercepted client's config properties on
+                 * interceptor config. */
+                rd_kafka_conf_set(ici->conf, name, val,
+                                  errstr, errstr_size);
+                /* UNKNOWN makes the conf_set() call continue with
+                 * other interceptors and finally the librdkafka properties. */
+                return RD_KAFKA_CONF_UNKNOWN;
         }
 
         return RD_KAFKA_CONF_UNKNOWN;
@@ -142,15 +233,24 @@ static void conf_init0 (rd_kafka_conf_t *conf);
  */
 static rd_kafka_resp_err_t on_conf_dup (rd_kafka_conf_t *new_conf,
                                         const rd_kafka_conf_t *old_conf,
+                                        size_t filter_cnt, const char **filter,
                                         void *ic_opaque) {
+        struct ici *ici = ic_opaque;
+        TEST_SAY("on_conf_dup(new_conf %p, old_conf %p, filter_cnt %"PRIusz
+                 ", ici %p)\n",
+                 new_conf, old_conf, filter_cnt, ici);
         conf_init0(new_conf);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
 
 static rd_kafka_resp_err_t on_conf_destroy (void *ic_opaque) {
-        printf("conf_destroy called (opaque %p vs %p)\n",
-               ic_opaque, my_interceptor_plug_opaque);
+        struct ici *ici = ic_opaque;
+        ici->on_conf_destroy_cnt++;
+        printf("conf_destroy called (opaque %p vs %p) ici %p\n",
+               ic_opaque, my_interceptor_plug_opaque, ici);
+        TEST_ASSERT(ici->on_conf_destroy_cnt == 1);
+        ici_destroy(ici);
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
@@ -162,16 +262,33 @@ static rd_kafka_resp_err_t on_conf_destroy (void *ic_opaque) {
  *        This internal method serves both cases.
  */
 static void conf_init0 (rd_kafka_conf_t *conf) {
+        struct ici *ici;
+        const char *filter[] = { "plugin.library.paths",
+                                 "interceptor_test." };
+        size_t filter_cnt = sizeof(filter) / sizeof(*filter);
+
+        /* Create new interceptor instance */
+        ici = calloc(1, sizeof(*ici));
+
+        ictest.conf_init.cnt++;
+        ICTEST_CNT_CHECK(conf_init);
+
+        /* Create own copy of configuration, after filtering out what
+         * brought us here (plugins and our own interceptor config). */
+        ici->conf = rd_kafka_conf_dup_filter(conf, filter_cnt, filter);
+        TEST_SAY("conf_init0(conf %p) for ici %p with ici->conf %p\n",
+                 conf, ici, ici->conf);
+
+
         /* Add interceptor methods */
-        rd_kafka_conf_interceptor_add_on_new(conf, __FILE__, on_new,
-                                             my_ic_opaque);
+        rd_kafka_conf_interceptor_add_on_new(conf, __FILE__, on_new, ici);
+
         rd_kafka_conf_interceptor_add_on_conf_set(conf, __FILE__, on_conf_set,
-                                                  NULL);
+                                                  ici);
         rd_kafka_conf_interceptor_add_on_conf_dup(conf, __FILE__, on_conf_dup,
-                                                  NULL);
+                                                  ici);
         rd_kafka_conf_interceptor_add_on_conf_destroy(conf, __FILE__,
-                                                      on_conf_destroy,
-                                                      NULL);
+                                                      on_conf_destroy, ici);
 }
 
 /**
@@ -183,7 +300,8 @@ rd_kafka_resp_err_t conf_init (rd_kafka_conf_t *conf,
                                char *errstr, size_t errstr_size) {
         *plug_opaquep = (void *)my_interceptor_plug_opaque;
 
-        printf("conf_init called (setting opaque to %p)\n", *plug_opaquep);
+        TEST_SAY("conf_init(conf %p) called (setting opaque to %p)\n",
+                 conf, *plug_opaquep);
 
         conf_init0(conf);
 

--- a/tests/interceptor_test/interceptor_test.h
+++ b/tests/interceptor_test/interceptor_test.h
@@ -1,0 +1,44 @@
+#pragma once
+
+
+struct ictcnt {
+        int cnt;
+        int min;
+        int max;
+};
+
+struct ictest {
+        struct ictcnt conf_init;
+        struct ictcnt on_new;
+
+        /* intercepted interceptor_test.config1 and .config2 properties */
+        char *config1;
+        char *config2;
+
+        /* intercepted session.timeout.ms and socket.timeout.ms */
+        char *session_timeout_ms;
+        char *socket_timeout_ms;
+};
+
+#define ictest_init(ICT) memset((ICT), 0, sizeof(ictest))
+#define ictest_cnt_init(CNT,MIN,MAX) do {                               \
+                (CNT)->cnt = 0;                                         \
+                (CNT)->min = MIN;                                       \
+                (CNT)->max = MAX;                                       \
+        } while (0)
+
+#define ictest_free(ICT) do {                                           \
+                if ((ICT)->config1) free((ICT)->config1);               \
+                if ((ICT)->config2) free((ICT)->config2);               \
+                if ((ICT)->session_timeout_ms) free((ICT)->session_timeout_ms); \
+                if ((ICT)->socket_timeout_ms) free((ICT)->socket_timeout_ms); \
+        } while (0)
+
+#define ICTEST_CNT_CHECK(F) do {                                        \
+                if (ictest.F.cnt > ictest.F.max)                        \
+                        TEST_FAIL("interceptor %s count %d > max %d",   \
+                                  # F, ictest.F.cnt, ictest.F.max);    \
+        } while (0)
+
+/* The ictest struct is defined and set up by the calling test. */
+extern struct ictest ictest;

--- a/tests/test.c
+++ b/tests/test.c
@@ -223,13 +223,9 @@ struct test tests[] = {
         _TEST(0063_clusterid, 0, TEST_BRKVER(0,10,0,0)),
         _TEST(0064_interceptors, 0),
         _TEST(0065_yield, 0),
-        _TEST(0066_plugins, TEST_F_LOCAL|TEST_F_KNOWN_ISSUE_WIN32 |
-#if __APPLE__
-              TEST_F_KNOWN_ISSUE
-#else
-              0
-#endif
-              , .extra = "dynamic loading of tests might not be fixed for this platform"),
+        _TEST(0066_plugins,
+              TEST_F_LOCAL|TEST_F_KNOWN_ISSUE_WIN32|TEST_F_KNOWN_ISSUE_OSX,
+              .extra = "dynamic loading of tests might not be fixed for this platform"),
         { NULL }
 };
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -148,6 +148,7 @@ _TEST_DECL(0062_stats_event);
 _TEST_DECL(0063_clusterid);
 _TEST_DECL(0064_interceptors);
 _TEST_DECL(0065_yield);
+_TEST_DECL(0066_plugins);
 
 /**
  * Define all tests here
@@ -222,6 +223,7 @@ struct test tests[] = {
         _TEST(0063_clusterid, 0, TEST_BRKVER(0,10,0,0)),
         _TEST(0064_interceptors, 0),
         _TEST(0065_yield, 0),
+        _TEST(0066_plugins, TEST_F_LOCAL|TEST_F_KNOWN_ISSUE_WIN32),
         { NULL }
 };
 
@@ -2833,7 +2835,7 @@ void test_conf_set (rd_kafka_conf_t *conf, const char *name, const char *val) {
                           name, val, errstr);
 }
 
-char *test_conf_get (rd_kafka_conf_t *conf, const char *name) {
+char *test_conf_get (const rd_kafka_conf_t *conf, const char *name) {
 	static RD_TLS char ret[256];
 	size_t ret_sz = sizeof(ret);
 	if (rd_kafka_conf_get(conf, name, ret, &ret_sz) != RD_KAFKA_CONF_OK)

--- a/tests/test.c
+++ b/tests/test.c
@@ -223,7 +223,13 @@ struct test tests[] = {
         _TEST(0063_clusterid, 0, TEST_BRKVER(0,10,0,0)),
         _TEST(0064_interceptors, 0),
         _TEST(0065_yield, 0),
-        _TEST(0066_plugins, TEST_F_LOCAL|TEST_F_KNOWN_ISSUE_WIN32),
+        _TEST(0066_plugins, TEST_F_LOCAL|TEST_F_KNOWN_ISSUE_WIN32 |
+#if __APPLE__
+              TEST_F_KNOWN_ISSUE
+#else
+              0
+#endif
+              , .extra = "dynamic loading of tests might not be fixed for this platform"),
         { NULL }
 };
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -145,6 +145,12 @@ struct test {
 #define TEST_F_KNOWN_ISSUE_WIN32 0
 #endif
 
+#ifdef __APPLE__
+#define TEST_F_KNOWN_ISSUE_OSX  TEST_F_KNOWN_ISSUE
+#else
+#define TEST_F_KNOWN_ISSUE_OSX  0
+#endif
+
 
 #define TEST_FAIL0(file,line,do_lock,fail_now,...) do {                 \
                 int is_thrd = 0;                                        \

--- a/tests/test.h
+++ b/tests/test.h
@@ -473,7 +473,7 @@ void test_consumer_close (rd_kafka_t *rk);
 void test_flush (rd_kafka_t *rk, int timeout_ms);
 
 void test_conf_set (rd_kafka_conf_t *conf, const char *name, const char *val);
-char *test_conf_get (rd_kafka_conf_t *conf, const char *name);
+char *test_conf_get (const rd_kafka_conf_t *conf, const char *name);
 int test_conf_match (rd_kafka_conf_t *conf, const char *name, const char *val);
 void test_topic_conf_set (rd_kafka_topic_conf_t *tconf,
                           const char *name, const char *val);

--- a/win32/librdkafka.sln
+++ b/win32/librdkafka.sln
@@ -161,20 +161,14 @@ Global
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|Mixed Platforms.Build.0 = Debug|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|Win32.ActiveCfg = Debug|Win32
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|Win32.Build.0 = Debug|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|x64.ActiveCfg = Debug|x64
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|x64.Build.0 = Debug|x64
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|x86.ActiveCfg = Debug|Win32
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Debug|x86.Build.0 = Debug|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|Any CPU.ActiveCfg = Release|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|Mixed Platforms.ActiveCfg = Release|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|Mixed Platforms.Build.0 = Release|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|Win32.ActiveCfg = Release|Win32
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|Win32.Build.0 = Release|Win32
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|x64.ActiveCfg = Release|x64
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|x64.Build.0 = Release|x64
 		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|x86.ActiveCfg = Release|Win32
-		{492CF5A9-EBF5-494E-8F71-B9B262C4D220}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\..\tests\0063-clusterid.cpp" />
     <ClCompile Include="..\..\tests\0064-interceptors.c" />
     <ClCompile Include="..\..\tests\0065-yield.cpp" />
+    <ClCompile Include="..\..\tests\0066-plugins.cpp" />
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />
     <ClCompile Include="..\..\src\tinycthread.c" />


### PR DESCRIPTION
This PR addresses:
 * fixed how interceptors interact with configuration object copying.
 * the platform-dependent shared-library filename extension is now appended if the initial load fails (allowing the same config  to be used on multiple platforms).
 * minor small fixes
