### PR TITLE
rdhdrhistogram: Fix incorrect float -> int cast causing havoc on MIPS.

### DIFF
--- a/src/rdhdrhistogram.c
+++ b/src/rdhdrhistogram.c
@@ -109,7 +109,7 @@ rd_hdr_histogram_t *rd_hdr_histogram_new (int64_t minValue, int64_t maxValue,
 
         subBucketHalfCountMagnitude = RD_MAX(subBucketCountMagnitude, 1) - 1;
 
-        unitMagnitude = RD_MAX((int32_t)floor(log2((double)minValue)), 0);
+        unitMagnitude = RD_MAX(floor(log2((double)minValue)), 0);
 
         subBucketCount = (int32_t)pow(2,
                                       (double)subBucketHalfCountMagnitude+1.0);


### PR DESCRIPTION
In rd_hdr_histogram_new() when minValue is 0, log2() will return -inf.
Casting -inf to int is undefined, and on MIPS this results in 2^31
but on other architectures it becomes zero instead (which is desired
in this function). Fix this by changing so the RD_MAX() compare
is done on floating point (0 is > -inf) and thus unitMagnitude
becomes 0 (as expected).

This bug caused the while() loop in said function to never terminate
which in turn caused the unit tests to hang.