### PR TITLE
packaging: Fix the Arch Linux PKGBUILD

### DIFF
--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -1,5 +1,30 @@
 pkgname=librdkafka
-pkgver=master
+pkgver=1.0.0.RC5.r11.g3cf68480
 pkgrel=1
-pkgdesc=The Apache Kafka C/C++ client library
-arch=('i686' 'x86_64')
+pkgdesc='The Apache Kafka C/C++ client library'
+url='https://github.com/edenhill/librdkafka'
+license=('BSD')
+arch=('x86_64')
+source=('git+https://github.com/edenhill/librdkafka#branch=master')
+sha256sums=('SKIP')
+depends=(glibc libsasl lz4 openssl zlib zstd)
+makedepends=(bash git python)
+
+pkgver() {
+	cd "$pkgname"
+	git describe --long --tags --match "v[0-9]*" | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+	cd "$pkgname"
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	cd "$pkgname"
+	make install DESTDIR="$pkgdir"
+	for f in $(find -type f -name 'LICENSE*'); do
+		install -D -m0644 "$f" "$pkgdir/usr/share/licenses/$pkgname/$f"
+	done
+}


### PR DESCRIPTION
* Build based on latest tag, as recommended by the packaging guidelines
* pkgver() will automatically override the pkgver value (but a static
  value must be defined either way)
* Do a complete build enabling all supported compression algorithms
  SSL/TLS for encryption and SASL for authentication. The dependencies
  are small enough that there's not much of a point in having them as
  optional dependencies, they're likely already installed on the target
  system and it avoids a bunch of guessing at runtime to figure out
  which capabilities are supported

With the current set of depends we end up with -lsasl2  -lssl  -llz4
-lm -lzstd  -lcrypto  -lz  -ldl -lpthread -lrt as build flags.