### PR TITLE
metadata: Expose broker rack information from metadata request.

### DIFF
--- a/src-cpp/MetadataImpl.cpp
+++ b/src-cpp/MetadataImpl.cpp
@@ -42,11 +42,12 @@ Metadata::~Metadata() {};
 class BrokerMetadataImpl : public BrokerMetadata {
  public:
   BrokerMetadataImpl(const rd_kafka_metadata_broker_t *broker_metadata)
-  :broker_metadata_(broker_metadata),host_(broker_metadata->host) {}
+  :broker_metadata_(broker_metadata),host_(broker_metadata->host),rack_(broker_metadata->rack) {}
 
   int32_t      id() const{return broker_metadata_->id;}
 
   const std::string host() const {return host_;}
+  const std::string rack() const {return rack_;}
   int port() const {return broker_metadata_->port;}
 
   virtual ~BrokerMetadataImpl() {}
@@ -54,6 +55,7 @@ class BrokerMetadataImpl : public BrokerMetadata {
  private:
   const rd_kafka_metadata_broker_t *broker_metadata_;
   const std::string host_;
+  const std::string rack_;
 };
 
 /**

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2179,6 +2179,9 @@ class BrokerMetadata {
   /** @returns Broker listening port */
   virtual int port() const = 0;
 
+  /** @returns Broker rack */
+  virtual const std::string rack() const = 0;
+
   virtual ~BrokerMetadata() = 0;
 };
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3106,6 +3106,7 @@ typedef struct rd_kafka_metadata_broker {
         int32_t     id;             /**< Broker Id */
         char       *host;           /**< Broker hostname */
         int         port;           /**< Broker listening port */
+        char       *rack;           /**< Broker rack (if configured) */
 } rd_kafka_metadata_broker_t;
 
 /**

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -271,8 +271,7 @@ rd_kafka_parse_Metadata (rd_kafka_broker_t *rkb,
                 rd_kafka_buf_read_i32a(rkbuf, md->brokers[i].port);
 
                 if (ApiVersion >= 1) {
-                        rd_kafkap_str_t rack;
-                        rd_kafka_buf_read_str(rkbuf, &rack);
+                        rd_kafka_buf_read_str_tmpabuf(rkbuf, &tbuf, md->brokers[i].rack);
                 }
         }
 


### PR DESCRIPTION
Currently rack information is read (if available) and discarded.
This change preserves that and makes it available to the caller.