### PR TITLE
CMake: Remove redundant LIBRDKAFKACPP_EXPORTS definition

### DIFF
--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -34,9 +34,6 @@ target_link_libraries(rdkafka++ PUBLIC rdkafka)
 target_include_directories(rdkafka++ PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
 if(NOT RDKAFKA_BUILD_STATIC)
     target_compile_definitions(rdkafka++ PRIVATE LIBRDKAFKACPP_EXPORTS)
-    if(WIN32)
-        target_compile_definitions(rdkafka++ INTERFACE LIBRDKAFKACPP_EXPORTS=0)
-    endif()
 endif()
 
 # Generate pkg-config file


### PR DESCRIPTION
Hi! I am creating a portfile for `librdkafka` in `vcpkg` these days. And I encountered several `unresolved external symbol` errors related to those static const data members defined  in `RdKafka::Topic` when I built `librdkafka` as a shared library on Win32: https://github.com/Microsoft/vcpkg/pull/5921#issuecomment-480585430

After some research, I found that this issue seems caused by a redundant `LIBRDKAFKACPP_EXPORTS` definition in this file: https://github.com/edenhill/librdkafka/blob/master/src-cpp/CMakeLists.txt#L37-L39
This redundant definition causes `RD_EXPORT` expanded as `__declspec(dllexport)` in a CMake-based project.

A small CMake project to help reproduce this problem: https://github.com/myd7349/Ongoing-Study/tree/master/cpp/CMake/vcpkg/librdkafka_pr_2274