### PR TITLE
Prevents destroy toppar when retry OffsetRequest

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1291,11 +1291,11 @@ static void rd_kafka_toppar_handle_Offset (rd_kafka_t *rk,
 		    err = RD_KAFKA_RESP_ERR__OUTDATED;
 	}
 
-    if (err != RD_KAFKA_RESP_ERR__OUTDATED) {
-        /* Parse and return Offset */
-        err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
-                                     rkbuf, request, offsets);
-    }
+        if (err != RD_KAFKA_RESP_ERR__OUTDATED) {
+            /* Parse and return Offset */
+            err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
+                                         rkbuf, request, offsets);
+        }
 
         if (!err &&
             (!(rktpar = rd_kafka_topic_partition_list_find(

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1292,9 +1292,9 @@ static void rd_kafka_toppar_handle_Offset (rd_kafka_t *rk,
 	}
 
         if (err != RD_KAFKA_RESP_ERR__OUTDATED) {
-            /* Parse and return Offset */
-            err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
-                                         rkbuf, request, offsets);
+                /* Parse and return Offset */
+                err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
+                                             rkbuf, request, offsets);
         }
 
         if (!err &&

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1277,10 +1277,6 @@ static void rd_kafka_toppar_handle_Offset (rd_kafka_t *rk,
 
         offsets = rd_kafka_topic_partition_list_new(1);
 
-        /* Parse and return Offset */
-        err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
-                                     rkbuf, request, offsets);
-
 	rd_rkb_dbg(rkb, TOPIC, "OFFSET",
 		   "Offset reply for "
 		   "topic %.*s [%"PRId32"] (v%d vs v%d)",
@@ -1294,6 +1290,12 @@ static void rd_kafka_toppar_handle_Offset (rd_kafka_t *rk,
 		/* Outdated request response, ignore. */
 		    err = RD_KAFKA_RESP_ERR__OUTDATED;
 	}
+
+    if (err != RD_KAFKA_RESP_ERR__OUTDATED) {
+        /* Parse and return Offset */
+        err = rd_kafka_handle_Offset(rkb->rkb_rk, rkb, err,
+                                     rkbuf, request, offsets);
+    }
 
         if (!err &&
             (!(rktpar = rd_kafka_topic_partition_list_find(


### PR DESCRIPTION
Fix for #2373.

Call `rd_kafka_handle_Offset` after checking op version and only when err is not `RD_KAFKA_RESP_ERR__OUTDATED`.
