### PR TITLE
Add dup config to C++ interface

### DIFF
--- a/src-cpp/ConfImpl.cpp
+++ b/src-cpp/ConfImpl.cpp
@@ -100,8 +100,6 @@ RdKafka::Conf *RdKafka::ConfImpl::dup() {
         newConf->partitioner_kp_cb_ = partitioner_kp_cb_;
         newConf->rebalance_cb_ = rebalance_cb_;
         newConf->offset_commit_cb_ = offset_commit_cb_;
-        newConf->cert_verify_cb_ = cert_verify_cb_;
-        newConf->cert_retrieve_cb_ = cert_retrieve_cb_;
         newConf->conf_type_ = conf_type_;
         
         if (conf_type_ == CONF_GLOBAL) {

--- a/src-cpp/ConfImpl.cpp
+++ b/src-cpp/ConfImpl.cpp
@@ -87,3 +87,28 @@ RdKafka::Conf *RdKafka::Conf::create (ConfType type) {
 
   return conf;
 }
+
+RdKafka::Conf *RdKafka::ConfImpl::dup() {
+    ConfImpl* newConf = new ConfImpl();
+    if (newConf) {
+        newConf->consume_cb_ = consume_cb_;
+        newConf->dr_cb_ = dr_cb_;
+        newConf->event_cb_ = event_cb_;
+        newConf->socket_cb_ = socket_cb_;
+        newConf->open_cb_ = open_cb_;
+        newConf->partitioner_cb_ = partitioner_cb_;
+        newConf->partitioner_kp_cb_ = partitioner_kp_cb_;
+        newConf->rebalance_cb_ = rebalance_cb_;
+        newConf->offset_commit_cb_ = offset_commit_cb_;
+        newConf->cert_verify_cb_ = cert_verify_cb_;
+        newConf->cert_retrieve_cb_ = cert_retrieve_cb_;
+        newConf->conf_type_ = conf_type_;
+        
+        if (conf_type_ == CONF_GLOBAL)
+            newConf->rk_conf_ = rd_kafka_conf_dup(rk_conf_);
+        else if( conf_type_ == CONF_TOPIC)
+            newConf->rkt_conf_ = rd_kafka_topic_conf_dup(rkt_conf_);
+    }
+
+    return newConf;
+}

--- a/src-cpp/ConfImpl.cpp
+++ b/src-cpp/ConfImpl.cpp
@@ -104,10 +104,14 @@ RdKafka::Conf *RdKafka::ConfImpl::dup() {
         newConf->cert_retrieve_cb_ = cert_retrieve_cb_;
         newConf->conf_type_ = conf_type_;
         
-        if (conf_type_ == CONF_GLOBAL)
+        if (conf_type_ == CONF_GLOBAL) {
             newConf->rk_conf_ = rd_kafka_conf_dup(rk_conf_);
-        else if( conf_type_ == CONF_TOPIC)
+            rd_kafka_conf_set_opaque(newConf->rk_conf_, this);
+        }
+        else if (conf_type_ == CONF_TOPIC) {
             newConf->rkt_conf_ = rd_kafka_topic_conf_dup(rkt_conf_);
+            rd_kafka_topic_conf_set_opaque(newConf->rkt_conf_, this);
+        }
     }
 
     return newConf;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1000,6 +1000,10 @@ class RD_EXPORT Conf {
   /** @brief Use with \p name = \c \"consume_cb\" */
   virtual Conf::ConfResult set (const std::string &name, ConsumeCb *consume_cb,
 				std::string &errstr) = 0;
+
+  /** @brief Duplicates the configuration object */
+  virtual Conf *Conf::dup() = 0;
+
 };
 
 /**@}*/

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1002,8 +1002,7 @@ class RD_EXPORT Conf {
 				std::string &errstr) = 0;
 
   /** @brief Duplicates the configuration object */
-  virtual Conf *Conf::dup() = 0;
-
+  virtual Conf *dup() = 0;
 };
 
 /**@}*/

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -684,6 +684,8 @@ class ConfImpl : public Conf {
     return Conf::CONF_OK;
   }
 
+  RdKafka::Conf *dup();
+
 
   ConsumeCb *consume_cb_;
   DeliveryReportCb *dr_cb_;


### PR DESCRIPTION
Added the ability to duplicate a configuration in the C++ interface.  This is exposed in the C interface but we need this in C++ interface too.