### PR TITLE
Enable low latency mode on win32.

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3716,8 +3716,8 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 					const char *name, uint16_t port,
 					int32_t nodeid) {
 	rd_kafka_broker_t *rkb;
-#ifndef _MSC_VER
         int r;
+#ifndef _MSC_VER
         sigset_t newset, oldset;
 #endif
 
@@ -3800,7 +3800,6 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
         rkb->rkb_wakeup_fd[1]     = -1;
         rkb->rkb_toppar_wakeup_fd = -1;
 
-#ifndef _MSC_VER /* pipes cant be mixed with WSAPoll on Win32 */
         if ((r = rd_pipe_nonblocking(rkb->rkb_wakeup_fd)) == -1) {
                 rd_rkb_log(rkb, LOG_ERR, "WAKEUPFD",
                            "Failed to setup broker queue wake-up fds: "
@@ -3832,7 +3831,6 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
                 rd_kafka_q_io_event_enable(rkb->rkb_ops, rkb->rkb_wakeup_fd[1],
                                            &onebyte, sizeof(onebyte));
         }
-#endif
 
         /* Lock broker's lock here to synchronise state, i.e., hold off
 	 * the broker thread until we've finalized the rkb. */

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -650,7 +650,6 @@ void rd_kafka_toppar_enq_msg (rd_kafka_toppar_t *rktp, rd_kafka_msg_t *rkm) {
         wakeup_fd = rktp->rktp_msgq_wakeup_fd;
         rd_kafka_toppar_unlock(rktp);
 
-#ifndef _MSC_VER
         if (wakeup_fd != -1 && queue_len == 1) {
                 char one = 1;
                 int r;
@@ -664,7 +663,6 @@ void rd_kafka_toppar_enq_msg (rd_kafka_toppar_t *rktp, rd_kafka_msg_t *rkm) {
                                      wakeup_fd,
                                      rd_strerror(errno));
         }
-#endif
 }
 
 

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -292,11 +292,7 @@ void rd_kafka_q_io_event (rd_kafka_q_t *rkq) {
                 return;
         }
 
-#ifdef _MSC_VER
-	r = _write(rkq->rkq_qio->fd, rkq->rkq_qio->payload, (int)rkq->rkq_qio->size);
-#else
-        r = write(rkq->rkq_qio->fd, rkq->rkq_qio->payload, rkq->rkq_qio->size);
-#endif
+        r = rd_write(rkq->rkq_qio->fd, rkq->rkq_qio->payload, rkq->rkq_qio->size);
 	if (r == -1) {
 		fprintf(stderr,
 			"[ERROR:librdkafka:rd_kafka_q_io_event: "


### PR DESCRIPTION
Enable low latency mode on windows by using a TCP connection in place of a named pipe.
This allows WSAPoll to wait on both the broker socket and wakeup events.