### PR TITLE
Fix build of rdkafka_example project for windows, when using Visual Studio 2017/2019

### DIFF
--- a/win32/common.vcxproj
+++ b/win32/common.vcxproj
@@ -31,6 +31,14 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
+  <!-- Visual Studio 2017 (15.0) -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>  
+  <!-- Visual Studio 2019 (16.0) -->
+  <PropertyGroup Condition="'$(VisualStudioVersion)' == '16.0'">
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>  
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>


### PR DESCRIPTION
    When building without the fix, you get an error:

    1>------ Build started: Project: rdkafka_example, Configuration: Release x64 ------
    1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\MSBuild\Microsoft\VC\v160\Microsoft.CppBuild.targets(379,5): error MSB8020: The build tools for v142 (Platform Toolset = 'v142') cannot be found. To build using the v142 build tools, please install v142 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution".
    1>Done building project "rdkafka_example.vcxproj" -- FAILED.

    The error is NOT fixed, when re-targeting the solution.
    The file common.vcxproj needs to contain the relevant platform toolset definitions, and this is what this commit does.