### PR TITLE
CMake: Enable linking with an external LZ4 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ write_basic_package_version_file(
 )
 
 install(
-    FILES "${project_config}" "${project_version}"
+    FILES "${project_config}" "${project_version}" "packaging/cmake/Modules/FindLZ4.cmake"
     DESTINATION "${config_install_dir}"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,14 +115,6 @@ set(WITH_LZ4_EXT OFF)
 if(ENABLE_LZ4_EXT)
   set(WITH_LZ4_EXT ON)
 endif()
-#if(ENABLE_LZ4_EXT)
-#  find_package(LZ4)
-#  if(LZ4_FOUND)
-#    set(WITH_LZ4_EXT ON)
-#  else()
-#    set(WITH_LZ4_EXT OFF)
-#  endif()
-#endif()
 # }
 
 # }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ set(config_install_dir "lib/cmake/${PROJECT_NAME}")
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(project_version "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
@@ -187,8 +188,14 @@ configure_package_config_file(
     INSTALL_DESTINATION "${config_install_dir}"
 )
 
+write_basic_package_version_file(
+    "${project_version}"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
 install(
-    FILES "${project_config}"
+    FILES "${project_config}" "${project_version}"
     DESTINATION "${config_install_dir}"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,12 @@ endif()
 option(ENABLE_LZ4_EXT "Enable external LZ4 library support" ON)
 set(WITH_LZ4_EXT OFF)
 if(ENABLE_LZ4_EXT)
-  set(WITH_LZ4_EXT ON)
+  find_package(LZ4)
+  if(LZ4_FOUND)
+    set(WITH_LZ4_EXT ON)
+  else()
+    message(STATUS "Using bundled LZ4 implementation.")
+  endif()
 endif()
 # }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ parseversion("src/rdkafka.h")
 
 project(RdKafka VERSION ${RDKAFKA_VERSION})
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/packaging/cmake/Modules/")
+
 # Options. No 'RDKAFKA_' prefix to match old C++ code. {
 
 # This option doesn't affect build in fact, only C code
@@ -15,7 +17,6 @@ option(WITHOUT_OPTIMIZATION "Disable optimization" OFF)
 option(ENABLE_DEVEL "Enable development asserts, checks, etc" OFF)
 option(ENABLE_REFCNT_DEBUG "Enable refcnt debugging" OFF)
 option(ENABLE_SHAREDPTR_DEBUG "Enable sharedptr debugging" OFF)
-
 set(TRYCOMPILE_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}/packaging/cmake/try_compile")
 
 # ZLIB {
@@ -106,6 +107,22 @@ if(WITH_SASL)
     set(WITH_SASL_CYRUS ON)
   endif()
 endif()
+# }
+
+# LZ4 {
+option(ENABLE_LZ4_EXT "Enable external LZ4 library support" ON)
+set(WITH_LZ4_EXT OFF)
+if(ENABLE_LZ4_EXT)
+  set(WITH_LZ4_EXT ON)
+endif()
+#if(ENABLE_LZ4_EXT)
+#  find_package(LZ4)
+#  if(LZ4_FOUND)
+#    set(WITH_LZ4_EXT ON)
+#  else()
+#    set(WITH_LZ4_EXT OFF)
+#  endif()
+#endif()
 # }
 
 # }

--- a/packaging/cmake/Config.cmake.in
+++ b/packaging/cmake/Config.cmake.in
@@ -18,6 +18,10 @@ if(@WITH_SSL@)
   endif()
 endif()
 
+if(@WITH_LZ4_EXT@)
+  find_dependency(LZ4)
+endif()
+
 find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")

--- a/packaging/cmake/Config.cmake.in
+++ b/packaging/cmake/Config.cmake.in
@@ -7,7 +7,12 @@ if(@WITH_ZLIB@)
 endif()
 
 if(@WITH_ZSTD@)
-  find_dependency(ZSTD)
+  find_library(ZSTD zstd)
+  if(NOT ZSTD)
+    message(ERROR "ZSTD library not found!")
+  else()
+    message(STATUS "Found ZSTD: " ${ZSTD})
+  endif()
 endif()
 
 if(@WITH_SSL@)

--- a/packaging/cmake/Modules/FindLZ4.cmake
+++ b/packaging/cmake/Modules/FindLZ4.cmake
@@ -1,0 +1,38 @@
+find_path(LZ4_INCLUDE_DIR
+  NAMES lz4.h
+  DOC "lz4 include directory")
+mark_as_advanced(LZ4_INCLUDE_DIR)
+find_library(LZ4_LIBRARY
+  NAMES lz4
+  DOC "lz4 library")
+mark_as_advanced(LZ4_LIBRARY)
+
+if (LZ4_INCLUDE_DIR)
+  file(STRINGS "${LZ4_INCLUDE_DIR}/lz4.h" _lz4_version_lines
+    REGEX "#define[ \t]+LZ4_VERSION_(MAJOR|MINOR|RELEASE)")
+  string(REGEX REPLACE ".*LZ4_VERSION_MAJOR *\([0-9]*\).*" "\\1" _lz4_version_major "${_lz4_version_lines}")
+  string(REGEX REPLACE ".*LZ4_VERSION_MINOR *\([0-9]*\).*" "\\1" _lz4_version_minor "${_lz4_version_lines}")
+  string(REGEX REPLACE ".*LZ4_VERSION_RELEASE *\([0-9]*\).*" "\\1" _lz4_version_release "${_lz4_version_lines}")
+  set(LZ4_VERSION "${_lz4_version_major}.${_lz4_version_minor}.${_lz4_version_release}")
+  unset(_lz4_version_major)
+  unset(_lz4_version_minor)
+  unset(_lz4_version_release)
+  unset(_lz4_version_lines)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LZ4
+  REQUIRED_VARS LZ4_LIBRARY LZ4_INCLUDE_DIR
+  VERSION_VAR LZ4_VERSION)
+
+if (LZ4_FOUND)
+  set(LZ4_INCLUDE_DIRS "${LZ4_INCLUDE_DIR}")
+  set(LZ4_LIBRARIES "${LZ4_LIBRARY}")
+
+  if (NOT TARGET LZ4::LZ4)
+    add_library(LZ4::LZ4 UNKNOWN IMPORTED)
+    set_target_properties(LZ4::LZ4 PROPERTIES
+      IMPORTED_LOCATION "${LZ4_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LZ4_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/packaging/cmake/config.h.in
+++ b/packaging/cmake/config.h.in
@@ -36,6 +36,7 @@
 #cmakedefine01 WITH_SASL
 #cmakedefine01 WITH_SASL_SCRAM
 #cmakedefine01 WITH_SASL_CYRUS
+#cmakedefine01 WITH_LZ4_EXT
 #cmakedefine01 HAVE_REGEX
 #cmakedefine01 HAVE_STRNDUP
 #define SOLIB_EXT "${CMAKE_SHARED_LIBRARY_SUFFIX}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,6 +223,9 @@ endif()
 if(WITH_ZSTD)
     string(APPEND PKG_CONFIG_REQUIRES "libzstd ")
 endif()
+if(WITH_LZ4_EXT)
+    string(APPEND PKG_CONFIG_REQUIRES "liblz4 ")
+endif()
 set(PKG_CONFIG_CFLAGS
     "-I\${includedir}"
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,7 +191,6 @@ if(WITH_LIBDL)
 endif()
 
 if(WITH_LZ4_EXT)
-  find_package(LZ4 REQUIRED)
   target_link_libraries(rdkafka PUBLIC LZ4::LZ4)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,9 +54,6 @@ set(
     tinycthread.c
     tinycthread_extra.c
     xxhash.c
-    lz4.c
-    lz4frame.c
-    lz4hc.c
 )
 
 if(WITH_LIBDL OR WIN32)
@@ -83,6 +80,10 @@ endif()
 
 if(WITH_ZSTD)
   list(APPEND sources rdkafka_zstd.c)
+endif()
+
+if(NOT WITH_LZ4_EXT)
+  list(APPEND sources lz4.c lz4frame.c lz4hc.c)
 endif()
 
 if(NOT HAVE_REGEX)
@@ -187,6 +188,11 @@ endif()
 
 if(WITH_LIBDL)
   target_link_libraries(rdkafka PUBLIC ${CMAKE_DL_LIBS})
+endif()
+
+if(WITH_LZ4_EXT)
+  find_package(LZ4 REQUIRED)
+  target_link_libraries(rdkafka PUBLIC LZ4::LZ4)
 endif()
 
 # Set up path to these sources for other sub-projects (tests, examples)


### PR DESCRIPTION
As mentioned in my last PR (https://github.com/edenhill/librdkafka/pull/2075#discussion_r229286103) this PR adds a CMake option `ENABLE_LZ4_EXT` to enable optional linking with an external LZ4 library.

It uses the CMake find module for LZ4 from https://github.com/Kitware/VTK/blob/master/CMake/FindLZ4.cmake to find the linker options for the LZ4 library.

The librdkafka pkg-config file and CMake package are updated to reflect the option.

Also, a package version file is generated for the librdkafka CMake package (it is optional, but good practice IMO).