### PR TITLE
Static library bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: c
 dist: trusty
 sudo: false
 cache: ccache
+
 env:
  global:
   - ARCH=x64
+
+addons:
+  apt:
+    packages:
+    # required by openssl installer
+    - perl
+
 matrix:
  include:
  - name: "Linux GCC: +centos +debian"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,31 @@ matrix:
  - name: "Linux GCC: +centos +debian"
    os: linux
    compiler: gcc
-   env: ADDITIONAL_BUILDS="centos debian"
+   env: ADDITIONAL_BUILDS="centos debian" LINKAGE=std
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
  - name: "Linux clang: +alpine"
    os: linux
    compiler: clang
-   env: ADDITIONAL_BUILDS="alpine"
+   env: ADDITIONAL_BUILDS="alpine" LINKAGE=std
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
+ - name: "Linux clang: +static +alpine-static"
+   os: linux
+   compiler: clang
+   env: ADDITIONAL_BUILDS="alpine-static" LINKAGE=static
+   before_script:
+    - ./configure --enable-static --install-deps --source-deps-only --disable-gssapi --disable-lz4-ext --prefix="$PWD/dest"
  - name: "OSX GCC"
    os: osx
    compiler: gcc
+   env: LINKAGE=std
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
  - name: "OSX clang: +static"
    os: osx
    compiler: clang
+   env: LINKAGE=static
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest" --enable-static
  - name: "Linux GCC: +integration-tests +copyright-check +doc-check"
@@ -77,7 +85,7 @@ deploy:
   region: us-west-1
   skip_cleanup: true
   local-dir: artifacts
-  upload-dir: librdkafka/p-librdkafka__bld-travis__plat-${TRAVIS_OS_NAME}__arch-${ARCH}__tag-${TRAVIS_TAG}__sha-${TRAVIS_COMMIT}__bid-${TRAVIS_JOB_NUMBER}
+  upload-dir: librdkafka/p-librdkafka__bld-travis__plat-${TRAVIS_OS_NAME}__arch-${ARCH}__tag-${TRAVIS_TAG}__sha-${TRAVIS_COMMIT}__bid-${TRAVIS_JOB_NUMBER}__lnk-${LINKAGE}
   on:
     repo: edenhill/librdkafka
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,13 @@ matrix:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
  - name: "OSX clang: +static"
    os: osx
+   # Use an older image to and disable syslog for broader compatibility
+   # with old and new osx versions.
+   osx_image: xcode9.2
    compiler: clang
    env: LINKAGE=static
    before_script:
-    - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest" --enable-static
+    - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest" --enable-static --disable-syslog
  - name: "Linux GCC: +integration-tests +copyright-check +doc-check"
    os: linux
    dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ matrix:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
  - name: "OSX clang: +static"
    os: osx
-   # Use an older image to and disable syslog for broader compatibility
+   # Use an older image to disable syslog and for broader compatibility
    # with old and new osx versions.
    osx_image: xcode9.2
    compiler: clang
-   env: LINKAGE=static
+   env: LINKAGE=static HOMEBREW_NO_AUTO_UPDATE=1
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest" --enable-static --disable-syslog
  - name: "Linux GCC: +integration-tests +copyright-check +doc-check"

--- a/LICENSE.lz4
+++ b/LICENSE.lz4
@@ -1,4 +1,4 @@
-src/xxhash.[ch] src/lz4*.[ch]: git@github.com:lz4/lz4.git e2827775ee80d2ef985858727575df31fc60f1f3
+src/rdxxhash.[ch] src/lz4*.[ch]: git@github.com:lz4/lz4.git e2827775ee80d2ef985858727575df31fc60f1f3
 
 LZ4 Library
 Copyright (c) 2011-2016, Yann Collet

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -114,7 +114,7 @@ THE SOFTWARE
 
 LICENSE.lz4
 --------------------------------------------------------------
-src/xxhash.[ch] src/lz4*.[ch]: git@github.com:lz4/lz4.git e2827775ee80d2ef985858727575df31fc60f1f3
+src/rdxxhash.[ch] src/lz4*.[ch]: git@github.com:lz4/lz4.git e2827775ee80d2ef985858727575df31fc60f1f3
 
 LZ4 Library
 Copyright (c) 2011-2016, Yann Collet

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ CHECK_FILES+=	CONFIGURATION.md \
 		examples/rdkafka_example examples/rdkafka_performance \
 		examples/rdkafka_example_cpp
 
-PACKAGE_NAME?=	librdkafka
+DOC_FILES+=	LICENSES.txt INTRODUCTION.md README.md CONFIGURATION.md STATISTICS.md
+
+PKGNAME?=	librdkafka
 VERSION?=	$(shell python packaging/get_version.py src/rdkafka.h)
 
 # Jenkins CI integration
@@ -24,7 +26,7 @@ libs:
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d || exit $?; done)
 
 CONFIGURATION.md: src/rdkafka.h examples
-	@printf "$(MKL_YELLOW)Updating$(MKL_CLR_RESET)\n"
+	@printf "$(MKL_YELLOW)Updating $@$(MKL_CLR_RESET)\n"
 	@echo "# Configuration properties" > CONFIGURATION.md.tmp
 	@(examples/rdkafka_performance -X list | \
 		sed 's/||/\\|\\|/g' >> \
@@ -37,8 +39,15 @@ file-check: CONFIGURATION.md LICENSES.txt examples
 check: file-check
 	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d $@ || exit $?; done)
 
-install uninstall:
-	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d $@ || exit $?; done)
+install-subdirs:
+	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d install || exit $?; done)
+
+install: install-subdirs doc-install
+
+uninstall-subdirs:
+	@(for d in $(LIBSUBDIRS); do $(MAKE) -C $$d uninstall || exit $?; done)
+
+uninstall: uninstall-subdirs doc-uninstall
 
 examples tests: .PHONY libs
 	$(MAKE) -C $@
@@ -60,10 +69,10 @@ distclean: clean deps-clean
 	rm -f config.log config.log.old
 
 archive:
-	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
-		-o $(PACKAGE_NAME)-$(VERSION).tar.gz HEAD
-	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
-		-o $(PACKAGE_NAME)-$(VERSION).zip HEAD
+	git archive --prefix=$(PKGNAME)-$(VERSION)/ \
+		-o $(PKGNAME)-$(VERSION).tar.gz HEAD
+	git archive --prefix=$(PKGNAME)-$(VERSION)/ \
+		-o $(PKGNAME)-$(VERSION).zip HEAD
 
 rpm: distclean
 	$(MAKE) -C packaging/rpm

--- a/configure.self
+++ b/configure.self
@@ -43,6 +43,8 @@ mkl_toggle_option "Feature" ENABLE_LZ4_EXT "--enable-lz4" "Deprecated: alias for
 # use the builtin tinycthread alternative.
 mkl_toggle_option "Feature" ENABLE_C11THREADS "--enable-c11threads" "Enable detection of C11 threads support in libc" "y"
 
+mkl_toggle_option "Feature" ENABLE_SYSLOG "--enable-syslog" "Enable logging to syslog" "y"
+
 
 function checks {
 
@@ -109,6 +111,15 @@ void foo (void) {
         mkl_meta_set "liblz4" "static" "liblz4.a"
         mkl_lib_check "liblz4" "WITH_LZ4_EXT" disable CC "-llz4" \
                       "#include <lz4frame.h>"
+    fi
+
+    if [[ $ENABLE_SYSLOG == y ]]; then
+        mkl_compile_check "syslog" "WITH_SYSLOG" disable CC "" \
+                          '
+#include <syslog.h>
+void foo (void) {
+    syslog(LOG_INFO, "test");
+}'
     fi
 
     # rapidjson (>=1.1.0) is used in tests to verify statistics data, not used

--- a/configure.self
+++ b/configure.self
@@ -96,8 +96,7 @@ void foo (void) {
     mkl_meta_set "zlib" "deb" "zlib1g-dev"
     mkl_meta_set "zlib" "rpm" "zlib-devel"
     mkl_meta_set "zlib" "apk" "zlib-dev"
-    mkl_meta_set "zlib" "static" "libz.a"
-    mkl_lib_check "zlib" "WITH_ZLIB" disable CC "-lz" \
+    mkl_lib_check --no-static "zlib" "WITH_ZLIB" disable CC "-lz" \
                   "#include <zlib.h>"
     mkl_check "libssl" disable
     mkl_check "libsasl2" disable

--- a/configure.self
+++ b/configure.self
@@ -4,7 +4,7 @@
 mkl_meta_set "description" "name"      "librdkafka"
 mkl_meta_set "description" "oneline"   "The Apache Kafka C/C++ library"
 mkl_meta_set "description" "long"      "Full Apache Kafka protocol support, including producer and consumer"
-mkl_meta_set "description" "copyright" "Copyright (c) 2012-2015 Magnus Edenhill"
+mkl_meta_set "description" "copyright" "Copyright (c) 2012-2019 Magnus Edenhill"
 
 # Enable generation of pkg-config .pc file
 mkl_mkvar_set "" GEN_PKG_CONFIG y
@@ -16,6 +16,7 @@ mkl_require pic
 mkl_require atomics
 mkl_require good_cflags
 mkl_require socket
+mkl_require zlib
 mkl_require libzstd
 mkl_require libssl
 mkl_require libsasl2
@@ -93,11 +94,7 @@ void foo (void) {
     fi
 
     # optional libs
-    mkl_meta_set "zlib" "deb" "zlib1g-dev"
-    mkl_meta_set "zlib" "rpm" "zlib-devel"
-    mkl_meta_set "zlib" "apk" "zlib-dev"
-    mkl_lib_check --no-static "zlib" "WITH_ZLIB" disable CC "-lz" \
-                  "#include <zlib.h>"
+    mkl_check "zlib" disable
     mkl_check "libssl" disable
     mkl_check "libsasl2" disable
     mkl_check "libzstd" disable
@@ -107,7 +104,7 @@ void foo (void) {
         mkl_allvar_set WITH_HDRHISTOGRAM WITH_HDRHISTOGRAM y
     fi
 
-    # Use builtin lz4 if linking statically or if --disable-lz4 is used.
+    # Use builtin lz4 if linking statically or if --disable-lz4-ext is used.
     if [[ $MKL_SOURCE_DEPS_ONLY != y ]] && [[ $WITH_STATIC_LINKING != y ]] && [[ $ENABLE_LZ4_EXT == y ]]; then
         mkl_meta_set "liblz4" "static" "liblz4.a"
         mkl_lib_check "liblz4" "WITH_LZ4_EXT" disable CC "-llz4" \

--- a/configure.self
+++ b/configure.self
@@ -94,6 +94,7 @@ void foo (void) {
 
     # optional libs
     mkl_meta_set "zlib" "deb" "zlib1g-dev"
+    mkl_meta_set "zlib" "rpm" "zlib-devel"
     mkl_meta_set "zlib" "apk" "zlib-dev"
     mkl_meta_set "zlib" "static" "libz.a"
     mkl_lib_check "zlib" "WITH_ZLIB" disable CC "-lz" \

--- a/debian/copyright
+++ b/debian/copyright
@@ -79,7 +79,7 @@ License: BSD-3-clause
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Files: src/xxhash.h src/xxhash.c
+Files: src/rdxxhash.h src/rdxxhash.c
 Copyright: 2012-2014, Yann Collet
 License: BSD-2-clause
 

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -114,6 +114,9 @@ else
 	ar -M < $$_tmp || exit 1 ; \
 	rm $$_tmp)
 endif
+	cp $@ $(LIBNAME)-static-dbg.a
+	strip -S $@
+	ranlib $@
 ifneq ($(MKL_DYNAMIC_LIBS),)
 	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: The following libraries were not available as static libraries and need to be linked dynamically: $(MKL_DYNAMIC_LIBS)$(MKL_CLR_RESET)\n"
 endif

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -36,6 +36,11 @@ else
 	LDD_PRINT="ldd"
 endif
 
+# DESTDIR must be an absolute path
+ifneq ($(DESTDIR),)
+DESTDIR:=$(abspath $(DESTDIR))
+endif
+
 INSTALL?=		install
 INSTALL_PROGRAM?=	$(INSTALL)
 INSTALL_DATA?=		$(INSTALL) -m 644
@@ -255,6 +260,15 @@ bin-uninstall:
 	rm -f $$DESTDIR$(bindir)/$(BIN)
 	rmdir $$DESTDIR$(bindir) || true
 
+doc-install: $(DOC_FILES)
+	@printf "$(MKL_YELLOW)Installing documentation to $$DESTDIR$(prefix)$(MKL_CLR_RESET)\n"
+	$(INSTALL) -d $$DESTDIR$(docdir)
+	$(INSTALL) $(DOC_FILES) $$DESTDIR$(docdir)
+
+doc-uninstall:
+	@printf "$(MKL_YELLOW)Uninstall documentation from $$DESTDIR$(prefix)$(MKL_CLR_RESET)\n"
+	for _f in $(DOC_FILES) ; do rm -f $$DESTDIR$(docdir)/$$_f ; done
+	rmdir $$DESTDIR$(docdir) || true
 
 generic-clean:
 	rm -f $(OBJS) $(DEPS)

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -82,7 +82,7 @@ mklove-check:
 	$(CXX) -MD -MP $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 
-lib: $(LIBFILENAME) $(LIBNAME).a $(LIBFILENAMELINK) lib-gen-pkg-config
+lib: $(LIBFILENAME) $(LIBNAME).a $(LIBNAME)-static.a $(LIBFILENAMELINK) lib-gen-pkg-config
 
 $(LIBNAME).lds: #overridable
 
@@ -93,6 +93,35 @@ $(LIBFILENAME): $(OBJS) $(LIBNAME).lds
 $(LIBNAME).a:	$(OBJS)
 	@printf "$(MKL_YELLOW)Creating static library $@$(MKL_CLR_RESET)\n"
 	$(AR) rcs$(ARFLAGS) $@ $(OBJS)
+
+ifeq ($(MKL_NO_SELFCONTAINED_STATIC_LIB),y)
+$(LIBNAME)-static.a:
+else
+$(LIBNAME)-static.a: $(LIBNAME).a
+ifneq ($(MKL_STATIC_LIBS),)
+	@printf "$(MKL_YELLOW)Creating self-contained static library $@$(MKL_CLR_RESET)\n"
+ifeq ($(HAS_LIBTOOL_STATIC),y)
+	$(LIBTOOL) -static -o $@ - $(LIBNAME).a $(MKL_STATIC_LIBS)
+else
+	(_tmp=$$(mktemp arstaticXXXXXX) ; \
+	echo "CREATE $@" > $$_tmp ; \
+	for _f in $(LIBNAME).a $(MKL_STATIC_LIBS) ; do \
+		echo "ADDLIB $$_f" >> $$_tmp ; \
+	done ; \
+	echo "SAVE" >> $$_tmp ; \
+	echo "END" >> $$_tmp ; \
+	cat $$_tmp ; \
+	ar -M < $$_tmp || exit 1 ; \
+	rm $$_tmp)
+endif
+ifneq ($(MKL_DYNAMIC_LIBS),)
+	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: The following libraries were not available as static libraries and need to be linked dynamically: $(MKL_DYNAMIC_LIBS)$(MKL_CLR_RESET)\n"
+endif
+else
+	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: Not creating self-contained static library $@: no static libraries available/enabled$(MKL_CLR_RESET)\n"
+endif
+endif
+
 
 $(LIBFILENAMELINK): $(LIBFILENAME)
 	@printf "$(MKL_YELLOW)Creating $@ symlink$(MKL_CLR_RESET)\n"
@@ -125,7 +154,7 @@ Name: $(LIBNAME)-static
 Description: $(MKL_APP_DESC_ONELINE) (static)
 Version: $(MKL_APP_VERSION)
 Cflags: -I$${includedir}
-Libs: -L$${libdir} $${libdir}/$(LIBNAME).a $(LIBS)
+Libs: -L$${libdir} $${libdir}/$(LIBNAME)-static.a $(MKL_DYNAMIC_LIBS)
 endef
 
 export _PKG_CONFIG_STATIC_DEF
@@ -134,7 +163,7 @@ $(LIBNAME0).pc: $(TOPDIR)/Makefile.config
 	@printf "$(MKL_YELLOW)Generating pkg-config file $@$(MKL_CLR_RESET)\n"
 	@echo "$$_PKG_CONFIG_DEF" > $@
 
-$(LIBNAME0)-static.pc: $(TOPDIR)/Makefile.config
+$(LIBNAME0)-static.pc: $(TOPDIR)/Makefile.config $(LIBNAME)-static.a
 	@printf "$(MKL_YELLOW)Generating pkg-config file $@$(MKL_CLR_RESET)\n"
 	@echo "$$_PKG_CONFIG_STATIC_DEF" > $@
 
@@ -184,19 +213,20 @@ copyright-check:
 
 lib-install:
 	@printf "$(MKL_YELLOW)Install $(LIBNAME) to $$DESTDIR$(prefix)$(MKL_CLR_RESET)\n"
-	$(INSTALL) -d $$DESTDIR$(includedir)/$(PKGNAME) && \
-	$(INSTALL) -d $$DESTDIR$(libdir) && \
-	$(INSTALL) $(HDRS) $$DESTDIR$(includedir)/$(PKGNAME) && \
-	$(INSTALL) $(LIBNAME).a $$DESTDIR$(libdir) && \
-	$(INSTALL) $(LIBFILENAME) $$DESTDIR$(libdir) && \
+	$(INSTALL) -d $$DESTDIR$(includedir)/$(PKGNAME)
+	$(INSTALL) -d $$DESTDIR$(libdir)
+	$(INSTALL) $(HDRS) $$DESTDIR$(includedir)/$(PKGNAME)
+	$(INSTALL) $(LIBNAME).a $$DESTDIR$(libdir)
+	[ ! -f $(LIBNAME)-static.a ] || $(INSTALL) $(LIBNAME)-static.a $$DESTDIR$(libdir)
+	$(INSTALL) $(LIBFILENAME) $$DESTDIR$(libdir)
 	[ -f "$(LIBNAME0).pc" ] && ( \
 		$(INSTALL) -d $$DESTDIR$(pkgconfigdir) && \
 		$(INSTALL) -m 0644 $(LIBNAME0).pc $$DESTDIR$(pkgconfigdir) \
-	) && \
+	)
 	[ -f "$(LIBNAME0)-static.pc" ] && ( \
 		$(INSTALL) -d $$DESTDIR$(pkgconfigdir) && \
 		$(INSTALL) -m 0644 $(LIBNAME0)-static.pc $$DESTDIR$(pkgconfigdir) \
-	) && \
+	)
 	(cd $$DESTDIR$(libdir) && ln -sf $(LIBFILENAME) $(LIBFILENAMELINK))
 
 lib-uninstall:
@@ -204,6 +234,7 @@ lib-uninstall:
 	for hdr in $(HDRS) ; do \
 		rm -f $$DESTDIR$(includedir)/$(PKGNAME)/$$hdr ; done
 	rm -f $$DESTDIR$(libdir)/$(LIBNAME).a
+	rm -f $$DESTDIR$(libdir)/$(LIBNAME)-static.a
 	rm -f $$DESTDIR$(libdir)/$(LIBFILENAME)
 	rm -f $$DESTDIR$(libdir)/$(LIBFILENAMELINK)
 	rmdir $$DESTDIR$(includedir)/$(PKGNAME) || true

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -1510,6 +1510,7 @@ function mkl_lib_check_static {
 #
 # Arguments:
 #  [--override-action=<action>]  (internal use, overrides action argument)
+#  [--no-static]  (do not attempt to link the library statically)
 #  [--libname=<lib>] (library name if different from config name, such as
 #                     when the libname includes a dash)
 #  config name (library name (for pkg-config))
@@ -1521,19 +1522,27 @@ function mkl_lib_check_static {
 function mkl_lib_check0 {
 
     local override_action=
-    if [[ $1 == --override-action=* ]]; then
-        override_action=${1#*=}
-        shift
-    fi
-
-    local staticopt=$(mkl_meta_get $1 "static" "")
-
+    local nostaticopt=
     local libnameopt=
-    local libname=$1
-    if [[ $1 == --libname* ]]; then
-        libnameopt=$1
-        libname="${libnameopt#*=}"
+    local libname=
+
+    while [[ $1 == --* ]]; do
+        if [[ $1 == --override-action=* ]]; then
+            override_action=${1#*=}
+        elif [[ $1 == --no-static ]]; then
+            nostaticopt=$1
+        elif [[ $1 == --libname* ]]; then
+            libnameopt=$1
+            libname="${libnameopt#*=}"
+        else
+            mkl_err "mkl_lib_check: invalid option $1"
+            exit 1
+        fi
         shift
+    done
+
+    if [[ -z $libname ]]; then
+        libname=$1
     fi
 
     local action=$3
@@ -1546,13 +1555,16 @@ function mkl_lib_check0 {
     if [[ $WITH_PKGCONFIG == "y" ]]; then
         # Let pkg-config populate CFLAGS, et.al.
         # Return on success.
-        mkl_pkg_config_check $libnameopt "$1" "$2" cont "$4" "$6" && return $?
+        mkl_pkg_config_check $nostaticopt $libnameopt "$1" "$2" cont "$4" "$6" && return $?
     fi
 
     local libs="$5"
-    local stlibs=$(mkl_lib_check_static $1 "$libs")
-    if [[ -n $stlibs ]]; then
-        libs=$stlibs
+
+    if [[ -z $nostaticopt ]]; then
+        local stlibs=$(mkl_lib_check_static $1 "$libs")
+        if [[ -n $stlibs ]]; then
+            libs=$stlibs
+        fi
     fi
 
     if ! mkl_compile_check "$1" "$2" "$action" "$4" "$libs" "$6"; then
@@ -1606,7 +1618,7 @@ function mkl_lib_check {
     # being used is in-fact from the dependency builder (if supported),
     # rather than a system installed alternative, so skip the pre-check and
     # go directly to dependency installation/build below.
-    if [[ $MKL_SOURCE_DEPS_ONLY != y ]] || ! mkl_dep_has_builder $1 ; then
+    if [[ $MKL_SOURCE_DEPS_ONLY != y ]] || ! mkl_dep_has_builder $name ; then
         mkl_lib_check0 --override-action=cont "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8"
         retcode=$?
         if [[ $retcode -eq 0 ]]; then
@@ -1632,6 +1644,7 @@ function mkl_lib_check {
 # Check for library with pkg-config
 # Automatically sets CFLAGS and LIBS from pkg-config information.
 # Arguments:
+#  [--no-static]  (do not attempt to link the library statically)
 #  [--libname=<lib>] (library name if different from config name, such as
 #                     when the libname includes a dash)
 #  config name
@@ -1640,6 +1653,12 @@ function mkl_lib_check {
 #  compiler (CC|CXX)
 #  source snippet
 function mkl_pkg_config_check {
+
+    local nostaticopt=
+    if [[ $1 == --no-static ]]; then
+        nostaticopt=$1
+        shift
+    fi
 
     local libname=$1
     if [[ $1 == --libname* ]]; then
@@ -1697,9 +1716,11 @@ $cflags"
 
     mkl_mkvar_append $1 "CFLAGS" "$cflags"
 
-    local stlibs=$(mkl_lib_check_static $1 "$libs")
-    if [[ -n $stlibs ]]; then
-        libs=$stlibs
+    if [[ -z $nostaticopt ]]; then
+        local stlibs=$(mkl_lib_check_static $1 "$libs")
+        if [[ -n $stlibs ]]; then
+            libs=$stlibs
+        fi
     fi
 
     mkl_dbg "$1: from pkg-config: LIBS: prepend $libs"

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -796,6 +796,19 @@ function mkl_generate_late_vars {
 # Generate output files.
 # Must be called following a succesful configure run.
 function mkl_generate {
+
+    # Generate MKL_STATIC_LIBS and MKL_DYNAMIC_LIBS from LIBS
+    local arg=
+    for arg in $LIBS ; do
+        if [[ $arg == -l* ]]; then
+            mkl_mkvar_append "" MKL_DYNAMIC_LIBS $arg
+        elif [[ $arg == *.a ]]; then
+            mkl_mkvar_append "" MKL_STATIC_LIBS $arg
+        else
+            mkl_dbg "Ignoring arg $arg from LIBS while building STATIC and DYNAMIC lists"
+        fi
+    done
+
     local mf=
     for mf in $MKL_GENERATORS ; do
         MKL_MODULE=${mf%:*}
@@ -1366,7 +1379,7 @@ function mkl_link_check0 {
     echo "#include <stdio.h>
 int main () { FILE *fp = stderr; return fp ? 0 : 0; }" > ${srcfile}.c
 
-    local cmd="${CC} $(mkl_mkvar_get CFLAGS) $(mkl_mkvar_get LDFLAGS) -c ${srcfile}.c -o ${srcfile}_out $libs";
+    local cmd="${CC} $(mkl_mkvar_get CFLAGS) $(mkl_mkvar_get LDFLAGS) ${srcfile}.c -o ${srcfile}_out $libs";
     mkl_dbg "Link check for $1: $cmd"
 
     local output

--- a/mklove/modules/configure.cc
+++ b/mklove/modules/configure.cc
@@ -57,7 +57,7 @@ function checks {
 
     # Provide prefix and checks for various other build tools.
     local t=
-    for t in LD:ld NM:nm OBJDUMP:objdump STRIP:strip ; do
+    for t in LD:ld NM:nm OBJDUMP:objdump STRIP:strip LIBTOOL:libtool ; do
         local tenv=${t%:*}
         t=${t#*:}
 	local tval="${!tenv}"
@@ -154,6 +154,8 @@ function checks {
             # OSX linker can't enable/disable static linking so we'll
             # need to find the .a through STATIC_LIB_libname env var
             mkl_mkvar_set staticlinking HAS_LDFLAGS_STATIC n
+            # libtool -static supported
+            mkl_mkvar_set staticlinking HAS_LIBTOOL_STATIC y
         fi
     fi
 }

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -100,7 +100,7 @@ if [[ $MKL_DISTRO != osx ]]; then
         fi
 
         echo "### Building"
-        make -j
+        make
 
         echo "### Installing to $destdir"
         make INSTALL_PREFIX="$destdir" install_sw

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -81,7 +81,7 @@ if [[ $MKL_DISTRO != osx ]]; then
         local destdir=$2
         local ver=1.0.2u
 
-        local conf_args="--openssldir=/usr/lib/ssl zlib shared"
+        local conf_args="--openssldir=/usr/lib/ssl no-shared no-zlib"
         if [[ $ver == 1.0.* ]]; then
             extra_conf_args="${extra_conf_args} no-krb5"
         fi
@@ -93,11 +93,8 @@ if [[ $MKL_DISTRO != osx ]]; then
                 tar xzf - --strip-components 1
         fi
 
-        if [[ ! -f config.log ]]; then
-            echo "### Configuring"
-            ./config --prefix="/usr" $conf_args || return $?
-            make -j clean
-        fi
+        echo "### Configuring"
+        ./config --prefix="/usr" $conf_args || return $?
 
         echo "### Building"
         make

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -79,7 +79,7 @@ if [[ $MKL_DISTRO != osx ]]; then
     function libcrypto_install_source {
         local name=$1
         local destdir=$2
-        local ver=1.0.2r
+        local ver=1.0.2u
 
         local conf_args="--openssldir=/usr/lib/ssl zlib shared"
         if [[ $ver == 1.0.* ]]; then

--- a/mklove/modules/configure.zlib
+++ b/mklove/modules/configure.zlib
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# zlib support, with installer
+#
+# Usage:
+#   mkl_require zlib
+#
+# And then call the following function from the correct place/order in checks:
+#   mkl_check zlib [<action>]
+#
+
+function manual_checks {
+    local action=$1
+
+    mkl_meta_set "zlib" "apk" "zlib-dev"
+    mkl_meta_set "zlib" "static" "libz.a"
+    mkl_lib_check "zlib" "WITH_ZLIB" $action CC "-lz" \
+                  "
+#include <zlib.h>
+
+void foo (void) {
+     z_stream *p = NULL;
+     inflate(p, 0);
+}
+"
+}
+
+
+# Install zlib from source tarball
+#
+# Param 1: name (zlib)
+# Param 2: install-dir-prefix (e.g., DESTDIR)
+# Param 2: version (optional)
+function install_source {
+    local name=$1
+    local destdir=$2
+    local ver=1.2.11
+
+    echo "### Installing $name $ver from source to $destdir"
+    if [[ ! -f Makefile ]]; then
+        curl -sL https://zlib.net/zlib-${ver}.tar.gz | \
+            tar xzf - --strip-components 1
+    fi
+
+    CFLAGS=-fPIC ./configure --static --prefix=/usr
+    make -j
+    make test
+    make DESTDIR="${destdir}" install
+    return $?
+}

--- a/packaging/RELEASE.md
+++ b/packaging/RELEASE.md
@@ -147,6 +147,15 @@ then upload it to NuGet manually:
  * https://www.nuget.org/packages/manage/upload
 
 
+### Create static bundle (for Go)
+
+    $ cd packaging/nuget
+    $ ./release.py --class StaticPackage v0.11.1-RC1
+
+Follow the Go client release instructions for updating its bundled librdkafka
+version based on the tar ball created here.
+
+
 ### Homebrew recipe update
 
 The brew-update-pr.sh script automatically pushes a PR to homebrew-core

--- a/packaging/alpine/build-alpine.sh
+++ b/packaging/alpine/build-alpine.sh
@@ -7,13 +7,14 @@ set -x
 
 if [ "$1" = "--in-docker" ]; then
     # Runs in docker, performs the actual build.
+    shift
 
     apk add bash curl gcc g++ make musl-dev bsd-compat-headers git python perl
 
     git clone /v /librdkafka
 
     cd /librdkafka
-    ./configure --install-deps --disable-gssapi --disable-lz4-ext --enable-static
+    ./configure --install-deps --disable-gssapi --disable-lz4-ext --enable-static $*
     make -j
     examples/rdkafka_example -X builtin.features
     make -C tests run_local_quick
@@ -21,7 +22,7 @@ if [ "$1" = "--in-docker" ]; then
     # Create a tarball in artifacts/
     cd src
     ldd librdkafka.so.1
-    tar cvzf /v/artifacts/alpine-librdkafka.tgz librdkafka.so.1
+    tar cvzf /v/artifacts/alpine-librdkafka.tgz librdkafka.so.1 librdkafka-static.a rdkafka-static.pc
     cd ../..
 
 else
@@ -33,5 +34,5 @@ else
 
     mkdir -p artifacts
 
-    exec docker run -v $PWD:/v alpine:3.8 /v/packaging/alpine/$(basename $0) --in-docker
+    exec docker run -v $PWD:/v alpine:3.8 /v/packaging/alpine/$(basename $0) --in-docker $*
 fi

--- a/packaging/cp/README.md
+++ b/packaging/cp/README.md
@@ -1,0 +1,14 @@
+# Confluent Platform package verification
+
+This small set of scripts verifies the librdkafka packages that
+are part of the Confluent Platform.
+
+The base_url is the http S3 bucket path to the a PR job, or similar.
+
+## How to use
+
+    $ ./verify-packages.sh 5.3 https://thes3bucketpath/X/Y
+
+
+Requires docker and patience.
+

--- a/packaging/cp/check_features.c
+++ b/packaging/cp/check_features.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <string.h>
+#include <librdkafka/rdkafka.h>
+
+int main (int argc, char **argv) {
+        rd_kafka_conf_t *conf;
+        char buf[512];
+        size_t sz = sizeof(buf);
+        rd_kafka_conf_res_t res;
+        static const char *expected_features = "ssl,sasl_gssapi,lz4,zstd";
+        char errstr[512];
+        int i;
+        int failures = 0;
+
+        printf("librdkafka %s (0x%x, define: 0x%x)\n",
+               rd_kafka_version_str(), rd_kafka_version(), RD_KAFKA_VERSION);
+
+        if (argc > 1 && !(argc & 1)) {
+                printf("Usage: %s [config.property config-value ..]\n",
+                       argv[0]);
+                return 1;
+        }
+
+        conf = rd_kafka_conf_new();
+        res = rd_kafka_conf_get(conf, "builtin.features", buf, &sz);
+
+        if (res != RD_KAFKA_CONF_OK) {
+                printf("ERROR: conf_get failed: %d\n", res);
+                return 1;
+        }
+
+        printf("builtin.features: %s\n", buf);
+
+        /* librdkafka allows checking for expected features
+         * by setting the corresponding feature flags in builtin.features,
+         * which will return an error if one or more flags are not enabled. */
+        if (rd_kafka_conf_set(conf, "builtin.features", expected_features,
+                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                printf("ERROR: expected at least features: %s\n"
+                       "got error: %s\n",
+                       expected_features, errstr);
+                failures++;
+        }
+
+        printf("all expected features matched: %s\n", expected_features);
+
+        /* Apply config from argv key value pairs */
+        for (i = 1 ; i+1 < argc ; i += 2) {
+                printf("verifying config %s=%s\n", argv[i], argv[i+1]);
+                if (rd_kafka_conf_set(conf, argv[i], argv[i+1],
+                                      errstr, sizeof(errstr)) !=
+                    RD_KAFKA_CONF_OK) {
+                        printf("ERROR: failed to set %s=%s: %s\n",
+                               argv[i], argv[i+1], errstr);
+                        failures++;
+                }
+        }
+
+        rd_kafka_conf_destroy(conf);
+
+        printf("%d failures\n", failures);
+
+        return !!failures;
+}

--- a/packaging/cp/verify-deb.sh
+++ b/packaging/cp/verify-deb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+
+set -e
+
+cpver=$1
+base_url=$2
+
+if [[ -z $base_url ]]; then
+    echo "Usage: $0 <cp-base-ver> <base_url>"
+    exit 1
+fi
+
+apt-get update
+apt-get install -y apt-transport-https wget
+
+wget -qO - ${base_url}/deb/${cpver}/archive.key | apt-key add -
+
+
+cat >/etc/apt/sources.list.d/Confluent.list <<EOF
+deb [arch=amd64] $base_url/deb/${cpver} stable main
+EOF
+
+apt-get update
+apt-get install -y librdkafka-dev gcc
+
+gcc /v/check_features.c -o /tmp/check_features -lrdkafka
+
+/tmp/check_features
+
+# Verify plugins
+apt-get install -y confluent-librdkafka-plugins
+
+/tmp/check_features plugin.library.paths monitoring-interceptor

--- a/packaging/cp/verify-packages.sh
+++ b/packaging/cp/verify-packages.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Verifies RPM and DEB packages from Confluent Platform
+#
+
+cpver=$1
+base_url=$2
+
+if [[ -z $base_url ]]; then
+    echo "Usage: $0 <CP-M.m-version> <base-url>"
+    echo ""
+    echo " <CP-M.m-version> is the Major.minor version of CP, e.g., 5.3"
+    echo " <base-url> is the release base bucket URL"
+    exit 1
+fi
+
+thisdir="$( cd "$(dirname "$0")" ; pwd -P )"
+
+echo "#### Verifying RPM packages ####"
+docker run -v $thisdir:/v centos:7 /v/verify-rpm.sh $cpver $base_url
+rpm_status=$?
+
+echo "#### Verifying Debian packages ####"
+docker run -v $thisdir:/v ubuntu:16.04 /v/verify-deb.sh $cpver $base_url
+deb_status=$?
+
+
+if [[ $rpm_status == 0 ]]; then
+    echo "SUCCESS: RPM packages verified"
+else
+    echo "ERROR: RPM package verification failed"
+fi
+
+if [[ $deb_status == 0 ]]; then
+    echo "SUCCESS: Debian packages verified"
+else
+    echo "ERROR: Debian package verification failed"
+fi
+
+if [[ $deb_status != 0 || $rpm_status != 0 ]]; then
+    exit 1
+fi
+

--- a/packaging/cp/verify-rpm.sh
+++ b/packaging/cp/verify-rpm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+
+set -e
+
+cpver=$1
+base_url=$2
+
+if [[ -z $base_url ]]; then
+    echo "Usage: $0 <cp-base-ver> <base_url>"
+    exit 1
+fi
+
+cat >/etc/yum.repos.d/Confluent.repo <<EOF
+[Confluent.dist]
+name=Confluent repository (dist)
+baseurl=$base_url/rpm/${cpver}/7
+gpgcheck=0
+gpgkey=$base_url/rpm/${cpver}/archive.key
+enabled=1
+[Confluent]
+name=Confluent repository
+baseurl=$base_url/rpm/${cpver}
+gpgcheck=1
+gpgkey=$base_url/rpm/${cpver}/archive.key
+enabled=1
+EOF
+
+yum install -y librdkafka-devel gcc
+
+gcc /v/check_features.c -o /tmp/check_features -lrdkafka
+
+/tmp/check_features
+
+# Verify plugins
+yum install -y confluent-librdkafka-plugins
+
+/tmp/check_features plugin.library.paths monitoring-interceptor

--- a/packaging/nuget/.gitignore
+++ b/packaging/nuget/.gitignore
@@ -1,5 +1,7 @@
 dl-*
 out-*
 *.nupkg
+*.tgz
+*.key
 *.pyc
 __pycache__

--- a/packaging/nuget/README.md
+++ b/packaging/nuget/README.md
@@ -51,3 +51,12 @@ The finalized nuget package maybe uploaded manually to NuGet.org
     $ ./release.py --upload "$(cat your-nuget-api.key)" v0.11.0
 
 
+
+## Other uses
+
+### Create static library bundles
+
+To create a bundle (tarball) of librdkafka self-contained static library
+builds, use the following command:
+
+    $ ./release.py --class StaticPackage v1.1.0

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -42,6 +42,7 @@ rename_vals = {'plat': {'windows': 'win'},
 #  sha     - git sha
 #  bid     - builder's build-id
 #  bldtype - Release, Debug (appveyor)
+#  lnk     - std, static
 #
 # Example:
 #   librdkafka/p-librdkafka__bld-travis__plat-linux__arch-x64__tag-v0.0.62__sha-d051b2c19eb0c118991cd8bc5cf86d8e5e446cde__bid-1562.1/librdkafka.tar.gz
@@ -445,6 +446,125 @@ class NugetPackage (Package):
             "runtimes/win-x86/native/msvcp120.dll",
             "runtimes/win-x86/native/zlib.dll",
             "runtimes/win-x86/native/libzstd.dll"]
+
+        missing = list()
+        with zfile.ZFile(path, 'r') as zf:
+            print('Verifying %s:' % path)
+
+            # Zipfiles may url-encode filenames, unquote them before matching.
+            pkgd = [urllib.unquote(x) for x in zf.getnames()]
+            missing = [x for x in expect if x not in pkgd]
+
+        if len(missing) > 0:
+            print('Missing files in package %s:\n%s' % (path, '\n'.join(missing)))
+            return False
+        else:
+            print('OK - %d expected files found' % len(expect))
+            return True
+
+
+class StaticPackage (Package):
+    """ Create a package with all static libraries """
+
+    # Only match statically linked artifacts
+    match = {'lnk': 'static'}
+
+    def __init__ (self, version, arts):
+        super(StaticPackage, self).__init__(version, arts, "static")
+
+    def cleanup(self):
+        if os.path.isdir(self.stpath):
+            shutil.rmtree(self.stpath)
+
+    def build (self, buildtype):
+        """ Build single package for all artifacts. """
+
+        self.stpath = tempfile.mkdtemp(prefix="out-", dir=".")
+
+        mappings = [
+            # rdkafka.h
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-clang.tar.gz'}, './include/librdkafka/rdkafka.h', 'rdkafka.h'],
+
+            # LICENSES.txt
+            [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './share/doc/librdkafka/LICENSES.txt', 'LICENSES.txt'],
+
+            # glibc linux static lib and pkg-config file
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/librdkafka-static.a', 'librdkafka_glibc_linux.a'],
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/pkgconfig/rdkafka-static.pc', 'librdkafka_glibc_linux.pc'],
+
+            # musl linux static lib and pkg-config file
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'alpine-librdkafka.tgz'}, 'librdkafka-static.a', 'librdkafka_musl_linux.a'],
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'alpine-librdkafka.tgz'}, 'rdkafka-static.pc', 'librdkafka_musl_linux.pc'],
+
+            # osx static lib and pkg-config file
+            [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/librdkafka-static.a', 'librdkafka_darwin.a'],
+            [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/pkgconfig/rdkafka-static.pc', 'librdkafka_darwin.pc'],
+        ]
+
+        for m in mappings:
+            attributes = m[0].copy()
+            attributes.update(self.match)
+            fname_glob = attributes['fname_glob']
+            del attributes['fname_glob']
+            fname_excludes = []
+            if 'fname_excludes' in attributes:
+                fname_excludes = attributes['fname_excludes']
+                del attributes['fname_excludes']
+
+            artifact = None
+            for a in self.arts.artifacts:
+                found = True
+
+                for attr in attributes:
+                    if attr not in a.info or a.info[attr] != attributes[attr]:
+                        found = False
+                        break
+
+                if not fnmatch(a.fname, fname_glob):
+                    found = False
+
+                for exclude in fname_excludes:
+                    if exclude in a.fname:
+                        found = False
+                        break
+
+                if found:
+                    artifact = a
+                    break
+
+            if artifact is None:
+                raise Exception('unable to find artifact with tags %s matching "%s"' % (str(attributes), fname_glob))
+
+            outf = os.path.join(self.stpath, m[2])
+            member = m[1]
+            try:
+                zfile.ZFile.extract(artifact.lpath, member, outf)
+            except KeyError as e:
+                raise Exception('file not found in archive %s: %s. Files in archive are: %s' % (artifact.lpath, e, zfile.ZFile(artifact.lpath).getnames()))
+
+        print('Tree extracted to %s' % self.stpath)
+
+        # After creating a bare-bone layout, create a tarball.
+        outname = "librdkafka-static-bundle-%s.tgz" % self.version
+        print('Writing to %s' % outname)
+        subprocess.check_call("(cd %s && tar cvzf ../%s .)" % \
+                              (self.stpath, outname),
+                              shell=True)
+
+        return outname
+
+
+    def verify (self, path):
+        """ Verify package """
+        expect = [
+            "./rdkafka.h",
+            "./LICENSES.txt",
+            "./librdkafka_glibc_linux.a",
+            "./librdkafka_glibc_linux.pc",
+            "./librdkafka_musl_linux.a",
+            "./librdkafka_musl_linux.pc",
+            "./librdkafka_darwin.a",
+            "./librdkafka_darwin.pc"]
 
         missing = list()
         with zfile.ZFile(path, 'r') as zf:

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -18,6 +18,11 @@ from collections import defaultdict
 import boto3
 from zfile import zfile
 
+if sys.version_info[0] < 3:
+    from urllib import unquote
+else:
+    from urllib.parse import unquote
+
 
 # Rename token values
 rename_vals = {'plat': {'windows': 'win'},
@@ -452,7 +457,7 @@ class NugetPackage (Package):
             print('Verifying %s:' % path)
 
             # Zipfiles may url-encode filenames, unquote them before matching.
-            pkgd = [urllib.unquote(x) for x in zf.getnames()]
+            pkgd = [unquote(x) for x in zf.getnames()]
             missing = [x for x in expect if x not in pkgd]
 
         if len(missing) > 0:
@@ -571,7 +576,7 @@ class StaticPackage (Package):
             print('Verifying %s:' % path)
 
             # Zipfiles may url-encode filenames, unquote them before matching.
-            pkgd = [urllib.unquote(x) for x in zf.getnames()]
+            pkgd = [unquote(x) for x in zf.getnames()]
             missing = [x for x in expect if x not in pkgd]
 
         if len(missing) > 0:

--- a/packaging/nuget/release.py
+++ b/packaging/nuget/release.py
@@ -28,6 +28,7 @@ if __name__ == '__main__':
     parser.add_argument("--sha", help="Also match on this git sha1", default=None)
     parser.add_argument("--nuget-version", help="The nuget package version (defaults to same as tag)", default=None)
     parser.add_argument("--upload", help="Upload package to after building, using provided NuGet API key", default=None, type=str)
+    parser.add_argument("--class", help="Packaging class (see packaging.py)", default="NugetPackage", dest="pkgclass")
     parser.add_argument("tag", help="Git tag to collect")
 
     args = parser.parse_args()
@@ -38,6 +39,13 @@ if __name__ == '__main__':
     match = {'tag': args.tag}
     if args.sha is not None:
         match['sha'] = args.sha
+
+    pkgclass = getattr(packaging, args.pkgclass)
+
+    try:
+        match.update(getattr(pkgclass, 'match'))
+    except:
+        pass
 
     arts = packaging.Artifacts(match, args.directory)
 
@@ -52,7 +60,7 @@ if __name__ == '__main__':
     if len(arts.artifacts) == 0:
         raise ValueError('No artifacts found for %s' % match)
 
-    print('Collected artifacts:')
+    print('Collected artifacts (%s):' % (arts.dlpath))
     for a in arts.artifacts:
         print(' %s' % a.lpath)
     print('')
@@ -68,7 +76,7 @@ if __name__ == '__main__':
 
     print('Building packages:')
 
-    p = packaging.NugetPackage(package_version, arts)
+    p = pkgclass(package_version, arts)
     pkgfile = p.build(buildtype='release')
 
     if not args.no_cleanup:

--- a/packaging/rpm/librdkafka.spec
+++ b/packaging/rpm/librdkafka.spec
@@ -73,8 +73,11 @@ rm -rf %{buildroot}
 %{_libdir}/librdkafka.so.%{soname}
 %{_libdir}/librdkafka++.so.%{soname}
 %defattr(-,root,root)
-%doc README.md CONFIGURATION.md INTRODUCTION.md STATISTICS.md
-%doc LICENSE LICENSES.txt
+%doc %{_docdir}/librdkafka/README.md
+%doc %{_docdir}/librdkafka/CONFIGURATION.md
+%doc %{_docdir}/librdkafka/INTRODUCTION.md
+%doc %{_docdir}/librdkafka/STATISTICS.md
+%doc %{_docdir}/librdkafka/LICENSES.txt
 
 %defattr(-,root,root)
 #%{_bindir}/rdkafka_example

--- a/packaging/rpm/librdkafka.spec
+++ b/packaging/rpm/librdkafka.spec
@@ -86,6 +86,7 @@ rm -rf %{buildroot}
 %{_includedir}/librdkafka
 %defattr(444,root,root)
 %{_libdir}/librdkafka.a
+%{_libdir}/librdkafka-static.a
 %{_libdir}/librdkafka.so
 %{_libdir}/librdkafka++.a
 %{_libdir}/librdkafka++.so

--- a/packaging/tools/distro-build.sh
+++ b/packaging/tools/distro-build.sh
@@ -18,8 +18,11 @@ case $distro in
     alpine)
         packaging/alpine/build-alpine.sh
         ;;
+    alpine-static)
+        packaging/alpine/build-alpine.sh --enable-static --source-deps-only
+        ;;
     *)
-        echo "Usage: $0 <centos|debian|alpine|travis>"
+        echo "Usage: $0 <centos|debian|alpine|alpine-static>"
         exit 1
         ;;
 esac

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -15,7 +15,7 @@ OBJS=		$(CXXSRCS:%.cpp=%.o)
 
 all: lib check
 
-
+MKL_NO_SELFCONTAINED_STATIC_LIB=y
 include ../mklove/Makefile.base
 
 # No linker script/symbol hiding for C++ library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ set(
     snappy.c
     tinycthread.c
     tinycthread_extra.c
-    xxhash.c
+    rdxxhash.c
 )
 
 if(WITH_SSL)

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ SRCS_$(WITH_ZSTD) += rdkafka_zstd.c
 SRCS_$(WITH_HDRHISTOGRAM) += rdhdrhistogram.c
 SRCS_$(WITH_SSL) += rdkafka_ssl.c
 
-SRCS_LZ4 = xxhash.c
+SRCS_LZ4 = rdxxhash.c
 ifneq ($(WITH_LZ4_EXT), y)
 # Use built-in liblz4
 SRCS_LZ4 += lz4.c lz4frame.c lz4hc.c

--- a/src/lz4frame.c
+++ b/src/lz4frame.c
@@ -94,7 +94,7 @@
 #define LZ4_HC_STATIC_LINKING_ONLY
 #include "lz4hc.h"
 #define XXH_STATIC_LINKING_ONLY
-#include "xxhash.h"
+#include "rdxxhash.h"
 
 
 /*-************************************

--- a/src/rd.h
+++ b/src/rd.h
@@ -75,6 +75,19 @@
 
 #include "rdtypes.h"
 
+#if WITH_SYSLOG
+#include <syslog.h>
+#else
+#define LOG_EMERG   0
+#define LOG_ALERT   1
+#define LOG_CRIT    2
+#define LOG_ERR     3
+#define LOG_WARNING 4
+#define LOG_NOTICE  5
+#define LOG_INFO    6
+#define LOG_DEBUG   7
+#endif
+
 
 /* Debug assert, only enabled with --enable-devel */
 #if ENABLE_DEVEL == 1

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -326,21 +326,27 @@ void rd_kafka_log_print(const rd_kafka_t *rk, int level,
 		fac, rk ? rk->rk_name : "", buf);
 }
 
-#ifndef _MSC_VER
 void rd_kafka_log_syslog (const rd_kafka_t *rk, int level,
 			  const char *fac, const char *buf) {
+#if WITH_SYSLOG
 	static int initialized = 0;
 
 	if (!initialized)
 		openlog("rdkafka", LOG_PID|LOG_CONS, LOG_USER);
 
 	syslog(level, "%s: %s: %s", fac, rk ? rk->rk_name : "", buf);
-}
+#else
+        rd_assert(!*"syslog support not enabled in this build");
 #endif
+}
 
 void rd_kafka_set_logger (rd_kafka_t *rk,
 			  void (*func) (const rd_kafka_t *rk, int level,
 					const char *fac, const char *buf)) {
+#if !WITH_SYSLOG
+        if (func == rd_kafka_log_syslog)
+                rd_assert(!*"syslog support not enabled in this build");
+#endif
 	rk->rk_conf.log_cb = func;
 }
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4370,6 +4370,8 @@ void rd_kafka_log_print(const rd_kafka_t *rk, int level,
 
 /**
  * @brief Builtin log sink: print to syslog.
+ * @remark This logger is only available if librdkafka was built
+ *         with syslog support.
  */
 RD_EXPORT
 void rd_kafka_log_syslog(const rd_kafka_t *rk, int level,

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -2523,6 +2523,10 @@ void rd_kafka_conf_set_throttle_cb (rd_kafka_conf_t *conf,
 void rd_kafka_conf_set_log_cb (rd_kafka_conf_t *conf,
 			  void (*log_cb) (const rd_kafka_t *rk, int level,
                                           const char *fac, const char *buf)) {
+#if !WITH_SYSLOG
+        if (log_cb == rd_kafka_log_syslog)
+                rd_assert(!*"syslog support not enabled in this build");
+#endif
         rd_kafka_anyconf_set_internal(_RK_GLOBAL, conf, "log_cb", log_cb);
 }
 

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -31,7 +31,6 @@
 
 #ifndef _MSC_VER
 #define _GNU_SOURCE  /* for strndup() */
-#include <syslog.h>
 #else
 typedef int mode_t;
 #endif

--- a/src/rdkafka_lz4.c
+++ b/src/rdkafka_lz4.c
@@ -33,7 +33,7 @@
 #else
 #include "lz4frame.h"
 #endif
-#include "xxhash.h"
+#include "rdxxhash.h"
 
 #include "rdbuf.h"
 

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -60,16 +60,6 @@ struct msghdr {
 	int            msg_iovlen;
 };
 
-#define LOG_EMERG   0
-#define LOG_ALERT   1
-#define LOG_CRIT    2
-#define LOG_ERR     3
-#define LOG_WARNING 4
-#define LOG_NOTICE  5
-#define LOG_INFO    6
-#define LOG_DEBUG   7
-
-
 
 /**
 * Annotations, attributes, optimizers

--- a/src/rdxxhash.c
+++ b/src/rdxxhash.c
@@ -114,7 +114,7 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 #include <assert.h>   /* assert */
 
 #define XXH_STATIC_LINKING_ONLY
-#include "xxhash.h"
+#include "rdxxhash.h"
 
 
 /* *************************************

--- a/src/rdxxhash.h
+++ b/src/rdxxhash.h
@@ -315,7 +315,7 @@ struct XXH64_state_s {
 
 
 #if defined(XXH_INLINE_ALL) || defined(XXH_PRIVATE_API)
-#  include "xxhash.c"   /* include xxhash function bodies as `static`, for inlining */
+#  include "rdxxhash.c"   /* include xxhash function bodies as `static`, for inlining */
 #endif
 
 #endif /* XXH_STATIC_LINKING_ONLY */

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -232,7 +232,7 @@
     <ClCompile Include="..\src\regexp.c" />
     <ClCompile Include="..\src\rdports.c" />
     <ClCompile Include="..\src\rdavl.c" />
-    <ClCompile Include="..\src\xxhash.c" />
+    <ClCompile Include="..\src\rdxxhash.c" />
     <ClCompile Include="..\src\lz4.c" />
     <ClCompile Include="..\src\lz4frame.c" />
     <ClCompile Include="..\src\lz4hc.c" />


### PR DESCRIPTION
Build static library bundles containing all external dependencies of librdkafka (or as many as possible).
This is to be used with confluent-kafka-go client ([demo here](https://github.com/confluentinc/confluent-kafka-go-example)).

Related Go PR:
https://github.com/confluentinc/confluent-kafka-go/pull/355