### PR TITLE
Add an option to dump the configuration

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -565,6 +565,7 @@ int main (int argc, char **argv) {
 			"will be set on topic object.\n"
 			"  -X list         Show full list of supported "
 			"properties.\n"
+			"  -X dump         Show configuration\n"
 			"  -X <prop>       Get single property value\n"
 			"\n"
 			" In Consumer mode:\n"


### PR DESCRIPTION
This is modelled to match the code in rdkafka_example.c: `-X dump` will dump
the configuration, and then exit the program successfully.

Fixes #1900