### PR TITLE
Handle infinite timeout (-1) on offsets for time

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2470,7 +2470,7 @@ rd_kafka_offsets_for_times (rd_kafka_t *rk,
         rd_list_destroy(&leaders);
 
         /* Wait for reply (or timeout) */
-        while (state.wait_reply > 0 && rd_timeout_remains(ts_end) > 0)
+        while (state.wait_reply > 0 && ((rd_timeout_remains(ts_end) > 0) || (timeout_ms == RD_POLL_INFINITE)))
                 rd_kafka_q_serve(rkq, rd_timeout_remains(ts_end),
                                 0, RD_KAFKA_Q_CB_CALLBACK,
                                  rd_kafka_poll_cb, NULL);

--- a/tests/0054-offset_time.cpp
+++ b/tests/0054-offset_time.cpp
@@ -137,7 +137,7 @@ static void test_offset_time (void) {
     query_parts.push_back(RdKafka::TopicPartition::create(topic, 1, timestamps[ti]));
 
     Test::Say(tostr() << "Attempting offsetsForTimes() for timestamp " << timestamps[ti] << "\n");
-    err = p->offsetsForTimes(query_parts, tmout_multip(-1));
+    err = p->offsetsForTimes(query_parts, -1);
     Test::print_TopicPartitions("offsetsForTimes", query_parts);
     if (err != RdKafka::ERR_NO_ERROR)
       Test::Fail("offsetsForTimes failed: " + RdKafka::err2str(err));

--- a/tests/0054-offset_time.cpp
+++ b/tests/0054-offset_time.cpp
@@ -136,7 +136,7 @@ static void test_offset_time (void) {
     query_parts.push_back(RdKafka::TopicPartition::create(topic, 0, timestamps[ti]));
     query_parts.push_back(RdKafka::TopicPartition::create(topic, 1, timestamps[ti]));
 
-    Test::Say(tostr() << "Attempting offsetsForTimes() for timestamp " << timestamps[ti] << "\n");
+    Test::Say(tostr() << "Attempting offsetsForTimes() for timestamp with a timeout of -1" << timestamps[ti] << "\n");
     err = p->offsetsForTimes(query_parts, -1);
     Test::print_TopicPartitions("offsetsForTimes", query_parts);
     if (err != RdKafka::ERR_NO_ERROR)

--- a/tests/0054-offset_time.cpp
+++ b/tests/0054-offset_time.cpp
@@ -130,6 +130,22 @@ static void test_offset_time (void) {
     fails += verify_offset(query_parts[1], timestamps[ti], timestamps[ti+1], RdKafka::ERR_NO_ERROR);
   }
 
+   /* repeat test with -1 timeout */
+  for (int ti = 0 ; ti < timestamp_cnt*2 ; ti += 2) {
+    RdKafka::TopicPartition::destroy(query_parts);
+    query_parts.push_back(RdKafka::TopicPartition::create(topic, 0, timestamps[ti]));
+    query_parts.push_back(RdKafka::TopicPartition::create(topic, 1, timestamps[ti]));
+
+    Test::Say(tostr() << "Attempting offsetsForTimes() for timestamp " << timestamps[ti] << "\n");
+    err = p->offsetsForTimes(query_parts, tmout_multip(-1));
+    Test::print_TopicPartitions("offsetsForTimes", query_parts);
+    if (err != RdKafka::ERR_NO_ERROR)
+      Test::Fail("offsetsForTimes failed: " + RdKafka::err2str(err));
+
+    fails += verify_offset(query_parts[0], timestamps[ti], timestamps[ti+1], RdKafka::ERR_NO_ERROR);
+    fails += verify_offset(query_parts[1], timestamps[ti], timestamps[ti+1], RdKafka::ERR_NO_ERROR);
+  }
+
   if (fails > 0)
     Test::Fail(tostr() << "See " << fails << " previous error(s)");
 


### PR DESCRIPTION
Example of failing test for issue raised in https://github.com/confluentinc/confluent-kafka-python/pull/268