### PR TITLE
Prevent infinite loop in rd_kafka_query_watermark_offsets()

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3130,11 +3130,12 @@ rd_kafka_query_watermark_offsets (rd_kafka_t *rk, const char *topic,
         rd_list_destroy(&leaders);
 
         /* Wait for reply (or timeout) */
-        while (state.err == RD_KAFKA_RESP_ERR__IN_PROGRESS &&
-               rd_kafka_q_serve(rkq, 100, 0, RD_KAFKA_Q_CB_CALLBACK,
-                                rd_kafka_poll_cb, NULL) !=
-               RD_KAFKA_OP_RES_YIELD)
-                ;
+        while (state.err == RD_KAFKA_RESP_ERR__IN_PROGRESS) {
+                if (rd_kafka_q_serve(rkq, 100, 0, RD_KAFKA_Q_CB_CALLBACK,
+                                     rd_kafka_poll_cb, NULL) == 0) {
+                        state.err = RD_KAFKA_RESP_ERR__TIMED_OUT;
+                }
+        }
 
         rd_kafka_q_destroy_owner(rkq);
 


### PR DESCRIPTION
Hi,

we've discovered an strange issue recently in one of our programs that use `librdkafka`. We found that program stuck in `rd_kafka_query_watermark_offsets()`. Here is a truncated stacktrace:

```
#0  0x00007f018c4b196a in pthread_cond_timedwait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
#1  0x00007f018b10ee59 in cnd_timedwait (cond=cond@entry=0x55d599512918, 
    mtx=mtx@entry=0x55d5995128f0, ts=ts@entry=0x7fffd3c3ea50) at tinycthread.c:462
#2  0x00007f018b10f273 in cnd_timedwait_abs (cnd=cnd@entry=0x55d599512918, 
    mtx=mtx@entry=0x55d5995128f0, tspec=tspec@entry=0x7fffd3c3ea50)
    at tinycthread_extra.c:100
#3  0x00007f018b0d8dff in rd_kafka_q_serve (rkq=rkq@entry=0x55d5995128f0, 
    timeout_ms=timeout_ms@entry=100, max_cnt=max_cnt@entry=0, 
    cb_type=cb_type@entry=RD_KAFKA_Q_CB_CALLBACK, 
    callback=callback@entry=0x7f018b0a7090 <rd_kafka_poll_cb>, opaque=opaque@entry=0x0)
    at rdkafka_queue.h:475
#4  0x00007f018b0a637e in rd_kafka_query_watermark_offsets (rk=<optimized out>, 
    topic=<optimized out>, partition=partition@entry=0, low=low@entry=0x7fffd3c3ecc0, 
    high=high@entry=0x7fffd3c3ecc8, timeout_ms=timeout_ms@entry=1000) at rdkafka.c:3102
...
```
According to our sysops it might be because kafka's `advertised.listeners` parameter was pointing to the host that at the moment was unreachable. Anyway I attached with gdb and saw that execution was trapped in an infinite loop in `rd_kafka_query_watermark_offsets()`:

```c
        /* Wait for reply (or timeout) */
        while (state.err == RD_KAFKA_RESP_ERR__IN_PROGRESS &&
               rd_kafka_q_serve(rkq, 100, 0, RD_KAFKA_Q_CB_CALLBACK,
                                rd_kafka_poll_cb, NULL) !=
               RD_KAFKA_OP_RES_YIELD)
                ;
```
I don't understand much of what's going on under the hood, but from looking at the `rd_kafka_q_serve()` function's code I assume it should return an integer value signifying the number of processed messages and zero in case of timeout. And therefore it's unclear why return value is compared to `RD_KAFKA_OP_RES_YIELD` which does not make sense to me. In our case this comparison failed all the time as `rd_kafka_q_serve()` returned zero and execution proceeded to the next iteration and so on. To me it looks like we should actually check for zero and set an error code if this condition satisfied. In this PR I tried to implement this idea and it fixed the initial issue in our case. I would be glad to hear your thoughts on this. Thanks!

ps: here is a [sample code](https://gist.github.com/zilder/e79240f791cf0996bfd31766ac07e42d) I used for tests