### PR TITLE
Always give a non-NULL result pointer to thrd_join

### DIFF
--- a/tests/0056-balanced_group_mt.c
+++ b/tests/0056-balanced_group_mt.c
@@ -259,8 +259,9 @@ int main_0056_balanced_group_mt (int argc, char **argv) {
 
         TIMING_START(&t_consume, "CONSUME.WAIT");
         for (i = 0; i < MAX_THRD_CNT; ++i) {
+                int res;
                 if (tids[i] != 0)
-                        thrd_join(tids[i], NULL);
+                        thrd_join(tids[i], &res);
         }
         TIMING_STOP(&t_consume);
 

--- a/tests/0075-retry.c
+++ b/tests/0075-retry.c
@@ -166,6 +166,7 @@ static void do_test_low_socket_timeout (const char *topic) {
         rd_kafka_topic_t *rkt;
         rd_kafka_resp_err_t err;
         const struct rd_kafka_metadata *md;
+        int res;
 
         mtx_init(&ctrl.lock, mtx_plain);
         cnd_init(&ctrl.cnd);
@@ -228,7 +229,7 @@ static void do_test_low_socket_timeout (const char *topic) {
         mtx_lock(&ctrl.lock);
         ctrl.term = 1;
         mtx_unlock(&ctrl.lock);
-        thrd_join(ctrl.thrd, NULL);
+        thrd_join(ctrl.thrd, &res);
 
         cnd_destroy(&ctrl.cnd);
         mtx_destroy(&ctrl.lock);

--- a/tests/sockem.c
+++ b/tests/sockem.c
@@ -74,7 +74,7 @@ typedef pthread_t thrd_t;
 #define thrd_create(THRD,START_ROUTINE,ARG) \
   pthread_create(THRD, NULL, START_ROUTINE, ARG)
 #define thrd_join(THRD,RETVAL) \
-  pthread_join(THRD, NULL)
+  pthread_join(THRD, RETVAL)
 
 
 static mtx_t sockem_lock;
@@ -640,7 +640,7 @@ static void sockem_bufs_purge (sockem_t *skm) {
 
 
 void sockem_close (sockem_t *skm) {
-
+        int res;
 
         mtx_lock(&sockem_lock);
         mtx_lock(&skm->lock);
@@ -658,7 +658,7 @@ void sockem_close (sockem_t *skm) {
 
         mtx_unlock(&skm->lock);
 
-        thrd_join(skm->thrd, NULL);
+        thrd_join(skm->thrd, &res);
 
         sockem_bufs_purge(skm);
 

--- a/tests/sockem_ctrl.c
+++ b/tests/sockem_ctrl.c
@@ -130,13 +130,15 @@ void sockem_ctrl_init (sockem_ctrl_t *ctrl) {
 }
 
 void sockem_ctrl_term (sockem_ctrl_t *ctrl) {
+        int res;
+
         /* Join controller thread */
         mtx_lock(&ctrl->lock);
         ctrl->term = 1;
         cnd_broadcast(&ctrl->cnd);
         mtx_unlock(&ctrl->lock);
 
-        thrd_join(ctrl->thrd, NULL);
+        thrd_join(ctrl->thrd, &res);
 
         cnd_destroy(&ctrl->cnd);
         mtx_destroy(&ctrl->lock);


### PR DESCRIPTION
With this commit, I can successfully run 'gmake -C tests run_local' on a solaris 11.4 machine; I haven't tested anything further than that.