### PR TITLE
CMake: Add check for C11 thread support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ endif(WIN32)
 # * HAVE_ATOMICS_64_SYNC
 # * HAVE_REGEX
 # * HAVE_STRNDUP
+# * WITH_C11THREADS
 # * LINK_ATOMIC
 include("packaging/cmake/try_compile/rdkafka_setup.cmake")
 

--- a/packaging/cmake/config.h.in
+++ b/packaging/cmake/config.h.in
@@ -38,4 +38,5 @@
 #cmakedefine01 WITH_SASL_CYRUS
 #cmakedefine01 HAVE_REGEX
 #cmakedefine01 HAVE_STRNDUP
+#cmakedefine01 WITH_C11THREADS
 #define SOLIB_EXT "${CMAKE_SHARED_LIBRARY_SUFFIX}"

--- a/packaging/cmake/try_compile/c11threads_test.c
+++ b/packaging/cmake/try_compile/c11threads_test.c
@@ -1,0 +1,14 @@
+#include <threads.h>
+
+static int start_func (void *arg) {
+   int iarg = *(int *)arg;
+   return iarg;
+}
+
+void main (void) {
+    thrd_t thr;
+    int arg = 1;
+    if (thrd_create(&thr, start_func, (void *)&arg) != thrd_success) {
+      ;
+    }
+}

--- a/packaging/cmake/try_compile/rdkafka_setup.cmake
+++ b/packaging/cmake/try_compile/rdkafka_setup.cmake
@@ -74,3 +74,12 @@ else()
   endif()
 endif()
 # }
+
+# C11 threads
+try_compile(
+    WITH_C11THREADS
+    "${CMAKE_CURRENT_BINARY_DIR}/try_compile"
+    "${TRYCOMPILE_SRC_DIR}/c11threads_test.c"
+    LINK_LIBRARIES "-pthread"
+)
+# }


### PR DESCRIPTION
This PR adds a check in the CMake files to detect C11 thread support on the build host to enable the conditional compilation of tinycthread.
Glibc version 2.28 introduced support for C11 threads, which leads to similar problems as reported in https://github.com/edenhill/librdkafka/issues/1998 on system that already use that Glibc version.