### PR TITLE
Fix Coverity parse warnings

### DIFF
--- a/src/rdposix.h
+++ b/src/rdposix.h
@@ -154,7 +154,7 @@ extern void __coverity_panic__(void);
 #define rd_assert(EXPR) do {                    \
                 if (!(EXPR))                    \
                         __coverity_panic__();   \
-        }
+        } while (0)
 #endif
 
 


### PR DESCRIPTION
This fixes the parse warnings generated by Coverity during a scan.