### PR TITLE
Broaded check for no-op when no messages read

### DIFF
--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1322,7 +1322,7 @@ rd_kafka_msgset_reader_run (rd_kafka_msgset_reader_t *msetr) {
                  * increase it automatically.
                  * If there was at least one control message there
                  * is probably not a size limit and nothing is done. */
-                if (msetr->msetr_ctrl_cnt > 0) {
+                if (msetr->msetr_ctrl_cnt > 0 || msetr->msetr_aborted_txns) {
                         /* Noop */
 
                 } else  if (rktp->rktp_fetch_msg_max_bytes < (1 << 30)) {


### PR DESCRIPTION
Additionally, i think it's misleading to use `RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE` in the error op below, as it's a broker error implying it originated from the broker. This had me confused for some time. I'll let you work out what to do with that.