### PR TITLE
Fix broker wake up

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2210,6 +2210,10 @@ static int rd_kafka_broker_op_serve (rd_kafka_broker_t *rkb,
                 ret = 0;
                 break;
 
+        case RD_KAFKA_OP_WAKEUP:
+                ret = 0;
+                break;
+
         default:
                 rd_kafka_assert(rkb->rkb_rk, !*"unhandled op type");
                 break;

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -586,8 +586,6 @@ rd_kafka_op_handle_std (rd_kafka_t *rk, rd_kafka_q_t *rkq,
                 return rd_kafka_op_call(rk, rkq, rko);
         else if (rko->rko_type == RD_KAFKA_OP_RECV_BUF) /* Handle Response */
                 rd_kafka_buf_handle_op(rko, rko->rko_err);
-        else if (rko->rko_type == RD_KAFKA_OP_WAKEUP)
-                ;/* do nothing, wake up is a fact anyway */
         else if (cb_type != RD_KAFKA_Q_CB_RETURN &&
                  rko->rko_type & RD_KAFKA_OP_REPLY &&
                  rko->rko_err == RD_KAFKA_RESP_ERR__DESTROY)


### PR DESCRIPTION
A WAKEUP operation in a broker queue didn't trigger immediate wakeup (`rd_kafka_q_pop` didn't return on WAKEUP). This fix makes sure that the broker immediately stops waiting on its operation queue in case of wake-up, instead of waiting the timeout in `rd_kafka_broker_ops_serve`.

I noticed this problem while working on https://github.com/edenhill/librdkafka/pull/1659.