### PR TITLE
Fix memory leak in cpp:Headers

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1800,13 +1800,15 @@ public:
      *
      * @remark The error code is used for when the Header is constructed
      *         internally by using RdKafka::Headers::get_last which constructs
-     *         a Header encapsulating the ErrorCode in the process
+     *         a Header encapsulating the ErrorCode in the process.
+     *         If err is set, the value and value_size fields will be undefined.
      */
     Header(const std::string &key,
            const void *value,
            size_t value_size,
            const RdKafka::ErrorCode err):
-    key_(key), err_(err), value_size_(value_size) {
+    key_(key), err_(err), value_(NULL), value_size_(value_size) {
+      if (err == ERR_NO_ERROR)
         value_ = copy_value(value, value_size);
     }
 
@@ -1829,6 +1831,9 @@ public:
       key_ = other.key_;
       err_ = other.err_;
       value_size_ = other.value_size_;
+
+      if (value_ != NULL)
+        free(value_);
 
       value_ = copy_value(other.value_, value_size_);
 

--- a/tests/0085-headers.cpp
+++ b/tests/0085-headers.cpp
@@ -329,6 +329,25 @@ static void test_failed_produce () {
   delete headers;
 }
 
+static void test_assignment_op () {
+  Test::Say("Test Header assignment operator\n");
+
+  RdKafka::Headers *headers = RdKafka::Headers::create();
+
+  headers->add("abc", "123");
+  headers->add("def", "456");
+
+  RdKafka::Headers::Header h = headers->get_last("abc");
+  h = headers->get_last("def");
+  RdKafka::Headers::Header h2 = h;
+  h = headers->get_last("nope");
+  RdKafka::Headers::Header h3 = h;
+  h = headers->get_last("def");
+
+  delete headers;
+}
+
+
 extern "C" {
   int main_0085_headers (int argc, char **argv) {
     topic = Test::mk_topic_name("0085-headers", 1);
@@ -371,6 +390,7 @@ extern "C" {
     test_get_last_gives_last_added_val();
     test_get_of_key_returns_all();
     test_failed_produce();
+    test_assignment_op();
 
     c->close();
     delete c;


### PR DESCRIPTION
Change-Id: Ib0aab2e663a6ec63426605f4bfb527a6ee95fd94

https://github.com/edenhill/librdkafka/issues/2431
This proposed fix for the Headers memory leaks in some case.
Have a nice day.