### PR TITLE
[FIX] pkg-config detection of libraries does not work

### DIFF
--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -167,7 +167,7 @@ for n in CFLAGS CPPFLAGS CXXFLAGS LDFLAGS ARFLAGS; do
     mkl_option "Compiler" "mk:$n" "--$n=$n" "Add $n flags"
 done
 
-mkl_option "Compiler" "env:PKG_CONFIG_PATH" "--pkg-config-path" "Extra paths for pkg-config"
+mkl_option "Compiler" "env:PKG_CONFIG_PATH" "--pkg-config-path=PKG_CONFIG_PATH" "Extra paths for pkg-config" "\$PKG_CONFIG_PATH"
 
 mkl_option "Compiler" "WITH_PROFILING" "--enable-profiling" "Enable profiling"
 mkl_option "Compiler" "WITH_STATIC_LINKING" "--enable-static" "Enable static linking"

--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -105,8 +105,6 @@ function checks {
     fi
     mkl_mkvar_set "pkgconfig" PKG_CONFIG $PKG_CONFIG
 
-    [[ ! -z "$PKG_CONFIG_PATH" ]] && mkl_env_append PKG_CONFIG_PATH "$PKG_CONFIG_PATH"
-
     # install
     if [ -z "$INSTALL" ]; then
 	if [[ $MKL_DISTRO == "SunOS" ]]; then

--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -105,6 +105,8 @@ function checks {
     fi
     mkl_mkvar_set "pkgconfig" PKG_CONFIG $PKG_CONFIG
 
+    [[ ! -z "$append_PKG_CONFIG_PATH" ]] && mkl_env_append PKG_CONFIG_PATH "$append_PKG_CONFIG_PATH" ":"
+
     # install
     if [ -z "$INSTALL" ]; then
 	if [[ $MKL_DISTRO == "SunOS" ]]; then
@@ -167,7 +169,7 @@ for n in CFLAGS CPPFLAGS CXXFLAGS LDFLAGS ARFLAGS; do
     mkl_option "Compiler" "mk:$n" "--$n=$n" "Add $n flags"
 done
 
-mkl_option "Compiler" "env:PKG_CONFIG_PATH" "--pkg-config-path=PKG_CONFIG_PATH" "Extra paths for pkg-config" "\$PKG_CONFIG_PATH"
+mkl_option "Compiler" "env:append_PKG_CONFIG_PATH" "--pkg-config-path=EXTRA_PATHS" "Extra paths for pkg-config"
 
 mkl_option "Compiler" "WITH_PROFILING" "--enable-profiling" "Enable profiling"
 mkl_option "Compiler" "WITH_STATIC_LINKING" "--enable-static" "Enable static linking"


### PR DESCRIPTION
This PR closes [Issue #1796 ](https://github.com/edenhill/librdkafka/issues/1796)

A log below shows that zlib, libcrypto, libssl are detected by pkg-config. A compilation was performed with a parameter `--pkg-config-path=$PKG_CONFIG_PATH`.

```
Removing config.log
rm -f config.log config.log.old
patching file mklove/modules/configure.cc
Hunk #1 succeeded at 169 (offset 2 lines).
patching file mklove/modules/configure.cc
checking for OS or distribution... ok (Ubuntu)
checking for C compiler from CC env... ok
checking for C++ compiler from CXX env... failed
checking for C++ compiler (g++)... ok
checking executable ld... ok
checking executable nm... ok
checking executable objdump... ok
checking executable strip... ok
checking for pkgconfig (by command)... ok
checking for install (by command)... ok
checking for PIC (by compile)... ok
checking for GNU-compatible linker options... ok
checking for GNU linker-script ld flag... ok
checking for __atomic_32 (by compile)... ok
checking for __atomic_64 (by compile)... ok
checking for socket (by compile)... ok
parsing version '0x000b04ff'... ok (0.11.4)
checking for librt (by pkg-config)... failed
checking for librt (by compile)... ok
checking for libpthread (by pkg-config)... failed
checking for libpthread (by compile)... ok
checking for libdl (by pkg-config)... failed
checking for libdl (by compile)... ok
checking for zlib (by pkg-config)... ok
checking for zlib (by compile)... ok (cached)
checking for libcrypto (by pkg-config)... ok
checking for libcrypto (by compile)... ok (cached)
checking for liblz4 (by pkg-config)... failed
checking for liblz4 (by compile)... failed (disable)
checking for libssl (by pkg-config)... ok
checking for libssl (by compile)... ok (cached)
checking for libsasl2 (by pkg-config)... failed
checking for libsasl2 (by compile)... failed (disable)
checking for libsasl (by pkg-config)... failed
checking for libsasl (by compile)... failed (disable)
checking for crc32chw (by compile)... failed (disable)
checking for regex (by compile)... ok
checking for strndup (by compile)... ok
checking for strerror_r (by compile)... ok
checking for pthread_setname_gnu (by compile)... ok
checking for nm (by env NM)... ok (cached)
checking for python (by command)... ok
Generated Makefile.config
Generated config.h
```