### PR TITLE
Issue-2368: Correct message timestamp type

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -754,7 +754,7 @@ void rd_kafka_msgq_set_metadata (rd_kafka_msgq_t *rkmq,
                 rkm->rkm_offset = base_offset++;
                 if (timestamp != -1) {
                         rkm->rkm_timestamp = timestamp;
-                        rkm->rkm_tstype = RD_KAFKA_MSG_ATTR_LOG_APPEND_TIME;
+                        rkm->rkm_tstype = RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME;
                 }
 
                 /* Don't downgrade a message from any form of PERSISTED


### PR DESCRIPTION
For topic configured with message.timestamp.type=LogAppendTime, type should be RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME.
Issue reference: https://github.com/edenhill/librdkafka/issues/2368