### PR TITLE
Minor fixes for Win32

### DIFF
--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -649,7 +649,7 @@ rd_kafka_set_replyq (rd_kafka_replyq_t *replyq,
 	replyq->q = rkq ? rd_kafka_q_keep(rkq) : NULL;
 	replyq->version = version;
 #if ENABLE_DEVEL
-	replyq->_id = strdup(__FUNCTION__);
+	replyq->_id = rd_strdup(__FUNCTION__);
 #endif
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,9 +100,6 @@ endif()
 
 add_executable(rdkafka_test ${sources})
 target_link_libraries(rdkafka_test PUBLIC rdkafka++)
-if(WIN32)
-    target_compile_definitions(rdkafka_test PRIVATE LIBRDKAFKACPP_EXPORTS=0)
-endif(WIN32)
 
 add_test(NAME RdKafkaTestInParallel COMMAND rdkafka_test -p5)
 add_test(NAME RdKafkaTestSequentially COMMAND rdkafka_test -p1)


### PR DESCRIPTION
- Remove redundant LIBRDKAFKACPP_EXPORTS definition in tests missed in #2274
  I want to apologize for it since I should have fixed it in #2274. But I didn't run the tests before: https://github.com/myd7349/vcpkg/blob/8aeafa192dc621f17be56108cabcc556fe6522b9/ports/librdkafka/portfile.cmake#L32, so I just missed it at that time.
  We can reproduce the link error caused by this definition on Win32 by:
  ```
  mkdir build
  cd build
  cmake ..
  cmake --build .
  ```
- Fix C4996 warning related to strdup
  When I was trying to build librdkafka on UWP, a C4996 error is reported by VS: 
  >e:\vcpkg\buildtrees\librdkafka\src\a34ca9b746-a24f4e04b2\src\rdkafka_queue.h(652): error C4996: 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup. See online help for details. (compiling source file

  Though the UWP build is still failed for some other reasons([install-x86-uwp-dbg-out.log](https://github.com/edenhill/librdkafka/files/3152143/install-x86-uwp-dbg-out.log)), I think this fix is reasonable since all other places in the code use `rd_strdup` instead of `strdup`.