### PR TITLE
gen-ssl-certs: fix rdkafka client cert. creation

### DIFF
--- a/tests/gen-ssl-certs.sh
+++ b/tests/gen-ssl-certs.sh
@@ -148,7 +148,7 @@ $PASS
 EOF
 
 	echo "########### Signing key"
-	openssl x509 -req -passin "pass:$PASS" -in ${PFX}client.req -CA $CA_CERT -CAkey ${CA_CERT}.key -CAserial ${CA_CERT}.srl -out ${PFX}client.pem -days $VALIDITY
+	openssl x509 -req -passin "pass:$PASS" -in ${PFX}client.req -CA $CA_CERT -CAkey ${CA_CERT}.key -CAcreateserial -out ${PFX}client.pem -days $VALIDITY
 
     fi
 


### PR DESCRIPTION
To reproduce this bug, you should execute in this order:

1) create a new ca-cert
`./gen-ssl-certs.sh ca ca-cert dummy-cn`

2) try to create a client certificate & key without keytool:
`./gen-ssl-certs.sh client ca-cert dummy_client_cert_ dummy_client`

You will get this error message:
fopen:No such file or directory:../crypto/bio/bss_file.c:72:fopen('ca-cert.srl','r')

After this fix, it should works like expected.