### PR TITLE
Update rdkafkacpp.h to fix -Wpedantic warning

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -76,7 +76,7 @@ extern "C" {
         struct rd_kafka_s;
         struct rd_kafka_topic_s;
         struct rd_kafka_message_s;
-};
+}
 
 namespace RdKafka {
 


### PR DESCRIPTION
Fix for:

In file included from test.cpp:54:0:
/opt/librdkafka/include/librdkafka/rdkafkacpp.h:79:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^