### PR TITLE
Provide SSL callbacks to handle retrieving and processing certificates

### DIFF
--- a/examples/rdkafka_consumer_example.cpp
+++ b/examples/rdkafka_consumer_example.cpp
@@ -53,6 +53,10 @@
 #include <unistd.h>
 #endif
 
+extern "C" {
+#include "../src/rdkafka.h"
+}
+
 /*
  * Typically include path in a real application would be
  * #include <librdkafka/rdkafkacpp.h>

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -47,10 +47,14 @@
 #include <getopt.h>
 #endif
 
+extern "C" {
+#include "../src/rdkafka.h"
+}
+
 /*
- * Typically include path in a real application would be
- * #include <librdkafka/rdkafkacpp.h>
- */
+* Typically include path in a real application would be
+* #include <librdkafka/rdkafkacpp.h>
+*/
 #include "rdkafkacpp.h"
 
 

--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -108,7 +108,6 @@ int RdKafka::stats_cb_trampoline (rd_kafka_t *rk, char *json, size_t json_len,
   return 0;
 }
 
-
 int RdKafka::socket_cb_trampoline (int domain, int type, int protocol,
                                    void *opaque) {
   RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
@@ -121,6 +120,34 @@ int RdKafka::open_cb_trampoline (const char *pathname, int flags, mode_t mode,
   RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
 
   return handle->open_cb_->open_cb(pathname, flags, static_cast<int>(mode));
+}
+
+int RdKafka::cert_verify_cb_trampoline(unsigned char* cert, long len, void *opaque)
+{
+    RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
+
+#if WITH_SSL
+    return handle->cert_verify_cb_->cert_verify_cb(cert, len);
+#else
+    RD_UNUSED(cert);
+    RD_UNUSED(len);
+      
+    return 0;
+#endif
+}
+
+long RdKafka::cert_retrieve_cb_trampoline(rd_kafka_certificate_type_t type, unsigned char** buffer, void *opaque)
+{
+    RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
+
+#if WITH_SSL
+    return handle->cert_retrieve_cb_->cert_retrieve_cb(type, buffer);
+#else
+    RD_UNUSED(type);
+    RD_UNUSED(cert);
+
+    return 0;
+#endif
 }
 
 RdKafka::ErrorCode RdKafka::HandleImpl::metadata (bool all_topics,
@@ -226,6 +253,20 @@ void RdKafka::HandleImpl::set_common_config (RdKafka::ConfImpl *confimpl) {
     rd_kafka_conf_set_socket_cb(confimpl->rk_conf_,
                                 RdKafka::socket_cb_trampoline);
     socket_cb_ = confimpl->socket_cb_;
+  }
+
+  if (confimpl->cert_verify_cb_) {
+      rd_kafka_conf_set_cert_verify_cb(confimpl->rk_conf_,
+          RdKafka::cert_verify_cb_trampoline);
+
+      cert_verify_cb_ = confimpl->cert_verify_cb_;
+  }
+
+  if (confimpl->cert_retrieve_cb_) {
+      rd_kafka_conf_set_cert_retrieve_cb(confimpl->rk_conf_,
+          RdKafka::cert_retrieve_cb_trampoline);
+
+      cert_retrieve_cb_ = confimpl->cert_retrieve_cb_;
   }
 
   if (confimpl->open_cb_) {

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -715,7 +715,37 @@ public:
   virtual ~OffsetCommitCb() { }
 };
 
+/**
+* @brief Certificate verify callback class
+*/
+class RD_EXPORT CertVerifyCb {
+public:
+    /**
+    * @brief Set certificate verification callback.
+    *
+    * The verification of the broker certificate will processed
+    * by this callback.
+    */
+    virtual int cert_verify_cb(unsigned char* cert, long len) = 0;
 
+
+    virtual ~CertVerifyCb() {}
+};
+
+/**
+* @brief Certificate retrieve callback class
+*/
+class RD_EXPORT CertRetrieveCb {
+public:
+    /**
+    * @brief Set certificate retrieve callback.
+    *
+    * The retrieval of the cetificate specified by the type will be returned by this callback.
+    */
+    virtual long cert_retrieve_cb(rd_kafka_certificate_type_t type, unsigned char** buffer) = 0;
+
+    virtual ~CertRetrieveCb() {}
+};
 
 /**
  * @brief \b Portability: SocketCb callback class
@@ -878,6 +908,16 @@ class RD_EXPORT Conf {
                                 OffsetCommitCb *offset_commit_cb,
                                 std::string &errstr) = 0;
 
+  /** @brief Use with \p name = \c \"ssl_verify_cb\" */
+  virtual Conf::ConfResult set(const std::string &name,
+                               CertVerifyCb *cert_verify_cb,
+                               std::string &errstr) = 0;
+
+  /** @brief Use with \p name = \c \"ssl_retrieve_cb\" */
+  virtual Conf::ConfResult set(const std::string &name,
+                               CertRetrieveCb *cert_retrieve_cb,
+                               std::string &errstr) = 0;
+
   /** @brief Query single configuration value
    *
    * Do not use this method to get callbacks registered by the configuration file.
@@ -932,6 +972,12 @@ class RD_EXPORT Conf {
    *           returns the value in \p offset_commit_cb. */
   virtual Conf::ConfResult get(OffsetCommitCb *&offset_commit_cb) const = 0;
 
+  /** @brief Use with \p name = \c \"ssl_verify_cb\" */
+  virtual Conf::ConfResult get(CertVerifyCb *&cert_verify_cb) const = 0;
+
+  /** @brief Use with \p name = \c \"ssl_retrieve_cb\" */
+  virtual Conf::ConfResult get(CertRetrieveCb *&cert_retrieve_cb) const = 0;
+
   /** @brief Dump configuration names and values to list containing
    *         name,value tuples */
   virtual std::list<std::string> *dump () = 0;
@@ -939,6 +985,7 @@ class RD_EXPORT Conf {
   /** @brief Use with \p name = \c \"consume_cb\" */
   virtual Conf::ConfResult set (const std::string &name, ConsumeCb *consume_cb,
 				std::string &errstr) = 0;
+
 };
 
 /**@}*/

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -34,11 +34,20 @@
 #include <cstring>
 #include <stdlib.h>
 
-#include "rdkafkacpp.h"
-
 extern "C" {
 #include "../src/rdkafka.h"
 }
+
+#include "rdkafkacpp.h"
+
+
+#ifdef _MSC_VER
+/* Visual Studio */
+#include "../src/win32_config.h"
+#else
+/* POSIX / UNIX based systems */
+#include "../config.h" /* mklove output */
+#endif
 
 #ifdef _MSC_VER
 typedef int mode_t;
@@ -70,6 +79,9 @@ void offset_commit_cb_trampoline0 (
         rd_kafka_t *rk,
         rd_kafka_resp_err_t err,
         rd_kafka_topic_partition_list_t *c_offsets, void *opaque);
+
+int cert_verify_cb_trampoline(unsigned char* cert, long len, void *opaque);
+long cert_retrieve_cb_trampoline(rd_kafka_certificate_type_t type, unsigned char** buffer, void *opaque);
 
 rd_kafka_topic_partition_list_t *
     partitions_to_c_parts (const std::vector<TopicPartition*> &partitions);
@@ -233,6 +245,8 @@ class ConfImpl : public Conf {
       partitioner_kp_cb_(NULL),
       rebalance_cb_(NULL),
       offset_commit_cb_(NULL),
+      cert_verify_cb_(NULL),
+      cert_retrieve_cb_(NULL),
       rk_conf_(NULL),
       rkt_conf_(NULL){}
   ~ConfImpl () {
@@ -402,6 +416,42 @@ class ConfImpl : public Conf {
     return Conf::CONF_OK;
   }
 
+  Conf::ConfResult set(const std::string &name,
+                       CertVerifyCb *cert_verify_cb,
+                       std::string &errstr) {
+
+      if (name != "ssl_verify_cb") {
+          errstr = "Invalid value type, expected RdKafka::CertVerifyCb";
+          return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+          errstr = "Requires RdKafka::Conf::CONF_GLOBAL object";
+          return Conf::CONF_INVALID;
+      }
+
+      cert_verify_cb_ = cert_verify_cb;
+      return Conf::CONF_OK;
+  }
+
+  Conf::ConfResult set(const std::string &name,
+                       CertRetrieveCb *cert_retrieve_cb,
+                       std::string &errstr) {
+
+      if (name != "ssl_retrieve_cb") {
+          errstr = "Invalid value type, expected RdKafka::CertRetrieveCb";
+          return Conf::CONF_INVALID;
+      }
+
+      if (!rk_conf_) {
+          errstr = "Requires RdKafka::Conf::CONF_GLOBAL object";
+          return Conf::CONF_INVALID;
+      }
+
+      cert_retrieve_cb_ = cert_retrieve_cb;
+      return Conf::CONF_OK;
+  }
+
   Conf::ConfResult get(const std::string &name, std::string &value) const {
     if (name.compare("dr_cb") == 0 ||
         name.compare("event_cb") == 0 ||
@@ -410,7 +460,9 @@ class ConfImpl : public Conf {
         name.compare("socket_cb") == 0 ||
         name.compare("open_cb") == 0 ||
         name.compare("rebalance_cb") == 0 ||
-        name.compare("offset_commit_cb") == 0 ) {
+        name.compare("offset_commit_cb") == 0 ||
+        name.compare("ssl_verify_cb") == 0 ||
+        name.compare("ssl_retrieve_cb") == 0 ) {
       return Conf::CONF_INVALID;
     }
     rd_kafka_conf_res_t res = RD_KAFKA_CONF_INVALID;
@@ -498,7 +550,22 @@ class ConfImpl : public Conf {
       return Conf::CONF_OK;
     }
 
+  /** @brief Use with \p name = \c \"ssl_verify_cb\" */
+  Conf::ConfResult get(CertVerifyCb *&cert_verify_cb) const {
+      if (!rk_conf_)
+      return Conf::CONF_INVALID;
+      cert_verify_cb = this->cert_verify_cb_;
+      return Conf::CONF_OK;
+  }
+      
 
+  /** @brief Use with \p name = \c \"ssl_retrieve_cb\" */
+  virtual Conf::ConfResult get(CertRetrieveCb *&cert_retrieve_cb) const {
+      if (!rk_conf_)
+      return Conf::CONF_INVALID;
+      cert_retrieve_cb = this->cert_retrieve_cb_;
+      return Conf::CONF_OK;
+  }
 
   std::list<std::string> *dump ();
 
@@ -529,6 +596,8 @@ class ConfImpl : public Conf {
   PartitionerKeyPointerCb *partitioner_kp_cb_;
   RebalanceCb *rebalance_cb_;
   OffsetCommitCb *offset_commit_cb_;
+  CertVerifyCb* cert_verify_cb_;
+  CertRetrieveCb* cert_retrieve_cb_;
   ConfType conf_type_;
   rd_kafka_conf_t *rk_conf_;
   rd_kafka_topic_conf_t *rkt_conf_;
@@ -626,6 +695,8 @@ class HandleImpl : virtual public Handle {
   PartitionerKeyPointerCb *partitioner_kp_cb_;
   RebalanceCb *rebalance_cb_;
   OffsetCommitCb *offset_commit_cb_;
+  CertVerifyCb *cert_verify_cb_;
+  CertRetrieveCb *cert_retrieve_cb_;
 };
 
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1678,6 +1678,35 @@ void rd_kafka_conf_set_open_cb (rd_kafka_conf_t *conf,
 #endif
 
 /**
+* @enum rd_kafka_certificate_type_t
+*
+* @brief Type of certificates
+*
+* @sa rd_kafka_conf_set_get_cert_cb()
+*/
+typedef enum _rd_kafka_certificate_type_t {
+    RD_KAFKA_CERTIFICATE_PUBLIC_KEY, 
+    RD_KAFKA_CERTIFICATE_PRIVATE_KEY,
+    RD_KAFKA_CERTIFICATE_PRIVATE_KEY_PASS
+} rd_kafka_certificate_type_t;
+
+/**
+* @brief : Sets the verification callback of the broker certificate
+*
+*/
+RD_EXPORT
+void rd_kafka_conf_set_cert_verify_cb(rd_kafka_conf_t *conf,
+    int(*cert_verify_cb) (unsigned char* cert, long len, void *opaque));
+
+/**
+* @brief : Sets the callback to recieve the client certificate
+*
+*/
+RD_EXPORT
+void rd_kafka_conf_set_cert_retrieve_cb(rd_kafka_conf_t *conf,
+    long(*cert_retrieve_cb) (rd_kafka_certificate_type_t type, unsigned char** buffer, void *opaque));
+
+/**
  * @brief Sets the application's opaque pointer that will be passed to callbacks
  */
 RD_EXPORT
@@ -2777,9 +2806,6 @@ int rd_kafka_consume_callback_queue(rd_kafka_queue_t *rkqu,
 
 
 /**@}*/
-
-
-
 
 /**
  * @name Simple Consumer API (legacy): Topic+partition offset store.

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -530,6 +530,20 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	_RK(ssl.keystore_password),
 	"Client's keystore (PKCS#12) password."
 	},
+    { _RK_GLOBAL, "ssl.handshake.info.enable", _RK_C_BOOL,
+    _RK(ssl.handshake_info),
+    "Report diagnostic information during SSL handshake",
+    0, 1, 0
+    },
+    { _RK_GLOBAL, "ssl.certificate.verify_cb", _RK_C_PTR,
+    _RK(ssl.cert_verify_cb),
+    "Client certificate verification callback."
+    },
+    { _RK_GLOBAL, "ssl.certificate.retrieve_cb", _RK_C_PTR,
+    _RK(ssl.cert_retrieve_cb),
+    "Client certificate retrieve callback."
+    },
+    
 #endif /* WITH_SSL */
 
         /* Point user in the right direction if they try to apply
@@ -1884,6 +1898,27 @@ void rd_kafka_conf_set_open_cb (rd_kafka_conf_t *conf,
         conf->open_cb = open_cb;
 }
 #endif
+
+void
+rd_kafka_conf_set_cert_verify_cb(rd_kafka_conf_t *conf,
+    int(*cert_verify_cb) (unsigned char* cert, long len, void *opaque)) {
+#if WITH_SSL
+    conf->ssl.cert_verify_cb = cert_verify_cb;
+#else
+    RD_UNUSED(conf);
+    RD_UNUSED(cert_verify_cb);
+#endif
+}
+
+void rd_kafka_conf_set_cert_retrieve_cb(rd_kafka_conf_t *conf,
+    long(*cert_retrieve_cb) (rd_kafka_certificate_type_t type, unsigned char** buffer, void *opaque)) {
+#if WITH_SSL
+    conf->ssl.cert_retrieve_cb = cert_retrieve_cb;
+#else
+    RD_UNUSED(conf);
+    RD_UNUSED(cert_retrieve_cb);
+#endif
+}
 
 void rd_kafka_conf_set_opaque (rd_kafka_conf_t *conf, void *opaque) {
 	conf->opaque = opaque;

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -98,9 +98,6 @@ typedef enum {
         RD_KAFKA_OFFSET_METHOD_BROKER
 } rd_kafka_offset_method_t;
 
-
-
-
 /**
  * Optional configuration struct passed to rd_kafka_new*().
  *
@@ -159,6 +156,9 @@ struct rd_kafka_conf_s {
 		char *crl_location;
 		char *keystore_location;
 		char *keystore_password;
+        int handshake_info;
+        int(*cert_verify_cb) (unsigned char* cert, long len, void *opaque);
+        long(*cert_retrieve_cb) (rd_kafka_certificate_type_t type, unsigned char** buffer, void *opaque);
 	} ssl;
 #endif
 

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -824,8 +824,7 @@ static int rd_kafka_transport_ssl_connect (rd_kafka_broker_t *rkb,
         SSL_set_info_callback(rktrans->rktrans_ssl, ssl_info_callback);
     }
 
-
-        rd_kafka_transport_ssl_clear_error(rktrans);
+    rd_kafka_transport_ssl_clear_error(rktrans);
 
 	r = SSL_connect(rktrans->rktrans_ssl);
 	if (r == 1) {
@@ -1148,6 +1147,7 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
             rd_kafka_dbg(rk, SECURITY, "SSL",
                 "Callback failed to return valid private key certificate");
     }
+
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
 	/* Curves */
 	if (rk->rk_conf.ssl.curves_list) {

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -69,9 +69,8 @@
 #if WITH_SSL
 static mtx_t *rd_kafka_ssl_locks;
 static int    rd_kafka_ssl_locks_cnt;
+static int verify_context_index;
 #endif
-
-
 
 /**
  * Low-level socket close
@@ -470,13 +469,16 @@ void rd_kafka_transport_ssl_term (void) {
 
 	CRYPTO_set_id_callback(NULL);
 	CRYPTO_set_locking_callback(NULL);
-        CRYPTO_cleanup_all_ex_data();
+    EVP_cleanup();
+    CRYPTO_cleanup_all_ex_data();
+    ERR_free_strings();
 
 	for (i = 0 ; i < rd_kafka_ssl_locks_cnt ; i++)
 		mtx_destroy(&rd_kafka_ssl_locks[i]);
 
 	rd_free(rd_kafka_ssl_locks);
 
+    verify_context_index = -1;
 }
 
 
@@ -497,7 +499,11 @@ void rd_kafka_transport_ssl_init (void) {
 	
 	SSL_load_error_strings();
 	SSL_library_init();
+
+    ERR_load_BIO_strings();
 	OpenSSL_add_all_algorithms();
+    ERR_load_crypto_strings();
+    verify_context_index = SSL_get_ex_new_index(0, "ssl verify context", NULL, NULL, NULL);
 }
 
 
@@ -658,6 +664,126 @@ static int rd_kafka_transport_ssl_passwd_cb (char *buf, int size, int rwflag,
 	return pwlen;
 }
 
+int verify_broker_callback(X509_STORE_CTX* ctx, void* arg)
+{
+    int validate = 0;
+    char errstr[512];
+    rd_kafka_t* rk = NULL;
+
+    errstr[0] = '\0';
+    if (arg) {
+        rk = arg;
+
+        X509* cert;
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Verification of peer certificate.");
+
+        cert = ctx->cert;
+        if (cert) {
+            int len;
+            char* buf = NULL;
+
+            char *subj = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
+            char *issuer = X509_NAME_oneline(X509_get_issuer_name(cert), NULL, 0);
+
+            if (subj && issuer) {
+                rd_kafka_dbg(rk, SECURITY, "SSL", 
+                    "Validating certificate Subject: %s Issurer: %s", subj, issuer);
+            }
+
+            if (subj)
+                OPENSSL_free(subj);
+            if (issuer)
+                OPENSSL_free(issuer);
+
+            len = i2d_X509(cert, &buf);
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Calling client callback to verify certificate");
+
+            if (!rk->rk_conf.ssl.cert_verify_cb(buf, len, rk->rk_conf.opaque)) {
+                rd_snprintf(errstr, sizeof(errstr),
+                    "client certificate verification callback failed.");
+
+                validate = 0;
+                X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_UNTRUSTED);
+            }
+            else {
+                rd_kafka_dbg(rk, SECURITY, "SSL",
+                    "Client callback successfully verified certificate.");
+
+                validate = 1;
+            }
+            if (buf)
+                OPENSSL_free(buf);
+        }
+        else
+            rd_snprintf(errstr, sizeof(errstr),
+                "failed to retrieve X509 cert from ctx");
+    }
+
+    if (strlen(errstr) > 0)
+        rd_kafka_log(rk, LOG_ERR, "SSL", "%s", errstr);
+
+    return validate;
+}
+
+void ssl_info_callback(const SSL *ssl, int type, int ret)
+{
+    char errstr[512];
+    char *str;
+    int w;
+    int len = 0;
+
+    errstr[0] = '\0';
+    str = errstr;
+    rd_kafka_t* rk = SSL_get_ex_data(ssl, verify_context_index);
+    w = type& ~SSL_ST_MASK;
+
+    if (w & SSL_ST_CONNECT)
+        rd_snprintf(str, sizeof(errstr),
+            "SSL_connect ");
+
+    else if (w & SSL_ST_ACCEPT)
+        rd_snprintf(str, sizeof(errstr),
+            "SSL_accept ");
+
+    else
+        rd_snprintf(str, sizeof(errstr),
+            "undefined ");
+
+    len = (int)strlen(errstr);
+    str += len;
+
+    if (type & SSL_CB_LOOP)
+        rd_snprintf(str, sizeof(errstr) - len,
+            "%s:%s\n", str, SSL_state_string_long(ssl));
+
+    else if (type & SSL_CB_ALERT)
+    {
+        rd_snprintf(str, sizeof(errstr) - len,
+            "SSL3 alert %s:%s:%s\n",
+            (type & SSL_CB_READ) ? "read" : "write",
+            SSL_alert_type_string_long(ret),
+            SSL_alert_desc_string_long(ret));
+    }
+    else if (type & SSL_CB_EXIT)
+    {
+        if (ret == 0)
+            rd_snprintf(str, sizeof(errstr) -len,
+                "%s:failed in %s\n",
+                str, SSL_state_string_long(ssl));
+        else if (ret < 0)
+        {
+            rd_snprintf(str, sizeof(errstr) - len,
+                "%s:error in %s\n",
+                str, SSL_state_string_long(ssl));
+        }
+    }
+
+    if (strlen(errstr) > 0)
+        rd_kafka_log(rk, LOG_INFO, "SSL", "%s", errstr);
+}
+
 /**
  * Set up SSL for a newly connected connection
  *
@@ -688,6 +814,16 @@ static int rd_kafka_transport_ssl_connect (rd_kafka_broker_t *rkb,
 	    !SSL_set_tlsext_host_name(rktrans->rktrans_ssl, name))
 		goto fail;
 #endif
+
+    if (rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.handshake_info) {
+
+        rd_kafka_dbg(rktrans->rktrans_rkb->rkb_rk, SECURITY, "SSL",
+            "Registering handshake debug info");
+
+        SSL_set_ex_data(rktrans->rktrans_ssl, verify_context_index, rktrans->rktrans_rkb->rkb_rk);
+        SSL_set_info_callback(rktrans->rktrans_ssl, ssl_info_callback);
+    }
+
 
         rd_kafka_transport_ssl_clear_error(rktrans);
 
@@ -872,6 +1008,146 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 		}
 	}
 
+    /* Register the peer verify callback on the context */
+    if (rk->rk_conf.ssl.cert_verify_cb) {
+
+        unsigned int mode = SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Setting verification mode %u", mode);
+
+        SSL_CTX_set_verify(
+            ctx,mode,
+            NULL);
+
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Registering verification callback");
+
+        SSL_CTX_set_cert_verify_callback(
+            ctx,
+            verify_broker_callback,
+            rk);
+    }
+
+    if (rk->rk_conf.ssl.cert_retrieve_cb) {
+
+        unsigned char* buffer = NULL;
+        long len = 0;
+
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Calling callback to retrieve client's public key certificate");
+        len = rk->rk_conf.ssl.cert_retrieve_cb(RD_KAFKA_CERTIFICATE_PUBLIC_KEY, &buffer, rk->rk_conf.opaque);
+        if (len) {
+            X509* cert;
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Retrieved client's public key certificate %u bytes",
+                len);
+
+            cert = X509_new();
+            if (cert) {
+                if (!d2i_X509(&cert, &buffer, len))
+                    rd_snprintf(errstr, errstr_size,
+                        "Failed to parse public key certificate with %u bytes",
+                        len);
+
+                r = SSL_CTX_use_certificate(ctx, cert);
+                X509_free(cert);
+
+                if (r != 1)
+                    goto fail;
+            }
+            else
+                rd_snprintf(errstr, errstr_size,
+                    "Failed to initialize X509");
+        }
+        else
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Callback failed to return valid public key certificate");
+
+        /* Get private key */
+        rd_kafka_dbg(rk, SECURITY, "SSL",
+            "Calling callback to retrieve client's private key certificate");
+        len = rk->rk_conf.ssl.cert_retrieve_cb(RD_KAFKA_CERTIFICATE_PRIVATE_KEY, &buffer, rk->rk_conf.opaque);
+        if (len) {
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Retrieved client's private key certificate %u bytes",
+                len);
+
+                BIO* bio = BIO_new_mem_buf(buffer, len);
+                if (bio) {
+                    PKCS12 *p12 = d2i_PKCS12_bio(bio, NULL);
+                    if (p12) {
+                        /*Get the private key password*/
+                        rd_kafka_dbg(rk, SECURITY, "SSL",
+                            "Calling callback to retrieve client's private key password");
+                        len = rk->rk_conf.ssl.cert_retrieve_cb(RD_KAFKA_CERTIFICATE_PRIVATE_KEY_PASS, &buffer, rk->rk_conf.opaque);
+                        if (len) {
+                            rd_kafka_dbg(rk, SECURITY, "SSL",
+                                "Retrieved client's private key password %u bytes",
+                                len);
+                            EVP_PKEY* pkey;
+                            X509 *cert;
+                            STACK_OF(X509) *ca = NULL;
+                            if (!PKCS12_parse(p12, buffer, &pkey, &cert, &ca)) {
+                                rd_snprintf(errstr, errstr_size,
+                                    "Error reading PKCS#12");
+
+                                PKCS12_free(p12);
+                                BIO_free(bio);
+                                EVP_PKEY_free(pkey);
+                                X509_free(cert);
+                                if (ca != NULL)
+                                    sk_X509_pop_free(ca, X509_free);
+
+                                goto fail;
+                            }
+                            else {
+                                if (ca != NULL)
+                                    sk_X509_pop_free(ca, X509_free);
+
+                                X509_free(cert);
+
+                                rd_kafka_dbg(rk, SECURITY, "SSL",
+                                    "Setting client private key");
+
+                                r = SSL_CTX_use_PrivateKey(ctx, pkey);
+                                EVP_PKEY_free(pkey);
+
+                                if (r != 1) {
+                                    PKCS12_free(p12);
+                                    BIO_free(bio);
+
+                                    goto fail;
+                                }
+
+                                rd_kafka_dbg(rk, SECURITY, "SSL",
+                                    "Checking client private key");
+
+                                r = SSL_CTX_check_private_key(ctx);
+                                if (r != 1) {
+                                    PKCS12_free(p12);
+                                    BIO_free(bio);
+
+                                    goto fail;
+                                }
+                            }
+                        }
+                        
+                        PKCS12_free(p12);
+                    } else
+                        rd_snprintf(errstr, errstr_size,
+                            "d2i_PKCS12_bio failed");
+                    
+                    BIO_free(bio);
+                }
+                else
+                    rd_snprintf(errstr, errstr_size,
+                        "Failed to initialize BIO");
+        }
+        else
+            rd_kafka_dbg(rk, SECURITY, "SSL",
+                "Callback failed to return valid private key certificate");
+    }
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
 	/* Curves */
 	if (rk->rk_conf.ssl.curves_list) {

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -681,7 +681,7 @@ int verify_broker_callback(X509_STORE_CTX* ctx, void* arg)
         cert = ctx->cert;
         if (cert) {
             int len;
-            char* buf = NULL;
+            unsigned char* buf = NULL;
 
             char *subj = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
             char *issuer = X509_NAME_oneline(X509_get_issuer_name(cert), NULL, 0);
@@ -1039,14 +1039,14 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
         if (len) {
             X509* cert;
             rd_kafka_dbg(rk, SECURITY, "SSL",
-                "Retrieved client's public key certificate %u bytes",
+                "Retrieved client's public key certificate %lu bytes",
                 len);
 
             cert = X509_new();
             if (cert) {
-                if (!d2i_X509(&cert, &buffer, len))
+                if (!d2i_X509(&cert, (const char**)&buffer, len))
                     rd_snprintf(errstr, errstr_size,
-                        "Failed to parse public key certificate with %u bytes",
+                        "Failed to parse public key certificate with %lu bytes",
                         len);
 
                 r = SSL_CTX_use_certificate(ctx, cert);
@@ -1069,7 +1069,7 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
         len = rk->rk_conf.ssl.cert_retrieve_cb(RD_KAFKA_CERTIFICATE_PRIVATE_KEY, &buffer, rk->rk_conf.opaque);
         if (len) {
             rd_kafka_dbg(rk, SECURITY, "SSL",
-                "Retrieved client's private key certificate %u bytes",
+                "Retrieved client's private key certificate %lu bytes",
                 len);
 
                 BIO* bio = BIO_new_mem_buf(buffer, len);
@@ -1082,7 +1082,7 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
                         len = rk->rk_conf.ssl.cert_retrieve_cb(RD_KAFKA_CERTIFICATE_PRIVATE_KEY_PASS, &buffer, rk->rk_conf.opaque);
                         if (len) {
                             rd_kafka_dbg(rk, SECURITY, "SSL",
-                                "Retrieved client's private key password %u bytes",
+                                "Retrieved client's private key password %lu bytes",
                                 len);
                             EVP_PKEY* pkey;
                             X509 *cert;


### PR DESCRIPTION
We have a custom security provider.  In our case we need to be able to allow this security provider to auth the certificate from the broker as well as retrieve the client certificate.  Since this is custom logic providing a callback to the client seems to handle this scenario,