### PR TITLE
don't fail kinit for ECHILD

### DIFF
--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -209,8 +209,7 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
                                      "returned ECHILD: %s: exit status "
                                      "unknown, assuming success",
                                      cmd);
-                }
-                else {
+                } else {
                         rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
                                      "Kerberos ticket refresh failed, "
                                      "errno=%d: Failed to execute %s",

--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -203,7 +203,13 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
         mtx_unlock(&rd_kafka_sasl_cyrus_kinit_lock);
 
         if (r == -1) {
-                if (errno != ECHILD) {
+                if (errno == ECHILD) {
+                        rd_kafka_log(rk, LOG_WARNING, "SASLREFRESH",
+                                     "Kerberos ticket refresh command returned ECHILD errno which means ",
+                                     "success is unknown, but probably okay so continuing as such: %s", 
+                                     cmd);
+                }
+                else {
                         rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
                                      "Kerberos ticket refresh failed, errno=%d: "
                                      "Failed to execute %s",

--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -205,14 +205,15 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
         if (r == -1) {
                 if (errno == ECHILD) {
                         rd_kafka_log(rk, LOG_WARNING, "SASLREFRESH",
-                                     "Kerberos ticket refresh command returned ECHILD errno which means ",
-                                     "success is unknown, but probably okay so continuing as such: %s", 
+                                     "Kerberos ticket refresh command "
+                                     "returned ECHILD: %s: exit status "
+                                     "unknown, assuming success",
                                      cmd);
                 }
                 else {
                         rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
-                                     "Kerberos ticket refresh failed, errno=%d: "
-                                     "Failed to execute %s",
+                                     "Kerberos ticket refresh failed, "
+                                     "errno=%d: Failed to execute %s",
                                      errno, cmd);
                         rd_free(cmd);
                         return -1;

--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -203,12 +203,14 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
         mtx_unlock(&rd_kafka_sasl_cyrus_kinit_lock);
 
         if (r == -1) {
-                rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
-                             "Kerberos ticket refresh failed: "
-                             "Failed to execute %s",
-                             cmd);
-                rd_free(cmd);
-                return -1;
+                if (errno != ECHILD) {
+                        rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
+                                     "Kerberos ticket refresh failed, errno=%d: "
+                                     "Failed to execute %s",
+                                     errno, cmd);
+                        rd_free(cmd);
+                        return -1;
+                }
         } else if (WIFSIGNALED(r)) {
                 rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
                              "Kerberos ticket refresh failed: %s: "

--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -211,9 +211,8 @@ static int rd_kafka_sasl_cyrus_kinit_refresh (rd_kafka_t *rk) {
                                      cmd);
                 } else {
                         rd_kafka_log(rk, LOG_ERR, "SASLREFRESH",
-                                     "Kerberos ticket refresh failed, "
-                                     "errno=%d: Failed to execute %s",
-                                     errno, cmd);
+                                     "Kerberos ticket refresh failed: %s: %s",
+                                     cmd, rd_strerror(errno));
                         rd_free(cmd);
                         return -1;
                 }


### PR DESCRIPTION
When librdkafka is used as a plugin and there is a signal handler that ignores ECHILD for plugins the kinit system call returns a -1 with errno ECHILD.  This can be safely ignored and just means the command finished before the wait for it could be issued.  This fixes an issue with pmacct using librdkafka as a plugin.