### PR TITLE
Added minimal v10 fetch protocol support for ZSTD

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -522,7 +522,7 @@ typedef enum {
         /** Topic deletion is disabled */
         RD_KAFKA_RESP_ERR_TOPIC_DELETION_DISABLED = 73,
         /** Unsupported compression type */
-        RD_KAFKA_RESP_ERR_UNSUPPORTED_COMPRESSION_TYPE = 74,
+        RD_KAFKA_RESP_ERR_UNSUPPORTED_COMPRESSION_TYPE = 76,
 
         RD_KAFKA_RESP_ERR_END_ALL,
 } rd_kafka_resp_err_t;


### PR DESCRIPTION
As per KIP-110, consumers must support v10 fetch to consume records
compressed with zstd.
This commit fixes Err-76 when fetching ZSTD enabled records from broker version >= 2.1.
Changes that have impact encapsulated under WITH_ZSTD define check