### PR TITLE
Fix 1386, messed up Null/Empty handling in the Consumer

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2150,6 +2150,16 @@ static int rd_kafka_broker_op_serve (rd_kafka_broker_t *rkb,
                 /* nop: just a wake-up. */
                 if (rkb->rkb_blocking_max_ms > 1)
                         rkb->rkb_blocking_max_ms = 1; /* Speed up termination*/
+                rd_rkb_dbg(rkb, BROKER, "TERM",
+                           "Received TERMINATE op in state %s: "
+                           "%d refcnts, %d toppar(s), %d fetch toppar(s), "
+                           "%d outbufs, %d waitresps, %d retrybufs",
+                           rd_kafka_broker_state_names[rkb->rkb_state],
+                           rd_refcnt_get(&rkb->rkb_refcnt),
+                           rkb->rkb_toppar_cnt, rkb->rkb_fetch_toppar_cnt,
+                           (int)rd_kafka_bufq_cnt(&rkb->rkb_outbufs),
+                           (int)rd_kafka_bufq_cnt(&rkb->rkb_waitresps),
+                           (int)rd_kafka_bufq_cnt(&rkb->rkb_retrybufs));
                 ret = 0;
                 break;
 

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -277,10 +277,10 @@ void rd_kafka_broker_fail (rd_kafka_broker_t *rkb,
 
 void rd_kafka_broker_destroy_final (rd_kafka_broker_t *rkb);
 
-static RD_INLINE RD_UNUSED void rd_kafka_broker_destroy (rd_kafka_broker_t *rkb) {
-        rd_refcnt_destroywrapper(&rkb->rkb_refcnt,
-                                 rd_kafka_broker_destroy_final(rkb));
-}
+#define rd_kafka_broker_destroy(rkb)                                    \
+        rd_refcnt_destroywrapper(&(rkb)->rkb_refcnt,                    \
+                                 rd_kafka_broker_destroy_final(rkb))
+
 
 void rd_kafka_broker_update (rd_kafka_t *rk, rd_kafka_secproto_t proto,
                              const struct rd_kafka_metadata_broker *mdb);

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -351,8 +351,11 @@ rd_tmpabuf_write_str0 (const char *func, int line,
                 int _klen;                                              \
                 rd_kafka_buf_read_i32a(rkbuf, _klen);                   \
                 (kbytes)->len = _klen;                                  \
-                if (RD_KAFKAP_BYTES_LEN(kbytes) == 0)                   \
+                if (RD_KAFKAP_BYTES_IS_NULL(kbytes)) {                  \
                         (kbytes)->data = NULL;                          \
+                        (kbytes)->len = 0;                              \
+                } else if (RD_KAFKAP_BYTES_LEN(kbytes) == 0)            \
+                        (kbytes)->data = "";                            \
                 else if (!((kbytes)->data =                             \
                            rd_slice_ensure_contig(&(rkbuf)->rkbuf_reader, \
                                                   _klen)))              \
@@ -384,8 +387,11 @@ rd_tmpabuf_write_str0 (const char *func, int line,
                                                 "varint parsing failed: " \
                                                 "buffer underflow");    \
                 (kbytes)->len = (int32_t)_len2;                         \
-                if (RD_KAFKAP_BYTES_LEN(kbytes) == 0)                   \
+                if (RD_KAFKAP_BYTES_IS_NULL(kbytes)) {                  \
                         (kbytes)->data = NULL;                          \
+                        (kbytes)->len = 0;                              \
+                } else if (RD_KAFKAP_BYTES_LEN(kbytes) == 0)            \
+                        (kbytes)->data = "";                            \
                 else if (!((kbytes)->data =                             \
                            rd_slice_ensure_contig(&(rkbuf)->rkbuf_reader, \
                                                   _len2)))              \

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1772,7 +1772,7 @@ static void rd_kafka_handle_Produce (rd_kafka_t *rk,
                                          rd_kafka_msg_head_s);
                         rkm->rkm_offset = offset +
                                 rd_atomic32_get(&request->rkbuf_msgq.
-                                                rkmq_msg_cnt);
+                                                rkmq_msg_cnt) - 1;
                         if (timestamp != -1) {
                                 rkm->rkm_timestamp = timestamp;
                                 rkm->rkm_tstype = RD_KAFKA_MSG_ATTR_LOG_APPEND_TIME;

--- a/tests/0070-null_empty.cpp
+++ b/tests/0070-null_empty.cpp
@@ -1,0 +1,187 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2016, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "testcpp.h"
+#include <cstring>
+
+/**
+ * Verification of difference between empty and null Key and Value
+ */
+
+
+static int check_equal (const char *exp,
+                         const char *actual, size_t len,
+                         std::string what) {
+  size_t exp_len = exp ? strlen(exp) : 0;
+  int failures = 0;
+
+  if (!actual && len != 0) {
+    Test::FailLater(tostr() << what << ": expected length 0 for Null, not " << len);
+    failures++;
+  }
+
+  if (exp) {
+    if (!actual) {
+      Test::FailLater(tostr() << what << ": expected \"" << exp << "\", not Null");
+      failures++;
+
+    } else if (len != exp_len || strncmp(exp, actual, exp_len)) {
+      Test::FailLater(tostr() << what << ": expected \"" << exp << "\", not \"" << actual << "\" (" << len << " bytes)");
+      failures++;
+    }
+
+  } else {
+    if (actual) {
+      Test::FailLater(tostr() << what << ": expected Null, not \"" << actual << "\" (" << len << " bytes)");
+      failures++;
+    }
+  }
+
+  if (!failures)
+    Test::Say(3, tostr() << what << ": matched expectation\n");
+
+  return failures;
+}
+
+
+static void do_test_null_empty (bool api_version_request) {
+  std::string topic = Test::mk_topic_name("0070_null_empty", 1);
+  const int partition = 0;
+
+  Test::Say(tostr() << "Testing with api.version.request=" << api_version_request << " on topic " << topic << " partition " << partition << "\n");
+
+  RdKafka::Conf *conf;
+  Test::conf_init(&conf, NULL, 0);
+  Test::conf_set(conf, "api.version.request",
+                 api_version_request ? "true" : "false");
+
+
+  std::string errstr;
+  RdKafka::Producer *p = RdKafka::Producer::create(conf, errstr);
+  if (!p)
+    Test::Fail("Failed to create Producer: " + errstr);
+  delete conf;
+
+  const int msgcnt = 8;
+  static const char *msgs[msgcnt*2] = {
+    NULL, NULL,
+    "key2", NULL,
+    "key3", "val3",
+    NULL, "val4",
+    "", NULL,
+    NULL, "",
+    "", ""
+  };
+
+  RdKafka::ErrorCode err;
+
+  for (int i = 0 ; i < msgcnt * 2 ; i += 2) {
+    Test::Say(3, tostr() << "Produce message #" << (i/2) <<
+              ": key=\"" << (msgs[i] ? msgs[i] : "Null") <<
+              "\", value=\"" << (msgs[i+1] ? msgs[i+1] : "Null") << "\"\n");
+    err = p->produce(topic, partition, RdKafka::Producer::RK_MSG_COPY,
+                     /* Value */
+                     (void *)msgs[i+1], msgs[i+1] ? strlen(msgs[i+1]) : 0,
+                     /* Key */
+                     (void *)msgs[i], msgs[i] ? strlen(msgs[i]) : 0,
+                     0, NULL);
+    if (err != RdKafka::ERR_NO_ERROR)
+      Test::Fail("Produce failed: " + RdKafka::err2str(err));
+  }
+
+  if (p->flush(3*5000) != 0)
+    Test::Fail("Not all messages flushed");
+
+  Test::Say(tostr() << "Produced " << msgcnt << " messages to " << topic << "\n");
+
+  delete p;
+
+  /*
+   * Now consume messages from the beginning, making sure they match
+   * what was produced.
+   */
+
+  /* Create consumer */
+  Test::conf_init(&conf, NULL, 10);
+  Test::conf_set(conf, "group.id", topic);
+  Test::conf_set(conf, "api.version.request",
+                 api_version_request ? "true" : "false");
+  Test::conf_set(conf, "enable.auto.commit", "false");
+
+  RdKafka::KafkaConsumer *c = RdKafka::KafkaConsumer::create(conf, errstr);
+  if (!c)
+    Test::Fail("Failed to create KafkaConsumer: " + errstr);
+  delete conf;
+
+  /* Assign the partition */
+  std::vector<RdKafka::TopicPartition*> parts;
+  parts.push_back(RdKafka::TopicPartition::create(topic, partition,
+                                                 RdKafka::Topic::OFFSET_BEGINNING));
+  err = c->assign(parts);
+  if (err != RdKafka::ERR_NO_ERROR)
+    Test::Fail("assign() failed: " + RdKafka::err2str(err));
+  RdKafka::TopicPartition::destroy(parts);
+
+  /* Start consuming */
+  int failures = 0;
+  for (int i = 0 ; i < msgcnt * 2 ; i += 2) {
+    RdKafka::Message *msg = c->consume(5000);
+    if (msg->err())
+      Test::Fail(tostr() << "consume() failed at message " << (i/2) << ": " <<
+                 msg->errstr());
+
+    /* verify key */
+    failures += check_equal(msgs[i], msg->key() ? msg->key()->c_str() : NULL, msg->key_len(),
+                            tostr() << "message #" << (i/2) << " (offset " << msg->offset() << ") key");
+    /* verify key_pointer() API as too */
+    failures += check_equal(msgs[i], (const char *)msg->key_pointer(), msg->key_len(),
+                tostr() << "message #" << (i/2) << " (offset " << msg->offset() << ") key");
+
+    /* verify value */
+    failures += check_equal(msgs[i+1], (const char *)msg->payload(), msg->len(),
+                tostr() << "message #" << (i/2) << " (offset " << msg->offset() << ") value");
+    delete msg;
+  }
+
+  Test::Say(tostr() << "Done consuming, closing. " << failures << " test failures\n");
+  if (failures)
+    Test::Fail(tostr() << "See " << failures << "  previous test failure(s)");
+
+  c->close();
+  delete c;
+}
+
+
+extern "C" {
+  int main_0070_null_empty (int argc, char **argv) {
+    do_test_null_empty(true);
+    do_test_null_empty(false);
+    return 0;
+  }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(
     0067-empty_topic.cpp
     0068-produce_timeout.c
     0069-consumer_add_parts.c
+    0070-null_empty.cpp
     test.c
     testcpp.cpp
     sockem.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -152,6 +152,7 @@ _TEST_DECL(0066_plugins);
 _TEST_DECL(0067_empty_topic);
 _TEST_DECL(0068_produce_timeout);
 _TEST_DECL(0069_consumer_add_parts);
+_TEST_DECL(0070_null_empty);
 
 /**
  * Define all tests here
@@ -234,6 +235,7 @@ struct test tests[] = {
         _TEST(0068_produce_timeout, 0),
 #endif
         _TEST(0069_consumer_add_parts, TEST_F_KNOWN_ISSUE_WIN32),
+        _TEST(0070_null_empty, 0),
         { NULL }
 };
 

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -154,6 +154,7 @@
     <ClCompile Include="..\..\tests\0067-empty_topic.cpp" />
     <ClCompile Include="..\..\tests\0068-produce_timeout.c" />
     <ClCompile Include="..\..\tests\0069-consumer_add_parts.c" />
+    <ClCompile Include="..\..\tests\0070-null_empty.cpp" />
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />
     <ClCompile Include="..\..\src\tinycthread.c" />


### PR DESCRIPTION
This also fixes an off-by-one error for the Producer's returned offsets when produce.offset.report=false (default)