### PR TITLE
Feature/retry timeout

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -537,13 +537,11 @@ static void rd_kafka_broker_timeout_scan (rd_kafka_broker_t *rkb, rd_ts_t now) {
                 rkb->rkb_req_timeouts   += req_cnt + q_cnt;
                 rd_atomic64_add(&rkb->rkb_c.req_timeouts, req_cnt + q_cnt);
 
-		/* If this was an in-flight request that timed out, or
-		 * the other queues has reached the socket.max.fails threshold,
-		 * we need to take down the connection. */
-                if ((req_cnt > 0 ||
-		     (rkb->rkb_rk->rk_conf.socket_max_fails &&
+		/* If the number of failures exceeds the socket.max.fails 
+		 * threshold, we need to take down the connection. */
+                if ((rkb->rkb_rk->rk_conf.socket_max_fails &&
 		      rkb->rkb_req_timeouts >=
-		      rkb->rkb_rk->rk_conf.socket_max_fails)) &&
+		      rkb->rkb_rk->rk_conf.socket_max_fails) &&
                     rkb->rkb_state >= RD_KAFKA_BROKER_STATE_UP) {
                         char rttinfo[32];
                         /* Print average RTT (if avail) to help diagnose. */

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -1750,9 +1750,14 @@ void rd_kafka_broker_buf_retry (rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
 
 	rd_atomic64_add(&rkb->rkb_c.tx_retries, 1);
 
-	rkbuf->rkbuf_ts_retry = rd_clock() +
+	rd_ts_t now = rd_clock();
+	rkbuf->rkbuf_ts_retry = now +
 		(rkb->rkb_rk->rk_conf.retry_backoff_ms * 1000);
-        /* Reset send offset */
+
+	/* Reset timeout */
+	rkbuf->rkbuf_ts_timeout = now + (rkbuf->rkbuf_ts_timeout - rkbuf->rkbuf_ts_enq);
+
+	/* Reset send offset */
         rd_slice_seek(&rkbuf->rkbuf_reader, 0);
 	rkbuf->rkbuf_corrid = 0;
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -1741,16 +1741,18 @@ void rd_kafka_broker_buf_retry (rd_kafka_broker_t *rkb, rd_kafka_buf_t *rkbuf) {
                 return;
         }
 
-        rd_rkb_dbg(rkb, PROTOCOL, "RETRY",
-                   "Retrying %sRequest (v%hd, %"PRIusz" bytes, retry %d/%d)",
-                   rd_kafka_ApiKey2str(rkbuf->rkbuf_reqhdr.ApiKey),
-                   rkbuf->rkbuf_reqhdr.ApiVersion,
-                   rd_slice_size(&rkbuf->rkbuf_reader),
-                   rkbuf->rkbuf_retries, rkb->rkb_rk->rk_conf.max_retries);
+	rd_ts_t now = rd_clock();
+
+	rd_rkb_dbg(rkb, PROTOCOL, "RETRY",
+		   "Retrying %sRequest (v%hd, %" PRIusz " bytes, retry %d/%d%s)",
+		   rd_kafka_ApiKey2str(rkbuf->rkbuf_reqhdr.ApiKey),
+		   rkbuf->rkbuf_reqhdr.ApiVersion,
+		   rd_slice_size(&rkbuf->rkbuf_reader),
+		   rkbuf->rkbuf_retries, rkb->rkb_rk->rk_conf.max_retries,
+		   now >= rkbuf->rkbuf_ts_timeout ? " timed out" : "");
 
 	rd_atomic64_add(&rkb->rkb_c.tx_retries, 1);
 
-	rd_ts_t now = rd_clock();
 	rkbuf->rkbuf_ts_retry = now +
 		(rkb->rkb_rk->rk_conf.retry_backoff_ms * 1000);
 


### PR DESCRIPTION
Requests that timeout appear not to be retried or rather they are retried and more or less instantly timeout again. It appears that this occurs because rkbuf_ts_timeout is not updated when a request is retried.

Before, we would see behavior like this.

```sh
%7|1508285460.943|RETRY|rdkafka#producer-1| [thrd:kafka-0.dev.idb.viasat.io:9092/bootstrap]: kafka-0.dev.idb.viasat.io:9092/0: Retrying MetadataRequest (v2, 91 bytes, retry 1/2)
%7|1508285460.943|RETRY|rdkafka#producer-1| [thrd:kafka-0.dev.idb.viasat.io:9092/bootstrap]: kafka-0.dev.idb.viasat.io:9092/0: Retrying MetadataRequest (v2, 91 bytes, retry 2/2)
%7|1508285460.943|REQTMOUT|rdkafka#producer-1| [thrd:kafka-0.dev.idb.viasat.io:9092/bootstrap]: kafka-0.dev.idb.viasat.io:9092/0: Timed out 1+1+0 requests
```

After this fix, the request waits a reasonable amount of time before retrying requests.

```sh
%7|1508427826.072|RETRY|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Retrying MetadataRequest (v2, 91 bytes, retry 1/2 timed out)
%7|1508427826.072|REQTMOUT|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Timed out 1+0+0 requests
%7|1508427827.113|SEND|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Sent MetadataRequest (v2, 91 bytes @ 0, CorrId 21)
%7|1508427887.204|RETRY|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Retrying MetadataRequest (v2, 91 bytes, retry 2/2 timed out)
%7|1508427887.204|REQTMOUT|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Timed out 1+0+0 requests
%7|1508427888.205|SEND|rdkafka#producer-1| [thrd:kafka-8.dev.idb.viasat.io:9092/bootstrap]: kafka-8.dev.idb.viasat.io:9092/8: Sent MetadataRequest (v2, 91 bytes @ 0, CorrId 22)
```

In this example, retry 2/2 also times out, which remains an issue we're trying to get to the bottom of, but in some cases the second retry does work.

Note that the logs above were pulled from slightly older code and this PR was updated for the latest changes.
