### PR TITLE
Librdkafka.so ref issue

### DIFF
--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -36,6 +36,7 @@ endif
 # we'll get those dependencies through the C library linkage.
 
 # TODO: does this need to be a build switch or can we do this all the time?
+# TODO: will this cause issues with static build?
 # We'll additionally look for this library's dependancies within the same directory.
 # eg librdkafka++.so will look for its dependancy library librdkafka.so within the same directory.
 LIBS := -L../src -lrdkafka -lstdc++ -Wl,-rpath,\$$ORIGIN

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -34,7 +34,11 @@ endif
 
 # Ignore previously defined library dependencies for the C library,
 # we'll get those dependencies through the C library linkage.
-LIBS := -L../src -lrdkafka -lstdc++
+
+# TODO: does this need to be a build switch or can we do this all the time?
+# We'll additionally look for this library's dependancies within the same directory.
+# eg librdkafka++.so will look for its dependancy library librdkafka.so within the same directory.
+LIBS := -L../src -lrdkafka -lstdc++ -Wl,-rpath,\$$ORIGIN
 
 CHECK_FILES+= $(LIBFILENAME) $(LIBNAME).a
 


### PR DESCRIPTION
This pull request attempts to solves a library not found issue by updating librdkafka++ library flags to include librdkafka++ 's current directory at runtime as a search path when looking for dependencies.  I've intentionally left TODO comments in with some of my concerns/questions with the understanding I'll need to refactor.

Why/what happened: 
In working with a node.js module "node-rdkafka" version 2.4.1 which uses librdkafka I encountered a file not found issue when librdkafka++.so was attempting to load shared library librdkafak.so. In summary it appears that even though node-rdkafka is compiled with librdkafka++ library's location as a search path, since librdkafka++ owns the librdkafka.so dependency there is no effect on where librdkafka++.so searches. In order to effect it I needed to update librdkafka++ to include a search path in its ELF Header.

see attached log (lines 1, 3-35, 54) showing failure to find library.
[librdkafka++.so.ldd.log](https://github.com/edenhill/librdkafka/files/2372021/librdkafka%2B%2B.so.ldd.log)

additional log showing node-rdkafka ldd output (lines 30-64, 79) with failure to find library.
[node-rdkafka.ldd.log](https://github.com/edenhill/librdkafka/files/2372054/node-rdkafka.ldd.log)

After adding librdkafka++'s runtime path to the search I have the following results:
see attached log (lines 1-10, 55): showing librdkafka.so found using librdkafka++'s runtime path.
[librdkafka++.so.updated.ldd.log](https://github.com/edenhill/librdkafka/files/2372056/librdkafka%2B%2B.so.updated.ldd.log)

additionally here is node-rdkafka's ldd output after updating librdkafka++'s Makefile (lines 30-32, 65): showing librdkafka.so found using librdkafka++ 's runtime path.
[node-rdkafka.ldd.updated.log](https://github.com/edenhill/librdkafka/files/2372057/node-rdkafka.ldd.updated.log)
