### PR TITLE
cmake build improve on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,9 @@ endif()
 
 option(RDKAFKA_BUILD_EXAMPLES "Build examples" ON)
 option(RDKAFKA_BUILD_TESTS "Build tests" ON)
-
+if(WIN32)
+    option(WITHOUT_WIN32_CONFIG "Avoid including win32_config.h on cmake builds" ON)
+endif(WIN32)
 
 # In:
 # * TRYCOMPILE_SRC_DIR

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,20 +1,30 @@
-add_executable(rdkafka_example rdkafka_example.c)
-target_link_libraries(rdkafka_example PUBLIC rdkafka)
+if(WIN32)
+    set(win32_sources ../win32/wingetopt.c ../win32/wingetopt.h)
+    set(win32_compile_defs "LIBRDKAFKACPP_EXPORTS=0")
+endif(WIN32)
 
-add_executable(rdkafka_simple_producer rdkafka_simple_producer.c)
+add_executable(rdkafka_simple_producer rdkafka_simple_producer.c ${win32_sources})
 target_link_libraries(rdkafka_simple_producer PUBLIC rdkafka)
 
-add_executable(rdkafka_consumer_example rdkafka_consumer_example.c)
-target_link_libraries(rdkafka_consumer_example PUBLIC rdkafka)
-
-add_executable(rdkafka_performance rdkafka_performance.c)
+add_executable(rdkafka_performance rdkafka_performance.c ${win32_sources})
 target_link_libraries(rdkafka_performance PUBLIC rdkafka)
 
-add_executable(rdkafka_example_cpp rdkafka_example.cpp)
+add_executable(rdkafka_example_cpp rdkafka_example.cpp ${win32_sources})
 target_link_libraries(rdkafka_example_cpp PUBLIC rdkafka++)
+target_compile_definitions(rdkafka_example_cpp PRIVATE ${win32_compile_defs})
 
-add_executable(kafkatest_verifiable_client kafkatest_verifiable_client.cpp)
-target_link_libraries(kafkatest_verifiable_client PUBLIC rdkafka++)
-
-add_executable(rdkafka_consumer_example_cpp rdkafka_consumer_example.cpp)
+add_executable(rdkafka_consumer_example_cpp rdkafka_consumer_example.cpp ${win32_sources})
 target_link_libraries(rdkafka_consumer_example_cpp PUBLIC rdkafka++)
+target_compile_definitions(rdkafka_consumer_example_cpp PRIVATE ${win32_compile_defs})
+
+# The targets below has Unix include dirs and do not compile on Windows.
+if(NOT WIN32)
+    add_executable(rdkafka_example rdkafka_example.c)
+    target_link_libraries(rdkafka_example PUBLIC rdkafka)
+    
+    add_executable(rdkafka_consumer_example rdkafka_consumer_example.c)
+    target_link_libraries(rdkafka_consumer_example PUBLIC rdkafka)
+    
+    add_executable(kafkatest_verifiable_client kafkatest_verifiable_client.cpp)
+    target_link_libraries(kafkatest_verifiable_client PUBLIC rdkafka++)
+endif(NOT WIN32)

--- a/packaging/cmake/README.md
+++ b/packaging/cmake/README.md
@@ -3,8 +3,6 @@
 The cmake build mode is experimental and not officially supported,
 the community is asked to maintain and support this mode through PRs.
 
-On Windows the option WITH_PLUGINS is set to off by default, but in src/win32_config.h macro WITH_PLUGINS is set to 1, this cause a link error, so you have to manually set WITH_PLUGINS to 0 in src/win32_config.h for cmake build to work without link errors.
-
 Set up build environment (from top-level librdkafka directory):
 
     $ cmake -H. -B_cmake_build

--- a/packaging/cmake/README.md
+++ b/packaging/cmake/README.md
@@ -3,6 +3,7 @@
 The cmake build mode is experimental and not officially supported,
 the community is asked to maintain and support this mode through PRs.
 
+On Windows the option WITH_PLUGINS is set to off by default, but in src/win32_config.h macro WITH_PLUGINS is set to 1, this cause a link error, so you have to manually set WITH_PLUGINS to 0 in src/win32_config.h for cmake build to work without link errors.
 
 Set up build environment (from top-level librdkafka directory):
 

--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -17,7 +17,9 @@ target_link_libraries(rdkafka++ PUBLIC rdkafka)
 
 # Support '#include <rdkafcpp.h>'
 target_include_directories(rdkafka++ PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
-
+if(NOT RDKAFKA_BUILD_STATIC)
+    target_compile_definitions(rdkafka++ PRIVATE LIBRDKAFKACPP_EXPORTS)
+endif()
 install(
     TARGETS rdkafka++
     EXPORT "${targets_export_name}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,12 +52,12 @@ set(
     lz4hc.c
 )
 
-if(WITH_LIBDL)
-    list(APPEND sources rddl.c)
+if(WITH_LIBDL OR WIN32)
+  list(APPEND sources rddl.c)
 endif()
 
 if(WITH_PLUGINS)
-    list(APPEND sources rdkafka_plugin.c)
+  list(APPEND sources rdkafka_plugin.c)
 endif()
 
 if(WIN32)
@@ -78,7 +78,30 @@ if(NOT HAVE_REGEX)
   list(APPEND sources regexp.c)
 endif()
 
+# Define flags with cmake instead of by defining them on win32_config.h
+if(WITHOUT_WIN32_CONFIG)
+  if(WITH_SSL)
+    list(APPEND rdkafka_compile_definitions WITH_SSL)
+  endif(WITH_SSL)
+  if(WITH_ZLIB)
+    list(APPEND rdkafka_compile_definitions WITH_ZLIB)
+  endif(WITH_ZLIB)
+  if(WITH_SNAPPY)
+    list(APPEND rdkafka_compile_definitions WITH_SNAPPY)
+  endif(WITH_SNAPPY)
+  if(WITH_SASL_SCRAM)
+    list(APPEND rdkafka_compile_definitions WITH_SASL_SCRAM)
+  endif(WITH_SASL_SCRAM)
+  if(ENABLE_DEVEL)
+    list(APPEND rdkafka_compile_definitions ENABLE_DEVEL)
+  endif(ENABLE_DEVEL)
+  if(WITH_PLUGINS)
+    list(APPEND rdkafka_compile_definitions WITH_PLUGINS)
+  endif(WITH_PLUGINS)
+endif()
+
 option(RDKAFKA_BUILD_STATIC "Build static rdkafka library" OFF)
+
 if(RDKAFKA_BUILD_STATIC)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(RDKAFKA_BUILD_MODE STATIC)
@@ -90,9 +113,17 @@ add_library(rdkafka ${RDKAFKA_BUILD_MODE} ${sources})
 
 # Support '#include <rdkafka.h>'
 target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
+target_compile_definitions(rdkafka PUBLIC ${rdkafka_compile_definitions})
 if(RDKAFKA_BUILD_STATIC)
   target_compile_definitions(rdkafka PUBLIC LIBRDKAFKA_STATICLIB)
 endif()
+if(WIN32)    
+  target_link_libraries(rdkafka PUBLIC crypt32)
+  if(NOT RDKAFKA_BUILD_STATIC)
+    target_compile_definitions(rdkafka PRIVATE LIBRDKAFKA_EXPORTS)  
+  endif()
+endif()
+
 # We need 'dummy' directory to support `#include "../config.h"` path
 set(dummy "${GENERATED_DIR}/dummy")
 file(MAKE_DIRECTORY "${dummy}")

--- a/src/win32_config.h
+++ b/src/win32_config.h
@@ -31,10 +31,12 @@
  */
 #pragma once
 
+#ifndef WITHOUT_WIN32_CONFIG
 #define WITH_SSL 1
 #define WITH_ZLIB 1
 #define WITH_SNAPPY 1
 #define WITH_SASL_SCRAM 1
 #define ENABLE_DEVEL 0
 #define WITH_PLUGINS 1
+#endif
 #define SOLIB_EXT ".dll"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,12 +72,20 @@ set(
     0077-compaction.c
     8000-idle.cpp
     test.c
-    testcpp.cpp
-    sockem.c
+    testcpp.cpp    
 )
+
+if(NOT WIN32)
+    list(APPEND sources sockem.c)
+else()
+    list(APPEND sources ../src/tinycthread.c)
+endif()
 
 add_executable(rdkafka_test ${sources})
 target_link_libraries(rdkafka_test PUBLIC rdkafka++)
+if(WIN32)
+    target_compile_definitions(rdkafka_test PRIVATE LIBRDKAFKACPP_EXPORTS=0)
+endif(WIN32)
 
 add_test(NAME RdKafkaTestInParallel COMMAND rdkafka_test -p5)
 add_test(NAME RdKafkaTestSequentially COMMAND rdkafka_test -p1)


### PR DESCRIPTION
In Windows, the option WITH_PLUGINS is set to OFF, but in src/win32_config.h you can find #define WITH_PLUGINS 1.
This cause link errors when you link against librdkafka. So you have to manually set #define WITH_PLUGINS 0 for the cmake build to work properly.