### PR TITLE
Fail configuration when requested library isn't present 

### DIFF
--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -912,7 +912,7 @@ Configuration summary:"
     local n=
     for n in $MKL_MKVARS ; do
         # Skip the boring booleans
-        if [[ $n == WITH_* || $n == WITHOUT_* || $n == HAVE_* || $n == def_* ]]; then
+        if [[ $n == ENABLE_* || $n == WITH_* || $n == WITHOUT_* || $n == HAVE_* || $n == def_* ]]; then
             continue
         fi
         printf "  %-24s %s\n" "$n" "${!n}"
@@ -1246,10 +1246,8 @@ function mkl_check_begin {
 # certain call ordering, such as dependent library checks.
 #
 # Param 1: module name
-# Param 2: action
 function mkl_check {
     local modname=$1
-    local action=$2
 
     local func="${modname}_manual_checks"
     if ! mkl_func_exists "$func" ; then
@@ -1257,7 +1255,7 @@ function mkl_check {
         return 1
     fi
 
-    $func "$2"
+    $func
     return $?
 }
 

--- a/mklove/modules/configure.libsasl2
+++ b/mklove/modules/configure.libsasl2
@@ -7,23 +7,26 @@
 #
 #
 # And then call the following function from the correct place/order in checks:
-#   mkl_check libsasl2 [<action>]
+#   mkl_check libsasl2
 #
 
-mkl_toggle_option "Feature" ENABLE_GSSAPI "--enable-gssapi" "Enable SASL GSSAPI support with Cyrus libsasl2" "y"
+mkl_toggle_option "Feature" ENABLE_GSSAPI "--enable-gssapi" "Enable SASL GSSAPI support with Cyrus libsasl2" "try"
 mkl_toggle_option "Feature" ENABLE_GSSAPI "--enable-sasl" "Deprecated: Alias for --enable-gssapi"
 
 function manual_checks {
-    local action=${1:-disable}
-
-    [[ $ENABLE_GSSAPI == y ]] || return 0
+    case "$ENABLE_GSSAPI" in
+        n) return 0 ;;
+        y) local action=fail ;;
+        try) local action=disable ;;
+        *) mkl_err "mklove internal error: invalid value for ENABLE_GSSAPI: $ENABLE_GSSAPI"; exit 1 ;;
+    esac
 
     mkl_meta_set "libsasl2" "deb" "libsasl2-dev"
     mkl_meta_set "libsasl2" "rpm" "cyrus-sasl"
     mkl_meta_set "libsasl2" "apk" "cyrus-sasl-dev"
 
-    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" disable CC "-lsasl2" "#include <sasl/sasl.h>" ; then
-        mkl_lib_check "libsasl" "WITH_SASL_CYRUS" disable CC "-lsasl" \
+    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" $action CC "-lsasl2" "#include <sasl/sasl.h>" ; then
+        mkl_lib_check "libsasl" "WITH_SASL_CYRUS" $action CC "-lsasl" \
                       "#include <sasl/sasl.h>"
     fi
 }

--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -8,20 +8,23 @@
 #
 
 # And then call the following function from the correct place/order in checks:
-#   mkl_check libssl [<action>]
+#   mkl_check libssl
 #
 #
 # This module is a bit hacky since OpenSSL provides both libcrypto and libssl,
 # the latter depending on the former, but from a user perspective it is
 # SSL that is the feature, not crypto.
 
-mkl_toggle_option "Feature" ENABLE_SSL "--enable-ssl" "Enable SSL support" "y"
+mkl_toggle_option "Feature" ENABLE_SSL "--enable-ssl" "Enable SSL support" "try"
 
 
 function manual_checks {
-    local action=${1:-disable}
-
-    [[ $ENABLE_SSL == y ]] || return 0
+    case "$ENABLE_SSL" in
+        n) return 0 ;;
+        y) local action=fail ;;
+        try) local action=disable ;;
+        *) mkl_err "mklove internal error: invalid value for ENABLE_SSL: $ENABLE_SSL"; exit 1 ;;
+    esac
 
     if [[ $MKL_DISTRO == "osx" ]]; then
         # Add brew's OpenSSL pkg-config path on OSX

--- a/mklove/modules/configure.libzstd
+++ b/mklove/modules/configure.libzstd
@@ -6,15 +6,18 @@
 #   mkl_require libzstd
 #
 # And then call the following function from the correct place/order in checks:
-#   mkl_check libzstd [<action>]
+#   mkl_check libzstd
 #
 
-mkl_toggle_option "Feature" ENABLE_ZSTD "--enable-zstd" "Enable support for ZSTD compression" "y"
+mkl_toggle_option "Feature" ENABLE_ZSTD "--enable-zstd" "Enable support for ZSTD compression" "try"
 
 function manual_checks {
-    local action=${1:-disable}
-
-    [[ $ENABLE_ZSTD == y ]] || return 0
+    case "$ENABLE_ZSTD" in
+        n) return 0 ;;
+        y) local action=fail ;;
+        try) local action=disable ;;
+        *) mkl_err "mklove internal error: invalid value for ENABLE_ZSTD: $ENABLE_ZSTD"; exit 1 ;;
+    esac
 
     mkl_meta_set "libzstd" "brew" "zstd"
     mkl_meta_set "libzstd" "apk" "zstd-dev zstd-static"

--- a/mklove/modules/configure.zlib
+++ b/mklove/modules/configure.zlib
@@ -6,11 +6,18 @@
 #   mkl_require zlib
 #
 # And then call the following function from the correct place/order in checks:
-#   mkl_check zlib [<action>]
+#   mkl_check zlib
 #
 
+mkl_toggle_option "Feature" ENABLE_ZLIB "--enable-zlib" "Enable support for zlib compression" "try"
+
 function manual_checks {
-    local action=$1
+    case "$ENABLE_ZLIB" in
+        n) return 0 ;;
+        y) local action=fail ;;
+        try) local action=disable ;;
+        *) mkl_err "mklove internal error: invalid value for ENABLE_ZLIB: $ENABLE_ZLIB"; exit 1 ;;
+    esac
 
     mkl_meta_set "zlib" "apk" "zlib-dev"
     mkl_meta_set "zlib" "static" "libz.a"


### PR DESCRIPTION
Two commits in here. Messages reproduced below. The tl;dr is this fixes edenhill/mklove#21 (which was spawned from #556). It seems like the change to configure.base should be incorporated into mklove, but it seems like more mklove development happens in this repository than there?

----

**Fail configuration when requested library isn't present**

If the user specifies --enable-XXX, fail configuration if XXX isn't
present. The prior behavior required the user to manually inspect the
configure output to determine whether the feature was actually enabled.
This was particularly problematic with downstream build systems, like
Cargo with rust-rdkafka, where the configure output is hidden from users
if configuration is successful.

The default behavior remains unchanged; if a user does not explicitly
request a feature with --enable-XXX nor dis-request it with
--disable-XXX, and the feature is enabled by default, then it is not be
an error if the feature cannot be found.

Note that this commit additionally excludes the `ENABLE_*` options from
the confugration summary, as they were misleading. For example, if a
user passed --enable-zstd, but zstd was not found on the system, the
configuration summary would report "ENABLE_ZSTD y"--merely reporting
that the user had requested zstd support, not that zstd support would
actually be available in the built library. (If the user does desire
that information, they can find it in the BUILT_WITH line, which
includes only the features that were actually possible to enable.)

---

**Allow disabling zlib when building with mklove**

For symmetry with the CMake build, which allows disabling zlib
explicitly.