### PR TITLE
Fixed socket recv error handling for MSVC build

### DIFF
--- a/src/rdkafka_transport.c
+++ b/src/rdkafka_transport.c
@@ -308,10 +308,14 @@ rd_kafka_transport_socket_recv0 (rd_kafka_transport_t *rktrans,
 
                 if (unlikely(r == SOCKET_ERROR)) {
 #ifdef _MSC_VER
-                        if (WSAGetLastError() == WSAEWOULDBLOCK)
+                        int errno_save = WSAGetLastError();
+                        if (errno_save == WSAEWOULDBLOCK)
                                 return sum;
-                        rd_snprintf(errstr, errstr_size, "%s",
-                                    socket_strerror(WSAGetLastError()));
+                        else {
+                                rd_snprintf(errstr, errstr_size, "%s",
+                                    socket_strerror(errno_save));
+                                return -1;
+                        }
 #else
                         if (socket_errno == EAGAIN)
                                 return sum;


### PR DESCRIPTION
Added socket recv error handling for MSVC build.
There's no returns when recv returns SOCKET_ERROR and error code is not WSAEWOULDBLOCK.
It causes crashes(calls rd_buf_write with size -1).