### PR TITLE
Use C11 threads when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 - (cd dest && tar cvzf ../artifacts/librdkafka.tar.gz .)
 - if [[ "${TRAVIS_OS_NAME}_$CC" == "linux_gcc" ]]; then packaging/rpm/mock-on-docker.sh ; fi
 - if [[ "${TRAVIS_OS_NAME}_$CC" == "linux_gcc" ]]; then docker run -it -v $PWD:/v microsoft/dotnet:2-sdk /v/packaging/tools/build-debian.sh /v /v/artifacts/librdkafka-debian9.tgz; fi
+- if [[ "${TRAVIS_OS_NAME}_$CC" == "linux_clang" ]]; then packaging/alpine/test-build.sh ; fi
 deploy:
   provider: s3
   access_key_id:

--- a/configure.librdkafka
+++ b/configure.librdkafka
@@ -41,7 +41,28 @@ function checks {
     # -lrt is needed on linux for clock_gettime: link it if it exists.
     mkl_lib_check "librt" "" cont CC "-lrt"
 
-    # required libs
+
+    # Use internal tinycthread if C11 threads not avaialable
+    mkl_lib_check "c11threads" WITH_C11THREADS disable CC "" \
+                  "
+#include <threads.h>
+
+
+static int start_func (void *arg) {
+   int iarg = *(int *)arg;
+   return iarg;
+}
+
+void foo (void) {
+    thrd_t thr;
+    int arg = 1;
+    if (thrd_create(&thr, start_func, (void *)&arg) != thrd_success) {
+      ;
+    }
+}
+"
+
+    # pthreads required (even if C11 threads available) for rwlocks
     mkl_lib_check "libpthread" "" fail CC "-lpthread" \
                   "#include <pthread.h>"
 

--- a/packaging/alpine/test-build-alpine.sh
+++ b/packaging/alpine/test-build-alpine.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+#
+# Build librdkafka on Alpine.
+# Must only be run from within an Alpine container where
+# the librdkafka root dir is mounted as /v
+#
+
+set -eu
+
+if [ ! -f /.dockerenv ] ; then
+    echo "$0 must be run in the docker container"
+    exit 1
+fi
+
+apk add bash gcc g++ make musl-dev bsd-compat-headers git python
+
+git clone /v /librdkafka
+
+cd /librdkafka
+./configure
+make
+make -C tests run_local
+cd ..

--- a/packaging/alpine/test-build.sh
+++ b/packaging/alpine/test-build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Build librdkafka on Alpine using Docker, and run the local test suite.
+#
+
+set -eu
+echo -e "\033[35m### Building on Alpine ###\033[0m"
+exec docker run -v $PWD:/v alpine:3.8 /v/packaging/alpine/test-build-alpine.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(
     rdvarint.c
     snappy.c
     tinycthread.c
+    tinycthread_extra.c
     xxhash.c
     lz4.c
     lz4frame.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,7 +36,8 @@ SRCS=		rdkafka.c rdkafka_broker.c rdkafka_msg.c rdkafka_topic.c \
 		rdkafka_partition.c rdkafka_subscription.c \
 		rdkafka_assignor.c rdkafka_range_assignor.c \
 		rdkafka_roundrobin_assignor.c rdkafka_feature.c \
-		rdcrc32.c crc32c.c rdmurmur2.c rdaddr.c rdrand.c rdlist.c tinycthread.c \
+		rdcrc32.c crc32c.c rdmurmur2.c rdaddr.c rdrand.c rdlist.c \
+		tinycthread.c tinycthread_extra.c \
 		rdlog.c rdstring.c rdkafka_event.c rdkafka_metadata.c \
 		rdregex.c rdports.c rdkafka_metadata_cache.c rdavl.c \
 		rdkafka_sasl.c rdkafka_sasl_plain.c rdkafka_interceptor.c \

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -23,9 +23,9 @@ freely, subject to the following restrictions:
 */
 
 #include "rd.h"
-#include "rdtime.h"
-#include "tinycthread.h"
 #include <stdlib.h>
+
+#if !WITH_C11THREADS
 
 /* Platform specific includes */
 #if defined(_TTHREAD_POSIX_)
@@ -387,7 +387,7 @@ int cnd_broadcast(cnd_t *cond)
 }
 
 #if defined(_TTHREAD_WIN32_)
-static int _cnd_timedwait_win32(cnd_t *cond, mtx_t *mtx, DWORD timeout)
+int _cnd_timedwait_win32(cnd_t *cond, mtx_t *mtx, DWORD timeout)
 {
   int result, lastWaiter;
 
@@ -476,56 +476,6 @@ int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts)
 }
 
 
-int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms) {
-  if (timeout_ms == -1 /* INFINITE*/)
-    return cnd_wait(cnd, mtx);
-#if defined(_TTHREAD_WIN32_)
-	return _cnd_timedwait_win32(cnd, mtx, (DWORD)timeout_ms);
-#else
-  int ret;
-	struct timeval tv;
-	struct timespec ts;
-
-	gettimeofday(&tv, NULL);
-  ts.tv_sec = tv.tv_sec;
-  ts.tv_nsec = tv.tv_usec * 1000;
-
-	ts.tv_sec  += timeout_ms / 1000;
-	ts.tv_nsec += (timeout_ms % 1000) * 1000000;
-
-	if (ts.tv_nsec >= 1000000000) {
-		ts.tv_sec++;
-		ts.tv_nsec -= 1000000000;
-	}
-
-  ret = pthread_cond_timedwait(cnd, mtx, &ts);
-  if (ret == ETIMEDOUT)
-  {
-    return thrd_timedout;
-  }
-  return ret == 0 ? thrd_success : thrd_error;
-#endif
-}
-
-int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp) {
-        rd_ts_t pre = rd_clock();
-        int r;
-        r = cnd_timedwait_ms(cnd, mtx, *timeout_msp);
-        if (r != thrd_timedout) {
-                /* Subtract spent time */
-                (*timeout_msp) -= (int)(rd_clock()-pre) / 1000;
-        }
-        return r;
-}
-
-int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec) {
-        if (tspec->tv_sec == RD_POLL_INFINITE)
-                return cnd_wait(cnd, mtx);
-        else if (tspec->tv_sec == RD_POLL_NOWAIT)
-                return thrd_timedout;
-
-        return cnd_timedwait(cnd, mtx, tspec);
-}
 
 #if defined(_TTHREAD_WIN32_)
 struct TinyCThreadTSSData {
@@ -689,15 +639,6 @@ thrd_t thrd_current(void)
 #endif
 }
 
-int thrd_is_current(thrd_t thr) {
-#if defined(_TTHREAD_WIN32_)
-	return GetThreadId(thr) == GetCurrentThreadId();
-#else	
-	return (pthread_self() == thr);
-#endif
-}
-
-
 int thrd_detach(thrd_t thr)
 {
   thrd_is_detached = 1;
@@ -808,14 +749,6 @@ void thrd_yield(void)
 #else
   sched_yield();
 #endif
-}
-
-int thrd_setname (const char *name) {
-#if HAVE_PTHREAD_SETNAME_GNU
-  if (!pthread_setname_np(pthread_self(), name))
-    return thrd_success;
-#endif
-  return thrd_error;
 }
 
 int tss_create(tss_t *key, tss_dtor_t dtor)
@@ -998,51 +931,9 @@ void call_once(once_flag *flag, void (*func)(void))
 #endif /* defined(_TTHREAD_WIN32_) */
 
 
-#if !defined(_TTHREAD_WIN32_)
-int rwlock_init (rwlock_t *rwl) {
-        int r = pthread_rwlock_init(rwl, NULL);
-        if (r) {
-                errno = r;
-                return thrd_error;
-        }
-        return thrd_success;
-}
-
-int rwlock_destroy (rwlock_t *rwl) {
-        int r = pthread_rwlock_destroy(rwl);
-        if (r) {
-                errno = r;
-                return thrd_error;
-        }
-        return thrd_success;
-}
-
-int rwlock_rdlock (rwlock_t *rwl) {
-        int r = pthread_rwlock_rdlock(rwl);
-        assert(r == 0);
-        return thrd_success;
-}
-
-int rwlock_wrlock (rwlock_t *rwl) {
-        int r = pthread_rwlock_wrlock(rwl);
-        assert(r == 0);
-        return thrd_success;
-}
-
-int rwlock_rdunlock (rwlock_t *rwl) {
-        int r = pthread_rwlock_unlock(rwl);
-        assert(r == 0);
-        return thrd_success;
-}
-
-int rwlock_wrunlock (rwlock_t *rwl) {
-        int r = pthread_rwlock_unlock(rwl);
-        assert(r == 0);
-        return thrd_success;
-}
-
-#endif /* !defined(_TTHREAD_WIN32_) */
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* !WITH_C11THREADS */

--- a/src/tinycthread.h
+++ b/src/tinycthread.h
@@ -25,6 +25,17 @@ freely, subject to the following restrictions:
 #ifndef _TINYCTHREAD_H_
 #define _TINYCTHREAD_H_
 
+/* Include config to know if C11 threads are available */
+#ifdef _MSC_VER
+#include "win32_config.h"
+#else
+#include "../config.h"
+#endif
+
+#if WITH_C11THREADS
+#include <threads.h>
+#else
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -313,19 +324,9 @@ int cnd_wait(cnd_t *cond, mtx_t *mtx);
 */
 int cnd_timedwait(cnd_t *cond, mtx_t *mtx, const struct timespec *ts);
 
-/** Same as cnd_timedwait() but takes a relative timeout in milliseconds.
- */
-int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms);
-
-/** Same as cnd_timedwait_ms() but updates the remaining time. */
-int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp);
-
-/** Same as cnd_timedwait() but honours RD_POLL_INFINITE (use cnd_wait()),
- *  and RD_POLL_NOWAIT (return thrd_timedout immediately).
- *
- *  @remark Set up \p tspec with rd_timeout_init_timespec().
- */
-int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec);
+#if defined(_TTHREAD_WIN32_)
+int _cnd_timedwait_win32(cnd_t *cond, mtx_t *mtx, DWORD timeout);
+#endif
 
 /* Thread */
 #if defined(_TTHREAD_WIN32_)
@@ -362,12 +363,6 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg);
 * @return The identifier of the calling thread.
 */
 thrd_t thrd_current(void);
-
-
-/** Checks if passed thread is the current thread.
- * @return non-zero if same thread, else 0.
- */
-int thrd_is_current(thrd_t thr);
 
 
 /** Dispose of any resources allocated to the thread when that thread exits.
@@ -416,11 +411,6 @@ int thrd_sleep(const struct timespec *duration, struct timespec *remaining);
 * continue to run.
 */
 void thrd_yield(void);
-
-/** Set thread system name if platform supports it (pthreads)
-* @return thrd_success or thrd_error
-*/
-int thrd_setname (const char *name);
 
 /* Thread local storage */
 #if defined(_TTHREAD_WIN32_)
@@ -495,41 +485,15 @@ int tss_set(tss_t key, void *val);
 
 
 
-
-/**
-* FIXME: description */
-#if defined(_TTHREAD_WIN32_)
-typedef struct rwlock_t {
-	SRWLOCK  lock;
-	int       rcnt;
-	int       wcnt;
-} rwlock_t;
-#define rwlock_init(rwl)    do { (rwl)->rcnt = (rwl)->wcnt = 0; InitializeSRWLock(&(rwl)->lock); } while (0)
-#define rwlock_destroy(rwl)
-#define rwlock_rdlock(rwl)   do { if (0) printf("Thr %i: at %i:   RDLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockShared(&(rwl)->lock); InterlockedIncrement(&(rwl)->rcnt); } while (0)
-#define rwlock_wrlock(rwl)   do { if (0) printf("Thr %i: at %i:   WRLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockExclusive(&(rwl)->lock); InterlockedIncrement(&(rwl)->wcnt); } while (0)
-#define rwlock_rdunlock(rwl) do { if (0) printf("Thr %i: at %i: RDUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt > 0 && (rwl)->wcnt >= 0); ReleaseSRWLockShared(&(rwl)->lock); InterlockedDecrement(&(rwl)->rcnt); } while (0)  
-#define rwlock_wrunlock(rwl) do { if (0) printf("Thr %i: at %i: RWUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt > 0); ReleaseSRWLockExclusive(&(rwl)->lock); InterlockedDecrement(&(rwl)->wcnt); } while (0)  
-
-#define rwlock_rdlock_d(rwl)   do { if (1) printf("Thr %i: at %i:   RDLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockShared(&(rwl)->lock); InterlockedIncrement(&(rwl)->rcnt); } while (0)
-#define rwlock_wrlock_d(rwl)   do { if (1) printf("Thr %i: at %i:   WRLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockExclusive(&(rwl)->lock); InterlockedIncrement(&(rwl)->wcnt); } while (0)
-#define rwlock_rdunlock_d(rwl) do { if (1) printf("Thr %i: at %i: RDUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt > 0 && (rwl)->wcnt >= 0); ReleaseSRWLockShared(&(rwl)->lock); InterlockedDecrement(&(rwl)->rcnt); } while (0)  
-#define rwlock_wrunlock_d(rwl) do { if (1) printf("Thr %i: at %i: RWUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt > 0); ReleaseSRWLockExclusive(&(rwl)->lock); InterlockedDecrement(&(rwl)->wcnt); } while (0)  
-
-
-#else
-typedef pthread_rwlock_t rwlock_t;
-
-int rwlock_init (rwlock_t *rwl);
-int rwlock_destroy (rwlock_t *rwl);
-int rwlock_rdlock (rwlock_t *rwl);
-int rwlock_wrlock (rwlock_t *rwl);
-int rwlock_rdunlock (rwlock_t *rwl);
-int rwlock_wrunlock (rwlock_t *rwl);
-
-#endif
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* !WITH_C11THREADS */
+
+/**
+ * @brief librdkafka extensions to c11threads
+ */
+#include "tinycthread_extra.h"
 
 #endif /* _TINYTHREAD_H_ */

--- a/src/tinycthread_extra.c
+++ b/src/tinycthread_extra.c
@@ -1,0 +1,153 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2018 Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * @brief Extra methods added to tinychtread/c11threads
+ */
+
+#include "rd.h"
+#include "rdtime.h"
+#include "tinycthread.h"
+
+
+int thrd_setname (const char *name) {
+#if HAVE_PTHREAD_SETNAME_GNU
+        if (!pthread_setname_np(pthread_self(), name))
+                return thrd_success;
+#endif
+        return thrd_error;
+}
+
+int thrd_is_current(thrd_t thr) {
+#if defined(_TTHREAD_WIN32_)
+        return GetThreadId(thr) == GetCurrentThreadId();
+#else
+        return (pthread_self() == thr);
+#endif
+}
+
+
+
+
+int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms) {
+        if (timeout_ms == -1 /* INFINITE*/)
+                return cnd_wait(cnd, mtx);
+#if defined(_TTHREAD_WIN32_)
+        return _cnd_timedwait_win32(cnd, mtx, (DWORD)timeout_ms);
+#else
+        struct timeval tv;
+        struct timespec ts;
+
+        gettimeofday(&tv, NULL);
+        ts.tv_sec = tv.tv_sec;
+        ts.tv_nsec = tv.tv_usec * 1000;
+
+        ts.tv_sec  += timeout_ms / 1000;
+        ts.tv_nsec += (timeout_ms % 1000) * 1000000;
+
+        if (ts.tv_nsec >= 1000000000) {
+                ts.tv_sec++;
+                ts.tv_nsec -= 1000000000;
+        }
+
+        return cnd_timedwait(cnd, mtx, &ts);
+#endif
+}
+
+int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp) {
+        rd_ts_t pre = rd_clock();
+        int r;
+        r = cnd_timedwait_ms(cnd, mtx, *timeout_msp);
+        if (r != thrd_timedout) {
+                /* Subtract spent time */
+                (*timeout_msp) -= (int)(rd_clock()-pre) / 1000;
+        }
+        return r;
+}
+
+int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec) {
+        if (tspec->tv_sec == RD_POLL_INFINITE)
+                return cnd_wait(cnd, mtx);
+        else if (tspec->tv_sec == RD_POLL_NOWAIT)
+                return thrd_timedout;
+
+        return cnd_timedwait(cnd, mtx, tspec);
+}
+
+
+/**
+ * @name Read-write locks
+ * @{
+ */
+#ifndef _MSC_VER
+int rwlock_init (rwlock_t *rwl) {
+        int r = pthread_rwlock_init(rwl, NULL);
+        if (r) {
+                errno = r;
+                return thrd_error;
+        }
+        return thrd_success;
+}
+
+int rwlock_destroy (rwlock_t *rwl) {
+        int r = pthread_rwlock_destroy(rwl);
+        if (r) {
+                errno = r;
+                return thrd_error;
+        }
+        return thrd_success;
+}
+
+int rwlock_rdlock (rwlock_t *rwl) {
+        int r = pthread_rwlock_rdlock(rwl);
+        assert(r == 0);
+        return thrd_success;
+}
+
+int rwlock_wrlock (rwlock_t *rwl) {
+        int r = pthread_rwlock_wrlock(rwl);
+        assert(r == 0);
+        return thrd_success;
+}
+
+int rwlock_rdunlock (rwlock_t *rwl) {
+        int r = pthread_rwlock_unlock(rwl);
+        assert(r == 0);
+        return thrd_success;
+}
+
+int rwlock_wrunlock (rwlock_t *rwl) {
+        int r = pthread_rwlock_unlock(rwl);
+        assert(r == 0);
+        return thrd_success;
+}
+/**@}*/
+
+
+#endif /* !_MSC_VER */

--- a/src/tinycthread_extra.h
+++ b/src/tinycthread_extra.h
@@ -1,0 +1,117 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2018 Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * @brief Extra methods added to tinychtread/c11threads
+ */
+
+
+#ifndef _TINYCTHREAD_EXTRA_H_
+#define _TINYCTHREAD_EXTRA_H_
+
+
+#ifndef _MSC_VER
+#include <pthread.h> /* needed for rwlock_t */
+#endif
+
+
+/**
+ * @brief Set thread system name if platform supports it (pthreads)
+ * @return thrd_success or thrd_error
+ */
+int thrd_setname (const char *name);
+
+/**
+ * @brief Checks if passed thread is the current thread.
+ * @return non-zero if same thread, else 0.
+ */
+int thrd_is_current(thrd_t thr);
+
+
+
+
+/**
+ * @brief Same as cnd_timedwait() but takes a relative timeout in milliseconds.
+ */
+int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms);
+
+/**
+ * @brief Same as cnd_timedwait_ms() but updates the remaining time.
+*/
+int cnd_timedwait_msp (cnd_t *cnd, mtx_t *mtx, int *timeout_msp);
+
+/**
+ * @brief Same as cnd_timedwait() but honours
+ *        RD_POLL_INFINITE (uses cnd_wait()),
+ *        and RD_POLL_NOWAIT (return thrd_timedout immediately).
+ *
+ *  @remark Set up \p tspec with rd_timeout_init_timespec().
+ */
+int cnd_timedwait_abs (cnd_t *cnd, mtx_t *mtx, const struct timespec *tspec);
+
+
+
+
+/**
+ * @brief Read-write locks
+ */
+
+#if defined(_TTHREAD_WIN32_)
+typedef struct rwlock_t {
+        SRWLOCK  lock;
+        int       rcnt;
+        int       wcnt;
+} rwlock_t;
+#define rwlock_init(rwl)    do { (rwl)->rcnt = (rwl)->wcnt = 0; InitializeSRWLock(&(rwl)->lock); } while (0)
+#define rwlock_destroy(rwl)
+#define rwlock_rdlock(rwl)   do { if (0) printf("Thr %i: at %i:   RDLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockShared(&(rwl)->lock); InterlockedIncrement(&(rwl)->rcnt); } while (0)
+#define rwlock_wrlock(rwl)   do { if (0) printf("Thr %i: at %i:   WRLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockExclusive(&(rwl)->lock); InterlockedIncrement(&(rwl)->wcnt); } while (0)
+#define rwlock_rdunlock(rwl) do { if (0) printf("Thr %i: at %i: RDUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt > 0 && (rwl)->wcnt >= 0); ReleaseSRWLockShared(&(rwl)->lock); InterlockedDecrement(&(rwl)->rcnt); } while (0)
+#define rwlock_wrunlock(rwl) do { if (0) printf("Thr %i: at %i: RWUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt > 0); ReleaseSRWLockExclusive(&(rwl)->lock); InterlockedDecrement(&(rwl)->wcnt); } while (0)
+
+#define rwlock_rdlock_d(rwl)   do { if (1) printf("Thr %i: at %i:   RDLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockShared(&(rwl)->lock); InterlockedIncrement(&(rwl)->rcnt); } while (0)
+#define rwlock_wrlock_d(rwl)   do { if (1) printf("Thr %i: at %i:   WRLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt >= 0); AcquireSRWLockExclusive(&(rwl)->lock); InterlockedIncrement(&(rwl)->wcnt); } while (0)
+#define rwlock_rdunlock_d(rwl) do { if (1) printf("Thr %i: at %i: RDUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt > 0 && (rwl)->wcnt >= 0); ReleaseSRWLockShared(&(rwl)->lock); InterlockedDecrement(&(rwl)->rcnt); } while (0)
+#define rwlock_wrunlock_d(rwl) do { if (1) printf("Thr %i: at %i: RWUNLOCK %p   %s (%i, %i)\n", GetCurrentThreadId(), __LINE__, rwl, __FUNCTION__, (rwl)->rcnt, (rwl)->wcnt); assert((rwl)->rcnt >= 0 && (rwl)->wcnt > 0); ReleaseSRWLockExclusive(&(rwl)->lock); InterlockedDecrement(&(rwl)->wcnt); } while (0)
+
+
+#else
+typedef pthread_rwlock_t rwlock_t;
+
+int rwlock_init (rwlock_t *rwl);
+int rwlock_destroy (rwlock_t *rwl);
+int rwlock_rdlock (rwlock_t *rwl);
+int rwlock_wrlock (rwlock_t *rwl);
+int rwlock_rdunlock (rwlock_t *rwl);
+int rwlock_wrunlock (rwlock_t *rwl);
+
+#endif
+
+
+#endif /* _TINYCTHREAD_EXTRA_H_ */

--- a/tests/0033-regex_subscribe.c
+++ b/tests/0033-regex_subscribe.c
@@ -427,7 +427,7 @@ int main_0033_regex_subscribe_local (int argc, char **argv) {
 
         rd_kafka_topic_partition_list_add(invalids, "not_a_regex", 0);
         rd_kafka_topic_partition_list_add(invalids, "^My[vV]alid..regex+", 0);
-        rd_kafka_topic_partition_list_add(invalids, "^??++", 99);
+        rd_kafka_topic_partition_list_add(invalids, "^a[b", 99);
 
         rd_kafka_topic_partition_list_add(empty, "not_a_regex", 0);
         rd_kafka_topic_partition_list_add(empty, "", 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,13 +80,13 @@ set(
     0088-produce_metadata_timeout.c
     8000-idle.cpp
     test.c
-    testcpp.cpp    
+    testcpp.cpp
 )
 
 if(NOT WIN32)
     list(APPEND sources sockem.c)
 else()
-    list(APPEND sources ../src/tinycthread.c)
+    list(APPEND sources ../src/tinycthread.c ../src/tinycthread_extra.c)
 endif()
 
 add_executable(rdkafka_test ${sources})

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@ OBJS	  = $(TESTSRCS_C:%.c=%.o) $(TESTSRCS_CXX:%.cpp=%.o)
 
 BIN	  = merged
 LIBS	 += -lrdkafka++ -lrdkafka -lstdc++
-OBJS	 += test.o testcpp.o tinycthread.o rdlist.o sockem.o
+OBJS	 += test.o testcpp.o tinycthread.o tinycthread_extra.o rdlist.o sockem.o
 CFLAGS += -I../src
 CXXFLAGS += -I../src -I../src-cpp
 LDFLAGS += -rdynamic -L../src -L../src-cpp
@@ -61,6 +61,9 @@ endif
 
 
 tinycthread.o: ../src/tinycthread.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
+
+tinycthread_extra.o: ../src/tinycthread_extra.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 rdlist.o: ../src/rdlist.c

--- a/win32/librdkafka.sln
+++ b/win32/librdkafka.sln
@@ -43,9 +43,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "interceptor_test", "interce
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="..\src\snappy.h" />
     <ClInclude Include="..\src\snappy_compat.h" />
     <ClInclude Include="..\src\tinycthread.h" />
+    <ClInclude Include="..\src\tinycthread_extra.h" />
     <ClInclude Include="..\src\rdwin32.h" />
     <ClInclude Include="..\src\win32_config.h" />
     <ClInclude Include="..\src\regexp.h" />
@@ -209,6 +210,7 @@
     <ClCompile Include="..\src\rdvarint.c" />
     <ClCompile Include="..\src\snappy.c" />
     <ClCompile Include="..\src\tinycthread.c" />
+    <ClCompile Include="..\src\tinycthread_extra.c" />
     <ClCompile Include="..\src\regexp.c" />
     <ClCompile Include="..\src\rdports.c" />
     <ClCompile Include="..\src\rdavl.c" />

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -6,7 +6,7 @@
     <RootNamespace>tests</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)common.vcxproj"/>
+  <Import Project="$(SolutionDir)common.vcxproj" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
@@ -172,6 +172,7 @@
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />
     <ClCompile Include="..\..\src\tinycthread.c" />
+    <ClCompile Include="..\..\src\tinycthread_extra.c" />
     <ClCompile Include="..\..\src\rdlist.c" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When libc provides C11 threads, which is the case with musl on alpine, the internal librdkafka c11 thread implementation (tinycthread), interferes with the musl symbols, leading to weird errors and crashes.

There are no code changes, only refactoring.

This PR makes librdkafka use the system C11 threads if available.

Reported in #1998 
