### PR TITLE
Fix clang warning [-Wstring-plus-int]

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -363,7 +363,7 @@ static const char *rd_kafka_type2str (rd_kafka_type_t type) {
 }
 
 #define _ERR_DESC(ENUM,DESC) \
-	[ENUM - RD_KAFKA_RESP_ERR__BEGIN] = { ENUM, # ENUM + 18/*pfx*/, DESC }
+	[ENUM - RD_KAFKA_RESP_ERR__BEGIN] = { ENUM, &(# ENUM)[18]/*pfx*/, DESC }
 
 static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
 	_ERR_DESC(RD_KAFKA_RESP_ERR__BEGIN, NULL),


### PR DESCRIPTION
This fix will silence clang warning [-Wstring-plus-int]

```
librdkafka/src/rdkafka.c:369:2: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
        _ERR_DESC(RD_KAFKA_RESP_ERR__BEGIN, NULL),
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
librdkafka/src/rdkafka.c:366:53: note: expanded from macro '_ERR_DESC'
        [ENUM - RD_KAFKA_RESP_ERR__BEGIN] = { ENUM, # ENUM + 18/*pfx*/, DESC }
                                                    ~~~~~~~^~~~
librdkafka/src/rdkafka.c:369:2: note: use array indexing to silence this warning
```