### PR TITLE
Disconnect regardless of socket.max.fails when partial request times out (#1955)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -26,7 +26,7 @@ socket.send.buffer.bytes                 |  *  | 0 .. 100000000  |             0
 socket.receive.buffer.bytes              |  *  | 0 .. 100000000  |             0 | Broker socket receive buffer size. System default is used if 0. <br>*Type: integer*
 socket.keepalive.enable                  |  *  | true, false     |         false | Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets <br>*Type: boolean*
 socket.nagle.disable                     |  *  | true, false     |         false | Disable the Nagle algorithm (TCP_NODELAY) on broker sockets. <br>*Type: boolean*
-socket.max.fails                         |  *  | 0 .. 1000000    |             1 | Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. NOTE: The connection is automatically re-established. <br>*Type: integer*
+socket.max.fails                         |  *  | 0 .. 1000000    |             1 | Disconnect from broker when this number of send failures (e.g., timed out requests) is reached. Disable with 0. WARNING: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker to become desynchronized in case of request timeouts. NOTE: The connection is automatically re-established. <br>*Type: integer*
 broker.address.ttl                       |  *  | 0 .. 86400000   |          1000 | How long to cache the broker address resolving results (milliseconds). <br>*Type: integer*
 broker.address.family                    |  *  | any, v4, v6     |           any | Allowed broker IP address families: any, v4, v6 <br>*Type: enum value*
 reconnect.backoff.jitter.ms              |  *  | 0 .. 3600000    |           500 | Throttle broker reconnection attempts by this value +-50%. <br>*Type: integer*

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -564,40 +564,45 @@ static int rd_kafka_broker_bufq_timeout_scan (rd_kafka_broker_t *rkb,
  * Locality: Broker thread
  */
 static void rd_kafka_broker_timeout_scan (rd_kafka_broker_t *rkb, rd_ts_t now) {
-	int req_cnt, retry_cnt, q_cnt;
+        int inflight_cnt, retry_cnt, outq_cnt;
+        int partial_cnt = 0;
 
 	rd_kafka_assert(rkb->rkb_rk, thrd_is_current(rkb->rkb_thread));
 
-	/* Outstanding requests waiting for response */
-	req_cnt = rd_kafka_broker_bufq_timeout_scan(
-		rkb, 1, &rkb->rkb_waitresps, NULL,
-		RD_KAFKA_RESP_ERR__TIMED_OUT, now);
+        /* In-flight requests waiting for response */
+        inflight_cnt = rd_kafka_broker_bufq_timeout_scan(
+                rkb, 1, &rkb->rkb_waitresps, NULL,
+                RD_KAFKA_RESP_ERR__TIMED_OUT, now);
 	/* Requests in retry queue */
 	retry_cnt = rd_kafka_broker_bufq_timeout_scan(
 		rkb, 0, &rkb->rkb_retrybufs, NULL,
 		RD_KAFKA_RESP_ERR__TIMED_OUT_QUEUE, now);
-	/* Requests in local queue not sent yet. */
-	q_cnt = rd_kafka_broker_bufq_timeout_scan(
-		rkb, 0, &rkb->rkb_outbufs, &req_cnt,
-		RD_KAFKA_RESP_ERR__TIMED_OUT_QUEUE, now);
+        /* Requests in local queue not sent yet.
+         * partial_cnt is included in outq_cnt and denotes a request
+         * that has been partially transmitted. */
+        outq_cnt = rd_kafka_broker_bufq_timeout_scan(
+                rkb, 0, &rkb->rkb_outbufs, &partial_cnt,
+                RD_KAFKA_RESP_ERR__TIMED_OUT_QUEUE, now);
 
-	if (req_cnt + retry_cnt + q_cnt > 0) {
-		rd_rkb_dbg(rkb, MSG|RD_KAFKA_DBG_BROKER,
-			   "REQTMOUT", "Timed out %i+%i+%i requests",
-			   req_cnt, retry_cnt, q_cnt);
+        if (inflight_cnt + retry_cnt + outq_cnt + partial_cnt > 0) {
+                rd_rkb_log(rkb, LOG_WARNING, "REQTMOUT",
+                           "Timed out %i in-flight, %i retry-queued, "
+                           "%i out-queue, %i partially-sent requests",
+                           inflight_cnt, retry_cnt, outq_cnt, partial_cnt);
 
-                /* Fail the broker if socket.max.fails is configured and
-                 * now exceeded. */
-                rkb->rkb_req_timeouts   += req_cnt + q_cnt;
-                rd_atomic64_add(&rkb->rkb_c.req_timeouts, req_cnt + q_cnt);
+                rkb->rkb_req_timeouts += inflight_cnt + outq_cnt;
+                rd_atomic64_add(&rkb->rkb_c.req_timeouts,
+                                inflight_cnt + outq_cnt);
 
-		/* If this was an in-flight request that timed out, or
-		 * the other queues has reached the socket.max.fails threshold,
-		 * we need to take down the connection. */
-                if (rkb->rkb_rk->rk_conf.socket_max_fails &&
-                    rkb->rkb_req_timeouts >=
-                    rkb->rkb_rk->rk_conf.socket_max_fails &&
-                    rkb->rkb_state >= RD_KAFKA_BROKER_STATE_UP) {
+                /* If this was a partially sent request that timed out, or the
+                 * number of timed out requests have reached the
+                 * socket.max.fails threshold, we need to take down the
+                 * connection. */
+                if (partial_cnt > 0 ||
+                    (rkb->rkb_rk->rk_conf.socket_max_fails &&
+                     rkb->rkb_req_timeouts >=
+                     rkb->rkb_rk->rk_conf.socket_max_fails &&
+                     rkb->rkb_state >= RD_KAFKA_BROKER_STATE_UP)) {
                         char rttinfo[32];
                         /* Print average RTT (if avail) to help diagnose. */
                         rd_avg_calc(&rkb->rkb_avg_rtt, now);

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -309,6 +309,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
           _RK(socket_max_fails),
           "Disconnect from broker when this number of send failures "
           "(e.g., timed out requests) is reached. Disable with 0. "
+          "WARNING: It is highly recommended to leave this setting at "
+          "its default value of 1 to avoid the client and broker to "
+          "become desynchronized in case of request timeouts. "
           "NOTE: The connection is automatically re-established.",
           0, 1000000, 1 },
 	{ _RK_GLOBAL, "broker.address.ttl", _RK_C_INT,


### PR DESCRIPTION
We can't restore the connection to a clean state when a partial
request times out, instead fail the connection and reconnect,
regardless of the socket.max.fails setting.