### PR TITLE
Fix a segment fault error in rdkafka_buf with zero-length string.

### DIFF
--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -334,7 +334,7 @@ rd_tmpabuf_write_str0 (const char *func, int line,
                 int _klen;                                              \
                 rd_kafka_buf_read_i16a(rkbuf, (kstr)->len);             \
                 _klen = RD_KAFKAP_STR_LEN(kstr);                        \
-                if (RD_KAFKAP_STR_LEN0(_klen) == 0)                     \
+                if (RD_KAFKAP_STR_IS_NULL(kstr))                        \
                         (kstr)->str = NULL;                             \
                 else if (!((kstr)->str =                                \
                            rd_slice_ensure_contig(&rkbuf->rkbuf_reader, \


### PR DESCRIPTION
(RD_KAFKAP_STR_LEN0(_klen) == 0) will treat zero-length as true as well,
and then assign NULL to kstr->str to cause segment fault in future access.
Fixed it by change it to (RD_KAFKAP_STR_IS_NULL(kstr))