### PR TITLE
Added generic pollable interface

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,5 +26,5 @@ if(NOT WIN32)
     target_link_libraries(rdkafka_consumer_example PUBLIC rdkafka)
     
     add_executable(kafkatest_verifiable_client kafkatest_verifiable_client.cpp)
-    target_link_libraries(kafkatest_verifiable_client PUBLIC rdkafka++)
+    target_link_libraries(kafkatest_verifiable_client PUBLIC rdkafka++ rt) #librt for clock_gettime
 endif(NOT WIN32)

--- a/src-cpp/ConsumerImpl.cpp
+++ b/src-cpp/ConsumerImpl.cpp
@@ -38,7 +38,7 @@ RdKafka::Consumer::~Consumer () {}
 RdKafka::Consumer *RdKafka::Consumer::create (RdKafka::Conf *conf,
                                               std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  RdKafka::ConfImpl *confimpl = static_cast<RdKafka::ConfImpl *>(conf);
   RdKafka::ConsumerImpl *rkc = new RdKafka::ConsumerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
 
@@ -75,7 +75,7 @@ int64_t RdKafka::Consumer::OffsetTail (int64_t offset) {
 RdKafka::ErrorCode RdKafka::ConsumerImpl::start (Topic *topic,
                                                  int32_t partition,
                                                  int64_t offset) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_consume_start(topicimpl->rkt_, partition, offset) == -1)
     return static_cast<RdKafka::ErrorCode>(rd_kafka_last_error());
@@ -88,8 +88,8 @@ RdKafka::ErrorCode RdKafka::ConsumerImpl::start (Topic *topic,
                                                  int32_t partition,
                                                  int64_t offset,
                                                  Queue *queue) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
-  RdKafka::QueueImpl *queueimpl = dynamic_cast<RdKafka::QueueImpl *>(queue);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::QueueImpl *queueimpl = static_cast<RdKafka::QueueImpl *>(queue);
 
   if (rd_kafka_consume_start_queue(topicimpl->rkt_, partition, offset,
                                    queueimpl->queue_) == -1)
@@ -101,7 +101,7 @@ RdKafka::ErrorCode RdKafka::ConsumerImpl::start (Topic *topic,
 
 RdKafka::ErrorCode RdKafka::ConsumerImpl::stop (Topic *topic,
                                                 int32_t partition) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_consume_stop(topicimpl->rkt_, partition) == -1)
     return static_cast<RdKafka::ErrorCode>(rd_kafka_last_error());
@@ -113,7 +113,7 @@ RdKafka::ErrorCode RdKafka::ConsumerImpl::seek (Topic *topic,
 						int32_t partition,
 						int64_t offset,
 						int timeout_ms) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_seek(topicimpl->rkt_, partition, offset, timeout_ms) == -1)
     return static_cast<RdKafka::ErrorCode>(rd_kafka_last_error());
@@ -124,7 +124,7 @@ RdKafka::ErrorCode RdKafka::ConsumerImpl::seek (Topic *topic,
 RdKafka::Message *RdKafka::ConsumerImpl::consume (Topic *topic,
                                                   int32_t partition,
                                                   int timeout_ms) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
   rd_kafka_message_t *rkmessage;
 
   rkmessage = rd_kafka_consume(topicimpl->rkt_, partition, timeout_ms);
@@ -174,7 +174,7 @@ int RdKafka::ConsumerImpl::consume_callback (RdKafka::Topic* topic,
 
 RdKafka::Message *RdKafka::ConsumerImpl::consume (Queue *queue,
                                                   int timeout_ms) {
-  RdKafka::QueueImpl *queueimpl = dynamic_cast<RdKafka::QueueImpl *>(queue);
+  RdKafka::QueueImpl *queueimpl = static_cast<RdKafka::QueueImpl *>(queue);
   rd_kafka_message_t *rkmessage;
 
   rkmessage = rd_kafka_consume_queue(queueimpl->queue_, timeout_ms);
@@ -225,7 +225,7 @@ int RdKafka::ConsumerImpl::consume_callback (Queue *queue,
                                              int timeout_ms,
                                              RdKafka::ConsumeCb *consume_cb,
                                              void *opaque) {
-  RdKafka::QueueImpl *queueimpl = dynamic_cast<RdKafka::QueueImpl *>(queue);
+  RdKafka::QueueImpl *queueimpl = static_cast<RdKafka::QueueImpl *>(queue);
   ConsumerImplQueueCallback context(consume_cb, opaque);
   return rd_kafka_consume_callback_queue(queueimpl->queue_, timeout_ms,
                                          &ConsumerImplQueueCallback::consume_cb_trampoline,

--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -311,7 +311,7 @@ RdKafka::ErrorCode
 RdKafka::HandleImpl::set_log_queue (RdKafka::Queue *queue) {
         rd_kafka_queue_t *rkqu = NULL;
         if (queue) {
-                QueueImpl *queueimpl = dynamic_cast<QueueImpl *>(queue);
+                QueueImpl *queueimpl = static_cast<QueueImpl *>(queue);
                 rkqu = queueimpl->queue_;
         }
         return static_cast<RdKafka::ErrorCode>(
@@ -328,7 +328,7 @@ partitions_to_c_parts (const std::vector<RdKafka::TopicPartition*> &partitions){
 
   for (unsigned int i = 0 ; i < partitions.size() ; i++) {
     const RdKafka::TopicPartitionImpl *tpi =
-        dynamic_cast<const RdKafka::TopicPartitionImpl*>(partitions[i]);
+        static_cast<const RdKafka::TopicPartitionImpl*>(partitions[i]);
     rd_kafka_topic_partition_t *rktpar =
       rd_kafka_topic_partition_list_add(c_parts,
 					tpi->topic_.c_str(), tpi->partition_);
@@ -351,7 +351,7 @@ update_partitions_from_c_parts (std::vector<RdKafka::TopicPartition*> &partition
     /* Find corresponding C++ entry */
     for (unsigned int j = 0 ; j < partitions.size() ; j++) {
       RdKafka::TopicPartitionImpl *pp =
-	dynamic_cast<RdKafka::TopicPartitionImpl*>(partitions[j]);
+	static_cast<RdKafka::TopicPartitionImpl*>(partitions[j]);
       if (!strcmp(p->topic, pp->topic_.c_str()) &&
 	  p->partition == pp->partition_) {
 	pp->offset_ = p->offset;

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -36,7 +36,7 @@ RdKafka::KafkaConsumer::~KafkaConsumer () {}
 RdKafka::KafkaConsumer *RdKafka::KafkaConsumer::create (RdKafka::Conf *conf,
                                                         std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  RdKafka::ConfImpl *confimpl = static_cast<RdKafka::ConfImpl *>(conf);
   RdKafka::KafkaConsumerImpl *rkc = new RdKafka::KafkaConsumerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
   size_t grlen;
@@ -219,7 +219,7 @@ RdKafka::ErrorCode
 RdKafka::KafkaConsumerImpl::seek (const RdKafka::TopicPartition &partition,
                                   int timeout_ms) {
   const RdKafka::TopicPartitionImpl *p =
-    dynamic_cast<const RdKafka::TopicPartitionImpl*>(&partition);
+    static_cast<const RdKafka::TopicPartitionImpl*>(&partition);
   rd_kafka_topic_t *rkt;
 
   if (!(rkt = rd_kafka_topic_new(rk_, p->topic_.c_str(), NULL)))

--- a/src-cpp/ProducerImpl.cpp
+++ b/src-cpp/ProducerImpl.cpp
@@ -52,7 +52,7 @@ static void dr_msg_cb_trampoline (rd_kafka_t *rk,
 RdKafka::Producer *RdKafka::Producer::create (RdKafka::Conf *conf,
                                               std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  RdKafka::ConfImpl *confimpl = static_cast<RdKafka::ConfImpl *>(conf);
   RdKafka::ProducerImpl *rkp = new RdKafka::ProducerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
 
@@ -94,7 +94,7 @@ RdKafka::ErrorCode RdKafka::ProducerImpl::produce (RdKafka::Topic *topic,
                                                    void *payload, size_t len,
                                                    const std::string *key,
                                                    void *msg_opaque) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_produce(topicimpl->rkt_, partition, msgflags,
                        payload, len,
@@ -113,7 +113,7 @@ RdKafka::ErrorCode RdKafka::ProducerImpl::produce (RdKafka::Topic *topic,
                                                    const void *key,
                                                    size_t key_len,
                                                    void *msg_opaque) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_produce(topicimpl->rkt_, partition, msgflags,
                        payload, len, key, key_len,
@@ -130,7 +130,7 @@ RdKafka::ProducerImpl::produce (RdKafka::Topic *topic,
                                 const std::vector<char> *payload,
                                 const std::vector<char> *key,
                                 void *msg_opaque) {
-  RdKafka::TopicImpl *topicimpl = dynamic_cast<RdKafka::TopicImpl *>(topic);
+  RdKafka::TopicImpl *topicimpl = static_cast<RdKafka::TopicImpl *>(topic);
 
   if (rd_kafka_produce(topicimpl->rkt_, partition, RD_KAFKA_MSG_F_COPY,
                        payload ? (void *)&(*payload)[0] : NULL,

--- a/src-cpp/QueueImpl.cpp
+++ b/src-cpp/QueueImpl.cpp
@@ -30,10 +30,6 @@
 
 #include "rdkafkacpp_int.h"
 
-RdKafka::Queue::~Queue () {
-
-}
-
 RdKafka::Queue *RdKafka::Queue::create (Handle *base) {
   RdKafka::QueueImpl *queueimpl = new RdKafka::QueueImpl;
   queueimpl->queue_ = rd_kafka_queue_new(dynamic_cast<HandleImpl*>(base)->rk_);

--- a/src-cpp/QueueImpl.cpp
+++ b/src-cpp/QueueImpl.cpp
@@ -41,7 +41,7 @@ RdKafka::QueueImpl::forward (Queue *queue) {
   if (!queue) {
     rd_kafka_queue_forward(queue_, NULL);
   } else {
-    QueueImpl *queueimpl = dynamic_cast<QueueImpl *>(queue);
+    QueueImpl *queueimpl = static_cast<QueueImpl *>(queue);
     rd_kafka_queue_forward(queue_, queueimpl->queue_);
   }
   return RdKafka::ERR_NO_ERROR;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -952,7 +952,7 @@ class RD_EXPORT Conf {
  * @brief Base class for generic polling functionality.
  */
    
-struct Pollable
+struct RD_EXPORT Pollable
 {
 	virtual ~Pollable(){}
 	

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -281,7 +281,7 @@ class ConfImpl : public Conf {
   Conf::ConfResult set (const std::string &name, const Conf *topic_conf,
                         std::string &errstr) {
     const ConfImpl *tconf_impl =
-        dynamic_cast<const RdKafka::ConfImpl *>(topic_conf);
+        static_cast<const RdKafka::ConfImpl *>(topic_conf);
     if (name != "default_topic_conf" || !tconf_impl->rkt_conf_) {
       errstr = "Invalid value type, expected RdKafka::Conf";
       return Conf::CONF_INVALID;
@@ -723,12 +723,12 @@ public:
     return static_cast<ErrorCode>(rd_kafka_commit(rk_, NULL, 1/*async*/));
   }
   ErrorCode commitSync (Message *message) {
-	  MessageImpl *msgimpl = dynamic_cast<MessageImpl*>(message);
+	  MessageImpl *msgimpl = static_cast<MessageImpl*>(message);
 	  return static_cast<ErrorCode>(
                   rd_kafka_commit_message(rk_, msgimpl->rkmessage_, 0/*sync*/));
   }
   ErrorCode commitAsync (Message *message) {
-	  MessageImpl *msgimpl = dynamic_cast<MessageImpl*>(message);
+	  MessageImpl *msgimpl = static_cast<MessageImpl*>(message);
 	  return static_cast<ErrorCode>(
                   rd_kafka_commit_message(rk_, msgimpl->rkmessage_,1/*async*/));
   }

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -704,12 +704,8 @@ public:
 
 
 
-class KafkaConsumerImpl : virtual public KafkaConsumer, virtual public HandleImpl {
+class KafkaConsumerImpl : public KafkaConsumer, public HandleImpl {
 public:
-  ~KafkaConsumerImpl () {
-
-  }
-
   static KafkaConsumer *create (Conf *conf, std::string &errstr);
 
   ErrorCode assignment (std::vector<TopicPartition*> &partitions);
@@ -825,7 +821,7 @@ private:
 };
 
 
-class QueueImpl : virtual public Queue {
+class QueueImpl : public Queue {
  public:
   ~QueueImpl () {
     rd_kafka_queue_destroy(queue_);
@@ -834,6 +830,7 @@ class QueueImpl : virtual public Queue {
   ErrorCode forward (Queue *queue);
   Message *consume (int timeout_ms);
   int poll (int timeout_ms);
+  void yield () { rd_kafka_yield(NULL); }
   void io_event_enable(int fd, const void *payload, size_t size);
 
   rd_kafka_queue_t *queue_;
@@ -843,7 +840,7 @@ class QueueImpl : virtual public Queue {
 
 
 
-class ConsumerImpl : virtual public Consumer, virtual public HandleImpl {
+class ConsumerImpl : public Consumer, public HandleImpl {
  public:
   ~ConsumerImpl () {
     rd_kafka_destroy(rk_); };
@@ -865,7 +862,7 @@ class ConsumerImpl : virtual public Consumer, virtual public HandleImpl {
 
 
 
-class ProducerImpl : virtual public Producer, virtual public HandleImpl {
+class ProducerImpl : public Producer, public HandleImpl {
 
  public:
   ~ProducerImpl () { if (rk_) rd_kafka_destroy(rk_); };


### PR DESCRIPTION
**Description:**
- Refactored poll/yield into base class for generic programming
- Removed unwanted virtual derivation in some classes as it makes static up-casting impossible (and has heavy runtime performance cost)
- Removed superfluous destructors (much better to leave compiler defaulted ones in place until specific logic needs to be inserted in them)
- Queue class now also has a **yield()** method. This is actually desirable as **Queue::poll()** calls **rd_kafka_q_serve()** which does check for the yield flag to be set. 
- Fixed a linker dependency on _librt_ (CMake would not compile on Redhat 7)

Example use of Pollable interface:

```
using poll_vector = std::vector<std::shared_ptr<RdKafka::Pollable>>;
poll_vector polls;

for (size_t i = 0; i < 10; ++i)
{
    polls.emplace_back(Producer::Create(...));
    polls.emplace_back(Consumer::Create(...));
}

//generic poll loop
void pollLoop(const poll_vector& polls)
{
    while (1)
    {
        for (auto&& pollable : polls) pollable->poll();
        std::this_thread::sleep_for(std::chrono::milliseconds(100));
    }
}

std::thread t(pollLoop, polls); //run loop
```
