### PR TITLE
Fix deadlock between rd_kafka_curr_msgs_{add,sub}

### DIFF
--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -391,10 +391,12 @@ rd_kafka_curr_msgs_add (rd_kafka_t *rk, unsigned int cnt, size_t size,
 		return RD_KAFKA_RESP_ERR_NO_ERROR;
 
 	mtx_lock(&rk->rk_curr_msgs.lock);
-	while (unlikely(rk->rk_curr_msgs.cnt + cnt >
-			rk->rk_curr_msgs.max_cnt ||
-			(unsigned long long)(rk->rk_curr_msgs.size + size) >
-			(unsigned long long)rk->rk_curr_msgs.max_size)) {
+	/* If rk->rk_curr_msgs.cnt is already 0, nothing will wake us up. */
+	while (unlikely(rk->rk_curr_msgs.cnt > 0 && (
+				rk->rk_curr_msgs.cnt + cnt >
+				rk->rk_curr_msgs.max_cnt ||
+				(unsigned long long)(rk->rk_curr_msgs.size + size) >
+				(unsigned long long)rk->rk_curr_msgs.max_size))) {
 		if (!block) {
 			mtx_unlock(&rk->rk_curr_msgs.lock);
 			return RD_KAFKA_RESP_ERR__QUEUE_FULL;


### PR DESCRIPTION
If `rk_curr_msgs.cnt` is 0 and `cnt` is more than `rk_curr_msgs.max_cnt`, this method will otherwise never return, because `rd_kafka_curr_msgs_sub` ran too fast.

https://github.com/edenhill/librdkafka/issues/2464
https://github.com/confluentinc/confluent-kafka-go-dev/issues/2