### PR TITLE
[Issues/1791] Add relative hyperlinks to table of contents in INTRODUCTION.md

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -25,7 +25,7 @@ The following chapters are available in this document
     * Producer API
     * Consumer API
   * Appendix
-    * Test detailts
+    * Test details
   
 
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -10,22 +10,22 @@ librdkafka also provides a native C++ interface.
 
 The following chapters are available in this document
 
-  * Performance
-    * Performance numbers
-    * High throughput
-    * Low latency
-    * Compression
-  * Message reliability
-  * Usage
-    * Documentation
-    * Initialization
-    * Configuration
-    * Threads and callbacks
-    * Brokers
-    * Producer API
-    * Consumer API
-  * Appendix
-    * Test details
+  * [Performance](#performance)
+    * [Performance numbers](#performance-numbers)
+    * [High throughput](#high-throughput)
+    * [Low latency](#low-latency)
+    * [Compression](#compression)
+  * [Message reliability](#message-reliability)
+  * [Usage](#usage)
+    * [Documentation](#documentation)
+    * [Initialization](#initialization)
+    * [Configuration](#configuration)
+    * [Threads and callbacks](#threads-and-callbacks)
+    * [Brokers](#brokers)
+    * [Producer API](#producer-api)
+    * [Consumer API](#simple-consumer-api-legacy)
+  * [Appendix](#appendix)
+    * [Test details](#test-details)
   
 
 


### PR DESCRIPTION
Fixes #1791
Also fixed a typo: "Test Detailts" => "Test Details"

It makes the document a tad bit uglier in plain-text mode but I believe the trade-off is okay, seeing as most people will be introduced through the GitHub interface for the first time.


