### PR TITLE
Improve pkg-config support

### DIFF
--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -176,7 +176,7 @@ includedir=$(includedir)
 Name: $(LIBNAME)-static
 Description: $(MKL_APP_DESC_ONELINE) (static)
 Version: $(MKL_APP_VERSION)
-Requires: $(MKL_PKGCONFIG_REQUIRES_PRIVATE:rdkafka=rdkafka-static)
+Requires: $(MKL_PKGCONFIG_REQUIRES:rdkafka=rdkafka-static)
 Cflags: -I$${includedir}
 Libs: -L$${libdir} $${pc_sysrootdir}$${libdir}/$(LIBNAME)-static.a $(MKL_PKGCONFIG_LIBS_PRIVATE)
 endef
@@ -269,7 +269,7 @@ lib-uninstall:
 bin-install:
 	@printf "$(MKL_YELLOW)Install $(BIN) to $$DESTDIR$(prefix)$(MKL_CLR_RESET)\n"
 	$(INSTALL) -d $$DESTDIR$(bindir) && \
-	$(INSTALL) $(BIN) $$DESTDIR$(bindir) 
+	$(INSTALL) $(BIN) $$DESTDIR$(bindir)
 
 bin-uninstall:
 	@printf "$(MKL_YELLOW)Uninstall $(BIN) from $$DESTDIR$(prefix)$(MKL_CLR_RESET)\n"

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -160,9 +160,10 @@ includedir=$(includedir)
 Name: $(LIBNAME)
 Description: $(MKL_APP_DESC_ONELINE)
 Version: $(MKL_APP_VERSION)
+Requires.private: $(MKL_PKGCONFIG_REQUIRES_PRIVATE)
 Cflags: -I$${includedir}
 Libs: -L$${libdir} -l$(LIBNAME0)
-Libs.private: $(LIBS)
+Libs.private: $(MKL_PKGCONFIG_LIBS_PRIVATE)
 endef
 
 export _PKG_CONFIG_DEF
@@ -175,8 +176,9 @@ includedir=$(includedir)
 Name: $(LIBNAME)-static
 Description: $(MKL_APP_DESC_ONELINE) (static)
 Version: $(MKL_APP_VERSION)
+Requires: $(MKL_PKGCONFIG_REQUIRES_PRIVATE:rdkafka=rdkafka-static)
 Cflags: -I$${includedir}
-Libs: -L$${libdir} $${libdir}/$(LIBNAME)-static.a $(MKL_DYNAMIC_LIBS)
+Libs: -L$${libdir} $${pc_sysrootdir}$${libdir}/$(LIBNAME)-static.a $(MKL_PKGCONFIG_LIBS_PRIVATE)
 endef
 
 export _PKG_CONFIG_STATIC_DEF

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -1724,6 +1724,11 @@ $cflags"
         local stlibs=$(mkl_lib_check_static $1 "$libs")
         if [[ -n $stlibs ]]; then
             libs=$stlibs
+        else
+            # if we don't find a static library to bundle into the
+            # -static.a, we need to export a pkgconfig dependency
+            # so it can be resolved when linking downstream packages
+            mkl_mkvar_append $1 "MKL_PKGCONFIG_REQUIRES" "$libname"
         fi
     fi
 
@@ -2338,8 +2343,3 @@ function mkl_toggle_option_lib {
     eval "function _tmp_func { mkl_lib_check \"$2\" \"$3\" \"$4\" CC \"$7\"; }"
     mkl_func_push MKL_CHECKS "$MKL_MODULE" _tmp_func
 }
-
-
-
-
-

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -1578,6 +1578,7 @@ function mkl_lib_check0 {
         # E.g., check for crypto and then ssl should result in -lssl -lcrypto
         mkl_dbg "$1: from lib_check: LIBS: prepend $libs"
         mkl_mkvar_prepend "$1" LIBS "$libs"
+        mkl_mkvar_prepend "$1" MKL_PKGCONFIG_LIBS_PRIVATE "$libs"
     fi
 
     return 0
@@ -1714,6 +1715,8 @@ $cflags"
             return 1
         fi
     fi
+
+    mkl_mkvar_append $1 "MKL_PKGCONFIG_REQUIRES_PRIVATE" "$libname"
 
     mkl_mkvar_append $1 "CFLAGS" "$cflags"
 

--- a/mklove/modules/configure.libsasl2
+++ b/mklove/modules/configure.libsasl2
@@ -25,8 +25,8 @@ function manual_checks {
     mkl_meta_set "libsasl2" "rpm" "cyrus-sasl"
     mkl_meta_set "libsasl2" "apk" "cyrus-sasl-dev"
 
-    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" $action CC "-lsasl2" "#include <sasl/sasl.h>" ; then
+    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" $action CC "-lsasl2" "#include <stddef.h>\n#include <sasl/sasl.h>" ; then
         mkl_lib_check "libsasl" "WITH_SASL_CYRUS" $action CC "-lsasl" \
-                      "#include <sasl/sasl.h>"
+                      "#include <stddef.h>\n#include <sasl/sasl.h>"
     fi
 }

--- a/mklove/modules/configure.libsasl2
+++ b/mklove/modules/configure.libsasl2
@@ -25,8 +25,12 @@ function manual_checks {
     mkl_meta_set "libsasl2" "rpm" "cyrus-sasl"
     mkl_meta_set "libsasl2" "apk" "cyrus-sasl-dev"
 
-    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" $action CC "-lsasl2" "#include <stddef.h>\n#include <sasl/sasl.h>" ; then
-        mkl_lib_check "libsasl" "WITH_SASL_CYRUS" $action CC "-lsasl" \
-                      "#include <stddef.h>\n#include <sasl/sasl.h>"
+    local sasl_includes="
+#include <stddef.h>
+#include <sasl/sasl.h>
+"
+
+    if ! mkl_lib_check "libsasl2" "WITH_SASL_CYRUS" $action CC "-lsasl2" "$sasl_includes" ; then
+        mkl_lib_check "libsasl" "WITH_SASL_CYRUS" $action CC "-lsasl" "$sasl_includes"
     fi
 }

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -38,6 +38,7 @@ endif
 # Ignore previously defined library dependencies for the C library,
 # we'll get those dependencies through the C library linkage.
 LIBS := -L../src -lrdkafka
+MKL_PKGCONFIG_REQUIRES_PRIVATE := rdkafka
 
 CHECK_FILES+= $(LIBFILENAME) $(LIBNAME).a
 

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -39,6 +39,7 @@ endif
 # we'll get those dependencies through the C library linkage.
 LIBS := -L../src -lrdkafka
 MKL_PKGCONFIG_REQUIRES_PRIVATE := rdkafka
+MKL_PKGCONFIG_REQUIRES := rdkafka
 
 CHECK_FILES+= $(LIBFILENAME) $(LIBNAME).a
 


### PR DESCRIPTION
1. Add required libraries (zlib, lz4, zstd, openssl, sasl2) to the
   pkg-config `Requires` field instead of to `Libs` if they were
   discovered via pkg-config. This allows pkg-config (and other tools
   built on top of the pkg-config metadata) to see librdkafka's full
   dependency graph.

2. Prefix full paths to librdkafka.a with the pkg-config variable
   ${pc_sysrootdir}. pkg-config automatically applies this prefix to
   paths passed to -I and -L, but nowhere else. This means that the
   previous link line in the -static.pc files is inconsistent, and
   would expand to

     -L${pc_sysrootdir}${libdir} ${libdir}/librdkafka.a

3. #include <stddef.h> when checking for sasl so that detection via
   pkg-config works. This is needed as sasl.h references some types
   that are defined in stddef.h.