### PR TITLE
Missing word in documentation

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -3329,7 +3329,7 @@ rd_kafka_topic_partition_list_str (const rd_kafka_topic_partition_list_t *rktpar
  *  - offset
  *  - err
  *
- * Will only partitions that are in both dst and src, other partitions will
+ * Will only update partitions that are in both dst and src, other partitions will
  * remain unchanged.
  */
 void


### PR DESCRIPTION
Just add a missing word in the documentation for a function.