### PR TITLE
max.poll.interval.ms: properly handle blocking calls

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2987,6 +2987,8 @@ rd_kafka_cgrp_op_serve (rd_kafka_t *rk, rd_kafka_q_t *rkq,
                 break;
 
         case RD_KAFKA_OP_SUBSCRIBE:
+                rd_kafka_app_polled(rk);
+
                 /* New atomic subscription (may be NULL) */
                 err = rd_kafka_cgrp_subscribe(
                         rkcg, rko->rko_u.subscribe.topics);

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -526,8 +526,6 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
         rd_kafka_q_t *fwdq;
         struct timespec timeout_tspec;
 
-        rd_kafka_app_polled(rk);
-
 	mtx_lock(&rkq->rkq_lock);
         if ((fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
                 /* Since the q_pop may block we need to release the parent
@@ -539,6 +537,9 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
 		return cnt;
 	}
         mtx_unlock(&rkq->rkq_lock);
+
+        if (timeout_ms)
+                rd_kafka_app_poll_blocking(rk);
 
         rd_timeout_init_timespec(&timeout_tspec, timeout_ms);
 
@@ -609,6 +610,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                 rd_kafka_op_destroy(rko);
         }
 
+        rd_kafka_app_polled(rk);
 
 	return cnt;
 }


### PR DESCRIPTION
Previous to this fix the app_polled time was only updated upon
entry to a (possibly) blocking function, such as consumer_poll().
If the call had a timeout > max.poll.interval.ms and there were no messages
for at least max.poll.interval.ms, the max poll check would kick in and
evict the consumer from the group due to inactivity.

We now signal to app_polled that we're in a blocking call
which prevents the max poll check to fire.