### PR TITLE
Fix LTO warning with gcc 8.

### DIFF
--- a/src/rdaddr.c
+++ b/src/rdaddr.c
@@ -131,7 +131,7 @@ const char *rd_addrinfo_prepare (const char *nodesvc,
 	if (nodelen) {
 		/* Truncate nodename if necessary. */
 		nodelen = RD_MIN(nodelen, sizeof(snode)-1);
-		strncpy(snode, nodesvc, nodelen);
+		memcpy(snode, nodesvc, nodelen);
 		snode[nodelen] = '\0';
 	}
 


### PR DESCRIPTION
Hi,

We are having some compilation warnings (error in our case since we use -Werror) when linking a program against librdkafka built using LTO and enabling LTO.

We have:
```
In function ‘rd_addrinfo_prepare’,
    inlined from ‘rd_getaddrinfo.constprop’ at rdaddr.c:160:17,
    inlined from ‘rd_kafka_broker_resolve’ at rdkafka_broker.c:634:19,
    inlined from ‘rd_kafka_broker_connect’ at rdkafka_broker.c:1287:6,
    inlined from ‘rd_kafka_broker_thread_main’ at rdkafka_broker.c:3328:8:
rdaddr.c:134:3: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
rdkafka_broker.c: In function ‘rd_kafka_broker_thread_main’:
rdaddr.c:129:13: note: length computed here
lto1: all warnings being treated as errors
```

While here gcc is clearly being over-strict (gcc uses LTO to infer from cross-compilation unit that actually we used strlen() for the length of strncpy, but other cases from other call sites might still be different), I actually don't think you really need strncpy here, given that you explicitely add yourself a '\0' just after the strncpy, just using memcpy should be fine.

Note: a similar "fix" for not a real problem was recently merged in curl (we hit that issue too): 
 https://github.com/curl/curl/commit/357161accda84cf678c579c652429d529e56db80

Cheers,
Romain