### PR TITLE
Don't store invalid offset as next one when pausing

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1531,7 +1531,9 @@ static void rd_kafka_toppar_pause_resume (rd_kafka_toppar_t *rktp,
 		if (rk->rk_type == RD_KAFKA_CONSUMER) {
 			/* Save offset of last consumed message+1 as the
 			 * next message to fetch on resume. */
-			rktp->rktp_next_offset = rktp->rktp_app_offset;
+			if (rktp->rktp_app_offset != RD_KAFKA_OFFSET_INVALID) {
+				rktp->rktp_next_offset = rktp->rktp_app_offset;
+			}
 
 			rd_kafka_dbg(rk, TOPIC, pause?"PAUSE":"RESUME",
 				     "%s %s [%"PRId32"]: at offset %s "


### PR DESCRIPTION
This fixes the issue where a consumer subscribes to a topic and then pause consumption where all consumer offsets are initially already EOF. Without this check, the offset that's used after resuming consumption is invalid, which ends up falling back to whatever `auto.reset.policy` is being used, which in turn makes the consumer "forget" about which offset was actually already committed.

This fixes #1307. I'm not sure if this has any undesired side effects but at least I'm sure I'm not hitting the issue anymore.