### PR TITLE
Added ERR__APPLICATION

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -285,6 +285,8 @@ enum ErrorCode {
         ERR__NOT_CONFIGURED = -145,
         /** Instance has been fenced */
         ERR__FENCED = -144,
+        /** Application generated error */
+        ERR__APPLICATION = -143,
 
         /** End internal error codes */
 	ERR__END = -100,

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -480,6 +480,8 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
                   "Local: Functionality not configured"),
         _ERR_DESC(RD_KAFKA_RESP_ERR__FENCED,
                   "Local: This instance has been fenced by a newer instance"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR__APPLICATION,
+                  "Local: Application generated error"),
 
 	_ERR_DESC(RD_KAFKA_RESP_ERR_UNKNOWN,
 		  "Unknown broker error"),

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -369,7 +369,9 @@ typedef enum {
         RD_KAFKA_RESP_ERR__NOT_CONFIGURED = -145,
         /** Instance has been fenced */
         RD_KAFKA_RESP_ERR__FENCED = -144,
-
+        /** Application generated error */
+        RD_KAFKA_RESP_ERR__APPLICATION = -143,
+        
 	/** End internal error codes */
 	RD_KAFKA_RESP_ERR__END = -100,
 


### PR DESCRIPTION
Along with adding support to the .NET binding for transactions, I'm adding a 'word count' example, which includes significant logic in the rebalance handlers. This has highlighted the need (or more big convenience really) for exceptions to be propagated through to the initiating function call (currently any unhandled exception in a handler will terminate the process). In order to do that, I need an error code to associate with application generated errors.