### PR TITLE
Don't let active logical broker connections hinder new connects (#2266)

### DIFF
--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -143,7 +143,7 @@ int rd_kafka_idemp_request_pid (rd_kafka_t *rk, rd_kafka_broker_t *rkb,
         } else {
                 /* Increase passed broker's refcount so we don't
                  * have to check if rkb should be destroyed or not below
-                 * (broker_any_usable() returns a new reference). */
+                 * (broker_any() returns a new reference). */
                 rd_kafka_broker_keep(rkb);
         }
 

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -163,8 +163,13 @@ struct rd_kafka_s {
 	TAILQ_HEAD(, rd_kafka_broker_s) rk_brokers;
         rd_list_t                  rk_broker_by_id; /* Fast id lookups. */
 	rd_atomic32_t              rk_broker_cnt;
-        rd_atomic32_t              rk_broker_up_cnt; /**< Number of brokers
-                                                      *   in state >= UP */
+        /**< Number of brokers in state >= UP */
+        rd_atomic32_t              rk_broker_up_cnt;
+        /**< Number of logical brokers in state >= UP, this is a sub-set
+         *   of rk_broker_up_cnt. */
+        rd_atomic32_t              rk_logical_broker_up_cnt;
+        /**< Number of brokers that are down, only includes brokers
+         *   that have had at least one connection attempt. */
 	rd_atomic32_t              rk_broker_down_cnt;
         /**< Logical brokers currently without an address.
          *   Used for calculating ERR__ALL_BROKERS_DOWN. */


### PR DESCRIPTION
The logical broker connections (such as to the group coordinator)
are reserved for specific use and shall not be reused for things like
Metadata requests. The code to lookup a usable broker to send
Metadata requests understood this, but the code to select a broker
to create a new connection to if no usable connections are
found (sparse connnections) did not understand this and already
thought there was an active connection (the logical broker connection)
and refused to set up a new one.

This could lead to consumers stalling consumption if it was fetching
from a single broker and that broker went down, no new connection
to the cluster would be made to refresh metadata.

This fixes #2266