### PR TITLE
fix: cleanup conf object if fails creating producer

### DIFF
--- a/src-cpp/ConsumerImpl.cpp
+++ b/src-cpp/ConsumerImpl.cpp
@@ -58,6 +58,9 @@ RdKafka::Consumer *RdKafka::Consumer::create (RdKafka::Conf *conf,
   if (!(rk = rd_kafka_new(RD_KAFKA_CONSUMER, rk_conf,
                           errbuf, sizeof(errbuf)))) {
     errstr = errbuf;
+    // rd_kafka_new() takes ownership only if succeeds
+    if (rk_conf)
+      rd_kafka_conf_destroy(rk_conf);
     delete rkc;
     return NULL;
   }

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -41,7 +41,7 @@ RdKafka::KafkaConsumer *RdKafka::KafkaConsumer::create (RdKafka::Conf *conf,
   rd_kafka_conf_t *rk_conf = NULL;
   size_t grlen;
 
-  if (!confimpl->rk_conf_) {
+  if (!confimpl || !confimpl->rk_conf_) {
     errstr = "Requires RdKafka::Conf::CONF_GLOBAL object";
     delete rkc;
     return NULL;
@@ -63,6 +63,8 @@ RdKafka::KafkaConsumer *RdKafka::KafkaConsumer::create (RdKafka::Conf *conf,
   if (!(rk = rd_kafka_new(RD_KAFKA_CONSUMER, rk_conf,
                           errbuf, sizeof(errbuf)))) {
     errstr = errbuf;
+    // rd_kafka_new() takes ownership only if succeeds
+    rd_kafka_conf_destroy(rk_conf);
     delete rkc;
     return NULL;
   }

--- a/src-cpp/ProducerImpl.cpp
+++ b/src-cpp/ProducerImpl.cpp
@@ -78,6 +78,9 @@ RdKafka::Producer *RdKafka::Producer::create (RdKafka::Conf *conf,
   if (!(rk = rd_kafka_new(RD_KAFKA_PRODUCER, rk_conf,
                           errbuf, sizeof(errbuf)))) {
     errstr = errbuf;
+    // rd_kafka_new() takes ownership only if succeeds
+    if (rk_conf)
+      rd_kafka_conf_destroy(rk_conf);
     delete rkp;
     return NULL;
   }


### PR DESCRIPTION
I notice there is memory leak in `RdKafka::Producer::create` if `rd_kafka_new` returns `NULL`.