### PR TITLE
Be consistent with rd_malloc/rd_free combos.

### DIFF
--- a/src-cpp/RdKafka.cpp
+++ b/src-cpp/RdKafka.cpp
@@ -50,3 +50,10 @@ int RdKafka::wait_destroyed (int timeout_ms) {
   return rd_kafka_wait_destroyed(timeout_ms);
 }
 
+void *RdKafka::mem_malloc (size_t size) {
+  return rd_kafka_mem_malloc(NULL, size);
+}
+
+void RdKafka::mem_free (void *ptr) {
+  rd_kafka_mem_free(NULL, ptr);
+}

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -992,6 +992,13 @@ class HandleImpl : virtual public Handle {
                                                 rk_, errstr.c_str()));
   };
 
+  void *mem_malloc (size_t size) {
+    return rd_kafka_mem_malloc(rk_, size);
+  };
+
+  void mem_free (void *ptr) {
+    rd_kafka_mem_free(rk_, ptr);
+  };
 
   rd_kafka_t *rk_;
   /* All Producer and Consumer callbacks must reside in HandleImpl and

--- a/src/lz4.c
+++ b/src/lz4.c
@@ -198,10 +198,13 @@ void  LZ4_free(void* p);
 # define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
 # define FREEMEM(p)        LZ4_free(p)
 #else
-# include <stdlib.h>   /* malloc, calloc, free */
-# define ALLOC(s)          malloc(s)
-# define ALLOC_AND_ZERO(s) calloc(1,s)
-# define FREEMEM(p)        free(p)
+struct rdkafka_s;
+extern void *rd_kafka_mem_malloc(struct rdkafka_s *rk, size_t s);
+extern void *rd_kafka_mem_calloc(struct rdkafka_s *rk, size_t n, size_t s);
+extern void rd_kafka_mem_free(struct rdkafka_s *rk, void *p);
+# define ALLOC(s)          rd_kafka_mem_malloc(NULL, s)
+# define ALLOC_AND_ZERO(s) rd_kafka_mem_calloc(NULL, 1, s)
+# define FREEMEM(p)        rd_kafka_mem_free(NULL, p)
 #endif
 
 #include <string.h>   /* memset, memcpy */

--- a/src/lz4frame.c
+++ b/src/lz4frame.c
@@ -72,10 +72,10 @@
  * by modifying below section.
  */
 #ifndef LZ4_SRC_INCLUDED   /* avoid redefinition when sources are coalesced */
-#  include <stdlib.h>   /* malloc, calloc, free */
-#  define ALLOC(s)          malloc(s)
-#  define ALLOC_AND_ZERO(s) calloc(1,(s))
-#  define FREEMEM(p)        free(p)
+#include "rd.h"   /* rd_malloc, rd_calloc, rd_free */
+#  define ALLOC(s)          rd_malloc(s)
+#  define ALLOC_AND_ZERO(s) rd_calloc(1,(s))
+#  define FREEMEM(p)        rd_free(p)
 #endif
 
 #include <string.h>   /* memset, memcpy, memmove */

--- a/src/rd.h
+++ b/src/rd.h
@@ -154,7 +154,7 @@ static RD_INLINE RD_UNUSED char *rd_strndup(const char *s, size_t len) {
 	char *n = strndup(s, len);
 	rd_assert(n);
 #else
-	char *n = (char *)malloc(len + 1);
+	char *n = (char *)rd_malloc(len + 1);
 	rd_assert(n);
 	memcpy(n, s, len);
 	n[len] = '\0';

--- a/src/rdavl.c
+++ b/src/rdavl.c
@@ -192,13 +192,13 @@ void rd_avl_destroy (rd_avl_t *ravl) {
                 rwlock_destroy(&ravl->ravl_rwlock);
 
         if (ravl->ravl_flags & RD_AVL_F_OWNER)
-                free(ravl);
+                rd_free(ravl);
 }
 
 rd_avl_t *rd_avl_init (rd_avl_t *ravl, rd_avl_cmp_t cmp, int flags) {
 
         if (!ravl) {
-                ravl = calloc(1, sizeof(*ravl));
+                ravl = rd_calloc(1, sizeof(*ravl));
                 flags |= RD_AVL_F_OWNER;
         } else {
                 memset(ravl, 0, sizeof(*ravl));

--- a/src/rdgz.c
+++ b/src/rdgz.c
@@ -96,7 +96,7 @@ void *rd_gz_decompress (const void *compressed, int compressed_len,
 
 		if (pass == 1) {
 			*decompressed_lenp = strm.total_out;
-			if (!(decompressed = malloc((size_t)(*decompressed_lenp)+1))) {
+			if (!(decompressed = rd_malloc((size_t)(*decompressed_lenp)+1))) {
 				inflateEnd(&strm);
 				return NULL;
 			}
@@ -113,6 +113,6 @@ void *rd_gz_decompress (const void *compressed, int compressed_len,
 
 fail:
 	if (decompressed)
-		free(decompressed);
+		rd_free(decompressed);
 	return NULL;
 }

--- a/src/rdhdrhistogram.c
+++ b/src/rdhdrhistogram.c
@@ -79,7 +79,7 @@
 #include "rdfloat.h"
 
 void rd_hdr_histogram_destroy (rd_hdr_histogram_t *hdr) {
-        free(hdr);
+        rd_free(hdr);
 }
 
 rd_hdr_histogram_t *rd_hdr_histogram_new (int64_t minValue, int64_t maxValue,
@@ -128,7 +128,7 @@ rd_hdr_histogram_t *rd_hdr_histogram_new (int64_t minValue, int64_t maxValue,
 
         bucketCount = bucketsNeeded;
         countsLen = (bucketCount + 1) * (subBucketCount / 2);
-        hdr = calloc(1, sizeof(*hdr) + (sizeof(*hdr->counts) * countsLen));
+        hdr = rd_calloc(1, sizeof(*hdr) + (sizeof(*hdr->counts) * countsLen));
         hdr->counts = (int64_t *)(hdr+1);
         hdr->allocatedSize = sizeof(*hdr) + (sizeof(*hdr->counts) * countsLen);
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1188,7 +1188,7 @@ static void rd_kafka_destroy_internal (rd_kafka_t *rk) {
          * reaches 1 and then decommissions itself. */
         TAILQ_FOREACH_SAFE(rkb, &rk->rk_brokers, rkb_link, rkb_tmp) {
                 /* Add broker's thread to wait_thrds list for later joining */
-                thrd = malloc(sizeof(*thrd));
+                thrd = rd_malloc(sizeof(*thrd));
                 *thrd = rkb->rkb_thread;
                 rd_list_add(&wait_thrds, thrd);
                 rd_kafka_wrunlock(rk);
@@ -1262,7 +1262,7 @@ static void rd_kafka_destroy_internal (rd_kafka_t *rk) {
                                rd_kafka_op_new(RD_KAFKA_OP_TERMINATE));
 
                 rk->rk_internal_rkb = NULL;
-                thrd = malloc(sizeof(*thrd));
+                thrd = rd_malloc(sizeof(*thrd));
                 *thrd = rkb->rkb_thread;
                 rd_list_add(&wait_thrds, thrd);
         }
@@ -1279,7 +1279,7 @@ static void rd_kafka_destroy_internal (rd_kafka_t *rk) {
                 int res;
                 if (thrd_join(*thrd, &res) != thrd_success)
                         ;
-                free(thrd);
+                rd_free(thrd);
         }
 
         rd_list_destroy(&wait_thrds);
@@ -4784,8 +4784,16 @@ rd_bool_t rd_kafka_dir_is_empty (const char *path) {
 }
 
 
+void *rd_kafka_mem_malloc (rd_kafka_t *rk, size_t size) {
+        return rd_malloc(size);
+}
+
+void *rd_kafka_mem_calloc(rd_kafka_t *rk, size_t num, size_t size) {
+        return rd_calloc(num, size);
+}
+
 void rd_kafka_mem_free (rd_kafka_t *rk, void *ptr) {
-        free(ptr);
+        rd_free(ptr);
 }
 
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3093,6 +3093,43 @@ rd_kafka_offsets_for_times (rd_kafka_t *rk,
                             int timeout_ms);
 
 
+
+/**
+ * @brief Allocate and zero memory using the same allocator librdkafka uses.
+ *
+ * This is typically an abstraction for the calloc(3) call and makes sure
+ * the application can use the same memory allocator as librdkafka for
+ * allocating pointers that are used by librdkafka.
+ *
+ * \p rk can be set to return memory allocated by a specific \c rk instance
+ * otherwise pass NULL for \p rk.
+ *
+ * @remark Memory allocated by rd_kafka_mem_calloc() must be freed using
+ *         rd_kafka_mem_free()
+ */
+RD_EXPORT
+void *rd_kafka_mem_calloc (rd_kafka_t *rk, size_t num, size_t size);
+
+
+
+/**
+ * @brief Allocate memory using the same allocator librdkafka uses.
+ *
+ * This is typically an abstraction for the malloc(3) call and makes sure
+ * the application can use the same memory allocator as librdkafka for
+ * allocating pointers that are used by librdkafka.
+ *
+ * \p rk can be set to return memory allocated by a specific \c rk instance
+ * otherwise pass NULL for \p rk.
+ *
+ * @remark Memory allocated by rd_kafka_mem_malloc() must be freed using
+ *         rd_kafka_mem_free()
+ */
+RD_EXPORT
+void *rd_kafka_mem_malloc (rd_kafka_t *rk, size_t size);
+
+
+
 /**
  * @brief Free pointer returned by librdkafka
  *

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5724,10 +5724,10 @@ static int unittest_set_intersect (void) {
                 rd_kafka_topic_partition_destroy_free,
                 PartitionMemberInfo_free);
 
-        gm1 = calloc(1, sizeof(*gm1));
+        gm1 = rd_calloc(1, sizeof(*gm1));
         gm1->rkgm_member_id = &id1;
         gm1->rkgm_group_instance_id = &id1;
-        gm2 = calloc(1, sizeof(*gm2));
+        gm2 = rd_calloc(1, sizeof(*gm2));
         gm2->rkgm_member_id = &id2;
         gm2->rkgm_group_instance_id = &id2;
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -2133,7 +2133,7 @@ rd_kafka_handle_ApiVersion (rd_kafka_t *rk,
 	rd_rkb_dbg(rkb, FEATURE, "APIVERSION",
 		   "Broker API support:");
 
-	*apis = malloc(sizeof(**apis) * ApiArrayCnt);
+	*apis = rd_malloc(sizeof(**apis) * ApiArrayCnt);
 
 	for (i = 0 ; i < ApiArrayCnt ; i++) {
 		struct rd_kafka_ApiVersion *api = &(*apis)[i];

--- a/src/rdkafka_sasl_scram.c
+++ b/src/rdkafka_sasl_scram.c
@@ -188,7 +188,7 @@ static int rd_base64_decode (const rd_chariov_t *in, rd_chariov_t *out) {
 
         if (EVP_DecodeBlock((uint8_t*)out->ptr, (uint8_t*)in->ptr,
                             (int)in->size) == -1) {
-                free(out->ptr);
+                rd_free(out->ptr);
                 out->ptr = NULL;
                 return -1;
         }

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -78,7 +78,7 @@ rd_list_t *rd_list_init_copy (rd_list_t *dst, const rd_list_t *src) {
 }
 
 static RD_INLINE rd_list_t *rd_list_alloc (void) {
-        return malloc(sizeof(rd_list_t));
+        return rd_malloc(sizeof(rd_list_t));
 }
 
 rd_list_t *rd_list_new (int initial_size, void (*free_cb) (void *)) {

--- a/src/rdstring.c
+++ b/src/rdstring.c
@@ -65,7 +65,7 @@ char *rd_string_render (const char *template,
 #define _assure_space(SZ) do {				\
 		if (of + (SZ) + 1 >= size) {		\
 			size = (size + (SZ) + 1) * 2;	\
-			buf = realloc(buf, size);	\
+			buf = rd_realloc(buf, size);	\
 		}					\
 	} while (0)
 	

--- a/src/rdxxhash.c
+++ b/src/rdxxhash.c
@@ -104,9 +104,9 @@
 ***************************************/
 /*! Modify the local functions below should you wish to use some other memory routines
 *   for malloc(), free() */
-#include <stdlib.h>
-static void* XXH_malloc(size_t s) { return malloc(s); }
-static void  XXH_free  (void* p)  { free(p); }
+#include "rd.h"
+static void* XXH_malloc(size_t s) { return rd_malloc(s); }
+static void  XXH_free  (void* p)  { rd_free(p); }
 /*! and for memcpy() */
 #include <string.h>
 static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }

--- a/src/snappy_compat.h
+++ b/src/snappy_compat.h
@@ -86,8 +86,8 @@ typedef unsigned long long u64;
 #endif
 
 
-#define vmalloc(x) malloc(x)
-#define vfree(x) free(x)
+#define vmalloc(x) rd_malloc(x)
+#define vfree(x) rd_free(x)
 
 #define EXPORT_SYMBOL(x)
 

--- a/src/tinycthread.c
+++ b/src/tinycthread.c
@@ -511,7 +511,7 @@ static void _tinycthread_tss_cleanup (void) {
 
   while (_tinycthread_tss_head != NULL) {
     data = _tinycthread_tss_head->next;
-    free (_tinycthread_tss_head);
+    rd_free (_tinycthread_tss_head);
     _tinycthread_tss_head = data;
   }
   _tinycthread_tss_head = NULL;
@@ -570,7 +570,7 @@ static void * _thrd_wrapper_function(void * aArg)
   arg = ti->mArg;
 
   /* The thread is responsible for freeing the startup information */
-  free((void *)ti);
+  rd_free((void *)ti);
 
   /* Call the actual client thread function */
   res = fun(arg);
@@ -591,7 +591,7 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
 {
   /* Fill out the thread startup information (passed to the thread wrapper,
      which will eventually free it) */
-  _thread_start_info* ti = (_thread_start_info*)malloc(sizeof(_thread_start_info));
+  _thread_start_info* ti = (_thread_start_info*)rd_malloc(sizeof(_thread_start_info));
   if (ti == NULL)
   {
     return thrd_nomem;
@@ -616,7 +616,7 @@ int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
   /* Did we fail to create the thread? */
   if(!*thr)
   {
-    free(ti);
+    rd_free(ti);
     return thrd_error;
   }
 
@@ -790,7 +790,7 @@ void tss_delete(tss_t key)
       _tinycthread_tss_tail = prev;
     }
 
-    free (data);
+    rd_free (data);
   }
   _tinycthread_tss_dtors[key] = NULL;
   TlsFree(key);
@@ -819,7 +819,7 @@ int tss_set(tss_t key, void *val)
   struct TinyCThreadTSSData* data = (struct TinyCThreadTSSData*)TlsGetValue(key);
   if (data == NULL)
   {
-    data = (struct TinyCThreadTSSData*)malloc(sizeof(struct TinyCThreadTSSData));
+    data = (struct TinyCThreadTSSData*)rd_malloc(sizeof(struct TinyCThreadTSSData));
     if (data == NULL)
     {
       return thrd_error;
@@ -845,7 +845,7 @@ int tss_set(tss_t key, void *val)
 
     if (!TlsSetValue(key, data))
     {
-      free (data);
+      rd_free (data);
 	  return thrd_error;
     }
   }


### PR DESCRIPTION
Sometimes rd_free is called on objects allocated with plain malloc. This is not consistent.