### PR TITLE
Provide RdKafka::Handle* to OAuthBearerTokenRefreshCb callback (#2607)

### DIFF
--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -140,7 +140,8 @@ RdKafka::oauthbearer_token_refresh_cb_trampoline (rd_kafka_t *rk,
   RdKafka::HandleImpl *handle = static_cast<RdKafka::HandleImpl *>(opaque);
 
   handle->oauthbearer_token_refresh_cb_->
-    oauthbearer_token_refresh_cb(std::string(oauthbearer_config ?
+    oauthbearer_token_refresh_cb(handle,
+                                 std::string(oauthbearer_config ?
                                              oauthbearer_config : ""));
 }
 

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -707,6 +707,10 @@ class RD_EXPORT OAuthBearerTokenRefreshCb {
  public:
   /**
    * @brief SASL/OAUTHBEARER token refresh callback class.
+   *
+   * @param handle The RdKafka::Handle which requires a refreshed token.
+   * @param oauthbearer_config The value of the
+   * \p sasl.oauthbearer.config configuration property for \p handle.
    */
   virtual void oauthbearer_token_refresh_cb (RdKafka::Handle* handle,
                                              const std::string &oauthbearer_config) = 0;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -707,9 +707,23 @@ class RD_EXPORT OAuthBearerTokenRefreshCb {
  public:
   /**
    * @brief SASL/OAUTHBEARER token refresh callback class.
+   *
+   * @deprecated Use the overloaded version of this function instead. This
+   * version will be unused, even though an implementation is required.
+   */
+  virtual void oauthbearer_token_refresh_cb (const std::string &oauthbearer_config) = 0;
+
+  /**
+   * @brief SASL/OAUTHBEARER token refresh callback class.
+   *
+   * @param handle The RdKafka::Handle which requires a refreshed token.
+   * @param oauthbearer_config The value of the
+   * \p sasl.oauthbearer.config configuration property for \p handle.
    */
   virtual void oauthbearer_token_refresh_cb (RdKafka::Handle* handle,
-                                             const std::string &oauthbearer_config) = 0;
+                                             const std::string &oauthbearer_config) {
+    oauthbearer_token_refresh_cb(oauthbearer_config);
+  }
 
   virtual ~OAuthBearerTokenRefreshCb() { }
 };

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -684,18 +684,18 @@ class RD_EXPORT DeliveryReportCb {
  * typically based on the configuration defined in \c sasl.oauthbearer.config.
  *
  * The \c oauthbearer_config argument is the value of the
- * sasl.oauthbearer.config configuration property.
+ * \c sasl.oauthbearer.config configuration property.
  *
- * The callback should invoke RdKafka::oauthbearer_set_token() or
- * RdKafka::oauthbearer_set_token_failure() to indicate success or failure,
- * respectively.
- *
+ * The callback should invoke RdKafka::Handle::oauthbearer_set_token() or
+ * RdKafka::Handle::oauthbearer_set_token_failure() to indicate success or
+ * failure, respectively.
+ * 
  * The refresh operation is eventable and may be received when an event
  * callback handler is set with an event type of
  * \c RdKafka::Event::EVENT_OAUTHBEARER_TOKEN_REFRESH.
  *
  * Note that before any SASL/OAUTHBEARER broker connection can succeed the
- * application must call RdKafka::oauthbearer_set_token() once -- either
+ * application must call RdKafka::Handle::oauthbearer_set_token() once -- either
  * directly or, more typically, by invoking RdKafka::poll() -- in order to
  * cause retrieval of an initial token to occur.
  *

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -707,23 +707,9 @@ class RD_EXPORT OAuthBearerTokenRefreshCb {
  public:
   /**
    * @brief SASL/OAUTHBEARER token refresh callback class.
-   *
-   * @deprecated Use the overloaded version of this function instead. This
-   * version will be unused, even though an implementation is required.
-   */
-  virtual void oauthbearer_token_refresh_cb (const std::string &oauthbearer_config) = 0;
-
-  /**
-   * @brief SASL/OAUTHBEARER token refresh callback class.
-   *
-   * @param handle The RdKafka::Handle which requires a refreshed token.
-   * @param oauthbearer_config The value of the
-   * \p sasl.oauthbearer.config configuration property for \p handle.
    */
   virtual void oauthbearer_token_refresh_cb (RdKafka::Handle* handle,
-                                             const std::string &oauthbearer_config) {
-    oauthbearer_token_refresh_cb(oauthbearer_config);
-  }
+                                             const std::string &oauthbearer_config) = 0;
 
   virtual ~OAuthBearerTokenRefreshCb() { }
 };

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -551,6 +551,7 @@ enum CertificateEncoding {
 
 /**@cond NO_DOC*/
 /* Forward declarations */
+class Handle;
 class Producer;
 class Message;
 class Headers;
@@ -707,7 +708,8 @@ class RD_EXPORT OAuthBearerTokenRefreshCb {
   /**
    * @brief SASL/OAUTHBEARER token refresh callback class.
    */
-  virtual void oauthbearer_token_refresh_cb (const std::string &oauthbearer_config) = 0;
+  virtual void oauthbearer_token_refresh_cb (RdKafka::Handle* handle,
+                                             const std::string &oauthbearer_config) = 0;
 
   virtual ~OAuthBearerTokenRefreshCb() { }
 };


### PR DESCRIPTION
This change provides  `RdKafka::OAuthBearerTokenRefreshCb::oauthbearer_token_refresh_cb()` with an `RdKafka::Handle*`. This gives the callback the proper `RdKafka::Handle` to call `oauthbearer_set_token()`/`oauthbearer_set_token_failure()`.

I've also updated the docs to more explicitly refer to the `RdKafka::Handle` methods.

Addresses issue: #2607 