### PR TITLE
Fix warnings on FreeBSD; it is very picky about _POSIX_C_SOURCE et al

### DIFF
--- a/src/rd.h
+++ b/src/rd.h
@@ -38,6 +38,16 @@
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L  /* for timespec on solaris */
 #endif
+/*
+ * AIX defines this and the value needs to be set correctly. For Solaris,
+ * src/rd.h defines _POSIX_SOURCE to be 200809L, which corresponds to XPG7,
+ * which itself is not compatible with _XOPEN_SOURCE on that platform.
+ */
+#if !defined(_AIX) && !defined(__sun)
+#define _XOPEN_SOURCE 700
+#endif
+/* FreeBSD does not set __BSD_VISIBLE if _POSIX_C_SOURCE is defined at all */
+#define __BSD_VISIBLE 1
 #endif
 
 #include <stdio.h>

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -28,25 +28,17 @@
 
 
 
-#ifndef _MSC_VER
-#define _GNU_SOURCE
-/*
- * AIX defines this and the value needs to be set correctly. For Solaris,
- * src/rd.h defines _POSIX_SOURCE to be 200809L, which corresponds to XPG7,
- * which itself is not compatible with _XOPEN_SOURCE on that platform.
- */
-#if !defined(_AIX) && !defined(__sun)
-#define _XOPEN_SOURCE
-#endif
-#include <signal.h>
-#endif
-
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
 
 #include "rd.h"
+
+#ifndef _MSC_VER
+#include <signal.h>
+#endif
+
 #include "rdkafka_int.h"
 #include "rdkafka_msg.h"
 #include "rdkafka_msgset.h"


### PR DESCRIPTION
This fixes the warnings in #1962 on FreeBSD

This turned out to be a bit of a rabbit hole: FreeBSD disables all the usual default visibility if you set _POSIX_C_SOURCE _at all_, so the warnings were coming from the implicit _XOPEN_SOURCE=700 being disabled.

Also, there doesn't seem to be any way to get the standard headers to set __BSD_VISIBLE (needed for alloca) when the default visibility is disabled, so we have to do that directly, which is ugly.