### PR TITLE
Make librdkafka compiles with ccache.

### DIFF
--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -39,7 +39,7 @@ function checks {
             fi
         fi
         export CXX="${CXX}"
-        mkl_mkvar_set "CXX" CXX $CXX
+        mkl_mkvar_set "CXX" CXX "$CXX"
     fi
 
     # Handle machine bits, if specified.


### PR DESCRIPTION
Ccache can be used to speed up compiling. When using ccache, we usually
set following environments variables:

```
export CC="ccache gcc"
export CXX="ccache g++"
```

In current version of configure.cc, we pass $CXX to function
mkl_mkvar_set without quoting marks:

```
mkl_mkvar_set "CXX" CXX $CXX
```
mkl_mkvar_set actually receives 4 variables: CXX, CXX, ccache and g++,
then mkl_mkvar_set will set CXX to ccache, but not "ccache g++", thus
causes errors when compiling files in folder src-cpp.