### PR TITLE
Fix for #1550 Misleading "All messages delivered!" message 

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -188,6 +188,7 @@ static void msg_delivered (rd_kafka_t *rk,
 	rd_ts_t now = rd_clock();
 	static int msgs;
 	double error_percent = 0;
+	
 	msgs++;
 
 	msgs_wait_cnt--;

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -188,7 +188,6 @@ static void msg_delivered (rd_kafka_t *rk,
 	rd_ts_t now = rd_clock();
 	static int msgs;
 	double error_percent = 0;
-
 	msgs++;
 
 	msgs_wait_cnt--;
@@ -241,7 +240,7 @@ static void msg_delivered (rd_kafka_t *rk,
 			error_percent = (cnt.msgs - cnt.msgs_dr_ok)/cnt.msgs * 100;
 		}
 		if (verbosity >= 2)
-			 printf("Messages delivered with failure percentage of %lf!\n",
+			 printf("Messages delivered with failure percentage of %.5f!\n",
 					error_percent);
 		t_end = rd_clock();
 		run = 0;
@@ -1467,6 +1466,7 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
+		cnt.msgs -= outq;
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -187,7 +187,7 @@ static void msg_delivered (rd_kafka_t *rk,
 	static rd_ts_t last;
 	rd_ts_t now = rd_clock();
 	static int msgs;
-
+	double error_percent = 0;
 	msgs++;
 
 	msgs_wait_cnt--;
@@ -236,8 +236,12 @@ static void msg_delivered (rd_kafka_t *rk,
         cnt.last_offset = rkmessage->offset;
 
 	if (msgs_wait_produce_cnt == 0 && msgs_wait_cnt == 0 && !forever) {
+		if (cnt.msgs > 0) {
+			error_percent = (cnt.msgs - cnt.msgs_dr_ok)/cnt.msgs * 100;
+		}
 		if (verbosity >= 2)
-			printf("All messages delivered!\n");
+			 printf("Messages delivered with failure percentage of %lf!\n",
+					error_percent);
 		t_end = rd_clock();
 		run = 0;
 	}

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1462,10 +1462,6 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
-<<<<<<< HEAD
-=======
-		
->>>>>>> Counting error in rdkafka_performance #1542
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -188,6 +188,7 @@ static void msg_delivered (rd_kafka_t *rk,
 	rd_ts_t now = rd_clock();
 	static int msgs;
 	double error_percent = 0;
+
 	msgs++;
 
 	msgs_wait_cnt--;

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1462,6 +1462,10 @@ int main (int argc, char **argv) {
 		outq = rd_kafka_outq_len(rk);
                 if (verbosity >= 2)
                         printf("%% %i messages in outq\n", outq);
+<<<<<<< HEAD
+=======
+		
+>>>>>>> Counting error in rdkafka_performance #1542
 		cnt.t_end = t_end;
 
 		if (cnt.tx_err > 0)

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3208,7 +3208,6 @@ rd_kafka_DescribeConfigsRequest (rd_kafka_broker_t *rkb,
         if (rd_list_cnt(configs) == 0) {
                 rd_snprintf(errstr, errstr_size,
                             "No config resources specified");
-		rd_kafka_replyq_destroy(&replyq);
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
         }
 
@@ -3218,7 +3217,6 @@ rd_kafka_DescribeConfigsRequest (rd_kafka_broker_t *rkb,
                 rd_snprintf(errstr, errstr_size,
                             "DescribeConfigs (KIP-133) not supported "
                             "by broker, requires broker version >= 0.11.0");
-		rd_kafka_replyq_destroy(&replyq);
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3208,6 +3208,7 @@ rd_kafka_DescribeConfigsRequest (rd_kafka_broker_t *rkb,
         if (rd_list_cnt(configs) == 0) {
                 rd_snprintf(errstr, errstr_size,
                             "No config resources specified");
+		rd_kafka_replyq_destroy(&replyq);
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
         }
 
@@ -3217,6 +3218,7 @@ rd_kafka_DescribeConfigsRequest (rd_kafka_broker_t *rkb,
                 rd_snprintf(errstr, errstr_size,
                             "DescribeConfigs (KIP-133) not supported "
                             "by broker, requires broker version >= 0.11.0");
+		rd_kafka_replyq_destroy(&replyq);
                 return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
         }
 


### PR DESCRIPTION
#1550 this is the fix , to change the message in msg_delivered. Earlier irrespective of delivery failures
it was showing "All messages delivered". Now post this change it will give the delivery failure percentage.

The Unit test result:

souracha@souracha-VirtualBox:~/librdkafka/librdkafka/examples$ ./rdkafka_performance -P -t test -b localhost:9092 -s 1000 -c 450000 -v
% Using random seed 1542016931, verbosity level 2
% Sending 450000 messages of size 1000 bytes
% All messages produced, now waiting for 398102 deliveries
% 450000 messages produced (450000000 bytes), 232741 delivered (offset 0, 0 failed) in 1001ms: 232438 msgs/s and 232.44 MB/s, 0 produce failures, 217259 in queue, no compression
Messages delivered with failure percentage of 0.000000!
% 0 messages in outq
% 450000 messages produced (450000000 bytes), 450000 delivered (offset 0, 0 failed) in 1687ms: 266638 msgs/s and 266.64 MB/s, 0 produce failures, 0 in queue, no compression
