### PR TITLE
avoid holding the toppar lock across a write syscall

### DIFF
--- a/src/rdkafka_msg.h
+++ b/src/rdkafka_msg.h
@@ -260,11 +260,15 @@ static RD_INLINE RD_UNUSED void rd_kafka_msgq_insert (rd_kafka_msgq_t *rkmq,
 /**
  * Append message to tail of message queue.
  */
-static RD_INLINE RD_UNUSED void rd_kafka_msgq_enq (rd_kafka_msgq_t *rkmq,
+static RD_INLINE RD_UNUSED int rd_kafka_msgq_enq (rd_kafka_msgq_t *rkmq,
 						rd_kafka_msg_t *rkm) {
+	int len;
+
 	TAILQ_INSERT_TAIL(&rkmq->rkmq_msgs, rkm, rkm_link);
-	rd_atomic32_add(&rkmq->rkmq_msg_cnt, 1);
+	len = rd_atomic32_add(&rkmq->rkmq_msg_cnt, 1);
 	rd_atomic64_add(&rkmq->rkmq_msg_bytes, rkm->rkm_len+rkm->rkm_key_len);
+	
+	return len;
 }
 
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -613,8 +613,7 @@ void rd_kafka_toppar_enq_msg (rd_kafka_toppar_t *rktp, rd_kafka_msg_t *rkm) {
 
 	rd_kafka_toppar_lock(rktp);
 	wakeup_fd = rktp->rktp_msgq_wakeup_fd;
-	rd_kafka_msgq_enq(&rktp->rktp_msgq, rkm);
-	queue_len = rd_kafka_msgq_len(&rktp->rktp_msgq);
+	queue_len = rd_kafka_msgq_enq(&rktp->rktp_msgq, rkm);
         rd_kafka_toppar_unlock(rktp);
 #ifndef _MSC_VER
         if (wakeup_fd != -1 && queue_len == 1) {


### PR DESCRIPTION
 Holding locks across syscalls is generally not a great idea since it
means spending longer with the lock and increases the chances the
process will spend time holding the lock but descheduled.  In this case
it is especially unfortunate because the write will make a broker thread
runnable if it is blocked on poll, but if the broker thread runs before
the thread calling write() it will immediately block again trying to
take the toppar lock.  This appears to reduce worst case latency by at
least 1ms, and quiet possibly much more, its hard to know exactly how
much should be attributed to this instead of other freek events hurting
worst case latency.  Its somewhat unfortunate we need to do a little
more work unconditionally, but the atomic accesses can be optimized
somewhat, and it may be a good idea to use the wakeup fd system more.