### PR TITLE
Fix issue #1704

### DIFF
--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -598,7 +598,7 @@ class ConfImpl : public Conf {
                               tmpValue, &size);
     else if (rkt_conf_)
       res = rd_kafka_topic_conf_get(rkt_conf_,
-                                    name.c_str(), NULL, &size);
+                                    name.c_str(), tmpValue, &size);
 
     if (res == RD_KAFKA_CONF_OK)
       value.assign(tmpValue);


### PR DESCRIPTION
I challenged a small fix. Please confirm it.
Fix issue #1704 (RdKafka::Conf::get(propName, propVal) returns an empty value for topic configuration properties)