### PR TITLE
rdkafka_performance: Don't sleep while waiting for delivery reports

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1400,11 +1400,17 @@ int main (int argc, char **argv) {
 			cnt.msgs++;
 			cnt.bytes += msgsize;
 
-                        if (rate_sleep)
-                                do_sleep(rate_sleep);
-
 			/* Must poll to handle delivery reports */
-			rd_kafka_poll(rk, 0);
+			if (rate_sleep) {
+				rd_ts_t next = rd_clock() + (rd_ts_t) rate_sleep;
+				do {
+					rd_kafka_poll(rk,
+						      (int)RD_MAX(0,
+						      (next - rd_clock()) / 1000));
+				} while (next > rd_clock());
+			} else {
+				rd_kafka_poll(rk, 0);
+			}
 
 			print_stats(rk, mode, otype, compression);
 		}


### PR DESCRIPTION
Sleeping here means we won't be looking for delivery reports, which in latency mode
is problematic: The latency is calculated in the delivery report callback based on the time
when that is called, which would be offset by the slept time.

In my case I'm using the tool with low message rates (1-10 messages/s), and the latencies reported
by the producer ended up between 1s (1 message/s) and 100ms (10 messages/s). Looking into this
showed that the sleeping for the `rate_sleep` means that the tool doesn't process delivery
reports until it has slept -- but the latency is based on the actual time of running the delivery report callback,
not the time the response was accepted by rdkafka.

Fix this problem by replacing the sleep with a busy loop that polls (with a hand-wavy timeout of at most 100ms).
I opted for not adding a `latency_mode` branch, but just do the polling in either case when the rate limiter is enabled.