### PR TITLE
Cleanup rd_kafka_toppar_leader_update

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1007,23 +1007,21 @@ void rd_kafka_toppar_broker_leave_for_remove (rd_kafka_toppar_t *rktp) {
  *        AND rd_kafka_toppar_lock(rktp) held.
  */
 void rd_kafka_toppar_broker_delegate (rd_kafka_toppar_t *rktp,
-				      rd_kafka_broker_t *rkb,
-				      int for_removal) {
+				      rd_kafka_broker_t *rkb) {
         rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
         int internal_fallback = 0;
 
 	rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "BRKDELGT",
 		     "%s [%"PRId32"]: delegate to broker %s "
-		     "(rktp %p, term %d, ref %d, remove %d)",
+		     "(rktp %p, term %d, ref %d)",
 		     rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
 		     rkb ? rkb->rkb_name : "(none)",
 		     rktp, rd_kafka_terminating(rk),
-		     rd_refcnt_get(&rktp->rktp_refcnt),
-		     for_removal);
+		     rd_refcnt_get(&rktp->rktp_refcnt));
 
         /* Delegate toppars with no leader to the
          * internal broker for bookkeeping. */
-        if (!rkb && !for_removal && !rd_kafka_terminating(rk)) {
+        if (!rkb && !rd_kafka_terminating(rk)) {
                 rkb = rd_kafka_broker_internal(rk);
                 internal_fallback = 1;
         }

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -453,8 +453,7 @@ void rd_kafka_toppar_next_offset_handle (rd_kafka_toppar_t *rktp,
                                          int64_t Offset);
 
 void rd_kafka_toppar_broker_delegate (rd_kafka_toppar_t *rktp,
-				      rd_kafka_broker_t *rkb,
-				      int for_removal);
+				      rd_kafka_broker_t *rkb);
 
 
 rd_kafka_resp_err_t rd_kafka_toppar_op_fetch_start (rd_kafka_toppar_t *rktp,

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -489,18 +489,18 @@ const char *rd_kafka_topic_name (const rd_kafka_topic_t *app_rkt) {
 int rd_kafka_toppar_leader_update (rd_kafka_toppar_t *rktp,
                                    int32_t leader_id, rd_kafka_broker_t *rkb) {
 
-        rktp->rktp_leader_id = leader_id;
+        if (rktp->rktp_leader_id != leader_id) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "TOPICUPD",
+                             "Topic %s [%"PRId32"] migrated from "
+                             "leader %"PRId32" to %"PRId32,
+                             rktp->rktp_rkt->rkt_topic->str,
+                             rktp->rktp_partition,
+                             rktp->rktp_leader_id, leader_id);
+                rktp->rktp_leader_id = leader_id;
+        }
 
 	if (!rkb) {
 		int had_leader = rktp->rktp_leader ? 1 : 0;
-
-                if (had_leader)
-                        rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "TOPICUPD",
-			     "Topic %s [%"PRId32"] migrated from "
-			     "broker %"PRId32" to internal broker",
-			     rktp->rktp_rkt->rkt_topic->str,
-			     rktp->rktp_partition,
-			     rktp->rktp_leader->rkb_nodeid);
 
 	        rd_kafka_toppar_broker_delegate(rktp, NULL);
 


### PR DESCRIPTION
additionally, the reason for the call to `rd_kafka_toppar_broker_delegate` in the case `had_leader` is false is not obvious to me (something to do with reference counting?). I assume it's necessary since the logic goes out of the way to make sure it happens, but i feel a comment is needed (or probably better, something refactored).