### PR TITLE
Fix build failure on hurd-i386

### DIFF
--- a/src/rd.h
+++ b/src/rd.h
@@ -168,8 +168,8 @@ static RD_INLINE RD_UNUSED char *rd_strndup(const char *s, size_t len) {
 #ifdef __APPLE__
 /* Some versions of MacOSX dont have IOV_MAX */
 #define IOV_MAX 1024
-#elif defined(_MSC_VER)
-/* There is no IOV_MAX on MSVC but it is used internally in librdkafka */
+#elif defined(_MSC_VER) || defined(__GNU__)
+/* There is no IOV_MAX on MSVC or GNU but it is used internally in librdkafka */
 #define IOV_MAX 1024
 #else
 #error "IOV_MAX not defined"

--- a/src/snappy_compat.h
+++ b/src/snappy_compat.h
@@ -5,7 +5,7 @@
 
 #ifdef __FreeBSD__
 #  include <sys/endian.h>
-#elif defined(__APPLE_CC_) || defined(__MACH__)  /* MacOS/X support */
+#elif defined(__APPLE_CC_) || (defined(__MACH__) && defined(__APPLE__))  /* MacOS/X support */
 #  include <machine/endian.h>
 
 #if    __DARWIN_BYTE_ORDER == __DARWIN_LITTLE_ENDIAN


### PR DESCRIPTION
Hello Magnus, this addresses an issue on hurd-i386 build failure we had
in Debian.

See https://bugs.debian.org/900716
Build logs https://buildd.debian.org/status/fetch.php?pkg=librdkafka&arch=hurd-i386&ver=0.11.6-1&stamp=1540378777&raw=0

Patch by Samuel Thibault <sthibault@debian.org>