### PR TITLE
Use separate connection to the group coordinator

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1706,10 +1706,8 @@ static int rd_kafka_thread_main (void *arg) {
                                      1000ll,
                                      rd_kafka_metadata_refresh_cb, NULL);
 
-        if (rk->rk_cgrp) {
-                rd_kafka_cgrp_reassign_broker(rk->rk_cgrp);
+        if (rk->rk_cgrp)
                 rd_kafka_q_fwd_set(rk->rk_cgrp->rkcg_ops, rk->rk_ops);
-        }
 
         if (rd_kafka_is_idempotent(rk))
                 rd_kafka_idemp_init(rk);
@@ -3406,10 +3404,10 @@ static void rd_kafka_dump0 (FILE *fp, rd_kafka_t *rk, int locks) {
                         RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
                         rd_kafka_cgrp_state_names[rkcg->rkcg_state],
                         rkcg->rkcg_flags);
-                fprintf(fp, "   coord_id %"PRId32", managing broker %s\n",
+                fprintf(fp, "   coord_id %"PRId32", broker %s\n",
                         rkcg->rkcg_coord_id,
-                        rkcg->rkcg_rkb ?
-                        rd_kafka_broker_name(rkcg->rkcg_rkb) : "(none)");
+                        rkcg->rkcg_curr_coord ?
+                        rd_kafka_broker_name(rkcg->rkcg_curr_coord):"(none)");
 
                 fprintf(fp, "  toppars:\n");
                 RD_LIST_FOREACH(s_rktp, &rkcg->rkcg_toppars, i) {

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2054,7 +2054,7 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *app_conf,
                      rk->rk_name,
                      rk->rk_conf.builtin_features, rk->rk_conf.debug);
 
-        rd_kafka_conf_warn_deprecated(rk);
+        rd_kafka_conf_warn(rk);
 
 	return rk;
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -136,9 +136,11 @@ static void rd_kafka_mk_brokername (char *dest, size_t dsize,
 				    const char *nodename, int32_t nodeid,
 				    rd_kafka_confsource_t source) {
 
-	/* Prepend protocol name to brokername, unless it is a
-	 * standard plaintext broker in which case we omit the protocol part. */
-	if (proto != RD_KAFKA_PROTO_PLAINTEXT) {
+        /* Prepend protocol name to brokername, unless it is a
+         * standard plaintext or logical broker in which case we
+         * omit the protocol part. */
+        if (proto != RD_KAFKA_PROTO_PLAINTEXT &&
+            source != RD_KAFKA_LOGICAL) {
 		int r = rd_snprintf(dest, dsize, "%s://",
 				    rd_kafka_secproto_names[proto]);
 		if (r >= (int)dsize) /* Skip proto name if it wont fit.. */
@@ -149,10 +151,11 @@ static void rd_kafka_mk_brokername (char *dest, size_t dsize,
 	}
 
 	if (nodeid == RD_KAFKA_NODEID_UA)
-		rd_snprintf(dest, dsize, "%s/%s",
+		rd_snprintf(dest, dsize, "%s%s",
 			    nodename,
-			    source == RD_KAFKA_INTERNAL ?
-			    "internal":"bootstrap");
+                            source == RD_KAFKA_LOGICAL ? "" :
+                            (source == RD_KAFKA_INTERNAL ?
+                             "/internal" : "/bootstrap"));
 	else
 		rd_snprintf(dest, dsize, "%s/%"PRId32, nodename, nodeid);
 }
@@ -784,9 +787,17 @@ rd_kafka_broker_send (rd_kafka_broker_t *rkb, rd_slice_t *slice) {
 
 
 
-static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb) {
+static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb,
+                                    const char *nodename) {
 	const char *errstr;
         int save_idx = 0;
+
+        if (!*nodename && rkb->rkb_source == RD_KAFKA_LOGICAL) {
+                rd_kafka_broker_fail(rkb, LOG_DEBUG,
+                                     RD_KAFKA_RESP_ERR__RESOLVE,
+                                     "Logical broker has no address yet");
+                return -1;
+        }
 
 	if (rkb->rkb_rsal &&
 	    rkb->rkb_ts_rsal_last + (rkb->rkb_rk->rk_conf.broker_addr_ttl*1000)
@@ -818,7 +829,7 @@ static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb) {
                                              rkb->rkb_err.err == errno ?
                                              NULL :
                                              "Failed to resolve '%s': %s",
-                                             rkb->rkb_nodename, errstr);
+                                             nodename, errstr);
 			return -1;
                 } else {
                         rkb->rkb_ts_rsal_last = rd_clock();
@@ -1130,6 +1141,9 @@ rd_kafka_broker_random (rd_kafka_t *rk,
         int cnt = 0;
 
         TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (RD_KAFKA_BROKER_IS_LOGICAL(rkb))
+                        continue;
+
                 rd_kafka_broker_lock(rkb);
                 if ((int)rkb->rkb_state == state &&
                     (!filter || !filter(rkb, opaque))) {
@@ -1240,6 +1254,9 @@ rd_kafka_broker_t *rd_kafka_broker_prefer (rd_kafka_t *rk, int32_t broker_id,
         int cnt = 0;
 
 	TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (RD_KAFKA_BROKER_IS_LOGICAL(rkb))
+                        continue;
+
 		rd_kafka_broker_lock(rkb);
 		if ((int)rkb->rkb_state == state) {
                         if (broker_id != -1 && rkb->rkb_nodeid == broker_id) {
@@ -1754,6 +1771,7 @@ static int rd_ut_reconnect_backoff (void) {
 static int rd_kafka_broker_connect (rd_kafka_broker_t *rkb) {
 	const rd_sockaddr_inx_t *sinx;
 	char errstr[512];
+        char nodename[RD_KAFKA_NODENAME_SIZE];
 
 	rd_rkb_dbg(rkb, BROKER, "CONNECT",
 		"broker in state %s connecting",
@@ -1763,13 +1781,15 @@ static int rd_kafka_broker_connect (rd_kafka_broker_t *rkb) {
 
         rd_kafka_broker_lock(rkb);
         rd_kafka_broker_set_state(rkb, RD_KAFKA_BROKER_STATE_CONNECT);
+        strncpy(nodename, rkb->rkb_nodename, sizeof(nodename));
+        rkb->rkb_connect_epoch = rkb->rkb_nodename_epoch;
         rd_kafka_broker_unlock(rkb);
 
         rd_kafka_broker_update_reconnect_backoff(rkb, &rkb->rkb_rk->rk_conf,
                                                  rd_clock());
 
-	if (rd_kafka_broker_resolve(rkb) == -1)
-		return -1;
+        if (rd_kafka_broker_resolve(rkb, nodename) == -1)
+                return -1;
 
 	sinx = rd_sockaddr_list_next(rkb->rkb_rsal);
 
@@ -2509,6 +2529,20 @@ static int rd_kafka_broker_cmp_by_id (const void *_a, const void *_b) {
 }
 
 
+/**
+ * @brief Set the broker logname (used in logs) to a copy of \p logname.
+ *
+ * @locality any
+ * @locks none
+ */
+static void rd_kafka_broker_set_logname (rd_kafka_broker_t *rkb,
+                                         const char *logname) {
+        mtx_lock(&rkb->rkb_logname_lock);
+        if (rkb->rkb_logname)
+                rd_free(rkb->rkb_logname);
+        rkb->rkb_logname = rd_strdup(logname);
+        mtx_unlock(&rkb->rkb_logname_lock);
+}
 
 /**
  * @brief Serve a broker op (an op posted by another thread to be handled by
@@ -2549,6 +2583,7 @@ static int rd_kafka_broker_op_serve (rd_kafka_broker_t *rkb,
                         strncpy(rkb->rkb_nodename,
                                 rko->rko_u.node.nodename,
                                 sizeof(rkb->rkb_nodename)-1);
+                        rkb->rkb_nodename_epoch++;
                         updated |= _UPD_NAME;
                 }
 
@@ -2581,10 +2616,7 @@ static int rd_kafka_broker_op_serve (rd_kafka_broker_t *rkb,
 				       RD_KAFKA_LEARNED);
                 if (strcmp(rkb->rkb_name, brokername)) {
                         /* Udate the name copy used for logging. */
-                        mtx_lock(&rkb->rkb_logname_lock);
-                        rd_free(rkb->rkb_logname);
-                        rkb->rkb_logname = rd_strdup(brokername);
-                        mtx_unlock(&rkb->rkb_logname_lock);
+                        rd_kafka_broker_set_logname(rkb, brokername);
 
                         rd_rkb_dbg(rkb, BROKER, "UPDATE",
                                    "Name changed from %s to %s",
@@ -2861,6 +2893,25 @@ static int rd_kafka_broker_op_serve (rd_kafka_broker_t *rkb,
                         rd_kafka_broker_set_state(
                                 rkb, RD_KAFKA_BROKER_STATE_TRY_CONNECT);
                         rd_kafka_broker_unlock(rkb);
+
+                } else if (rkb->rkb_state >=
+                           RD_KAFKA_BROKER_STATE_TRY_CONNECT) {
+                        rd_bool_t do_disconnect = rd_false;
+
+                        /* If the nodename was changed since the last connect,
+                         * close the current connection. */
+
+                        rd_kafka_broker_lock(rkb);
+                        do_disconnect = (rkb->rkb_connect_epoch !=
+                                         rkb->rkb_nodename_epoch);
+                        rd_kafka_broker_unlock(rkb);
+
+                        if (do_disconnect)
+                                rd_kafka_broker_fail(
+                                        rkb, LOG_DEBUG,
+                                        RD_KAFKA_RESP_ERR__NODE_UPDATE,
+                                        "Closing connection due to "
+                                        "nodename change");
                 }
                 break;
 
@@ -4377,10 +4428,18 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 
 	rkb = rd_calloc(1, sizeof(*rkb));
 
-        rd_kafka_mk_nodename(rkb->rkb_nodename, sizeof(rkb->rkb_nodename),
-                             name, port);
-        rd_kafka_mk_brokername(rkb->rkb_name, sizeof(rkb->rkb_name),
-                               proto, rkb->rkb_nodename, nodeid, source);
+        if (source != RD_KAFKA_LOGICAL) {
+                rd_kafka_mk_nodename(rkb->rkb_nodename,
+                                     sizeof(rkb->rkb_nodename),
+                                     name, port);
+                rd_kafka_mk_brokername(rkb->rkb_name, sizeof(rkb->rkb_name),
+                                       proto, rkb->rkb_nodename,
+                                       nodeid, source);
+        } else {
+                /* Logical broker does not have a nodename (address) or port
+                 * at initialization. */
+                rd_snprintf(rkb->rkb_name, sizeof(rkb->rkb_name), "%s", name);
+        }
 
 	rkb->rkb_source = source;
 	rkb->rkb_rk = rk;
@@ -4533,6 +4592,111 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 	return rkb;
 }
 
+
+/**
+ * @brief Adds a logical broker.
+ *
+ *        Logical brokers act just like any broker handle, but will not have
+ *        an initial address set. The address (or nodename is it is called
+ *        internally) can be set from another broker handle
+ *        by calling rd_kafka_broker_set_nodename().
+ *
+ *        This allows maintaining a logical group coordinator broker
+ *        handle that can ambulate between real broker addresses.
+ *
+ *        Logical broker constraints:
+ *         - will not have a broker-id set (-1).
+ *         - will not have a port set (0).
+ *         - the address for the broker may change.
+ *         - the name of broker will not correspond to the address,
+ *           but the \p name given here.
+ *
+ * @returns a new broker, holding a refcount for the caller.
+ *
+ * @locality any rdkafka thread
+ * @locks none
+ */
+rd_kafka_broker_t *rd_kafka_broker_add_logical (rd_kafka_t *rk,
+                                                const char *name) {
+        rd_kafka_broker_t *rkb;
+
+        rd_kafka_wrlock(rk);
+        rkb = rd_kafka_broker_add(rk, RD_KAFKA_LOGICAL,
+                                  rk->rk_conf.security_protocol,
+                                  name, 0/*port*/, -1/*brokerid*/);
+        rd_kafka_wrunlock(rk);
+
+        rd_dassert(RD_KAFKA_BROKER_IS_LOGICAL(rkb));
+        rd_kafka_broker_keep(rkb);
+        return rkb;
+}
+
+
+/**
+ * @brief Update the nodename (address) of broker \p rkb
+ *        with the nodename from broker \p from_rkb (may be NULL).
+ *
+ *        If \p rkb is connected, the connection will be torn down.
+ *        A new connection may be attempted to the new address
+ *        if a persistent connection is needed (standard connection rules).
+ *
+ *        The broker's logname is also updated to include \p from_rkb's
+ *        broker id.
+ *
+ * @param from_rkb Use the nodename from this broker. If NULL, clear
+ *                 the \p rkb nodename.
+ *
+ * @locks none
+ */
+void rd_kafka_broker_set_nodename (rd_kafka_broker_t *rkb,
+                                   rd_kafka_broker_t *from_rkb) {
+        char nodename[RD_KAFKA_NODENAME_SIZE];
+        char brokername[RD_KAFKA_NODENAME_SIZE];
+        int32_t nodeid;
+        rd_bool_t changed = rd_false;
+
+        rd_assert(RD_KAFKA_BROKER_IS_LOGICAL(rkb));
+
+        rd_assert(rkb != from_rkb);
+
+        /* Get nodename from from_rkb */
+        if (from_rkb) {
+                rd_kafka_broker_lock(from_rkb);
+                strncpy(nodename, from_rkb->rkb_nodename, sizeof(nodename));
+                nodeid = from_rkb->rkb_nodeid;
+                rd_kafka_broker_unlock(from_rkb);
+        } else {
+                *nodename = '\0';
+                nodeid = -1;
+        }
+
+        /* Set nodename on rkb */
+        rd_kafka_broker_lock(rkb);
+        if (strcmp(rkb->rkb_nodename, nodename)) {
+                strncpy(rkb->rkb_nodename, nodename,
+                        sizeof(rkb->rkb_nodename));
+                rkb->rkb_nodename_epoch++;
+                changed = rd_true;
+        }
+        rd_kafka_broker_unlock(rkb);
+
+        /* Update the log name to include (or exclude) the nodeid.
+         * The nodeid is appended as "..logname../nodeid" */
+        rd_kafka_mk_brokername(brokername, sizeof(brokername),
+                               rkb->rkb_proto,
+                               rkb->rkb_name, nodeid,
+                               rkb->rkb_source);
+
+        rd_kafka_broker_set_logname(rkb, brokername);
+
+        if (!changed)
+                return;
+
+        /* Trigger a disconnect & reconnect */
+        rd_kafka_broker_schedule_connection(rkb);
+}
+
+
 /**
  * @brief Find broker by nodeid (not -1) and
  *        possibly filtered by state (unless -1).
@@ -4592,6 +4756,9 @@ static rd_kafka_broker_t *rd_kafka_broker_find (rd_kafka_t *rk,
         rd_kafka_mk_nodename(nodename, sizeof(nodename), name, port);
 
 	TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (RD_KAFKA_BROKER_IS_LOGICAL(rkb))
+                        continue;
+
 		rd_kafka_broker_lock(rkb);
 		if (!rd_kafka_terminating(rk) &&
 		    rkb->rkb_proto == proto &&
@@ -5150,7 +5317,10 @@ void rd_kafka_broker_active_toppar_del (rd_kafka_broker_t *rkb,
 
 
 /**
- * @brief Schedule connection for \p rkb
+ * @brief Schedule connection for \p rkb.
+ *        Will trigger disconnection for logical brokers whose nodename
+ *        was changed.
+ *
  * @locality any
  * @locks none
  */

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -194,7 +194,18 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
         uint16_t            rkb_port;                          /* TCP port */
         char               *rkb_origname;                      /* Original
                                                                 * host name */
-
+        int                 rkb_nodename_epoch; /**< Bumped each time
+                                                 *   the nodename is changed.
+                                                 *   Compared to
+                                                 *   rkb_connect_epoch
+                                                 *   to trigger a reconnect
+                                                 *   for logical broker
+                                                 *   when the nodename is
+                                                 *   updated. */
+        int                 rkb_connect_epoch;  /**< The value of
+                                                 *   rkb_nodename_epoch at the
+                                                 *   last connection attempt.
+                                                 */
 
         /* Logging name is a copy of rkb_name, protected by its own mutex */
         char               *rkb_logname;
@@ -385,6 +396,15 @@ rd_kafka_broker_t *rd_kafka_broker_add (rd_kafka_t *rk,
 					rd_kafka_secproto_t proto,
 					const char *name, uint16_t port,
 					int32_t nodeid);
+
+rd_kafka_broker_t *rd_kafka_broker_add_logical (rd_kafka_t *rk,
+                                                const char *name);
+
+/** @define returns true if broker is logical. No locking is needed. */
+#define RD_KAFKA_BROKER_IS_LOGICAL(rkb) ((rkb)->rkb_source == RD_KAFKA_LOGICAL)
+
+void rd_kafka_broker_set_nodename (rd_kafka_broker_t *rkb,
+                                   rd_kafka_broker_t *from_rkb);
 
 void rd_kafka_broker_connect_up (rd_kafka_broker_t *rkb);
 void rd_kafka_broker_connect_done (rd_kafka_broker_t *rkb, const char *errstr);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -214,12 +214,14 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new (rd_kafka_t *rk,
         rd_interval_init(&rkcg->rkcg_join_intvl);
         rd_interval_init(&rkcg->rkcg_timeout_scan_intvl);
 
-        if (RD_KAFKAP_STR_IS_NULL(group_id)) {
-                /* No group configured: Operate in legacy/SimpleConsumer mode */
-                rd_kafka_simple_consumer_add(rk);
-                /* no need look up group coordinator (no queries) */
-                rd_interval_disable(&rkcg->rkcg_coord_query_intvl);
-        }
+        /* Create a logical group coordinator broker to provide
+         * a dedicated connection for group coordination.
+         * This is needed since JoinGroup may block for up to
+         * max.poll.interval.ms, effectively blocking and timing out
+         * any other protocol requests (such as Metadata).
+         * The address for this broker will be updated when
+         * the group coordinator is assigned. */
+        rkcg->rkcg_coord = rd_kafka_broker_add_logical(rk, "GroupCoordinator");
 
         if (rk->rk_conf.enable_auto_commit &&
             rk->rk_conf.auto_commit_interval_ms > 0)
@@ -234,86 +236,21 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new (rd_kafka_t *rk,
 }
 
 
-
 /**
- * Select a broker to handle this cgrp.
- * It will prefer the coordinator broker but if that is not available
- * any other broker that is Up will be used, and if that also fails
- * uses the internal broker handle.
- *
- * NOTE: The returned rkb will have had its refcnt increased.
+ * @brief Set the group coordinator broker.
  */
-static rd_kafka_broker_t *rd_kafka_cgrp_select_broker (rd_kafka_cgrp_t *rkcg) {
-        rd_kafka_broker_t *rkb = NULL;
+static void rd_kafka_cgrp_coord_set_broker (rd_kafka_cgrp_t *rkcg,
+                                            rd_kafka_broker_t *rkb) {
 
+        rd_assert(rkcg->rkcg_curr_coord == NULL);
 
-        /* No need for a managing broker when cgrp is terminated */
-        if (rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM)
-                return NULL;
+        rd_assert(RD_KAFKA_CGRP_BROKER_IS_COORD(rkcg, rkb));
 
-        rd_kafka_rdlock(rkcg->rkcg_rk);
-        /* Try to find the coordinator broker, if it isn't found
-         * move the cgrp to any other Up broker which will
-         * do further coord querying while waiting for the
-         * proper broker to materialise.
-         * If that also fails, go with the internal broker */
-        if (rkcg->rkcg_coord_id != -1)
-                rkb = rd_kafka_broker_find_by_nodeid(rkcg->rkcg_rk,
-                                                     rkcg->rkcg_coord_id);
-        if (!rkb)
-                rkb = rd_kafka_broker_prefer(rkcg->rkcg_rk,
-                                             rkcg->rkcg_coord_id,
-                                             RD_KAFKA_BROKER_STATE_UP);
-        if (!rkb)
-                rkb = rd_kafka_broker_internal(rkcg->rkcg_rk);
+        rkcg->rkcg_curr_coord = rkb;
+        rd_kafka_broker_keep(rkb);
 
-        rd_kafka_rdunlock(rkcg->rkcg_rk);
-
-        /* Dont change managing broker unless warranted.
-         * This means do not change to another non-coordinator broker
-         * while we are waiting for the proper coordinator broker to
-         * become available. */
-        if (rkb && rkcg->rkcg_rkb && rkb != rkcg->rkcg_rkb) {
-		int old_is_coord, new_is_coord;
-
-		rd_kafka_broker_lock(rkb);
-		new_is_coord = RD_KAFKA_CGRP_BROKER_IS_COORD(rkcg, rkb);
-		rd_kafka_broker_unlock(rkb);
-
-		rd_kafka_broker_lock(rkcg->rkcg_rkb);
-		old_is_coord = RD_KAFKA_CGRP_BROKER_IS_COORD(rkcg,
-							     rkcg->rkcg_rkb);
-		rd_kafka_broker_unlock(rkcg->rkcg_rkb);
-
-		if (!old_is_coord && !new_is_coord &&
-		    rkcg->rkcg_rkb->rkb_source != RD_KAFKA_INTERNAL) {
-			rd_kafka_broker_destroy(rkb);
-			rkb = rkcg->rkcg_rkb;
-			rd_kafka_broker_keep(rkb);
-		}
-        }
-
-        return rkb;
-}
-
-
-
-
-/**
- * Assign cgrp to broker.
- *
- * Locality: rdkafka main thread
- */
-static void rd_kafka_cgrp_assign_broker (rd_kafka_cgrp_t *rkcg,
-					 rd_kafka_broker_t *rkb) {
-
-	rd_kafka_assert(NULL, rkcg->rkcg_rkb == NULL);
-
-	rkcg->rkcg_rkb = rkb;
-	rd_kafka_broker_keep(rkb);
-
-        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "BRKASSIGN",
-                     "Group \"%.*s\" management assigned to broker %s",
+        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "COORDSET",
+                     "Group \"%.*s\" coordinator set to broker %s",
                      RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
                      rd_kafka_broker_name(rkb));
 
@@ -322,115 +259,113 @@ static void rd_kafka_cgrp_assign_broker (rd_kafka_cgrp_t *rkcg,
         if (!rd_interval_disabled(&rkcg->rkcg_coord_query_intvl))
                 rd_interval_reset(&rkcg->rkcg_coord_query_intvl);
 
-        if (RD_KAFKA_CGRP_BROKER_IS_COORD(rkcg, rkb))
-                rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER_TRANSPORT);
+        rd_kafka_cgrp_set_state(rkcg,
+                                RD_KAFKA_CGRP_STATE_WAIT_BROKER_TRANSPORT);
 
         rd_kafka_broker_persistent_connection_add(
-                rkb, &rkb->rkb_persistconn.coord);
+                rkcg->rkcg_coord, &rkcg->rkcg_coord->rkb_persistconn.coord);
+
+        /* Set the logical coordinator's nodename to the
+         * proper broker's nodename, this will trigger a (re)connect
+         * to the new address. */
+        rd_kafka_broker_set_nodename(rkcg->rkcg_coord, rkb);
 }
 
 
 /**
- * Unassign cgrp from current broker.
- *
- * Locality: main thread
+ * @brief Reset/clear the group coordinator broker.
  */
-static void rd_kafka_cgrp_unassign_broker (rd_kafka_cgrp_t *rkcg) {
-        rd_kafka_broker_t *rkb = rkcg->rkcg_rkb;
+static void rd_kafka_cgrp_coord_clear_broker (rd_kafka_cgrp_t *rkcg) {
+        rd_kafka_broker_t *rkb = rkcg->rkcg_curr_coord;
 
-	rd_kafka_assert(NULL, rkcg->rkcg_rkb);
-        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "BRKUNASSIGN",
-                     "Group \"%.*s\" management unassigned "
-                     "from broker handle %s",
+        rd_assert(rkcg->rkcg_curr_coord);
+        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "COORDCLEAR",
+                     "Group \"%.*s\" broker %s is no longer coordinator",
                      RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
                      rd_kafka_broker_name(rkb));
 
-        rd_kafka_broker_persistent_connection_del(
-                rkb, &rkb->rkb_persistconn.coord);
+        rd_assert(rkcg->rkcg_coord);
 
-        rkcg->rkcg_rkb = NULL;
-        rd_kafka_broker_destroy(rkb); /* from assign() */
+        rd_kafka_broker_persistent_connection_del(
+                rkcg->rkcg_coord,
+                &rkcg->rkcg_coord->rkb_persistconn.coord);
+
+        /* Clear the ephemeral broker's nodename.
+         * This will also trigger a disconnect. */
+        rd_kafka_broker_set_nodename(rkcg->rkcg_coord, NULL);
+
+        rkcg->rkcg_curr_coord = NULL;
+        rd_kafka_broker_destroy(rkb); /* from set_coord_broker() */
 }
 
 
 /**
- * Assign cgrp to a broker to handle.
- * It will prefer the coordinator broker but if that is not available
- * any other broker that is Up will be used, and if that also fails
- * uses the internal broker handle.
+ * @brief Update/set the group coordinator.
  *
- * Returns 1 if the cgrp was reassigned, else 0.
+ * Will do nothing if there's been no change.
+ *
+ * @returns 1 if the coordinator was updated, else 0.
  */
-int rd_kafka_cgrp_reassign_broker (rd_kafka_cgrp_t *rkcg) {
-        rd_kafka_broker_t *rkb;
+static int rd_kafka_cgrp_coord_update (rd_kafka_cgrp_t *rkcg,
+                                       int32_t coord_id) {
+        rd_kafka_broker_t *rkb = NULL;
 
-        rkb = rd_kafka_cgrp_select_broker(rkcg);
+        /* Don't do anything while terminating */
+        if (rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM)
+                return 0;
 
-        if (rkb == rkcg->rkcg_rkb) {
-		int is_coord = 0;
-
-		if (rkb) {
-			rd_kafka_broker_lock(rkb);
-			is_coord = RD_KAFKA_CGRP_BROKER_IS_COORD(rkcg, rkb);
-			rd_kafka_broker_unlock(rkb);
-		}
-		if (is_coord)
-                        rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER_TRANSPORT);
-                else
-                        rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER);
-
-                if (rkb)
-                        rd_kafka_broker_destroy(rkb);
-                return 0; /* No change */
+        /* No coordinator change? */
+        if (rkcg->rkcg_coord_id == coord_id) {
+                /* If a coord query returned the same coordinator,
+                 * advance cgrp to the next state. */
+                if (rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_WAIT_COORD &&
+                    coord_id != -1)
+                        rd_kafka_cgrp_set_state(
+                                rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER);
+                return 0;
         }
 
-        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "BRKREASSIGN",
-                     "Group \"%.*s\" management reassigned from "
-                     "broker %s to %s",
+        if (coord_id != -1) {
+                /* Try to find the coordinator broker */
+                rd_kafka_rdlock(rkcg->rkcg_rk);
+                rkb = rd_kafka_broker_find_by_nodeid(rkcg->rkcg_rk, coord_id);
+                rd_kafka_rdunlock(rkcg->rkcg_rk);
+
+                /* It is possible, due to stale metadata, that the
+                 * coordinator id points to a broker we still don't know
+                 * about. In this case the client will continue
+                 * querying metadata and querying for the coordinator
+                 * until a match is found. */
+        }
+
+        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "CGRPCOORD",
+                     "Group \"%.*s\" changing coordinator %"PRId32" (%s) "
+                     "-> %"PRId32" (%s)",
                      RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
-                     rkcg->rkcg_rkb ?
-                     rd_kafka_broker_name(rkcg->rkcg_rkb) : "(none)",
-                     rkb ? rd_kafka_broker_name(rkb) : "(none)");
+                     rkcg->rkcg_coord_id,
+                     rkcg->rkcg_curr_coord ?
+                     rd_kafka_broker_name(rkcg->rkcg_curr_coord) : "none",
+                     coord_id,
+                     rkb ? rd_kafka_broker_name(rkb) : "none");
 
 
-        if (rkcg->rkcg_rkb)
-                rd_kafka_cgrp_unassign_broker(rkcg);
+        /*
+         * Update coord id and broker handle
+         */
+        rkcg->rkcg_coord_id = coord_id;
+
+        if (rkcg->rkcg_curr_coord)
+                rd_kafka_cgrp_coord_clear_broker(rkcg);
 
         rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER);
 
         if (rkb) {
-		rd_kafka_cgrp_assign_broker(rkcg, rkb);
-		rd_kafka_broker_destroy(rkb); /* from select_broker() */
-	}
+                rd_kafka_cgrp_coord_set_broker(rkcg, rkb);
+                rd_kafka_broker_destroy(rkb); /* from find_by_nodeid() */
+        }
 
         return 1;
 }
-
-
-/**
- * Update the cgrp's coordinator and move it to that broker.
- */
-void rd_kafka_cgrp_coord_update (rd_kafka_cgrp_t *rkcg, int32_t coord_id) {
-
-        if (rkcg->rkcg_coord_id == coord_id) {
-		if (rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_WAIT_COORD)
-			rd_kafka_cgrp_set_state(rkcg,
-						RD_KAFKA_CGRP_STATE_WAIT_BROKER);
-                return;
-	}
-
-        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "CGRPCOORD",
-                     "Group \"%.*s\" changing coordinator %"PRId32" -> %"PRId32,
-                     RD_KAFKAP_STR_PR(rkcg->rkcg_group_id), rkcg->rkcg_coord_id,
-                     coord_id);
-        rkcg->rkcg_coord_id = coord_id;
-
-        rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_WAIT_BROKER);
-
-        rd_kafka_cgrp_reassign_broker(rkcg);
-}
-
-
 
 
 
@@ -559,11 +494,12 @@ void rd_kafka_cgrp_coord_query (rd_kafka_cgrp_t *rkcg,
  * @locality main thread
  */
 void rd_kafka_cgrp_coord_dead (rd_kafka_cgrp_t *rkcg, rd_kafka_resp_err_t err,
-			       const char *reason) {
-	rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "COORD",
-		     "Group \"%.*s\": marking the coordinator dead: %s: %s",
-		     RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
-		     rd_kafka_err2str(err), reason);
+                               const char *reason) {
+        rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "COORD",
+                     "Group \"%.*s\": "
+                     "marking the coordinator (%"PRId32") dead: %s: %s",
+                     RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
+                     rkcg->rkcg_coord_id, rd_kafka_err2str(err), reason);
 
 	rd_kafka_cgrp_coord_update(rkcg, -1);
 
@@ -642,15 +578,17 @@ static void rd_kafka_cgrp_leave (rd_kafka_cgrp_t *rkcg) {
         rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_WAIT_LEAVE;
 
         if (rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_UP) {
-                rd_rkb_dbg(rkcg->rkcg_rkb, CONSUMER, "LEAVE",
+                rd_rkb_dbg(rkcg->rkcg_curr_coord, CONSUMER, "LEAVE",
                            "Leaving group");
-                rd_kafka_LeaveGroupRequest(rkcg->rkcg_rkb, rkcg->rkcg_group_id,
+                rd_kafka_LeaveGroupRequest(rkcg->rkcg_coord,
+                                           rkcg->rkcg_group_id,
                                            rkcg->rkcg_member_id,
                                            RD_KAFKA_REPLYQ(rkcg->rkcg_ops, 0),
                                            rd_kafka_cgrp_handle_LeaveGroup,
                                            rkcg);
         } else
-                rd_kafka_cgrp_handle_LeaveGroup(rkcg->rkcg_rk, rkcg->rkcg_rkb,
+                rd_kafka_cgrp_handle_LeaveGroup(rkcg->rkcg_rk,
+                                                rkcg->rkcg_coord,
                                                 RD_KAFKA_RESP_ERR__WAIT_COORD,
                                                 NULL, NULL, rkcg);
 }
@@ -762,8 +700,9 @@ rd_kafka_cgrp_assignor_run (rd_kafka_cgrp_t *rkcg,
         rd_kafka_cgrp_set_join_state(rkcg, RD_KAFKA_CGRP_JOIN_STATE_WAIT_SYNC);
 
         /* Respond to broker with assignment set or error */
-        rd_kafka_SyncGroupRequest(rkcg->rkcg_rkb,
-                                  rkcg->rkcg_group_id, rkcg->rkcg_generation_id,
+        rd_kafka_SyncGroupRequest(rkcg->rkcg_coord,
+                                  rkcg->rkcg_group_id,
+                                  rkcg->rkcg_generation_id,
                                   rkcg->rkcg_member_id,
                                   members, err ? 0 : member_cnt,
                                   RD_KAFKA_REPLYQ(rkcg->rkcg_ops, 0),
@@ -893,7 +832,7 @@ rd_kafka_group_MemberMetadata_consumer_read (
  * @brief cgrp handler for JoinGroup responses
  * opaque must be the cgrp handle.
  *
- * @locality cgrp broker thread
+ * @locality rdkafka main thread (unless ERR__DESTROY: arbitrary thread)
  */
 static void rd_kafka_cgrp_handle_JoinGroup (rd_kafka_t *rk,
                                             rd_kafka_broker_t *rkb,
@@ -1276,13 +1215,13 @@ static void rd_kafka_cgrp_join (rd_kafka_cgrp_t *rkcg) {
                 return;
         }
 
-        rd_rkb_dbg(rkcg->rkcg_rkb, CONSUMER, "JOIN",
+        rd_rkb_dbg(rkcg->rkcg_curr_coord, CONSUMER, "JOIN",
                    "Joining group \"%.*s\" with %d subscribed topic(s)",
                    RD_KAFKAP_STR_PR(rkcg->rkcg_group_id),
                    rd_list_cnt(rkcg->rkcg_subscribed_topics));
 
         rd_kafka_cgrp_set_join_state(rkcg, RD_KAFKA_CGRP_JOIN_STATE_WAIT_JOIN);
-        rd_kafka_JoinGroupRequest(rkcg->rkcg_rkb, rkcg->rkcg_group_id,
+        rd_kafka_JoinGroupRequest(rkcg->rkcg_coord, rkcg->rkcg_group_id,
                                   rkcg->rkcg_member_id,
                                   rkcg->rkcg_rk->rk_conf.group_protocol_type,
                                   rkcg->rkcg_subscribed_topics,
@@ -1437,14 +1376,13 @@ err:
 /**
  * @brief Send Heartbeat
  */
-static void rd_kafka_cgrp_heartbeat (rd_kafka_cgrp_t *rkcg,
-                                     rd_kafka_broker_t *rkb) {
+static void rd_kafka_cgrp_heartbeat (rd_kafka_cgrp_t *rkcg) {
         /* Skip heartbeat if we have one in transit */
         if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_HEARTBEAT_IN_TRANSIT)
                 return;
 
         rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_HEARTBEAT_IN_TRANSIT;
-        rd_kafka_HeartbeatRequest(rkb, rkcg->rkcg_group_id,
+        rd_kafka_HeartbeatRequest(rkcg->rkcg_coord, rkcg->rkcg_group_id,
                                   rkcg->rkcg_generation_id,
                                   rkcg->rkcg_member_id,
                                   RD_KAFKA_REPLYQ(rkcg->rkcg_ops, 0),
@@ -1474,8 +1412,13 @@ static void rd_kafka_cgrp_terminated (rd_kafka_cgrp_t *rkcg) {
 	rd_kafka_q_disable(rkcg->rkcg_ops);
 	rd_kafka_q_purge(rkcg->rkcg_ops);
 
-	if (rkcg->rkcg_rkb)
-		rd_kafka_cgrp_unassign_broker(rkcg);
+	if (rkcg->rkcg_curr_coord)
+		rd_kafka_cgrp_coord_clear_broker(rkcg);
+
+        if (rkcg->rkcg_coord) {
+                rd_kafka_broker_destroy(rkcg->rkcg_coord);
+                rkcg->rkcg_coord = NULL;
+        }
 
         if (rkcg->rkcg_reply_rko) {
                 /* Signal back to application. */
@@ -1744,7 +1687,8 @@ rd_kafka_cgrp_partitions_fetch_start0 (rd_kafka_cgrp_t *rkcg,
             RD_KAFKA_OFFSET_METHOD_BROKER) {
 
                 /* Fetch offsets for all assigned partitions */
-                rd_kafka_cgrp_offsets_fetch(rkcg, rkcg->rkcg_rkb, assignment);
+                rd_kafka_cgrp_offsets_fetch(rkcg, rkcg->rkcg_coord,
+                                            assignment);
 
         } else {
 		rd_kafka_cgrp_set_join_state(rkcg,
@@ -1826,8 +1770,8 @@ static int rd_kafka_cgrp_defer_offset_commit (rd_kafka_cgrp_t *rkcg,
                      rkcg->rkcg_group_id->str,
                      rd_kafka_cgrp_state_names[rkcg->rkcg_state],
                      reason,
-                     rkcg->rkcg_rkb ?
-                     rd_kafka_broker_name(rkcg->rkcg_rkb) :
+                     rkcg->rkcg_curr_coord ?
+                     rd_kafka_broker_name(rkcg->rkcg_curr_coord) :
                      "none");
 
         rko->rko_flags |= RD_KAFKA_OP_F_REPROCESS;
@@ -2117,17 +2061,13 @@ static void rd_kafka_cgrp_offsets_commit (rd_kafka_cgrp_t *rkcg,
                 goto err;
 	}
 
-        if (rkcg->rkcg_state != RD_KAFKA_CGRP_STATE_UP || !rkcg->rkcg_rkb ||
-	    rkcg->rkcg_rkb->rkb_source == RD_KAFKA_INTERNAL) {
-
+        if (rkcg->rkcg_state != RD_KAFKA_CGRP_STATE_UP) {
                 rd_kafka_dbg(rkcg->rkcg_rk, CONSUMER, "COMMIT",
                              "Deferring \"%s\" offset commit "
-                             "for %d partition(s) in state %s: %s",
+                             "for %d partition(s) in state %s: "
+                             "no coordinator available",
                              reason, valid_offsets,
-                             rd_kafka_cgrp_state_names[rkcg->rkcg_state],
-                             (!rkcg->rkcg_rkb ||
-                              rkcg->rkcg_rkb->rkb_source == RD_KAFKA_INTERNAL)
-                             ? "no coordinator available" : "not in state up");
+                             rd_kafka_cgrp_state_names[rkcg->rkcg_state]);
 
 		if (rd_kafka_cgrp_defer_offset_commit(rkcg, rko, reason))
 			return;
@@ -2137,13 +2077,13 @@ static void rd_kafka_cgrp_offsets_commit (rd_kafka_cgrp_t *rkcg,
 	} else {
                 int r;
 
-                rd_rkb_dbg(rkcg->rkcg_rkb, CONSUMER, "COMMIT",
+                rd_rkb_dbg(rkcg->rkcg_coord, CONSUMER, "COMMIT",
                            "Committing offsets for %d partition(s): %s",
                            valid_offsets, reason);
 
                 /* Send OffsetCommit */
                 r = rd_kafka_OffsetCommitRequest(
-                            rkcg->rkcg_rkb, rkcg, 1, offsets,
+                            rkcg->rkcg_coord, rkcg, 1, offsets,
                             RD_KAFKA_REPLYQ(rkcg->rkcg_ops, op_version),
                             rd_kafka_cgrp_op_handle_OffsetCommit, rko,
                         reason);
@@ -2509,8 +2449,9 @@ void rd_kafka_cgrp_handle_heartbeat_error (rd_kafka_cgrp_t *rkcg,
                              "Heartbeat failed due to coordinator (%s) "
                              "no longer available: %s: "
                              "re-querying for coordinator",
-                             rkcg->rkcg_rkb ?
-                             rd_kafka_broker_name(rkcg->rkcg_rkb) : "none",
+                             rkcg->rkcg_curr_coord ?
+                             rd_kafka_broker_name(rkcg->rkcg_curr_coord) :
+                             "none",
                              rd_kafka_err2str(err));
 		/* Remain in joined state and keep querying for coordinator */
 		rd_interval_expedite(&rkcg->rkcg_coord_query_intvl, 0);
@@ -2908,7 +2849,6 @@ rd_kafka_cgrp_op_serve (rd_kafka_t *rk, rd_kafka_q_t *rkq,
                         rd_kafka_op_t *rko, rd_kafka_q_cb_type_t cb_type,
                         void *opaque) {
         rd_kafka_cgrp_t *rkcg = opaque;
-        rd_kafka_broker_t *rkb = rkcg->rkcg_rkb;
         rd_kafka_toppar_t *rktp;
         rd_kafka_resp_err_t err;
         const int silent_op = rko->rko_type == RD_KAFKA_OP_RECV_BUF;
@@ -2960,7 +2900,7 @@ rd_kafka_cgrp_op_serve (rd_kafka_t *rk, rd_kafka_q_t *rkq,
                 if (rkcg->rkcg_state != RD_KAFKA_CGRP_STATE_UP ||
                     (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE)) {
                         rd_kafka_op_handle_OffsetFetch(
-                                rkcg->rkcg_rk, rkb,
+                                rkcg->rkcg_rk, NULL,
                                 RD_KAFKA_RESP_ERR__WAIT_COORD,
                                 NULL, NULL, rko);
                         rko = NULL; /* rko freed by handler */
@@ -2968,7 +2908,7 @@ rd_kafka_cgrp_op_serve (rd_kafka_t *rk, rd_kafka_q_t *rkq,
                 }
 
                 rd_kafka_OffsetFetchRequest(
-                        rkb, 1,
+                        rkcg->rkcg_coord, 1,
                         rko->rko_u.offset_fetch.partitions,
                         RD_KAFKA_REPLYQ(rkcg->rkcg_ops,
                                         rkcg->rkcg_version),
@@ -3097,15 +3037,7 @@ rd_kafka_cgrp_op_serve (rd_kafka_t *rk, rd_kafka_q_t *rkq,
 /**
  * Client group's join state handling
  */
-static void rd_kafka_cgrp_join_state_serve (rd_kafka_cgrp_t *rkcg,
-                                            rd_kafka_broker_t *rkb) {
-
-        if (0) // FIXME
-        rd_rkb_dbg(rkb, CGRP, "JOINFSM",
-                   "Group \"%s\" in join state %s with%s subscription",
-                   rkcg->rkcg_group_id->str,
-                   rd_kafka_cgrp_join_state_names[rkcg->rkcg_join_state],
-                   rkcg->rkcg_subscription ? "" : "out");
+static void rd_kafka_cgrp_join_state_serve (rd_kafka_cgrp_t *rkcg) {
 
         switch (rkcg->rkcg_join_state)
         {
@@ -3133,7 +3065,7 @@ static void rd_kafka_cgrp_join_state_serve (rd_kafka_cgrp_t *rkcg,
                     rd_interval(&rkcg->rkcg_heartbeat_intvl,
                                 rkcg->rkcg_rk->rk_conf.
                                 group_heartbeat_intvl_ms * 1000, 0) > 0)
-                        rd_kafka_cgrp_heartbeat(rkcg, rkb);
+                        rd_kafka_cgrp_heartbeat(rkcg);
                 break;
         }
 
@@ -3143,7 +3075,7 @@ static void rd_kafka_cgrp_join_state_serve (rd_kafka_cgrp_t *rkcg,
  * Called from main thread to serve the operational aspects of a cgrp.
  */
 void rd_kafka_cgrp_serve (rd_kafka_cgrp_t *rkcg) {
-	rd_kafka_broker_t *rkb = rkcg->rkcg_rkb;
+	rd_kafka_broker_t *rkb = rkcg->rkcg_coord;
 	int rkb_state = RD_KAFKA_BROKER_STATE_INIT;
         rd_ts_t now;
 
@@ -3197,8 +3129,8 @@ void rd_kafka_cgrp_serve (rd_kafka_cgrp_t *rkcg) {
 
         case RD_KAFKA_CGRP_STATE_WAIT_BROKER:
                 /* See if the group should be reassigned to another broker. */
-                if (rd_kafka_cgrp_reassign_broker(rkcg))
-                        goto retry; /* broker reassigned, retry state-machine
+                if (rd_kafka_cgrp_coord_update(rkcg, rkcg->rkcg_coord_id))
+                        goto retry; /* Coordinator changed, retry state-machine
                                      * to speed up next transition. */
 
                 /* Coordinator query */
@@ -3227,7 +3159,7 @@ void rd_kafka_cgrp_serve (rd_kafka_cgrp_t *rkcg) {
                         rd_kafka_cgrp_set_state(rkcg, RD_KAFKA_CGRP_STATE_UP);
 
                         /* Serve join state to trigger (re)join */
-                        rd_kafka_cgrp_join_state_serve(rkcg, rkb);
+                        rd_kafka_cgrp_join_state_serve(rkcg);
 
                         /* Start fetching if we have an assignment. */
                         if (rkcg->rkcg_assignment &&
@@ -3249,7 +3181,7 @@ void rd_kafka_cgrp_serve (rd_kafka_cgrp_t *rkcg) {
                         rd_kafka_cgrp_coord_query(rkcg,
                                                   "intervaled in state up");
 
-                rd_kafka_cgrp_join_state_serve(rkcg, rkb);
+                rd_kafka_cgrp_join_state_serve(rkcg);
                 break;
 
         }

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -51,7 +51,6 @@ extern const char *rd_kafka_cgrp_join_state_names[];
  * Client group
  */
 typedef struct rd_kafka_cgrp_s {
-        TAILQ_ENTRY(rd_kafka_cgrp_s) rkcg_rkb_link;  /* rkb_cgrps */
         const rd_kafkap_str_t    *rkcg_group_id;
         rd_kafkap_str_t          *rkcg_member_id;  /* Last assigned MemberId */
         const rd_kafkap_str_t    *rkcg_client_id;
@@ -172,24 +171,24 @@ typedef struct rd_kafka_cgrp_s {
 
 	int                rkcg_assigned_cnt;       /* Assigned partitions */
 
-        int32_t            rkcg_coord_id;           /* Current coordinator id */
-
         int32_t            rkcg_generation_id;      /* Current generation id */
 
         rd_kafka_assignor_t *rkcg_assignor;         /* Selected partition
                                                      * assignor strategy. */
 
-        rd_kafka_broker_t *rkcg_rkb;                /* Current handling broker,
-                                                     * if the coordinator broker
-                                                     * is not available this
-                                                     * will be another broker
-                                                     * that will handle the
-                                                     * querying of coordinator
-                                                     * etc.
-                                                     * Broker in this sense
-                                                     * is a broker_t object,
-                                                     * not necessarily a
-                                                     * real broker. */
+        int32_t            rkcg_coord_id;      /**< Current coordinator id,
+                                                *   or -1 if not known. */
+
+        rd_kafka_broker_t *rkcg_curr_coord;    /**< Current coordinator
+                                                *   broker handle, or NULL.
+                                                *   rkcg_coord's nodename is
+                                                *   updated to this broker's
+                                                *   nodename when there is a
+                                                *   coordinator change. */
+        rd_kafka_broker_t *rkcg_coord;         /**< The dedicated coordinator
+                                                *   broker handle.
+                                                *   Will be updated when the
+                                                *   coordinator changes. */
 
         /* Current subscription */
         rd_kafka_topic_partition_list_t *rkcg_subscription;
@@ -286,8 +285,6 @@ void rd_kafka_cgrp_handle_SyncGroup (rd_kafka_cgrp_t *rkcg,
                                      rd_kafka_resp_err_t err,
                                      const rd_kafkap_bytes_t *member_state);
 void rd_kafka_cgrp_set_join_state (rd_kafka_cgrp_t *rkcg, int join_state);
-
-int rd_kafka_cgrp_reassign_broker (rd_kafka_cgrp_t *rkcg);
 
 void rd_kafka_cgrp_coord_query (rd_kafka_cgrp_t *rkcg,
 				const char *reason);

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -90,6 +90,7 @@ typedef enum {
 	RD_KAFKA_CONFIGURED,
 	RD_KAFKA_LEARNED,
 	RD_KAFKA_INTERNAL,
+        RD_KAFKA_LOGICAL
 } rd_kafka_confsource_t;
 
 typedef	enum {

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -474,7 +474,7 @@ const char *rd_kafka_topic_conf_finalize (rd_kafka_type_t cltype,
                                           rd_kafka_topic_conf_t *tconf);
 
 
-int rd_kafka_conf_warn_deprecated (rd_kafka_t *rk);
+int rd_kafka_conf_warn (rd_kafka_t *rk);
 
 
 #include "rdkafka_confval.h"


### PR DESCRIPTION
    Create separate connection to consumer Group Coordinator

    Since JoinGroupRequests may block for up to max.poll.interval.ms,
    which may be set very high (hours..), any sub-sequent requests
    on the same connection, such as Metadata refreshes, would time out
    and tear down the connection, triggering another rebalance.

    This commit adds support for logical brokers, in this case
    a GroupCoordinator broker, which initially doesn't have an address
    but is updated by the cgrp to connect to the group coordinator.
    This connection is then used for all group-related protocol requests,
    Join, Sync, Leave, OffsetCommit, leaving the standard broker
    connections for other protocol use.

    As a side-effect this commit also deletes legacy cgrp code from when
    it used to run on the broker thread.

    Also improves HOLB detection and handling.