### PR TITLE
Fixed murmur2 partitioner to make it compatible with java version

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -671,7 +671,7 @@ rd_kafka_msg_partitioner_murmur2 (const rd_kafka_topic_t *rkt,
                                   int32_t partition_cnt,
                                   void *rkt_opaque,
                                   void *msg_opaque) {
-        return rd_murmur2(key, keylen) % partition_cnt;
+        return (rd_murmur2(key, keylen) & 0x7fffffff) % partition_cnt;
 }
 
 int32_t rd_kafka_msg_partitioner_murmur2_random (const rd_kafka_topic_t *rkt,
@@ -687,7 +687,7 @@ int32_t rd_kafka_msg_partitioner_murmur2_random (const rd_kafka_topic_t *rkt,
                                                        rkt_opaque,
                                                        msg_opaque);
         else
-                return rd_murmur2(key, keylen) % partition_cnt;
+                return (rd_murmur2(key, keylen) & 0x7fffffff) % partition_cnt;
 }
 
 


### PR DESCRIPTION
* In [kafka java producer](https://github.com/apache/kafka/blob/1.1.0/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java#L69), the partition is `abs(hash(key)) % num_partition`
* while in librdkafka it's`hash(key) % num_partition`. 

This incompatibility would cause trouble when the python producer and java producer are used to write to the same topic.