### PR TITLE
Add getaddrinfo callback

### DIFF
--- a/src/rdaddr.c
+++ b/src/rdaddr.c
@@ -143,7 +143,10 @@ const char *rd_addrinfo_prepare (const char *nodesvc,
 
 
 
-rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
+rd_sockaddr_list_t *rd_getaddrinfo (int(*getaddrinfo_cb)(const char *node, const char *service,
+                         const struct addrinfo *hints,
+                         struct addrinfo **res),
+                     const char *nodesvc, const char *defsvc,
 				    int flags, int family,
 				    int socktype, int protocol,
 				    const char **errstr) {
@@ -165,7 +168,12 @@ rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
 	if (*svc)
 		defsvc = svc;
 		
-	if ((r = getaddrinfo(node, defsvc, &hints, &ais))) {
+    if (getaddrinfo_cb) {
+        r = getaddrinfo_cb(node, defsvc, &hints, &ais);
+    } else {
+        r = getaddrinfo(node, defsvc, &hints, &ais);
+    }
+    if (r) {
 #ifdef EAI_SYSTEM
 		if (r == EAI_SYSTEM)
 #else

--- a/src/rdaddr.h
+++ b/src/rdaddr.h
@@ -153,7 +153,10 @@ rd_sockaddr_list_next (rd_sockaddr_list_t *rsal) {
 				     * FIXME: Guessing non-used bits like this
 				     *        is a bad idea. */
 
-rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
+rd_sockaddr_list_t *rd_getaddrinfo (int(*getaddrinfo_cb)(const char *node, const char *service,
+        const struct addrinfo *hints,
+        struct addrinfo **res),
+                    const char *nodesvc, const char *defsvc,
 				    int flags, int family,
 				    int socktype, int protocol,
 				    const char **errstr);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -81,6 +81,7 @@ typedef SSIZE_T ssize_t;
 
 #else
 #include <sys/socket.h> /* for sockaddr, .. */
+#include <netdb.h> /* for struct addrinfo */
 
 #define RD_UNUSED __attribute__((unused))
 #define RD_INLINE inline
@@ -1868,6 +1869,24 @@ void rd_kafka_conf_set_oauthbearer_token_refresh_cb (
         void (*oauthbearer_token_refresh_cb) (rd_kafka_t *rk,
                                               const char *oauthbearer_config,
                                               void *opaque));
+
+/**
+ * @brief Set broker name resolution callback.
+ *
+ * The getaddrinfo callback is responsible for resolving broker name \p node
+ * to its corresponding ip addresses \p res.
+ *
+ * \p getaddrinfo_cb shall return 0 on success (name resolved) or an error
+ * number (errno) on error.
+ *
+ * @remark The callback will be called from an internal librdkafka thread.
+ */
+RD_EXPORT
+void rd_kafka_conf_set_getaddrinfo_cb (rd_kafka_conf_t *conf,
+                                  int (*getaddrinfo_cb) (const char *node,
+                                                    const char *service,
+                                                    const struct addrinfo *hints,
+                                                    struct addrinfo **res));
 
 /**
  * @brief Set socket callback.

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -842,7 +842,8 @@ static int rd_kafka_broker_resolve (rd_kafka_broker_t *rkb,
 
 	if (!rkb->rkb_rsal) {
 		/* Resolve */
-		rkb->rkb_rsal = rd_getaddrinfo(rkb->rkb_nodename,
+        rkb->rkb_rsal = rd_getaddrinfo(rkb->rkb_rk->rk_conf.getaddrinfo_cb,
+                           rkb->rkb_nodename,
 					       RD_KAFKA_PORT_STR,
 					       AI_ADDRCONFIG,
 					       rkb->rkb_rk->rk_conf.

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -503,6 +503,10 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
           _RK(background_event_cb),
           "Background queue event callback "
           "(set with rd_kafka_conf_set_background_event_cb())" },
+        { _RK_GLOBAL, "getaddrinfo_cb", _RK_C_PTR,
+          _RK(getaddrinfo_cb),
+          "Broker name resolution callback",
+        },
         { _RK_GLOBAL, "socket_cb", _RK_C_PTR,
           _RK(socket_cb),
           "Socket creation callback to provide race-free CLOEXEC",
@@ -2478,6 +2482,15 @@ void rd_kafka_conf_set_oauthbearer_token_refresh_cb(rd_kafka_conf_t *conf,
         rd_kafka_anyconf_set_internal(_RK_GLOBAL, conf,
                 "oauthbearer_token_refresh_cb", oauthbearer_token_refresh_cb);
 #endif
+}
+
+void rd_kafka_conf_set_getaddrinfo_cb (rd_kafka_conf_t *conf,
+                                  int (*getaddrinfo_cb) (const char *node,
+                                                    const char *service,
+                                                    const struct addrinfo *hints,
+                                                    struct addrinfo **res)) {
+        rd_kafka_anyconf_set_internal(_RK_GLOBAL, conf, "getaddrinfo_cb",
+                                      getaddrinfo_cb);
 }
 
 void rd_kafka_conf_set_socket_cb (rd_kafka_conf_t *conf,

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -434,6 +434,11 @@ struct rd_kafka_conf_s {
 			 size_t json_len,
 			 void *opaque);
 
+    /* Broker name resolution callback */
+	int(*getaddrinfo_cb)(const char *node, const char *service,
+	        const struct addrinfo *hints,
+	        struct addrinfo **res);
+
         /* Socket creation callback */
         int (*socket_cb) (int domain, int type, int protocol, void *opaque);
 

--- a/tests/0006-symbols.c
+++ b/tests/0006-symbols.c
@@ -57,6 +57,7 @@ int main_0006_symbols (int argc, char **argv) {
                 rd_kafka_conf_set_error_cb(NULL, NULL);
                 rd_kafka_conf_set_stats_cb(NULL, NULL);
                 rd_kafka_conf_set_log_cb(NULL, NULL);
+                rd_kafka_conf_set_getaddrinfo_cb(NULL, NULL);
                 rd_kafka_conf_set_socket_cb(NULL, NULL);
 		rd_kafka_conf_set_rebalance_cb(NULL, NULL);
 		rd_kafka_conf_set_offset_commit_cb(NULL, NULL);


### PR DESCRIPTION
Here is a proposal for a callback to getaddrinfo(). This is extension to librdkafka existing socket() and connect() callbacks. 

This callback is used to control the whole connection process starting from getaddrinfo_cb then socket_cb and finally connect_cb. 
  
In details, it provides rd_kafka_conf_set_getaddrinfo_cb() to add the getaddrinfo_cb callback. 

Moreover, the typical usage is for a router that has 2 wan interfaces to reach the kafka broker. Each wan interface is in a different network namespace and can be up or down.
Since, the kafka client is launched in the root namespace, it needs to be called (via getaddrinfo_cb()) in order to resolve the broker name in a network namespace where the wan interface is up. 
Otherwise, if the kafka client starts in a network namespace where the wan interface is down, it gets stuck there retrying getaddrinfo() indefinitely without success. 
