### PR TITLE
OpenBSD support

### DIFF
--- a/src/rdaddr.h
+++ b/src/rdaddr.h
@@ -39,7 +39,7 @@
 #include <ws2ipdef.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(_AIX)
+#if defined(__FreeBSD__) || defined(_AIX) || defined(__OpenBSD__)
 #include <sys/socket.h>
 #endif
 

--- a/src/rdposix.h
+++ b/src/rdposix.h
@@ -65,7 +65,7 @@
 /**
 * Allocation
 */
-#if !defined(__FreeBSD__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
 /* alloca(3) is in stdlib on FreeBSD */
 #include <alloca.h>
 #endif


### PR DESCRIPTION
Both points that reference FreeBSD should also check for OpenBSD as OS.

I was able to compile the library on OpenBSD with these two minor changes.