### PR TITLE
Fix rd_kafka_handle_OffsetCommit

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -734,8 +734,12 @@ rd_kafka_handle_OffsetCommit (rd_kafka_t *rk,
         int i;
 	int actions;
 
-        if (err)
-		goto err;
+        if (err) {
+		if ((rk->rk_cgrp->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) && err == RD_KAFKA_RESP_ERR__TRANSPORT)
+			goto done;
+		else
+			goto err;
+	}
 
         rd_kafka_buf_read_i32(rkbuf, &TopicArrayCnt);
         for (i = 0 ; i < TopicArrayCnt ; i++) {


### PR DESCRIPTION
To avoid consumer be stuck while closing if no response for outgoing OffsetCommit.

To reproduce the problem,
1. Start a consumer. (enable.auto.offset.store=false, enable.auto.commit=false, auto.commit.interval.ms=0)
2. Let consumer poll some messages.
3. Block all kafka brokers. (kill -STOP xxx. note: here we keep blocking it)
4. Let consumer commit these offsets (for previously polled messages)
5. Call `rdkafka_consumer_close`, and wait...wait...  It just could NEVER be finished!

Root cause:
Since the OffsetCommitRequest is in the `output queue`, it would keep retrying (`incr_retry` is 0) and refuse admitting failure. Thus, the `rkcg_wait_commit_cnt` could never become 0!


--------------------------------------------------------------------------
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.

ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.
