### PR TITLE
Possible race condition in rd_kafka_q_destroy

### DIFF
--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -152,6 +152,13 @@ void rd_kafka_q_destroy (rd_kafka_q_t *rkq) {
         do_delete = !--rkq->rkq_refcnt;
         mtx_unlock(&rkq->rkq_lock);
 
+        // A race condition may be introduced
+        // if another thread increases the reference count
+        // at this point, after we check it's zero
+        // but before rd_kafka_q_destroy_final is called.
+        // This condition is handled internally by
+        // rd_kafka_q_destroy_final
+
         if (unlikely(do_delete))
                 rd_kafka_q_destroy_final(rkq);
 }


### PR DESCRIPTION
In rare cases, we've experienced a segfault with the following stack trace.

```sh
#0  0x00007ffff6a01bd0 in pthread_mutex_lock () from /usr/lib64/libpthread.so.0
#1  0x00007ffff73ef689 in mtx_lock () from /usr/lib64/libidb.so
#2  0x00007ffff7394903 in rd_kafka_q_enq () from /usr/lib64/libidb.so
#3  0x00007ffff739edf4 in rd_kafka_broker_update () from /usr/lib64/libidb.so
#4  0x00007ffff73f32a1 in rd_kafka_parse_Metadata () from /usr/lib64/libidb.so
#5  0x00007ffff73c3924 in rd_kafka_handle_Metadata () from /usr/lib64/libidb.so
#6  0x00007ffff73b8f5d in rd_kafka_buf_callback () from /usr/lib64/libidb.so
#7  0x00007ffff73c2dec in rd_kafka_op_handle_std () from /usr/lib64/libidb.so
#8  0x00007ffff73c2e1c in rd_kafka_op_handle () from /usr/lib64/libidb.so
#9  0x00007ffff73bd5d7 in rd_kafka_q_serve () from /usr/lib64/libidb.so
#10 0x00007ffff738af2c in rd_kafka_thread_main () from /usr/lib64/libidb.so
#11 0x00007ffff73ef607 in _thrd_wrapper_function () from /usr/lib64/libidb.so
#12 0x00007ffff69ffdc5 in start_thread () from /usr/lib64/libpthread.so.0
#13 0x00007ffff536976d in clone () from /usr/lib64/libc.so.6
```

It appears that `rkq->rkq_lock` is somehow null in `rd_kafka_q_enq`.

Upon inspection of the `rd_kafka_q_destroy` method, we identified a possible race condition where the `rkq` struct could be freed while another thread has a reference to it, which seems like it could cause the segfault above. Details of the race condition are added in comments and a straightforward check is added in `rd_kafka_q_destroy_final` to prevent freeing a queue with a reference count greater than 0.