### PR TITLE
OpenSSL initialization compatibility for v1.1.0 and later

### DIFF
--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -522,11 +522,18 @@ void rd_kafka_transport_ssl_init (void) {
 		CRYPTO_set_id_callback(rd_kafka_transport_ssl_threadid_cb);
 #endif
 	}
-#endif
-	
+
+        /* OPENSSL_init_ssl(3) and OPENSSL_init_crypto(3) say:
+         * "As of version 1.1.0 OpenSSL will automatically allocate
+         * all resources that it needs so no explicit initialisation
+         * is required. Similarly it will also automatically
+         * deinitialise as required."
+         */
 	SSL_load_error_strings();
 	SSL_library_init();
 	OpenSSL_add_all_algorithms();
+#endif
+
 }
 
 


### PR DESCRIPTION
OpenSSL v1.1.0 made all of the init stuff optional and deprecated the old functions in favor of `OPENSSL_init_ssl` and `OPENSSL_init_crypto`. There are compatibility macros in place, but only if you compile with openssl's api compatibility switch set.

This change lets librdkafka compile against OpenSSL with the API compatibility level set as late as 1.1.0.

I've only done moderate testing ("it works for me").