### PR TITLE
Fix timeout reuse in queue calls (#1863)

### DIFF
--- a/src/rdatomic.h
+++ b/src/rdatomic.h
@@ -110,6 +110,12 @@ static RD_INLINE int32_t RD_UNUSED rd_atomic32_set(rd_atomic32_t *ra, int32_t v)
 	r = ra->val = v;
 	mtx_unlock(&ra->lock);
 	return r;
+#elif HAVE_ATOMICS_32_ATOMIC
+        __atomic_store_n(&ra->val, v, __ATOMIC_SEQ_CST);
+        return v;
+#elif HAVE_ATOMICS_32_SYNC
+        (void)__sync_lock_test_and_set(&ra->val, v);
+        return v;
 #else
 	return ra->val = v; // FIXME
 #endif
@@ -183,6 +189,12 @@ static RD_INLINE int64_t RD_UNUSED rd_atomic64_set(rd_atomic64_t *ra, int64_t v)
 	r = ra->val;
 	mtx_unlock(&ra->lock);
 	return r;
+#elif HAVE_ATOMICS_64_ATOMIC
+        __atomic_store_n(&ra->val, v, __ATOMIC_SEQ_CST);
+        return v;
+#elif HAVE_ATOMICS_64_SYNC
+        (void)__sync_lock_test_and_set(&ra->val, v);
+        return v;
 #else
 	return ra->val = v; // FIXME
 #endif

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3333,7 +3333,7 @@ rd_kafka_resp_err_t rd_kafka_flush (rd_kafka_t *rk, int timeout_ms) {
         while (((qlen = rd_kafka_q_len(rk->rk_rep)) > 0 ||
                 (msg_cnt = rd_kafka_curr_msgs_cnt(rk)) > 0) &&
                !rd_kafka_yield_thread &&
-               (tmout = rd_timeout_remains_limit(ts_end, 100))!=RD_POLL_NOWAIT)
+               (tmout = rd_timeout_remains_limit(ts_end, 10)) != RD_POLL_NOWAIT)
                 rd_kafka_poll(rk, tmout);
 
 	return qlen + msg_cnt > 0 ? RD_KAFKA_RESP_ERR__TIMED_OUT :

--- a/src/rdtime.h
+++ b/src/rdtime.h
@@ -139,6 +139,32 @@ static RD_INLINE rd_ts_t rd_timeout_init (int timeout_ms) {
 
 
 /**
+ * @brief Initialize an absolute timespec timeout based on the provided
+ *        relative \p timeout_ms.
+ *
+ * To be used with cnd_timedwait_abs().
+ *
+ * Honours RD_POLL_INFITE and RD_POLL_NOWAIT (reflected in tspec.tv_sec).
+ */
+static RD_INLINE void rd_timeout_init_timespec (struct timespec *tspec,
+                                                int timeout_ms) {
+        if (timeout_ms == RD_POLL_INFINITE ||
+            timeout_ms == RD_POLL_NOWAIT) {
+                tspec->tv_sec = timeout_ms;
+                tspec->tv_nsec = 0;
+        } else {
+                timespec_get(tspec, TIME_UTC);
+                tspec->tv_sec  += timeout_ms / 1000;
+                tspec->tv_nsec += (timeout_ms % 1000) * 1000000;
+                if (tspec->tv_nsec > 1000000000) {
+                        tspec->tv_nsec -= 1000000000;
+                        tspec->tv_sec++;
+                }
+        }
+}
+
+
+/**
  * @brief Same as rd_timeout_remains() but with microsecond precision
  */
 static RD_INLINE rd_ts_t rd_timeout_remains_us (rd_ts_t abs_timeout) {

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -518,6 +518,15 @@ int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp) {
         return r;
 }
 
+int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec) {
+        if (tspec->tv_sec == RD_POLL_INFINITE)
+                return cnd_wait(cnd, mtx);
+        else if (tspec->tv_sec == RD_POLL_NOWAIT)
+                return thrd_timedout;
+
+        return cnd_timedwait(cnd, mtx, tspec);
+}
+
 #if defined(_TTHREAD_WIN32_)
 struct TinyCThreadTSSData {
   void* value;

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -320,6 +320,13 @@ int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms);
 /** Same as cnd_timedwait_ms() but updates the remaining time. */
 int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp);
 
+/** Same as cnd_timedwait() but honours RD_POLL_INFINITE (use cnd_wait()),
+ *  and RD_POLL_NOWAIT (return thrd_timedout immediately).
+ *
+ *  @remark Set up \p tspec with rd_timeout_init_timespec().
+ */
+int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec);
+
 /* Thread */
 #if defined(_TTHREAD_WIN32_)
 typedef HANDLE thrd_t;


### PR DESCRIPTION
The timeout_ms parameter was reused as-is in certain loops, causing the timeout to never actually decrease.

This PR fixes this, and optimizes a few other places, to use an absolute end time instead.

Also chucked in an unrelated atomic fix for good measures.

Testing revealed that rd_kafka_flush() was unnecessarily slow, so fixed that as well.