### PR TITLE
Fill metadata in rd_kafka_committed & rd_kafka_offsets_for_times.

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -3410,6 +3410,11 @@ rd_kafka_topic_partition_list_update (rd_kafka_topic_partition_list_t *dst,
 
                 d->offset = s->offset;
                 d->err    = s->err;
+                if (d->metadata) {
+                        rd_free(d->metadata);
+                        d->metadata = NULL;
+                        d->metadata_size = 0;
+                }
                 if (s->metadata_size > 0) {
                         d->metadata =
                                 rd_malloc(s->metadata_size);

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -3386,6 +3386,8 @@ rd_kafka_topic_partition_list_str (const rd_kafka_topic_partition_list_t *rktpar
  * @brief Update \p dst with info from \p src.
  *
  * Fields updated:
+ *  - metadata
+ *  - metadata_size
  *  - offset
  *  - err
  *
@@ -3408,6 +3410,13 @@ rd_kafka_topic_partition_list_update (rd_kafka_topic_partition_list_t *dst,
 
                 d->offset = s->offset;
                 d->err    = s->err;
+                if (s->metadata_size > 0) {
+                        d->metadata =
+                                rd_malloc(s->metadata_size);
+                        d->metadata_size = s->metadata_size;
+                        memcpy((void *)d->metadata, s->metadata,
+                                s->metadata_size);
+                }
         }
 }
 


### PR DESCRIPTION
Currently rd_kafka_committed returns list with empty  metadata:

![Выделение_021](https://user-images.githubusercontent.com/881794/60683738-170b0700-9ea2-11e9-8650-43e9733c0d00.png)
