### PR TITLE
Log the value that couldn't be found for s2f configuration options

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -1330,8 +1330,9 @@ rd_kafka_anyconf_set_prop (int scope, void *conf,
 
 			/* No match */
 			rd_snprintf(errstr, errstr_size,
-				 "Invalid value for "
-				 "configuration property \"%s\"", prop->name);
+                                "Invalid value \"%.*s\" for "
+                                "configuration property \"%s\"",
+                                (int)(t-s), s, prop->name);
 			return RD_KAFKA_CONF_INVALID;
 
 		}

--- a/tests/0004-conf.c
+++ b/tests/0004-conf.c
@@ -381,6 +381,30 @@ int main_0004_conf (int argc, char **argv) {
 		rd_kafka_conf_destroy(conf);
 	}
 
+        {
+                rd_kafka_conf_res_t res;
+
+                TEST_SAY("Error reporting for S2F properties\n");
+                conf = rd_kafka_conf_new();
+
+                res = rd_kafka_conf_set(conf, "debug",
+                        "cgrp,invalid-value,topic", errstr, sizeof(errstr));
+
+                TEST_ASSERT(res == RD_KAFKA_CONF_INVALID,
+                        "expected 'debug=invalid-value' to fail with INVALID, "
+                        "not %d", res);
+                TEST_ASSERT(strstr(errstr, "invalid-value"),
+                        "expected invalid value to be mentioned in error, "
+                        "not \"%s\"", errstr);
+                TEST_ASSERT(
+                        !strstr(errstr, "cgrp") && !strstr(errstr, "topic"),
+                        "expected only invalid value to be mentioned, "
+                        "not \"%s\"", errstr);
+                TEST_SAY(_C_GRN "Ok: %s\n" _C_CLR, errstr);
+
+                rd_kafka_conf_destroy(conf);
+        }
+
 	/* Canonical int values, aliases, s2i-verified strings */
 	{
 		static const struct {


### PR DESCRIPTION
This helped me to find an issue in our configuration: node-rdkafka is lagging behind master (obviously), and the `consumer` value for the `debug` configuration option wasn't supported in that version yet.