### PR TITLE
Update the message size when a pattern is provided via -m

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -788,7 +788,7 @@ int main (int argc, char **argv) {
 	int opt;
 	int sendflags = 0;
 	char *msgpattern = "librdkafka_performance testing!";
-	int msgsize = (int)strlen(msgpattern);
+	int msgsize = -1;
 	const char *debug = NULL;
 	rd_ts_t now;
 	char errstr[512];
@@ -1247,6 +1247,9 @@ int main (int argc, char **argv) {
 
 	if (msgcnt != -1)
 		forever = 0;
+
+	if (msgsize == -1)
+		msgsize = (int)strlen(msgpattern);
 
 	topic = topics->elems[0].topic;
 


### PR DESCRIPTION
I wanted to use the performance tool to stress our application, which requires messages with specific content (JSON, authorization parts, types, ...). Using `-m` to specify the JSON was easy, but I found it very counter-intuitive that it would repeat the pattern/cut it off unless I explicitly also specified the length.

This PR changes this behavior so that the length gets adjusted by default when `-m` is used. A user that wants cut-off/repeat can specify the length as before by setting it _after_ the `-m` switch.

For my purposes this is enough, but it would break uses where the caller runs `rdkafka_performance -s SIZE -m PATTERN`. One approach for avoiding this breakage would be track whether the user set the size explicitly, and only update in `-m` when that is not the case. Thoughts?