### PR TITLE
Some small enhancements to gen-ssl-certs.sh

### DIFF
--- a/tests/gen-ssl-certs.sh
+++ b/tests/gen-ssl-certs.sh
@@ -60,7 +60,7 @@ elif [[ $OP == "server" && ! -z "$CA_CERT" && ! -z "$PFX" && ! -z "$CN" ]]; then
 
     #Step 1
     echo "############ Generating key"
-    keytool -storepass "$PASS" -keypass "$PASS" -keystore ${PFX}server.keystore.jks -alias localhost -validity $VALIDITY -genkey <<EOF
+    keytool -storepass "$PASS" -keypass "$PASS" -keystore ${PFX}server.keystore.jks -alias localhost -validity $VALIDITY -genkey -keyalg RSA <<EOF
 $CN
 $OU
 $O
@@ -104,7 +104,7 @@ yes
 EOF
 
 	echo "############ Generating key"
-	keytool -storepass "$PASS" -keypass "$PASS" -keystore ${PFX}client.keystore.jks -alias localhost -validity $VALIDITY -genkey <<EOF
+	keytool -storepass "$PASS" -keypass "$PASS" -keystore ${PFX}client.keystore.jks -alias localhost -validity $VALIDITY -genkey -keyalg RSA <<EOF
 $CN
 $OU
 $O
@@ -131,7 +131,7 @@ EOF
     else
 	# Standard OpenSSL keys
 	echo "############ Generating key"
-	openssl genrsa -des3 -passout "pass:$PASS" -out ${PFX}client.key 1024 
+	openssl genrsa -des3 -passout "pass:$PASS" -out ${PFX}client.key 2048 
 	
 	echo "############ Generating request"
 	openssl req -passin "pass:$PASS" -passout "pass:$PASS" -key ${PFX}client.key -new -out ${PFX}client.req \
@@ -148,7 +148,7 @@ $PASS
 EOF
 
 	echo "########### Signing key"
-	openssl x509 -req -passin "pass:$PASS" -in ${PFX}client.req -CA $CA_CERT -CAkey ${CA_CERT}.key -CAserial ${CA_CERT}.srl -out ${PFX}client.pem
+	openssl x509 -req -passin "pass:$PASS" -in ${PFX}client.req -CA $CA_CERT -CAkey ${CA_CERT}.key -CAserial ${CA_CERT}.srl -out ${PFX}client.pem -days $VALIDITY
 
     fi
 


### PR DESCRIPTION
I promised a pull request in https://github.com/edenhill/librdkafka/issues/1765 and forgot about it. Not necessarily bad, because I found a few more things. In detail, this changes:

 - specify the keyalg to be RSA as it may default to DSA, which Java/Kafka(?) does not cope well with
 - pass the validity period when signing a non-java client key
 - change the key length to the current "recommended" minimum

(The last one might not be the best idea, if you are also using this script in some kind of CI setting. Please tell me what you think.)