### PR TITLE
Fixing Counting error in rdkafka_performance #1542

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1432,7 +1432,6 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
-
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1432,7 +1432,7 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
-		
+
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1432,9 +1432,7 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
-		cnt.msgs -= outq;
-		cnt.bytes -= msgsize * outq;
-
+		
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)


### PR DESCRIPTION
Removing the deduction of outq len from the total message produced count, which creates unnecessary mismatch between delivered and produced counters if in case there is some messages in outq.
Reference: issue#1542