### PR TITLE
Fix bug: that broker stucked and recovered will cause producer stuck

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3190,8 +3190,10 @@ static int rd_kafka_broker_thread_main (void *arg) {
 		case RD_KAFKA_BROKER_STATE_UP:
 			if (rkb->rkb_nodeid == RD_KAFKA_NODEID_UA)
 				rd_kafka_broker_ua_idle(rkb, RD_POLL_INFINITE);
-			else if (rk->rk_type == RD_KAFKA_PRODUCER)
+			else if (rk->rk_type == RD_KAFKA_PRODUCER) {
 				rd_kafka_broker_producer_serve(rkb);
+				rkb->rkb_blocking_max_ms = rk->rk_conf.socket_blocking_max_ms;
+			}
 			else if (rk->rk_type == RD_KAFKA_CONSUMER)
 				rd_kafka_broker_consumer_serve(rkb);
 


### PR DESCRIPTION
We found this problem with a network error. The producer lost connect with the broker, and after a few minutes, the network recovered but the client stuck forever. (The broker's status in client is CONNECT)

How to Reproduce: client connect a kafka broker, send SIGSTOP to kafka broker, wait 10~15 minutes, then send SIGCONT to kafka broker, the producer will stuck with a big probability.