### PR TITLE
fix off by one issue in rd_kafka_offsets_store

### DIFF
--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -714,7 +714,7 @@ rd_kafka_offsets_store (rd_kafka_t *rk,
                 }
 
                 rd_kafka_offset_store0(rd_kafka_toppar_s2i(s_rktp),
-                                       rktpar->offset, 1/*lock*/);
+                                       rktpar->offset+1, 1/*lock*/);
                 rd_kafka_toppar_destroy(s_rktp);
 
                 rktpar->err = RD_KAFKA_RESP_ERR_NO_ERROR;


### PR DESCRIPTION
There is a discrepancy between `rd_kafka_offsets_store` and `rd_kafka_offset_store` where only the latter automatically increment the offset by 1 and it's probably the desired the behavior in most scenarios.

This PR basically lets `rd_kafka_offsets_store` to do the same.

Please let me know if there is rationale behind the discrepancy or if this is indeed a bug.

More context:
I encountered this issue when running a go consumer, and used `consumer.StoreOffsets` which calls `rd_kafka_offsets_store`. And it came as a surprise to me that restarting an up-to-date consumer would replay the latest message.

Will add tests if necessary.