### PR TITLE
minor fix to rdkafka_example usage: add lz4 and zstd compression codec to usage.

### DIFF
--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -524,7 +524,7 @@ int main (int argc, char **argv) {
 			"  -p <num>        Partition (random partitioner)\n"
 			"  -b <brokers>    Broker address (localhost:9092)\n"
 			"  -z <codec>      Enable compression:\n"
-			"                  none|gzip|snappy\n"
+			"                  none|gzip|snappy|lz4|zstd\n"
 			"  -o <offset>     Start offset (consumer):\n"
 			"                  beginning, end, NNNNN or -NNNNN\n"
 			"                  wmark returns the current hi&lo "

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -407,7 +407,7 @@ int main (int argc, char **argv) {
             "                  random (default), hash\n"
             "  -b <brokers>    Broker address (localhost:9092)\n"
             "  -z <codec>      Enable compression:\n"
-            "                  none|gzip|snappy\n"
+            "                  none|gzip|snappy|lz4|zstd\n"
             "  -o <offset>     Start offset (consumer)\n"
             "  -e              Exit consumer when last message\n"
             "                  in partition has been received.\n"


### PR DESCRIPTION
update the usage with the compression codec of lz4 and zstd