### PR TITLE
Add cl-rdkafka to language bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Questions and discussions are also welcome on the [Confluent Community slack](ht
 
   * C#/.NET: [confluent-kafka-dotnet](https://github.com/confluentinc/confluent-kafka-dotnet) (based on [rdkafka-dotnet](https://github.com/ah-/rdkafka-dotnet))
   * C++: [cppkafka](https://github.com/mfontanini/cppkafka)
+  * Common Lisp [cl-rdkafka](https://github.com/SahilKang/cl-rdkafka)
   * D (C-like): [librdkafka](https://github.com/DlangApache/librdkafka/)
   * D (C++-like): [librdkafkad](https://github.com/tamediadigital/librdkafka-d)
   * Erlang: [erlkaf](https://github.com/silviucpp/erlkaf)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Questions and discussions are also welcome on the [Confluent Community slack](ht
 
   * C#/.NET: [confluent-kafka-dotnet](https://github.com/confluentinc/confluent-kafka-dotnet) (based on [rdkafka-dotnet](https://github.com/ah-/rdkafka-dotnet))
   * C++: [cppkafka](https://github.com/mfontanini/cppkafka)
-  * Common Lisp [cl-rdkafka](https://github.com/SahilKang/cl-rdkafka)
+  * Common Lisp: [cl-rdkafka](https://github.com/SahilKang/cl-rdkafka)
   * D (C-like): [librdkafka](https://github.com/DlangApache/librdkafka/)
   * D (C++-like): [librdkafkad](https://github.com/tamediadigital/librdkafka-d)
   * Erlang: [erlkaf](https://github.com/silviucpp/erlkaf)


### PR DESCRIPTION
I've created and released a Common Lisp library on top of librdkafka and would like to list it on the README.