### PR TITLE
provide scope validation for config options

### DIFF
--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -298,6 +298,9 @@ struct rd_kafka_conf_s {
 
         /* For use with value-less properties. */
         int     dummy;
+        
+        /* Identifies the scope of this configuration (e.g. producer or consumer) */
+        int scope;
 };
 
 int rd_kafka_socket_cb_linux (int domain, int type, int protocol, void *opaque);
@@ -341,6 +344,9 @@ struct rd_kafka_topic_conf_s {
 
 	/* Application provided opaque pointer (this is rkt_opaque) */
 	void   *opaque;
+	
+    /* Identifies the scope of this configuration (e.g. producer or consumer) */
+    int scope;
 };
 
 

--- a/tests/0004-conf.c
+++ b/tests/0004-conf.c
@@ -223,17 +223,17 @@ int main_0004_conf (int argc, char **argv) {
 	rd_kafka_conf_t *ignore_conf, *conf, *conf2;
 	rd_kafka_topic_conf_t *ignore_topic_conf, *tconf, *tconf2;
 	char errstr[512];
-        rd_kafka_resp_err_t err;
+	rd_kafka_resp_err_t err;
 	const char **arr_orig, **arr_dup;
 	size_t cnt_orig, cnt_dup;
 	int i;
-        const char *topic;
+	const char *topic;
 	static const char *gconfs[] = {
 		"message.max.bytes", "12345", /* int property */
 		"client.id", "my id", /* string property */
 		"debug", "topic,metadata,interceptor", /* S2F property */
 		"topic.blacklist", "__.*", /* #778 */
-                "auto.offset.reset", "earliest", /* Global->Topic fallthru */
+		"auto.offset.reset", "earliest", /* Global->Topic fallthru */
 #if WITH_ZLIB
 		"compression.codec", "gzip", /* S2I property */
 #endif
@@ -251,7 +251,7 @@ int main_0004_conf (int argc, char **argv) {
 	rd_kafka_conf_destroy(ignore_conf);
 	rd_kafka_topic_conf_destroy(ignore_topic_conf);
 
-        topic = test_mk_topic_name("0004", 0);
+	topic = test_mk_topic_name("0004", 0);
 
 	/* Set up a global config object */
 	conf = rd_kafka_conf_new();


### PR DESCRIPTION
### Description
* Provided scope validation for handle and topic configuration settings.
* Provided scope validation for callbacks.
* State is stored in the `scope` member of the configuration handles. As options are added, the configuration scope is also updated to reflect the scope of the option. If at some point an option is added which does not match the current scope state, `RD_KAFKA_CONF_SCOPE_MISMATCH` is returned. 
* Default topic configurations are made to reflect the scope of the handle configuration and vice-versa.
* Duplication of a configuration will preserve it's current scope value.
* By default the scope starts as `RD_GLOBAL` for handle configurations and `RD_TOPIC` for topic configurations.
* `RD_CGRP` will set the configuration scope to `RD_CONSUMER`.
* The feature can be enabled/disabled via `void rd_kafka_conf_enable_scope_validation(int enable)`. By default it is _disabled_.