### PR TITLE
rdkafka-performance: busy wait to wait short periods of time

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1303,11 +1303,17 @@ int main (int argc, char **argv) {
 			cnt.bytes += msgsize;
 
                         if (rate_sleep) {
+				if (rate_sleep > 100) {
 #ifdef _MSC_VER
-                                Sleep(rate_sleep / 1000);
+					Sleep(rate_sleep / 1000);
 #else
-                                usleep(rate_sleep);
+					usleep(rate_sleep);
 #endif
+				} else {
+					rd_ts_t next = rd_clock() + rate_sleep;
+					while (next > rd_clock())
+						;
+				}
                         }
 
 			/* Must poll to handle delivery reports */


### PR DESCRIPTION
On linux once a process is done sleeping it takes about 5 microseconds
to start running again. By default linux allows 50 microseconds of
slack in the length of sleep() calls to optimize the number of wakeups.
The amount of timerslack can be reduced to 1 nanosecond, but the time
to get rescheduled and run does not appear to be easily modifiable.  As
a result it is not really possible to use a sleep() variant to wait for
less than 55 microseconds, and for lengths of time not much more than
that it will not be terribly accurate.  So if we need to produce
messages more frequently than every 100 microseconds we busy wait
instead of calling usleep().  100 is a somewhat arbitrary number, but
its close to twice the minimum length of time a process would sleep by
default.  This is also suboptimal for single core machines, but people
probably don't develope kafka related software on those, and if they do
producing messages at the kind of rate where this matters will be rather
difficult.