### PR TITLE
stop calling cnd_timedwait() with a timeout of 0h

### DIFF
--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -359,7 +359,10 @@ rd_kafka_op_t *rd_kafka_q_pop_serve (rd_kafka_q_t *rkq, int timeout_ms,
                                         break; /* Proper op, handle below. */
                         }
 
-                        /* No op, wait for one */
+                        /* No op, wait for one if we have time left */
+			if (timeout_ms == 0)
+				break;
+
                         pre = rd_clock();
 			if (cnd_timedwait_ms(&rkq->rkq_cond,
 					     &rkq->rkq_lock,

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -360,10 +360,10 @@ rd_kafka_op_t *rd_kafka_q_pop_serve (rd_kafka_q_t *rkq, int timeout_ms,
                         }
 
                         /* No op, wait for one if we have time left */
-			if (timeout_ms == 0)
-				break;
+                        if (timeout_ms == RD_POLL_NOWAIT)
+                                break;
 
-                        pre = rd_clock();
+			pre = rd_clock();
 			if (cnd_timedwait_ms(&rkq->rkq_cond,
 					     &rkq->rkq_lock,
 					     timeout_ms) ==


### PR DESCRIPTION
 Waiting 0ms to be signaled the queue now contains elements doesn't
really mean anything.  However per the POSIX specification of
pthread_cond_timedwait() the lock must be released and reacquired.  As a
result if we skip calling cnd_timedwait() when the timeout is 0 we
improve average and best case latency in various conditions by between
0.1 and 0.2ms.