### PR TITLE
fix#2425 rdkafka_example_cpp -L to list metadata can't assign topic

### DIFF
--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -658,7 +658,7 @@ int main (int argc, char **argv) {
       class RdKafka::Metadata *metadata;
 
       /* Fetch metadata */
-      RdKafka::ErrorCode err = producer->metadata(topic!=NULL, topic,
+      RdKafka::ErrorCode err = producer->metadata(!topic, topic,
                               &metadata, 5000);
       if (err != RdKafka::ERR_NO_ERROR) {
         std::cerr << "%% Failed to acquire metadata: "


### PR DESCRIPTION
./rdkafka_example_cpp -L -b 172.17.0.2:9092 -t test_topic
./rdkafka_example_cpp -L -b 172.17.0.2:9092
execute above two commands, the result is the same. The reason is topic!=NULL should be !topic in 661 line