### PR TITLE
Prevent int overflow while computing abs_timeout for producer request…

### DIFF
--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -640,7 +640,7 @@ rd_kafka_buf_set_abs_timeout (rd_kafka_buf_t *rkbuf, int timeout_ms,
         if (!now)
                 now = rd_clock();
         rkbuf->rkbuf_rel_timeout = 0;
-        rkbuf->rkbuf_abs_timeout = now + ((int64_t)timeout_ms * 1000);
+        rkbuf->rkbuf_abs_timeout = now + ((rd_ts_t)timeout_ms * 1000);
 }
 
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1979,7 +1979,7 @@ int rd_kafka_ProduceRequest (rd_kafka_broker_t *rkb, rd_kafka_toppar_t *rktp) {
                  * to produce anyway */
                 tmout = 100;
         } else {
-                tmout = (int)(first_msg_timeout > INT_MAX ? INT_MAX : first_msg_timeout);
+                tmout = (int)RD_MIN(INT_MAX, first_msg_timeout);
         }
 
         /* Set absolute timeout (including retries), the


### PR DESCRIPTION
tried to prevent int overflow and avoid incorrect message timeout (#2015)