### PR TITLE
Support for in-memory SSL configuration

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1069,6 +1069,31 @@ rd_kafka_conf_res_t rd_kafka_conf_set(rd_kafka_conf_t *conf,
 
 
 /**
+* @brief Sets an _RK_C_BYTES type configuration property.
+*
+* \p conf must have been previously created with rd_kafka_conf_new().
+*
+* Fallthrough:
+* Topic-level bytes-based configuration properties may be set using this interface
+* in which case they are applied on the \c default_topic_conf.
+* If no \c default_topic_conf has been set one will be created.
+* Any sub-sequent rd_kafka_conf_set_default_topic_conf() calls will
+* replace the current default topic configuration.
+*
+* @returns \c rd_kafka_conf_res_t to indicate success or failure.
+* In case of failure \p errstr is updated to contain a human readable
+* error string.
+*/
+RD_EXPORT
+rd_kafka_conf_res_t rd_kafka_conf_set_bytes(rd_kafka_conf_t *const conf,
+    const char *name,
+    const char* pBytes,
+    unsigned int length,
+    char *errstr,
+    size_t errstr_size);
+
+
+/**
  * @brief Enable event sourcing.
  * \p events is a bitmask of \c RD_KAFKA_EVENT_* of events to enable
  * for consumption by `rd_kafka_queue_poll()`.

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -112,6 +112,11 @@ struct rd_kafka_conf_s {
 		char *cert_location;
 		char *ca_location;
 		char *crl_location;
+
+		rd_kafkap_str_t *cert_location_inmemory;
+		rd_kafkap_str_t *ca_location_inmemory;
+		rd_kafkap_str_t *key_inmemory;
+		int key_inmemory_nid_type;
 	} ssl;
 #endif
 

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -790,7 +790,7 @@ void rd_kafka_transport_ssl_ctx_term (rd_kafka_t *rk) {
  */
 int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 				     char *errstr, size_t errstr_size) {
-	int r;
+	int r = 0;
 	SSL_CTX *ctx;
 
         if (errstr_size > 0)
@@ -828,8 +828,45 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 		}
 	}
 
+    if (rk->rk_conf.ssl.ca_location_inmemory) {
+		X509 *pX509;
+		X509_STORE *pX509Store;
 
-	if (rk->rk_conf.ssl.ca_location) {
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Loading CA certificate from memory");
+
+        pX509 = d2i_X509(NULL,
+            (const unsigned char **)&rk->rk_conf.ssl.ca_location_inmemory->str,
+            rk->rk_conf.ssl.ca_location_inmemory->len);
+
+        if (pX509) {
+            pX509Store = SSL_CTX_get_cert_store(ctx);
+
+            if (pX509Store)	{
+                r = X509_STORE_add_cert(pX509Store, pX509);
+            }
+            else {
+                rd_kafka_dbg(rk, SECURITY, "SSL",
+                    "Failure getting X509 store");
+            }
+
+            X509_free(pX509);
+        }
+        else {
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Failure decoding in-memory CA certificate bytes to X509");
+        }
+
+		rd_kafkap_str_destroy(rk->rk_conf.ssl.ca_location_inmemory);
+		rk->rk_conf.ssl.ca_location_inmemory = NULL;
+
+        if (r != 1) {
+            rd_snprintf(errstr, errstr_size,
+                "ssl.ca.location_inmemory failed: ");
+            goto fail;
+        }
+    }
+    else if (rk->rk_conf.ssl.ca_location) {
 		/* CA certificate location, either file or directory. */
 		int is_dir = rd_kafka_path_is_dir(rk->rk_conf.ssl.ca_location);
 
@@ -883,7 +920,37 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 				     X509_V_FLAG_CRL_CHECK);
 	}
 
-	if (rk->rk_conf.ssl.cert_location) {
+    if (rk->rk_conf.ssl.cert_location_inmemory) {
+		X509 *pX509;
+
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Loading certificate from memory");
+
+        pX509 = d2i_X509(NULL, 
+            (const unsigned char **)&rk->rk_conf.ssl.cert_location_inmemory->str,
+            rk->rk_conf.ssl.cert_location_inmemory->len);
+
+        if (pX509) {
+            r = SSL_CTX_use_certificate(ctx,
+                pX509);
+
+            X509_free(pX509);
+        }
+        else {
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Failure decoding in-memory certificate bytes to X509");
+        }
+
+		rd_kafkap_str_destroy(rk->rk_conf.ssl.cert_location_inmemory);
+		rk->rk_conf.ssl.cert_location_inmemory = NULL;
+
+        if (r != 1) {
+            rd_snprintf(errstr, errstr_size,
+                "ssl.certificate.location_inmemory failed: ");
+            goto fail;
+        }
+    }
+    else if (rk->rk_conf.ssl.cert_location) {
 		rd_kafka_dbg(rk, SECURITY, "SSL",
 			     "Loading certificate from file %s",
 			     rk->rk_conf.ssl.cert_location);
@@ -898,7 +965,35 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
                 }
 	}
 
-	if (rk->rk_conf.ssl.key_location) {
+    if (rk->rk_conf.ssl.key_inmemory) {
+        char *pszPkType = "unsupported";
+
+        if (rk->rk_conf.ssl.key_inmemory_nid_type == EVP_PKEY_DSA) {
+            pszPkType = "DSA";
+        }
+        else if (rk->rk_conf.ssl.key_inmemory_nid_type == EVP_PKEY_RSA) {
+            pszPkType = "RSA";
+        }
+
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Loading %s private key from memory",
+            pszPkType);
+
+        r = SSL_CTX_use_PrivateKey_ASN1(rk->rk_conf.ssl.key_inmemory_nid_type,
+            ctx,
+            (const unsigned char*)rk->rk_conf.ssl.key_inmemory->str,
+            rk->rk_conf.ssl.key_inmemory->len);
+
+		rd_kafkap_str_destroy(rk->rk_conf.ssl.key_inmemory);
+		rk->rk_conf.ssl.key_inmemory = NULL;
+
+        if (r != 1) {
+            rd_snprintf(errstr, errstr_size,
+                "ssl.key.inmemory failed: ");
+            goto fail;
+        }
+    }
+    else if (rk->rk_conf.ssl.key_location) {
 		rd_kafka_dbg(rk, SECURITY, "SSL",
 			     "Loading private key file from %s",
 			     rk->rk_conf.ssl.key_location);


### PR DESCRIPTION
Allow the SSL user-certificate, CA-certificate and private key to be passed in-memory into the library and configured against the OpenSSL context.

The newly-supported configuration settings are (following the same convention as their file-based counterparts):
- "ssl.key_inmemory" - In-memory client private key (ASN.1-encoded DSA or RSA bytes: specify with ssl.key_inmemory_type), used for authentication.
- "ssl.key_inmemory_type" - In-memory client private key type: DSA or RSA.
- "ssl.certificate.location_inmemory" - In-memory X509 certificate bytes used for authentication.
- "ssl.ca.location_inmemory" - In-memory X509 CA certificate bytes for verifying the broker's key.