### PR TITLE
Batch produce requests to multiple topics and partitions.

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -235,6 +235,8 @@ typedef struct rd_kafka_topic_conf_s rd_kafka_topic_conf_t;
 typedef struct rd_kafka_queue_s rd_kafka_queue_t;
 typedef struct rd_kafka_op_s rd_kafka_event_t;
 typedef struct rd_kafka_topic_result_s rd_kafka_topic_result_t;
+typedef struct rd_kafka_produce_ctx_s rd_kafka_produce_ctx_t;
+typedef struct rd_kafka_produce_calculator_s rd_kafka_produce_calculator_t;
 /* @endcond */
 
 

--- a/src/rdkafka_buf.c
+++ b/src/rdkafka_buf.c
@@ -52,9 +52,7 @@ void rd_kafka_buf_destroy_final (rd_kafka_buf_t *rkbuf) {
                 }
                 break;
 
-        case RD_KAFKAP_Produce:
-                if (rkbuf->rkbuf_u.Produce.s_rktp)
-                        rd_kafka_toppar_destroy(rkbuf->rkbuf_u.Produce.s_rktp);
+        default:
                 break;
         }
 

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -594,12 +594,6 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
                         mtx_t *decr_lock;
 
                 } Metadata;
-                struct {
-                        shptr_rd_kafka_toppar_t *s_rktp;
-                        rd_kafka_pid_t pid;  /**< Producer Id and Epoch */
-                        int32_t base_seq;    /**< Base sequence */
-                        int64_t base_msgid;  /**< Base msgid */
-                } Produce;
         } rkbuf_u;
 
         const char *rkbuf_uflow_mitigation; /**< Buffer read underflow

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -916,6 +916,10 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
           "the producer. "
           "Requires `enable.idempotence=true`.",
           0, 1, 1 },
+        { _RK_GLOBAL|_RK_PRODUCER, "produce.request.max.partitions", _RK_C_INT,
+          _RK(produce_request_max_partitions),
+          "Maximum number of partitions to include in a single produce request.",
+          1, 10000000, 10 },
         { _RK_GLOBAL|_RK_PRODUCER|_RK_HIGH, "queue.buffering.max.messages",
           _RK_C_INT,
 	  _RK(queue_buffering_max_msgs),

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -322,6 +322,7 @@ struct rd_kafka_conf_s {
                                       *   gapless guarantee can't be
                                       *   satisfied. */
         } eos;
+        int    produce_request_max_partitions;
 	int    queue_buffering_max_msgs;
 	int    queue_buffering_max_kbytes;
 	int    buffering_max_ms;

--- a/src/rdkafka_msgset.h
+++ b/src/rdkafka_msgset.h
@@ -29,15 +29,140 @@
 #ifndef _RDKAFKA_MSGSET_H_
 #define _RDKAFKA_MSGSET_H_
 
+/* This calculator is used to get accurate topic, partition, and message
+ * counts to pass into rd_kafka_produce_ctx_init so that a buffer of
+ * adequate size will be allocated.
+ */
+struct rd_kafka_produce_calculator_s
+{
+    /* Counts used to estimate payload size. */
+    int rkpca_topic_cnt;
+    int rkpca_partition_cnt;
+    int rkpca_message_cnt;
+    size_t rkpca_message_size;
+
+    /* Topic specific configurations.
+     * All topics in a batch must use the same values. */
+    int rkpca_request_req_acks;
+    int rkpca_request_timeout_ms;
+
+    /* Cached header sizes used in calculation. */
+    size_t rkpca_produce_header_size;
+    size_t rkpca_topic_header_size;
+    size_t rkpca_partition_header_size;
+    size_t rkpca_message_set_header_size;
+    size_t rkpca_message_overhead;
+
+    /* Track previous topic added to see if it changed. */
+    rd_kafka_topic_t *rkpca_rkt_prev;
+};
+
+/* Context used to store data while constructing a produce batch.
+ * The resulting batch will be written into a buffer created in
+ * rd_kafka_produce_ctx_init, and returned in rd_kafka_produce_ctx_finalize.
+ * Toppars are added using rd_kafka_produce_ctx_append_toppar and must
+ * conform to the settings passed into the init method or appending will fail.
+ */
+struct rd_kafka_produce_ctx_s {
+        rd_kafka_broker_t *rkpc_rkb;
+
+        /* User variables set in rd_kafka_produce_ctx_init */
+        int rkpc_topic_max;             /* Max topics which can be added to batch. */
+        int rkpc_partition_max;         /* Max partitions which can be added to batch. */
+        int rkpc_message_max;           /* Max partitions which can be added to batch. */
+        size_t rkpc_message_bytes_size; /* Max message bytes which can be added to batch. */
+        void *rkpc_opaque;              /* User data associated with the request. */
+
+        /* Produce batch option. All topics / partitions must share these options. */
+        int rkpc_required_acks;
+        int rkpc_request_timeout_ms;
+
+        /* Options set by rd_kafka_produce_request_select_caps in rd_kafka_produce_ctx_init. */
+        int rkpc_api_version;
+        int rkpc_msg_version;
+        int rkpc_features;
+
+        /* Counts of topics / partitions / messages written to a produce batch. */
+        int rkpc_appended_topic_cnt;
+        int rkpc_appended_partition_cnt;
+        int rkpc_appended_message_cnt;
+        size_t rkpc_appended_message_bytes;
+
+        /* As messages are added to a batch, this will be the earliest timeout
+         * time of the messages in the batch. */
+        rd_ts_t rkpc_first_timeout;
+
+        /* The offset of topic count in the batch header. This will be updated
+         * to the actual count in rd_kafka_produce_ctx_finalize. */
+        size_t rkpc_topic_cnt_offset;
+
+        /* The last topic appended to the batch. This is used when appending
+         * partitions to know when a new topic header is needed. */
+        rd_kafka_itopic_t *rkpc_active_topic;
+
+        /* The offset of the partition count within a topic header. This will
+         * be updated to the actual partition count when a partition for a
+         * different topic is appended or in rd_kafka_produce_ctx_finalize. */
+        size_t rkpc_active_topic_partition_cnt_offset;
+
+        /* Count of partitions appended for the current topic.
+         * Used to update the count at the offset above. */
+        int rkpc_active_topic_partition_cnt;
+
+        /* Track whether the previous append call was a partial write. In that
+         * case, no more messages may be added so the context must be finalized. */
+        int rkpc_full;
+
+        /* The buffer used when writing. */
+        rd_kafka_buf_t *rkpc_buf;
+
+        /* Idempotent producer's current Producer Id */
+        rd_kafka_pid_t rkpc_pid;
+
+        /* Active toppar first message information */
+        struct {
+                uint64_t   msgid;  /**< Internal/original message id. */
+                int32_t    seq;    /**< Epoch's sequence after adjusting
+                                    *   for current epoch and wrapping. */
+        } rkpc_active_firstmsg;
+};
 
 /**
- * @name MessageSet writers
+ * @name Multiple message set produce request handling.
+ * @{
+ *
+ * These functions are for packing multiple message
+ * sets within a single produce request.
  */
+
+void
+rd_kafka_produce_calculator_init(rd_kafka_produce_calculator_t *rkpca,
+                                 rd_kafka_broker_t *rkb);
+
+int
+rd_kafka_produce_calculator_add(rd_kafka_produce_calculator_t *rkpca,
+                                rd_kafka_toppar_t *rktp);
+
+int
+rd_kafka_produce_ctx_init (rd_kafka_produce_ctx_t *rkpc,
+                           rd_kafka_broker_t *rkb,
+                           int topic_max,
+                           int partition_max,
+                           int message_max,
+                           size_t message_bytes_size,
+                           int required_acks,
+                           int request_timeout_ms,
+                           rd_kafka_pid_t pid,
+                           void* opaque);
+
+int
+rd_kafka_produce_ctx_append_toppar (rd_kafka_produce_ctx_t *rkpc,
+                                    rd_kafka_toppar_t *rktp,
+                                    int *appended_msg_cnt,
+                                    size_t *appended_msg_bytes);
+
 rd_kafka_buf_t *
-rd_kafka_msgset_create_ProduceRequest (rd_kafka_broker_t *rkb,
-                                       rd_kafka_toppar_t *rktp,
-                                       const rd_kafka_pid_t pid,
-                                       size_t *MessageSetSizep);
+rd_kafka_produce_ctx_finalize (rd_kafka_produce_ctx_t *rkpc);
 
 /**
  * @name MessageSet readers

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -661,7 +661,7 @@ void rd_kafka_toppar_enq_msg (rd_kafka_toppar_t *rktp, rd_kafka_msg_t *rkm) {
         if (unlikely(queue_len == 1 &&
                      (wakeup_q = rktp->rktp_msgq_wakeup_q)))
                 rd_kafka_q_keep(wakeup_q);
-
+                
         rd_kafka_toppar_unlock(rktp);
 
         if (wakeup_q) {

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -74,6 +74,7 @@ struct rd_kafka_toppar_err {
 struct rd_kafka_toppar_s { /* rd_kafka_toppar_t */
 	TAILQ_ENTRY(rd_kafka_toppar_s) rktp_rklink;  /* rd_kafka_t link */
 	TAILQ_ENTRY(rd_kafka_toppar_s) rktp_rkblink; /* rd_kafka_broker_t link*/
+        TAILQ_ENTRY(rd_kafka_toppar_s) rktp_batch_link; /* rd_kafka_broker_t link for batch produce */
         CIRCLEQ_ENTRY(rd_kafka_toppar_s) rktp_activelink; /* rkb_active_toppars */
 	TAILQ_ENTRY(rd_kafka_toppar_s) rktp_rktlink; /* rd_kafka_itopic_t link*/
         TAILQ_ENTRY(rd_kafka_toppar_s) rktp_cgrplink;/* rd_kafka_cgrp_t link */

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -202,8 +202,24 @@ void rd_kafka_SaslHandshakeRequest (rd_kafka_broker_t *rkb,
 				    rd_kafka_resp_cb_t *resp_cb,
 				    void *opaque);
 
-int rd_kafka_ProduceRequest (rd_kafka_broker_t *rkb, rd_kafka_toppar_t *rktp,
+int rd_kafka_ProduceRequest (rd_kafka_broker_t *rkb,
+                             rd_kafka_toppar_t *rktp,
                              const rd_kafka_pid_t pid);
+
+int rd_kafka_ProduceRequest_init(rd_kafka_produce_ctx_t *rkpc,
+                                 rd_kafka_broker_t *rkb,
+                                 const rd_kafka_pid_t pid,
+                                 int topic_max,
+                                 int partition_max,
+                                 int message_max,
+                                 size_t message_bytes_size,
+                                 int required_acks,
+                                 int request_timeout_ms);
+
+int rd_kafka_ProduceRequest_append(rd_kafka_produce_ctx_t *rkpc,
+                                   rd_kafka_toppar_t *rktp);
+
+int rd_kafka_ProduceRequest_finalize(rd_kafka_produce_ctx_t *rkpc);
 
 rd_kafka_resp_err_t
 rd_kafka_CreateTopicsRequest (rd_kafka_broker_t *rkb,


### PR DESCRIPTION
I know this is a large diff, the intent is to reduce the overall number of produce requests since it seems that there is a high overhead per request on the broker.

This code allows for producing to multiple topics and partitions within a single produce request. It does not currently address producing multiple message sets for the same toppar within the same request.

The batch producing has been thoroughly vetted, however it was originally written on top of rdkafka 0.11.4. I have rebased to pick up the sparse connection and idempotent producer changes, and re-run the latency measurements as shown below.

I added the config var "produce.request.max.partitions" to limit the number of toppars contained within one request. Setting this to 1 will mimic existing behavior.

I am attaching latency measurements from before and after the change producing 1,000,000 messages to a topic which has 200 partitions, and one which has 1,000 partitions. The message rate is 20,000 messages per second. The only change is switching out the code used to produce, all config values remain the same.

On the charts, the X axis is message number and the Y axis is time in ms.
For our test, we are running against a 4 node kafka cluster. The producer and consumer are on the same machine, so there should be no deviation of timestamps.

The charts are divided into seven sub-charts, which show the following:
1.  Time between call to rd_kafka_produce until rdkafka message is created.
2. Time between 1 and message set being created.
3. Time between 2 and produce request being sent by producer in rd_kafka_send.
4. Time between 3 to fetch request received by consumer in rd_kafka_recv.
5. Time between 4 to call to rd_kafka_consume0.
6. Time between 5 and message handled by app code.
7. Total time between rd_kafka_produce to message consumed by consumer app.

**Latency charts: 1 topic 200 partitions**
**BASELINE**
![consumer_baseline_200](https://user-images.githubusercontent.com/34898621/52244956-84cfea00-2894-11e9-95bf-0c870a80b9a4.png)
**BATCH**
![consumer_batch_200](https://user-images.githubusercontent.com/34898621/52244965-8d282500-2894-11e9-8248-f57f541d0416.png)

**Latency charts: 1 topic 1000 partitions**
**BASELINE**
![consumer_baseline_1000](https://user-images.githubusercontent.com/34898621/52244974-9fa25e80-2894-11e9-8051-8e934477447b.png)
**BATCH**
![consumer_batch_1000](https://user-images.githubusercontent.com/34898621/52244987-a6c96c80-2894-11e9-990a-0ce8fbf7e26f.png)