### PR TITLE
Missing return on error causes use-after-free in SASL code

### DIFF
--- a/src/rdkafka_sasl_scram.c
+++ b/src/rdkafka_sasl_scram.c
@@ -602,6 +602,7 @@ rd_kafka_sasl_scram_handle_server_first_message (rd_kafka_transport_t *rktrans,
                             "Invalid Base64 Salt in server-first-message");
                 rd_free(server_nonce);
                 rd_free(salt_b64.ptr);
+                return -1;
         }
         rd_free(salt_b64.ptr);
 


### PR DESCRIPTION
rd_kafka_sasl_scram_handle_server_first_message() in rdkafka_sasl_scram.c has a missing return in the case of "if (rd_base64_decode(&salt_b64, &salt) == -1)"

This results in salt_b64.ptr being free'ed twice and causes a use-after-free. Does not seem like a security issue to me, since it is not controlled by the attacker, but still worth fixing imo,