### PR TITLE
revise src/rdkafka_sasl_cyrus.c

### DIFF
--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -457,7 +457,9 @@ static int rd_kafka_sasl_cyrus_client_new (rd_kafka_transport_t *rktrans,
         memcpy(state->callbacks, callbacks, sizeof(callbacks));
 
         /* Acquire or refresh ticket if kinit is configured */ 
-        rd_kafka_sasl_cyrus_kinit_refresh(rkb);
+        if(rd_kafka_sasl_cyrus_kinit_refresh(rkb) != 0){
+		return -1;
+	};
 
         r = sasl_client_new(rk->rk_conf.sasl.service_name, hostname,
                             NULL, NULL, /* no local & remote IP checks */


### PR DESCRIPTION
When I use kerberos, I found a bug in src/rdkafka_sasl_cyrus.c.

When the keytab file is a wrong one, the data can still be transfered to kafka brokers. 

After I review the source of rdkafka for several times, I find that, the function rd_kafka_sasl_cyrus_client_new invokes the function rd_kafka_sasl_cyrus_kinit_refresh to kinit a keytab file. However, when rd_kafka_sasl_cyrus_kinit_refresh returns -1, it means kinit operation comes to a failure. But rd_kafka_sasl_cyrus_client_new can still execute the following code lines after invoking the function rd_kafka_sasl_cyrus_kinit_refresh. 