### PR TITLE
Pass member_id to rkas_get_metadata_cb()

### DIFF
--- a/src/rdkafka_assignor.c
+++ b/src/rdkafka_assignor.c
@@ -138,7 +138,8 @@ rd_kafka_consumer_protocol_member_metadata_new (
 
 rd_kafkap_bytes_t *
 rd_kafka_assignor_get_metadata (rd_kafka_assignor_t *rkas,
-				const rd_list_t *topics) {
+				const rd_list_t *topics,
+				const char *member_id RD_UNUSED) {
         return rd_kafka_consumer_protocol_member_metadata_new(
                 topics, rkas->rkas_userdata,
                 rkas->rkas_userdata_size);

--- a/src/rdkafka_assignor.h
+++ b/src/rdkafka_assignor.h
@@ -85,7 +85,8 @@ typedef struct rd_kafka_assignor_s {
 
         rd_kafkap_bytes_t *(*rkas_get_metadata_cb) (
                 struct rd_kafka_assignor_s *rkpas,
-		const rd_list_t *topics);
+                const rd_list_t *topics,
+                const char *member_id);
 
 
         void (*rkas_on_assignment_cb) (const char *member_id,
@@ -98,7 +99,8 @@ typedef struct rd_kafka_assignor_s {
 
 rd_kafkap_bytes_t *
 rd_kafka_assignor_get_metadata (rd_kafka_assignor_t *rkpas,
-				const rd_list_t *topics);
+				const rd_list_t *topics,
+				const char *member_id);
 
 
 void rd_kafka_assignor_update_subscription (rd_kafka_assignor_t *rkpas,

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1180,7 +1180,8 @@ void rd_kafka_JoinGroupRequest (rd_kafka_broker_t *rkb,
 		if (!rkas->rkas_enabled)
 			continue;
                 rd_kafka_buf_write_kstr(rkbuf, rkas->rkas_protocol_name);
-                member_metadata = rkas->rkas_get_metadata_cb(rkas, topics);
+                member_metadata = rkas->rkas_get_metadata_cb(rkas, topics,
+                                                             member_id->str);
                 rd_kafka_buf_write_kbytes(rkbuf, member_metadata);
                 rd_kafkap_bytes_destroy(member_metadata);
         }


### PR DESCRIPTION
I am currently working on adding support for the sticky assignment strategy to librdkafka in my fork, and that implies being able to persist the current assignment of partitions to a consumer as userData. I'm using the `rkas_on_assignment_cb()` callback to store the assignment for a particular group member and then look it up and serialize and return it from `rkas_get_metadata_cb()`.

However, to be able to look up the current assignment for a particular consumer I need to identify it and currently no argument is passed to `rkas_get_metadata_cb()` that can be used to identify the consumer that the metadata is being assembled for.

Therefore I added `member_id` as the last argument of `rkas_get_metadata_cb()` and changed `rd_kafka_JoinGroupRequest()` to pass it.

This should not be introducing any binary or source code incompatibilities because `rkas_get_metadata_cb()` is only used internally within the library.