### PR TITLE
Handle additional retvals from cnd_timedwait_abs()

### DIFF
--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -389,8 +389,8 @@ rd_kafka_op_t *rd_kafka_q_pop_serve (rd_kafka_q_t *rkq, int timeout_ms,
 
                         if (cnd_timedwait_abs(&rkq->rkq_cond,
                                               &rkq->rkq_lock,
-                                              &timeout_tspec) ==
-                            thrd_timedout) {
+                                              &timeout_tspec) !=
+                            thrd_success) {
 				mtx_unlock(&rkq->rkq_lock);
 				return NULL;
 			}
@@ -551,7 +551,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                 while (!(rko = TAILQ_FIRST(&rkq->rkq_q)) &&
                        !rd_kafka_q_check_yield(rkq) &&
                        cnd_timedwait_abs(&rkq->rkq_cond, &rkq->rkq_lock,
-                                         &timeout_tspec) != thrd_timedout)
+                                         &timeout_tspec) == thrd_success)
                         ;
 
 		if (!rko) {


### PR DESCRIPTION
Handle additional retvals from `cnd_timedwait_abs() ` to avoid infinite loop.