### PR TITLE
Fix UBSan errors

### DIFF
--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -125,8 +125,8 @@ rd_tmpabuf_write0 (const char *func, int line,
 		   rd_tmpabuf_t *tab, const void *buf, size_t size) {
 	void *ptr = rd_tmpabuf_alloc0(func, line, tab, size);
 
-	if (ptr && buf)
-		memcpy(ptr, buf, size);
+        if (likely(ptr && size))
+                memcpy(ptr, buf, size);
 
 	return ptr;
 }

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -125,7 +125,7 @@ rd_tmpabuf_write0 (const char *func, int line,
 		   rd_tmpabuf_t *tab, const void *buf, size_t size) {
 	void *ptr = rd_tmpabuf_alloc0(func, line, tab, size);
 
-	if (ptr)
+	if (ptr && buf)
 		memcpy(ptr, buf, size);
 
 	return ptr;

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -246,6 +246,10 @@ int rd_list_cmp_trampoline (const void *_a, const void *_b) {
 }
 
 void rd_list_sort (rd_list_t *rl, int (*cmp) (const void *, const void *)) {
+	if (rl->rl_elems == NULL) {
+		return;
+	}
+
 	rd_list_cmp_curr = cmp;
         qsort(rl->rl_elems, rl->rl_cnt, sizeof(*rl->rl_elems),
 	      rd_list_cmp_trampoline);

--- a/src/rdlist.c
+++ b/src/rdlist.c
@@ -246,9 +246,8 @@ int rd_list_cmp_trampoline (const void *_a, const void *_b) {
 }
 
 void rd_list_sort (rd_list_t *rl, int (*cmp) (const void *, const void *)) {
-	if (rl->rl_elems == NULL) {
-		return;
-	}
+        if (unlikely(rl->rl_elems == NULL))
+                return;
 
 	rd_list_cmp_curr = cmp;
         qsort(rl->rl_elems, rl->rl_cnt, sizeof(*rl->rl_elems),


### PR DESCRIPTION
rd_tmpabuf_write is sometimes called with a NULL buffer to clone,
leading to UB when calling memcpy.

It doesn't look like the func could just return NULL in this case
either. Almost all the callers ignore the possibility of NULL, or
are interpreting NULL as an allocation failure.