### PR TITLE
Use `configure` to test for SSL capabilities to support LibreSSL

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -485,7 +485,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
 	  "protocol. See manual page for `ciphers(1)` and "
 	  "`SSL_CTX_set_cipher_list(3)."
 	},
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
         { _RK_GLOBAL, "ssl.curves.list", _RK_C_STR,
           _RK(ssl.curves_list),
           "The supported-curves extension in the TLS ClientHello message specifies "

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -148,7 +148,7 @@ struct rd_kafka_conf_s {
 	struct {
 		SSL_CTX *ctx;
 		char *cipher_suites;
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
 		char *curves_list;
 		char *sigalgs_list;
 #endif

--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -872,7 +872,7 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
 		}
 	}
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
 	/* Curves */
 	if (rk->rk_conf.ssl.curves_list) {
 		rd_kafka_dbg(rk, SECURITY, "SSL",


### PR DESCRIPTION
The commit adding support for the ssl.sigalgs.list config option (3cc0ab6) checks the version of openssl (`#if OPENSSL_VERSION_NUMBER >= 0x1000200fL`) to determine if the `SSL_CTX_set1_sigalgs_list()` function is available.

Libressl (for some reason) defines the `OPENSSL_VERSION_NUMBER` as `0x20000000L`, but it doesn't (yet) support these newer APIs.

Augment version checks with `&& !defined(LIBRESSL_VERSION_NUMBER)` to compile with LibreSSL.

Closes #1896