### PR TITLE
CMake: Generate pk-gconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(RdKafka)
+project(RdKafka VERSION 0.11.6)
 
 # Options. No 'RDKAFKA_' prefix to match old C++ code. {
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.2)
-project(RdKafka VERSION 0.11.6)
+
+include("packaging/cmake/parseversion.cmake")
+parseversion("src/rdkafka.h")
+
+project(RdKafka VERSION ${RDKAFKA_VERSION})
 
 # Options. No 'RDKAFKA_' prefix to match old C++ code. {
 

--- a/packaging/cmake/parseversion.cmake
+++ b/packaging/cmake/parseversion.cmake
@@ -1,0 +1,60 @@
+# hex2dec(<out-var> <input>):
+# Convert a hexadecimal value <input> to decimal and write the result
+# to <out-var>.
+macro(hex2dec var val)
+    set(${var} 0)
+
+    set(hex2dec_idx 0)
+    string(LENGTH "${val}" hex2dec_len)
+
+    while(hex2dec_idx LESS hex2dec_len)
+        string(SUBSTRING ${val} ${hex2dec_idx} 1 hex2dec_char)
+
+        if(hex2dec_char MATCHES "[0-9]")
+            set(hex2dec_char ${hex2dec_char})
+        elseif(hex2dec_char MATCHES "[aA]")
+            set(hex2dec_char 10)
+        elseif(hex2dec_char MATCHES "[bB]")
+            set(hex2dec_char 11)
+        elseif(hex2dec_char MATCHES "[cC]")
+            set(hex2dec_char 12)
+        elseif(hex2dec_char MATCHES "[dD]")
+            set(hex2dec_char 13)
+        elseif(hex2dec_char MATCHES "[eE]")
+            set(hex2dec_char 14)
+        elseif(hex2dec_char MATCHES "[fF]")
+            set(hex2dec_char 15)
+        else()
+            message(FATAL_ERROR "Invalid format for hexidecimal character: " ${hex2dec_char})
+        endif()
+
+        math(EXPR hex2dec_char "${hex2dec_char} << ((${hex2dec_len}-${hex2dec_idx}-1)*4)")
+        math(EXPR ${var} "${${var}}+${hex2dec_char}")
+        math(EXPR hex2dec_idx "${hex2dec_idx}+1")
+    endwhile()
+endmacro(hex2dec)
+
+# parseversion(<filepath>):
+# Parse the file given by <filepath> for the RD_KAFKA_VERSION constant
+# and convert the hex value to decimal version numbers.
+# Creates the following CMake variables:
+# * RDKAFKA_VERSION
+# * RDKAFKA_VERSION_MAJOR
+# * RDKAFKA_VERSION_MINOR
+# * RDKAFKA_VERSION_REVISION
+# * RDKAFKA_VERSION_PRERELEASE
+macro(parseversion path)
+    file(STRINGS ${path} rdkafka_version_def REGEX "#define  *RD_KAFKA_VERSION  *\(0x[a-f0-9]*\)\.*")
+    string(REGEX REPLACE "#define  *RD_KAFKA_VERSION  *0x" "" rdkafka_version_hex ${rdkafka_version_def})
+
+    string(SUBSTRING ${rdkafka_version_hex} 0 2 rdkafka_version_major_hex)
+    string(SUBSTRING ${rdkafka_version_hex} 2 2 rdkafka_version_minor_hex)
+    string(SUBSTRING ${rdkafka_version_hex} 4 2 rdkafka_version_revision_hex)
+    string(SUBSTRING ${rdkafka_version_hex} 6 2 rdkafka_version_prerelease_hex)
+
+    hex2dec(RDKAFKA_VERSION_MAJOR ${rdkafka_version_major_hex})
+    hex2dec(RDKAFKA_VERSION_MINOR ${rdkafka_version_minor_hex})
+    hex2dec(RDKAFKA_VERSION_REVISION ${rdkafka_version_revision_hex})
+    hex2dec(RDKAFKA_VERSION_PRERELEASE ${rdkafka_version_prerelease_hex})
+    set(RDKAFKA_VERSION "${RDKAFKA_VERSION_MAJOR}.${RDKAFKA_VERSION_MINOR}.${RDKAFKA_VERSION_REVISION}")
+endmacro(parseversion)

--- a/packaging/cmake/rdkafka.pc.in
+++ b/packaging/cmake/rdkafka.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${prefix}/lib
+
+Name: @PKG_CONFIG_NAME@
+Description: @PKG_CONFIG_DESCRIPTION@
+Version: @PKG_CONFIG_VERSION@
+Requires: @PKG_CONFIG_REQUIRES@
+Cflags: @PKG_CONFIG_CFLAGS@
+Libs: @PKG_CONFIG_LIBS@
+Libs.private: @PKG_CONFIG_LIBS_PRIVATE@

--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -37,6 +37,55 @@ if(NOT RDKAFKA_BUILD_STATIC)
         target_compile_definitions(rdkafka++ INTERFACE LIBRDKAFKACPP_EXPORTS=0)
     endif()
 endif()
+
+# Generate pkg-config file
+set(PKG_CONFIG_NAME
+    "librdkafka++"
+)
+set(PKG_CONFIG_DESCRIPTION
+    "The Apache Kafka C/C++ library"
+)
+set(PKG_CONFIG_VERSION
+    "${PROJECT_VERSION}"
+)
+set(PKG_CONFIG_REQUIRES "rdkafka")
+set(PKG_CONFIG_CFLAGS
+    "-I\${includedir}"
+)
+set(PKG_CONFIG_LIBS
+    "-L\${libdir} -lrdkafka++"
+)
+set(PKG_CONFIG_LIBS_PRIVATE
+    "-lrdkafka -lstdc++"
+)
+configure_file(
+    "../packaging/cmake/rdkafka.pc.in"
+    "${GENERATED_DIR}/rdkafka++.pc"
+    @ONLY
+)
+install(FILES ${GENERATED_DIR}/rdkafka++.pc
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+if(RDKAFKA_BUILD_STATIC)
+  set(PKG_CONFIG_NAME
+    "librdkafka++-static"
+  )
+  set(PKG_CONFIG_DESCRIPTION
+    "The Apache Kafka C/C++ library (static)"
+  )
+  set(PKG_CONFIG_LIBS
+    "-L\${libdir} \${libdir}/librdkafka++.a"
+  )
+  configure_file(
+    "../packaging/cmake/rdkafka.pc.in"
+    "${GENERATED_DIR}/rdkafka++-static.pc"
+    @ONLY
+  )
+  install(FILES ${GENERATED_DIR}/rdkafka.pc
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
+endif()
+
 install(
     TARGETS rdkafka++
     EXPORT "${targets_export_name}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,6 +214,9 @@ endif()
 if(WITH_SASL_CYRUS)
   string(APPEND PKG_CONFIG_REQUIRES "libsasl2 ")
 endif()
+if(WITH_ZSTD)
+    string(APPEND PKG_CONFIG_REQUIRES "libzstd ")
+endif()
 set(PKG_CONFIG_CFLAGS
     "-I\${includedir}"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,8 +221,12 @@ set(PKG_CONFIG_LIBS
     "-L\${libdir} -lrdkafka"
 )
 set(PKG_CONFIG_LIBS_PRIVATE
-    "-lpthread -lrt"
+    "-lpthread"
 )
+find_library(RT_LIBRARY rt)
+if(RT_LIBRARY)
+  string(APPEND PKG_CONFIG_LIBS_PRIVATE " -lrt")
+endif()
 if(WITH_PLUGINS)
   string(APPEND PKG_CONFIG_LIBS_PRIVATE " -ldl")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,66 @@ endif()
 #set(rdkafka_SRC_DIR ${PROJECT_SOURCE_DIR}
 #    CACHE INTERNAL "${PROJECT_NAME} source dir" FORCE)
 
+# Generate pkg-config file
+set(PKG_CONFIG_NAME
+    "librdkafka"
+)
+set(PKG_CONFIG_DESCRIPTION
+    "The Apache Kafka C/C++ library"
+)
+set(PKG_CONFIG_VERSION
+    "${PROJECT_VERSION}"
+)
+set(PKG_CONFIG_REQUIRES "")
+if(WITH_ZLIB)
+  string(APPEND PKG_CONFIG_REQUIRES "zlib ")
+endif()
+if(WITH_SSL)
+    string(APPEND PKG_CONFIG_REQUIRES "libssl ")
+endif()
+if(WITH_SASL_CYRUS)
+  string(APPEND PKG_CONFIG_REQUIRES "libsasl2 ")
+endif()
+set(PKG_CONFIG_CFLAGS
+    "-I\${includedir}"
+)
+set(PKG_CONFIG_LIBS
+    "-L\${libdir} -lrdkafka"
+)
+set(PKG_CONFIG_LIBS_PRIVATE
+    "-lpthread -lrt"
+)
+if(WITH_PLUGINS)
+  string(APPEND PKG_CONFIG_LIBS_PRIVATE " -ldl")
+endif()
+configure_file(
+  "../packaging/cmake/rdkafka.pc.in"
+  "${GENERATED_DIR}/rdkafka.pc"
+  @ONLY
+)
+install(FILES ${GENERATED_DIR}/rdkafka.pc
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+if(RDKAFKA_BUILD_STATIC)
+  set(PKG_CONFIG_NAME
+    "librdkafka-static"
+  )
+  set(PKG_CONFIG_DESCRIPTION
+    "The Apache Kafka C/C++ library (static)"
+  )
+  set(PKG_CONFIG_LIBS
+    "-L\${libdir} \${libdir}/librdkafka.a"
+  )
+  configure_file(
+    "../packaging/cmake/rdkafka.pc.in"
+    "${GENERATED_DIR}/rdkafka-static.pc"
+    @ONLY
+  )
+  install(FILES ${GENERATED_DIR}/rdkafka.pc
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+  )
+endif()
+
 install(
     TARGETS rdkafka
     EXPORT "${targets_export_name}"


### PR DESCRIPTION
Generate the pkg-config files with CMake.

It uses the configure_file function from CMake to generate the pkg-config files for the C and C++ libraries (shared and optionally static variant) from the same template file.

Since the pkg-config files contain the version, the CMake project version is set.