### PR TITLE
Use _WIN32 preprocessor macro instead of _MSC_VER

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -55,7 +55,7 @@ extern "C" {
 #endif
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <basetsd.h>
 #ifndef WIN32_MEAN_AND_LEAN
 #define WIN32_MEAN_AND_LEAN


### PR DESCRIPTION
_MSC_VER is only defined by MSVC, but other compilers, e.g. gcc from MinGW, can also be used to build librdkafka on Windows. _WIN32 is not compiler-specific.