### PR TITLE
Create a new rd_kafka_conf_set_free_payload_cb API to set the callbac…

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1409,6 +1409,9 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *app_conf,
 		rk->rk_conf.enabled_events |= RD_KAFKA_EVENT_REBALANCE;
 	if (rk->rk_conf.offset_commit_cb)
 		rk->rk_conf.enabled_events |= RD_KAFKA_EVENT_OFFSET_COMMIT;
+	if (rk->rk_conf.free_payload_cb)
+		rk->rk_conf.enabled_events |= RD_KAFKA_EVENT_FREE_PAYLOAD;
+
 
 	/* Convenience Kafka protocol null bytes */
 	rk->rk_null_bytes = rd_kafkap_bytes_new(NULL, 0);
@@ -2720,6 +2723,11 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
         case RD_KAFKA_OP_TERMINATE:
                 /* nop: just a wake-up */
                 break;
+
+        case RD_KAFKA_OP_PAYLOAD_FREE:
+            if (likely(rk->rk_conf.free_payload_cb != NULL))
+                    rk->rk_conf.free_payload_cb(rk, rko->rko_u.payload_free.payload);
+            break;
 
         default:
                 rd_kafka_assert(rk, !*"cant handle op type");

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1329,6 +1329,11 @@ void rd_kafka_conf_set_dr_msg_cb(rd_kafka_conf_t *conf,
                                                      rkmessage,
                                                      void *opaque));
 
+RD_EXPORT
+void rd_kafka_conf_set_free_payload_cb (rd_kafka_conf_t *conf,
+			      void (*free_payload_cb) (rd_kafka_t *rk,
+					     void *payload));
+
 
 /**
  * @brief \b Consumer: Set consume callback for use with rd_kafka_consumer_poll()
@@ -3448,6 +3453,7 @@ typedef int rd_kafka_event_type_t;
 #define RD_KAFKA_EVENT_REBALANCE     0x10 /**< Group rebalance (consumer) */
 #define RD_KAFKA_EVENT_OFFSET_COMMIT 0x20 /**< Offset commit result */
 #define RD_KAFKA_EVENT_STATS         0x40 /**< Stats */
+#define RD_KAFKA_EVENT_FREE_PAYLOAD  0x50 /**< Free message payload when RD_KAFKA_MSG_F_FREE is used */
 
 
 typedef struct rd_kafka_op_s rd_kafka_event_t;

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -761,6 +761,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	  _RK(dr_err_only),
 	  "Only provide delivery reports for failed messages.",
 	  0, 1, 0 },
+	{ _RK_GLOBAL|_RK_PRODUCER, "free_payload_cb", _RK_C_PTR,
+	      _RK(free_payload_cb),
+	      "Free payload callback (set with rd_kafka_conf_set_free_payload_cb())" },
 	{ _RK_GLOBAL|_RK_PRODUCER, "dr_cb", _RK_C_PTR,
 	  _RK(dr_cb),
 	  "Delivery report callback (set with rd_kafka_conf_set_dr_cb())" },
@@ -1703,6 +1706,9 @@ void rd_kafka_conf_set_dr_msg_cb (rd_kafka_conf_t *conf,
         conf->dr_msg_cb = dr_msg_cb;
 }
 
+void rd_kafka_conf_set_free_payload_cb(rd_kafka_conf_t *conf, void (*free_payload_cb)(rd_kafka_t *rk, void *payload)) {
+    conf->free_payload_cb = free_payload_cb;
+}
 
 void rd_kafka_conf_set_consume_cb (rd_kafka_conf_t *conf,
                                    void (*consume_cb) (rd_kafka_message_t *

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -258,6 +258,8 @@ struct rd_kafka_conf_s {
         int    log_thread_name;
         int    log_connection_close;
 
+        void (*free_payload_cb) (rd_kafka_t *rk, void *payload);
+
         /* Error callback */
 	void (*error_cb) (rd_kafka_t *rk, int err,
 			  const char *reason, void *opaque);

--- a/src/rdkafka_event.c
+++ b/src/rdkafka_event.c
@@ -53,6 +53,8 @@ const char *rd_kafka_event_name (const rd_kafka_event_t *rkev) {
 		return "OffsetCommit";
 	case RD_KAFKA_EVENT_STATS:
 		return "Stats";
+	case RD_KAFKA_EVENT_FREE_PAYLOAD:
+		return "PayloadFree";
 	default:
 		return "?unknown?";
 	}

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -107,6 +107,7 @@ typedef enum {
         RD_KAFKA_OP_METADATA,        /* Metadata response */
         RD_KAFKA_OP_LOG,             /* Log */
         RD_KAFKA_OP_WAKEUP,          /* Wake-up signaling */
+        RD_KAFKA_OP_PAYLOAD_FREE, /* Free message payload */
         RD_KAFKA_OP__END
 } rd_kafka_op_type_t;
 
@@ -320,6 +321,10 @@ struct rd_kafka_op_s {
                         int  level;
                         char *str;
                 } log;
+
+                struct {
+                        void *payload;
+                } payload_free;
 	} rko_u;
 };
 


### PR DESCRIPTION
Create a new rd_kafka_conf_set_free_payload_cb API to set the callback to free memory pointer passed to rd_kafka_produce API when RD_KAFKA_MSG_F_FREE flag is set. This is a common scenario when a custom application memory management is used. For performance-critical applications passing RD_KAFKA_MSG_F_FREE will eliminate extra malloc and memcpy calls to allocate and copy message payload memory. Librdkafka currently calls free(payload) to free memory in rd_kafka_msg_destroy when RD_KAFKA_MSG_F_FREE is set. This will result in undefined behavior when a custom memory allocation is used in the application and the payload pointer memory is not allocated with calloc, malloc, or realloc. To enable this scenario following code changes are proposed:

1. Create a new  rd_kafka_conf_set_free_payload_cb to set a free payload callback intended to call  custom memory deallocation application function.
2. Create a new RD_KAFKA_OP_PAYLOAD_FREE operation.
3. In rd_kafka_msg_destroy enqueue  RD_KAFKA_OP_PAYLOAD_FREE operation to the tail of the 'rkq' queue with RD_KAFKA_PRIO_MEDIUM priority. This will result in d_kafka_poll_cb call.
4. In rd_kafka_poll_cb free the payload by calling the application callback ( rk→rk_conf.free_payload_cb).

Only C code is currently implemented. C++ changes are proposed.

---
rdkafka_op.h
rdkafka_msg.c
rdkafka_event.c
rdkafka_conf.h
rdkafka_conf.c
rdkafka.h
rdkafka.c