### PR TITLE
stop using typeof in rdkafka_transport.c

### DIFF
--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -141,7 +141,7 @@ ssize_t rd_kafka_transport_socket_sendmsg (rd_kafka_transport_t *rktrans,
         rd_slice_get_iov(slice, msg.msg_iov, &iovlen, IOV_MAX,
                          /* FIXME: Measure the effects of this */
                          rktrans->rktrans_sndbuf_size);
-        msg.msg_iovlen = (typeof(msg.msg_iovlen))iovlen;
+        msg.msg_iovlen = (int)iovlen;
 
 #ifdef sun
         /* See recvmsg() comment. Setting it here to be safe. */
@@ -259,7 +259,7 @@ rd_kafka_transport_socket_recvmsg (rd_kafka_transport_t *rktrans,
         rd_buf_get_write_iov(rbuf, msg.msg_iov, &iovlen, IOV_MAX,
                              /* FIXME: Measure the effects of this */
                              rktrans->rktrans_rcvbuf_size);
-        msg.msg_iovlen = (typeof(msg.msg_iovlen))iovlen;
+        msg.msg_iovlen = (int)iovlen;
 
 #ifdef sun
         /* SunOS doesn't seem to set errno when recvmsg() fails


### PR DESCRIPTION
The typeof operator is non standard, and at least XLC doesn't support
it.  While the type of msghdr::msg_iovlen is a bit of a mess the largest
value we will ever want to store in it is IOV_MAX. IOV_MAX should be
much smaller than INT_MAX, and in both cases the array whose length we
are providing is on the stack, so it should easily fit in an int.  We
know that the length should be non negative, so it should be safe to
cast to int, and then allow C promotion rules to widen to the actual
type of msg_iovlen if larger.