### PR TITLE
Make rd_kafka_pause|resume_partitions() synchronous (#2455)

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -631,11 +631,13 @@ rd_kafka_rebalance_op (rd_kafka_cgrp_t *rkcg,
         rkcg->rkcg_c.rebalance_cnt++;
         rd_kafka_wrunlock(rkcg->rkcg_rk);
 
-	/* Pause current partition set consumers until new assign() is called */
-	if (rkcg->rkcg_assignment)
-		rd_kafka_toppars_pause_resume(rkcg->rkcg_rk, 1,
-					      RD_KAFKA_TOPPAR_F_LIB_PAUSE,
-					      rkcg->rkcg_assignment);
+        /* Pause current partition set consumers until new assign() is called */
+        if (rkcg->rkcg_assignment)
+                rd_kafka_toppars_pause_resume(rkcg->rkcg_rk,
+                                              rd_true/*pause*/,
+                                              RD_ASYNC,
+                                              RD_KAFKA_TOPPAR_F_LIB_PAUSE,
+                                              rkcg->rkcg_assignment);
 
 	if (!(rkcg->rkcg_rk->rk_conf.enabled_events & RD_KAFKA_EVENT_REBALANCE)
 	    || !assignment
@@ -2305,9 +2307,11 @@ rd_kafka_cgrp_unassign (rd_kafka_cgrp_t *rkcg) {
                 rd_kafka_toppar_unlock(rktp);
         }
 
-	/* Resume partition consumption. */
-	rd_kafka_toppars_pause_resume(rkcg->rkcg_rk, 0/*resume*/,
-				      RD_KAFKA_TOPPAR_F_LIB_PAUSE,
+        /* Resume partition consumption. */
+        rd_kafka_toppars_pause_resume(rkcg->rkcg_rk,
+                                      rd_false/*resume*/,
+                                      RD_ASYNC,
+                                      RD_KAFKA_TOPPAR_F_LIB_PAUSE,
                                       old_assignment);
 
         rd_kafka_topic_partition_list_destroy(old_assignment);

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -505,8 +505,9 @@ void rd_kafka_toppar_leader_unavailable (rd_kafka_toppar_t *rktp,
                                          rd_kafka_resp_err_t err);
 
 rd_kafka_resp_err_t
-rd_kafka_toppars_pause_resume (rd_kafka_t *rk, int pause, int flag,
-			       rd_kafka_topic_partition_list_t *partitions);
+rd_kafka_toppars_pause_resume (rd_kafka_t *rk,
+                               rd_bool_t pause, rd_async_t async, int flag,
+                               rd_kafka_topic_partition_list_t *partitions);
 
 
 rd_kafka_topic_partition_t *rd_kafka_topic_partition_new (const char *topic,

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -171,16 +171,22 @@ rd_kafka_subscription (rd_kafka_t *rk,
 
 rd_kafka_resp_err_t
 rd_kafka_pause_partitions (rd_kafka_t *rk,
-			   rd_kafka_topic_partition_list_t *partitions) {
-	return rd_kafka_toppars_pause_resume(rk, 1, RD_KAFKA_TOPPAR_F_APP_PAUSE,
-					     partitions);
+                           rd_kafka_topic_partition_list_t *partitions) {
+        return rd_kafka_toppars_pause_resume(rk,
+                                             rd_true/*pause*/,
+                                             RD_SYNC,
+                                             RD_KAFKA_TOPPAR_F_APP_PAUSE,
+                                             partitions);
 }
 
 
 rd_kafka_resp_err_t
 rd_kafka_resume_partitions (rd_kafka_t *rk,
-			   rd_kafka_topic_partition_list_t *partitions) {
-	return rd_kafka_toppars_pause_resume(rk, 0, RD_KAFKA_TOPPAR_F_APP_PAUSE,
-					     partitions);
+                           rd_kafka_topic_partition_list_t *partitions) {
+        return rd_kafka_toppars_pause_resume(rk,
+                                             rd_false/*resume*/,
+                                             RD_SYNC,
+                                             RD_KAFKA_TOPPAR_F_APP_PAUSE,
+                                             partitions);
 }
 

--- a/src/rdtypes.h
+++ b/src/rdtypes.h
@@ -51,6 +51,15 @@ typedef uint8_t rd_bool_t;
 #define rd_false  0
 
 
+/**
+ * @enum Denotes an async or sync operation
+ */
+typedef enum {
+        RD_SYNC = 0, /**< Synchronous/blocking */
+        RD_ASYNC,    /**< Asynchronous/non-blocking */
+} rd_async_t;
+
+
 /*
  * Helpers
  */


### PR DESCRIPTION
This makes sure that a consumer_poll() call after pause() will not
return any messages.