### PR TITLE
Purge and retry buffers in outbuf queue on connection fail (#1913)

### DIFF
--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -588,6 +588,12 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
 };
 
 
+/**
+ * @returns true if buffer has been sent on wire, else 0.
+ */
+#define rd_kafka_buf_was_sent(rkbuf)                    \
+        ((rkbuf)->rkbuf_flags & RD_KAFKA_OP_F_SENT)
+
 typedef struct rd_kafka_bufq_s {
 	TAILQ_HEAD(, rd_kafka_buf_s) rkbq_bufs;
 	rd_atomic32_t  rkbq_cnt;

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -67,6 +67,7 @@ typedef struct rd_kafka_replyq_s {
 #define RD_KAFKA_OP_F_CRC         0x8  /* rkbuf: Perform CRC calculation */
 #define RD_KAFKA_OP_F_BLOCKING    0x10 /* rkbuf: blocking protocol request */
 #define RD_KAFKA_OP_F_REPROCESS   0x20 /* cgrp: Reprocess at a later time. */
+#define RD_KAFKA_OP_F_SENT        0x80 /* rkbuf: request sent on wire */
 
 
 typedef enum {

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1869,7 +1869,7 @@ static void rd_kafka_handle_Produce (rd_kafka_t *rk,
                          * we will retry at a later time but not increment
                          * the retry count since there is no risk
                          * of duplicates. */
-                        if (err == RD_KAFKA_RESP_ERR__TIMED_OUT_QUEUE)
+                        if (!rd_kafka_buf_was_sent(request))
                                 incr_retry = 0;
 
                         /* Since requests are specific to a broker


### PR DESCRIPTION
There are multiple parts to this fix:
 * A request/response handler can now check if a failing request
   was sent out on the wire (or did not make it past the output
   queue).
 * The retry code now only increments the retry count for actually
   sent requests.
 * When the broker connection goes down, requests in the output queue
   are now purged to have their handler callbacks called which in turn
   will trigger a (now free) retry.
 * ProduceRequests are not retried, but their messages are put back
   on the partition queue (existing behaviour).