### PR TITLE
Mention rdkafka-ruby in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ See the [wiki](https://github.com/edenhill/librdkafka/wiki) for a FAQ.
   * Python: [confluent-kafka-python](https://github.com/confluentinc/confluent-kafka-python)
   * Python: [PyKafka](https://github.com/Parsely/pykafka)
   * Ruby: [Hermann](https://github.com/reiseburo/hermann)
+  * Ruby: [rdkafka-ruby](https://github.com/thijsc/rdkafka-ruby)
   * Rust: [rust-rdkafka](https://github.com/fede1024/rust-rdkafka)
   * Tcl: [KafkaTcl](https://github.com/flightaware/kafkatcl)
   * Swift: [Perfect-Kafka](https://github.com/PerfectlySoft/Perfect-Kafka)


### PR DESCRIPTION
I heard a colleague mention this lib but hard a hard time finding it, figured it would be nice to mention in the README.