### PR TITLE
fix for processing of enable.ssl.certificate.verification

### DIFF
--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -532,6 +532,9 @@ rd_kafka_transport_ssl_io_event (rd_kafka_transport_t *rktrans, int events) {
  * @brief Verify SSL handshake was valid.
  */
 static int rd_kafka_transport_ssl_verify (rd_kafka_transport_t *rktrans) {
+        if (!rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.enable_verify) {
+                return 0;
+        }
         long int rl;
         X509 *cert;
 
@@ -544,7 +547,7 @@ static int rd_kafka_transport_ssl_verify (rd_kafka_transport_t *rktrans) {
                 return -1;
         }
 
-        if (rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.enable_verify && (rl = SSL_get_verify_result(rktrans->rktrans_ssl)) != X509_V_OK) {
+        if ((rl = SSL_get_verify_result(rktrans->rktrans_ssl)) != X509_V_OK) {
                 rd_kafka_broker_fail(rktrans->rktrans_rkb, LOG_ERR,
                                      RD_KAFKA_RESP_ERR__SSL,
                                      "Failed to verify broker certificate: %s",

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -544,7 +544,7 @@ static int rd_kafka_transport_ssl_verify (rd_kafka_transport_t *rktrans) {
                 return -1;
         }
 
-        if ((rl = SSL_get_verify_result(rktrans->rktrans_ssl)) != X509_V_OK) {
+        if (rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.enable_verify && (rl = SSL_get_verify_result(rktrans->rktrans_ssl)) != X509_V_OK) {
                 rd_kafka_broker_fail(rktrans->rktrans_rkb, LOG_ERR,
                                      RD_KAFKA_RESP_ERR__SSL,
                                      "Failed to verify broker certificate: %s",

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -532,11 +532,11 @@ rd_kafka_transport_ssl_io_event (rd_kafka_transport_t *rktrans, int events) {
  * @brief Verify SSL handshake was valid.
  */
 static int rd_kafka_transport_ssl_verify (rd_kafka_transport_t *rktrans) {
-        if (!rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.enable_verify) {
-                return 0;
-        }
         long int rl;
         X509 *cert;
+
+        if (!rktrans->rktrans_rkb->rkb_rk->rk_conf.ssl.enable_verify)
+                return 0;
 
         cert = SSL_get_peer_certificate(rktrans->rktrans_ssl);
         X509_free(cert);

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -1073,7 +1073,8 @@ int rd_kafka_ssl_ctx_init (rd_kafka_t *rk, char *errstr, size_t errstr_size) {
 
         /* Set up broker certificate verification. */
         SSL_CTX_set_verify(ctx,
-                           rk->rk_conf.ssl.enable_verify ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,
+                           rk->rk_conf.ssl.enable_verify ?
+                           SSL_VERIFY_PEER : SSL_VERIFY_NONE,
                            rk->rk_conf.ssl.cert_verify_cb ?
                            rd_kafka_transport_ssl_cert_verify_cb : NULL);
 

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -1070,7 +1070,7 @@ int rd_kafka_ssl_ctx_init (rd_kafka_t *rk, char *errstr, size_t errstr_size) {
 
         /* Set up broker certificate verification. */
         SSL_CTX_set_verify(ctx,
-                           rk->rk_conf.ssl.enable_verify ? SSL_VERIFY_PEER : 0,
+                           rk->rk_conf.ssl.enable_verify ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,
                            rk->rk_conf.ssl.cert_verify_cb ?
                            rd_kafka_transport_ssl_cert_verify_cb : NULL);
 


### PR DESCRIPTION
ignoring result of SSL_get_verify_result if **enable_verify == false**
lil chore: using SSL_VERIFY_NONE instead of 0 in SSL_CTX_set_verify
## the problem this patch closes is:
if I have a self-signed and expired certificate, then I can’t get the software to work with the option **enable.ssl.certificate.verification = false**, because the **rd_kafka_transport_ssl_verify** function will always return -1 and the process will always try to reconnect