### PR TITLE
Add rd_kafka_destroy_flags()

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -2043,9 +2043,52 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type, rd_kafka_conf_t *conf,
  * @brief Destroy Kafka handle.
  *
  * @remark This is a blocking operation.
+ * @remark rd_kafka_consumer_close() will be called from this function
+ *         if the instance type is RD_KAFKA_CONSUMER, a \c group.id was
+ *         configured, and the rd_kafka_consumer_close() was not
+ *         explicitly called by the application. This in turn may
+ *         trigger consumer callbacks, such as rebalance_cb.
+ *         Use rd_kafka_destroy_flags() with
+ *         RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE to avoid this behaviour.
+ *
+ * @sa rd_kafka_destroy_flags()
  */
 RD_EXPORT
 void        rd_kafka_destroy(rd_kafka_t *rk);
+
+
+/**
+ * @brief Destroy Kafka handle according to specified destroy flags
+ *
+ */
+RD_EXPORT
+void rd_kafka_destroy_flags (rd_kafka_t *rk, int flags);
+
+/**
+ * @brief Flags for rd_kafka_destroy_flags()
+ */
+
+/*!
+ * Immediate non-blocking destruction without waiting for all resources
+ * to be cleaned up.
+ *
+ * @warning Memory and resource leaks possible.
+ *
+ * @remark This flag automatically sets RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE.
+ */
+#define RD_KAFKA_DESTROY_F_IMMEDIATE 0x4
+
+/*!
+ * Don't call consumer_close() to leave group and commit final offsets.
+ *
+ * This also disables consumer callbacks to be called from rd_kafka_destroy*(),
+ * such as rebalance_cb.
+ *
+ * The consumer group handler is still closed internally, but from an
+ * application perspective none of the functionality from consumer_close()
+ * is performed.
+ */
+#define RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE 0x8
 
 
 

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -152,7 +152,39 @@ struct rd_kafka_s {
         rd_kafkap_str_t *rk_group_id;    /* Consumer group id */
 
 	int              rk_flags;
-	rd_atomic32_t    rk_terminate;
+	rd_atomic32_t    rk_terminate;   /**< Set to RD_KAFKA_DESTROY_F_..
+                                          *   flags instance
+                                          *   is being destroyed.
+                                          *   The value set is the
+                                          *   destroy flags from
+                                          *   rd_kafka_destroy*() and
+                                          *   the two internal flags shown
+                                          *   below.
+                                          *
+                                          * Order:
+                                          * 1. user_flags | .._F_DESTROY_CALLED
+                                          *    is set in rd_kafka_destroy*().
+                                          * 2. consumer_close() is called
+                                          *    for consumers.
+                                          * 3. .._F_TERMINATE is set to
+                                          *    signal all background threads
+                                          *    to terminate.
+                                          */
+
+#define RD_KAFKA_DESTROY_F_TERMINATE 0x1 /**< Internal flag to make sure
+                                          *   rk_terminate is set to non-zero
+                                          *   value even if user passed
+                                          *   no destroy flags. */
+#define RD_KAFKA_DESTROY_F_DESTROY_CALLED 0x2 /**< Application has called
+                                               *  ..destroy*() and we've
+                                               * begun the termination
+                                               * process.
+                                               * This flag is needed to avoid
+                                               * rk_terminate from being
+                                               * 0 when destroy_flags()
+                                               * is called with flags=0
+                                               * and prior to _F_TERMINATE
+                                               * has been set. */
 	rwlock_t         rk_lock;
 	rd_kafka_type_t  rk_type;
 	struct timeval   rk_tv_state_change;
@@ -337,9 +369,29 @@ void rd_kafka_destroy_final (rd_kafka_t *rk);
 
 
 /**
- * Returns true if 'rk' handle is terminating.
+ * @returns true if \p rk handle is terminating.
+ *
+ * @remark If consumer_close() is called from destroy*() it will be
+ *         called prior to _F_TERMINATE being set and will thus not
+ *         be able to use rd_kafka_terminating() to know it is shutting down.
+ *         That code should instead just check that rk_terminate is non-zero
+ *         (the _F_DESTROY_CALLED flag will be set).
  */
-#define rd_kafka_terminating(rk) (rd_atomic32_get(&(rk)->rk_terminate))
+#define rd_kafka_terminating(rk) (rd_atomic32_get(&(rk)->rk_terminate) & \
+                                  RD_KAFKA_DESTROY_F_TERMINATE)
+
+/**
+ * @returns the destroy flags set matching \p flags, which might be
+ *          a subset of the flags.
+ */
+#define rd_kafka_destroy_flags_check(rk,flags) \
+        (rd_atomic32_get(&(rk)->rk_terminate) & (flags))
+
+/**
+ * @returns true if no consumer callbacks, or standard consumer_close
+ *          behaviour, should be triggered. */
+#define rd_kafka_destroy_flags_no_consumer_close(rk) \
+        rd_kafka_destroy_flags_check(rk, RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE)
 
 #define rd_kafka_is_simple_consumer(rk) \
         (rd_atomic32_get(&(rk)->rk_simple_cnt) > 0)

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -343,6 +343,65 @@ rd_kafka_q_enq0 (rd_kafka_q_t *rkq, rd_kafka_op_t *rko, int at_head) {
 
 
 /**
+ * @brief Enqueue \p rko either at head or tail of \p rkq.
+ *
+ * The provided \p rko is either enqueued or destroyed.
+ *
+ * \p orig_destq is the original (outermost) dest queue for which
+ * this op was enqueued, before any queue forwarding has kicked in.
+ * The rko_serve callback from the orig_destq will be set on the rko
+ * if there is no rko_serve callback already set, and the \p rko isn't
+ * failed because the final queue is disabled.
+ *
+ * @returns 1 if op was enqueued or 0 if queue is disabled and
+ * there was no replyq to enqueue on in which case the rko is destroyed.
+ *
+ * @locality any thread.
+ */
+static RD_INLINE RD_UNUSED
+int rd_kafka_q_enq1 (rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
+                     rd_kafka_q_t *orig_destq, int at_head, int do_lock) {
+        rd_kafka_q_t *fwdq;
+
+        if (do_lock)
+                mtx_lock(&rkq->rkq_lock);
+
+        rd_dassert(rkq->rkq_refcnt > 0);
+
+        if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
+                /* Queue has been disabled, reply to and fail the rko. */
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+
+                return rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__DESTROY);
+        }
+
+        if (!(fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
+                if (!rko->rko_serve && orig_destq->rkq_serve) {
+                        /* Store original queue's serve callback and opaque
+                         * prior to forwarding. */
+                        rko->rko_serve = orig_destq->rkq_serve;
+                        rko->rko_serve_opaque = orig_destq->rkq_opaque;
+                }
+
+                rd_kafka_q_enq0(rkq, rko, at_head);
+                cnd_signal(&rkq->rkq_cond);
+                if (rkq->rkq_qlen == 1)
+                        rd_kafka_q_io_event(rkq);
+
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+        } else {
+                if (do_lock)
+                        mtx_unlock(&rkq->rkq_lock);
+                rd_kafka_q_enq1(fwdq, rko, orig_destq, at_head, 1/*do lock*/);
+                rd_kafka_q_destroy(fwdq);
+        }
+
+        return 1;
+}
+
+/**
  * @brief Enqueue the 'rko' op at the tail of the queue 'rkq'.
  *
  * The provided 'rko' is either enqueued or destroyed.
@@ -350,44 +409,12 @@ rd_kafka_q_enq0 (rd_kafka_q_t *rkq, rd_kafka_op_t *rko, int at_head) {
  * @returns 1 if op was enqueued or 0 if queue is disabled and
  * there was no replyq to enqueue on in which case the rko is destroyed.
  *
- * Locality: any thread.
+ * @locality any thread.
+ * @locks rkq MUST NOT be locked
  */
 static RD_INLINE RD_UNUSED
 int rd_kafka_q_enq (rd_kafka_q_t *rkq, rd_kafka_op_t *rko) {
-	rd_kafka_q_t *fwdq;
-
-	mtx_lock(&rkq->rkq_lock);
-
-        rd_dassert(rkq->rkq_refcnt > 0);
-
-        if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
-
-                /* Queue has been disabled, reply to and fail the rko. */
-                mtx_unlock(&rkq->rkq_lock);
-
-                return rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__DESTROY);
-        }
-
-        if (!rko->rko_serve && rkq->rkq_serve) {
-                /* Store original queue's serve callback and opaque
-                 * prior to forwarding. */
-                rko->rko_serve = rkq->rkq_serve;
-                rko->rko_serve_opaque = rkq->rkq_opaque;
-        }
-
-	if (!(fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
-		rd_kafka_q_enq0(rkq, rko, 0);
-		cnd_signal(&rkq->rkq_cond);
-		if (rkq->rkq_qlen == 1)
-			rd_kafka_q_io_event(rkq);
-		mtx_unlock(&rkq->rkq_lock);
-	} else {
-		mtx_unlock(&rkq->rkq_lock);
-		rd_kafka_q_enq(fwdq, rko);
-		rd_kafka_q_destroy(fwdq);
-	}
-
-        return 1;
+        return rd_kafka_q_enq1(rkq, rko, rkq, 0/*at tail*/, 1/*do lock*/);
 }
 
 
@@ -399,37 +426,12 @@ int rd_kafka_q_enq (rd_kafka_q_t *rkq, rd_kafka_op_t *rko) {
  * @returns 1 if op was enqueued or 0 if queue is disabled and
  * there was no replyq to enqueue on in which case the rko is destroyed.
  *
- * @locks rkq MUST BE LOCKED
- *
- * Locality: any thread.
+ * @locality any thread
+ * @locks rkq MUST BE locked
  */
 static RD_INLINE RD_UNUSED
 int rd_kafka_q_reenq (rd_kafka_q_t *rkq, rd_kafka_op_t *rko) {
-        rd_kafka_q_t *fwdq;
-
-        rd_dassert(rkq->rkq_refcnt > 0);
-
-        if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY)))
-                return rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__DESTROY);
-
-        if (!rko->rko_serve && rkq->rkq_serve) {
-                /* Store original queue's serve callback and opaque
-                 * prior to forwarding. */
-                rko->rko_serve = rkq->rkq_serve;
-                rko->rko_serve_opaque = rkq->rkq_opaque;
-        }
-
-        if (!(fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
-                rd_kafka_q_enq0(rkq, rko, 1/*at_head*/);
-                cnd_signal(&rkq->rkq_cond);
-                if (rkq->rkq_qlen == 1)
-                        rd_kafka_q_io_event(rkq);
-        } else {
-                rd_kafka_q_enq(fwdq, rko);
-                rd_kafka_q_destroy(fwdq);
-        }
-
-        return 1;
+        return rd_kafka_q_enq1(rkq, rko, rkq, 1/*at head*/, 0/*don't lock*/);
 }
 
 

--- a/src/rdkafka_timer.c
+++ b/src/rdkafka_timer.c
@@ -229,7 +229,7 @@ void rd_kafka_timers_run (rd_kafka_timers_t *rkts, int timeout_us) {
 
         rd_kafka_timers_lock(rkts);
 
-	while (!rd_atomic32_get(&rkts->rkts_rk->rk_terminate) && now <= end) {
+	while (!rd_kafka_terminating(rkts->rkts_rk) && now <= end) {
 		int64_t sleeptime;
 		rd_kafka_timer_t *rtmr;
 

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -773,7 +773,7 @@ static void rd_kafka_topic_assign_uas (rd_kafka_itopic_t *rkt,
 void rd_kafka_topic_metadata_none (rd_kafka_itopic_t *rkt) {
 	rd_kafka_topic_wrlock(rkt);
 
-	if (unlikely(rd_atomic32_get(&rkt->rkt_rk->rk_terminate))) {
+	if (unlikely(rd_kafka_terminating(rkt->rkt_rk))) {
 		/* Dont update metadata while terminating, do this
 		 * after acquiring lock for proper synchronisation */
 		rd_kafka_topic_wrunlock(rkt);

--- a/tests/0084-destroy_flags.c
+++ b/tests/0084-destroy_flags.c
@@ -1,0 +1,198 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2018, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @name Test rd_kafka_destroy_flags()
+ */
+
+
+#include "test.h"
+
+
+static RD_TLS int rebalance_cnt = 0;
+
+static void destroy_flags_rebalance_cb (rd_kafka_t *rk, rd_kafka_resp_err_t err,
+                                        rd_kafka_topic_partition_list_t *parts,
+                                        void *opaque) {
+        rebalance_cnt++;
+
+        TEST_SAY("rebalance_cb: %s with %d partition(s)\n",
+                 rd_kafka_err2str(err), parts->cnt);
+
+        switch (err)
+        {
+        case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
+                test_consumer_assign("rebalance", rk, parts);
+                break;
+
+        case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
+                test_consumer_unassign("rebalance", rk);
+                break;
+
+        default:
+                TEST_FAIL("rebalance_cb: error: %s", rd_kafka_err2str(err));
+        }
+}
+
+struct df_args {
+        rd_kafka_type_t client_type;
+        int produce_cnt;
+        int consumer_subscribe;
+};
+
+static void do_test_destroy_flags (const char *topic,
+                                   int destroy_flags,
+                                   int local_mode,
+                                   const struct df_args *args) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+        test_timing_t t_destroy;
+
+        TEST_SAY(_C_MAG "[ test destroy_flags 0x%x for client_type %d, "
+                 "produce_cnt %d, subscribe %d, %s mode ]\n" _C_CLR,
+                 destroy_flags, args->client_type,
+                 args->produce_cnt, args->consumer_subscribe,
+                 local_mode ? "local" : "broker");
+
+        test_conf_init(&conf, NULL, 20);
+
+        if (local_mode)
+                test_conf_set(conf, "bootstrap.servers", "");
+
+        if (args->client_type == RD_KAFKA_PRODUCER) {
+
+                rk = test_create_handle(args->client_type, conf);
+
+                if (args->produce_cnt > 0) {
+                        rd_kafka_topic_t *rkt;
+                        int msgcounter = 0;
+
+                        rkt = test_create_producer_topic(rk, topic, NULL);
+                        test_produce_msgs_nowait(rk, rkt, 0,
+                                                 RD_KAFKA_PARTITION_UA,
+                                                 0, 10000, NULL, 100,
+                                                 &msgcounter);
+                        rd_kafka_topic_destroy(rkt);
+                }
+
+        } else {
+                int i;
+
+                TEST_ASSERT(args->client_type == RD_KAFKA_CONSUMER);
+
+                rk = test_create_consumer(topic, destroy_flags_rebalance_cb,
+                                          conf, NULL);
+
+                if (args->consumer_subscribe) {
+                        test_consumer_subscribe(rk, topic);
+
+                        if (!local_mode) {
+                                TEST_SAY("Waiting for assignment\n");
+                                while (rebalance_cnt == 0)
+                                        test_consumer_poll_once(rk, NULL, 1000);
+                        }
+                }
+
+                for (i = 0 ; i < 5 ; i++)
+                        test_consumer_poll_once(rk, NULL, 100);
+        }
+
+
+        rebalance_cnt = 0;
+        TEST_SAY(_C_YEL "Calling rd_kafka_destroy_flags(0x%x)\n" _C_CLR,
+                 destroy_flags);
+        TIMING_START(&t_destroy, "rd_kafka_destroy_flags(0x%x)", destroy_flags);
+        rd_kafka_destroy_flags(rk, destroy_flags);
+        TIMING_STOP(&t_destroy);
+
+        if (destroy_flags & RD_KAFKA_DESTROY_F_IMMEDIATE)
+                TIMING_ASSERT_LATER(&t_destroy, 0, 50);
+        else if (destroy_flags & RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE)
+                TIMING_ASSERT_LATER(&t_destroy, 0, 200);
+        else
+                TIMING_ASSERT_LATER(&t_destroy, 0, 1000);
+
+        if (args->consumer_subscribe &&
+            !(destroy_flags & (RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE|
+                               RD_KAFKA_DESTROY_F_IMMEDIATE))) {
+                if (!local_mode)
+                        TEST_ASSERT(rebalance_cnt > 0,
+                                    "expected final rebalance callback");
+        } else
+                TEST_ASSERT(rebalance_cnt == 0,
+                            "expected no rebalance callbacks, got %d",
+                            rebalance_cnt);
+
+        TEST_SAY(_C_GRN "[ test destroy_flags 0x%x for client_type %d, "
+                 "produce_cnt %d, subscribe %d, %s mode: PASS ]\n" _C_CLR,
+                 destroy_flags, args->client_type,
+                 args->produce_cnt, args->consumer_subscribe,
+                 local_mode ? "local" : "broker");
+}
+
+
+/**
+ * @brief Destroy with flags
+ */
+static void destroy_flags (int local_mode) {
+        const struct df_args args[] = {
+                { RD_KAFKA_PRODUCER, 0, 0 },
+                { RD_KAFKA_PRODUCER, 10000, 0 },
+                { RD_KAFKA_CONSUMER, 0, 1 },
+                { RD_KAFKA_CONSUMER, 0, 0 }
+        };
+        const int flag_combos[] = { 0,
+                                    RD_KAFKA_DESTROY_F_IMMEDIATE,
+                                    RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE,
+                                    RD_KAFKA_DESTROY_F_IMMEDIATE |
+                                    RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE };
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        int i, j;
+
+        for (i = 0 ; i < (int)RD_ARRAYSIZE(args) ; i++) {
+                for (j = 0 ; j < (int)RD_ARRAYSIZE(flag_combos) ; j++) {
+                        do_test_destroy_flags(topic,
+                                              flag_combos[j],
+                                              local_mode,
+                                              &args[i]);
+                }
+        }
+
+}
+
+
+
+int main_0084_destroy_flags_local (int argc, char **argv) {
+        destroy_flags(1/*no brokers*/);
+        return 0;
+}
+
+int main_0084_destroy_flags (int argc, char **argv) {
+        destroy_flags(0/*with brokers*/);
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ set(
     0081-admin.c
     0082-fetch_max_bytes.cpp
     0083-cb_event.c
+    0084-destroy_flags.c
     8000-idle.cpp
     test.c
     testcpp.cpp    

--- a/tests/test.c
+++ b/tests/test.c
@@ -173,6 +173,8 @@ _TEST_DECL(0080_admin_ut);
 _TEST_DECL(0081_admin);
 _TEST_DECL(0082_fetch_max_bytes);
 _TEST_DECL(0083_cb_event);
+_TEST_DECL(0084_destroy_flags_local);
+_TEST_DECL(0084_destroy_flags);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -279,7 +281,8 @@ struct test tests[] = {
         _TEST(0081_admin, 0, TEST_BRKVER(0,10,2,0)),
         _TEST(0082_fetch_max_bytes, 0, TEST_BRKVER(0,10,1,0)),
         _TEST(0083_cb_event, 0, TEST_BRKVER(0,9,0,0)),
-
+        _TEST(0084_destroy_flags_local, TEST_F_LOCAL),
+        _TEST(0084_destroy_flags, 0),
         /* Manual tests */
         _TEST(8000_idle, TEST_F_MANUAL),
 

--- a/tests/testshared.h
+++ b/tests/testshared.h
@@ -180,11 +180,11 @@ typedef struct test_timing_s {
 
 #define TIMING_ASSERT0(TIMING,DO_FAIL_LATER,TMIN_MS,TMAX_MS) do {       \
         if (!TIMING_STOPPED(TIMING))                                    \
-                TIMING_STOP(&timing);                                   \
+                TIMING_STOP(TIMING);                                    \
         int _dur_ms = (int)TIMING_DURATION(TIMING) / 1000;              \
         if (TMIN_MS <= _dur_ms && _dur_ms <= TMAX_MS)                   \
                 break;                                                  \
-        if (test_on_ci)                                                 \
+        if (test_on_ci || strcmp(test_mode, "bare"))                    \
                 TEST_WARN("%s: expected duration %d <= %d <= %d ms%s\n", \
                           (TIMING)->name, TMIN_MS, _dur_ms, TMAX_MS,    \
                           ": not FAILING test on CI");                  \

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="..\..\tests\0081-admin.c" />
     <ClCompile Include="..\..\tests\0082-fetch_max_bytes.cpp" />
     <ClCompile Include="..\..\tests\0083-cb_event.c" />
+    <ClCompile Include="..\..\tests\0084-destroy_flags.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />


### PR DESCRIPTION
From Dispose() you would call `rd_kafka_destroy_flags(RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE)`.

This should probably be changed in the Python destructor as well.