### PR TITLE
do not call timespec_get on mac

### DIFF
--- a/src/rdtime.h
+++ b/src/rdtime.h
@@ -195,7 +195,13 @@ static RD_INLINE void rd_timeout_init_timespec_us (struct timespec *tspec,
                 tspec->tv_sec = timeout_us;
                 tspec->tv_nsec = 0;
         } else {
+#ifdef __APPLE__
+                struct timeval tv;
+                gettimeofday(&tv, NULL);
+                TIMEVAL_TO_TIMESPEC(&tv, tspec);
+#else
                 timespec_get(tspec, TIME_UTC);
+#endif
                 tspec->tv_sec  += timeout_us / 1000000;
                 tspec->tv_nsec += (timeout_us % 1000000) * 1000;
                 if (tspec->tv_nsec >= 1000000000) {
@@ -220,7 +226,13 @@ static RD_INLINE void rd_timeout_init_timespec (struct timespec *tspec,
                 tspec->tv_sec = timeout_ms;
                 tspec->tv_nsec = 0;
         } else {
+#ifdef __APPLE__
+                struct timeval tv;
+                gettimeofday(&tv, NULL);
+                TIMEVAL_TO_TIMESPEC(&tv, tspec);
+#else
                 timespec_get(tspec, TIME_UTC);
+#endif
                 tspec->tv_sec  += timeout_ms / 1000;
                 tspec->tv_nsec += (timeout_ms % 1000) * 1000000;
                 if (tspec->tv_nsec >= 1000000000) {


### PR DESCRIPTION
`rdtime.h` avoids use of timespec on macos in general, but it was introduced in #7ee0fdcfd . With the latest 10.15 SDK, timespec_get is gone, and the library breaks.
This is a very simple correction, there may be a better way.

```
dyld: lazy symbol binding failed: Symbol not found: _timespec_get
...
Expected in: /usr/lib/libSystem.B.dylib```
