### PR TITLE
Fix format specifier for printing size_t

### DIFF
--- a/src/lz4frame.c
+++ b/src/lz4frame.c
@@ -834,7 +834,7 @@ size_t LZ4F_compressUpdate(LZ4F_cctx* cctxPtr,
     LZ4F_lastBlockStatus lastBlockCompressed = notDone;
     compressFunc_t const compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel);
 
-    DEBUGLOG(4, "LZ4F_compressUpdate (srcSize=%zu)", srcSize);
+    DEBUGLOG(4, "LZ4F_compressUpdate (srcSize=%"PRIusz")", srcSize);
 
     if (cctxPtr->cStage != 1) return err0r(LZ4F_ERROR_GENERIC);
     if (dstCapacity < LZ4F_compressBound_internal(srcSize, &(cctxPtr->prefs), cctxPtr->tmpInSize))

--- a/src/rdbuf.c
+++ b/src/rdbuf.c
@@ -325,7 +325,7 @@ void rd_buf_destroy (rd_buf_t *rbuf) {
                 float fill_grade = (float)rbuf->rbuf_len /
                         (float)rbuf->rbuf_size;
 
-                printf("fill grade: %.2f%% (%zu bytes over-allocated)\n",
+                printf("fill grade: %.2f%% (%"PRIusz" bytes over-allocated)\n",
                        fill_grade * 100.0f, overalloc);
         }
 #endif

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -96,7 +96,7 @@ rd_tmpabuf_alloc0 (const char *func, int line, rd_tmpabuf_t *tab, size_t size) {
 	if (unlikely(tab->of + size > tab->size)) {
 		if (tab->assert_on_fail) {
 			fprintf(stderr,
-				"%s: %s:%d: requested size %zd + %zd > %zd\n",
+				"%s: %s:%d: requested size %"PRIusz" + %"PRIusz" > %"PRIusz"\n",
 				__FUNCTION__, func, line, tab->of, size,
 				tab->size);
 			assert(!*"rd_tmpabuf_alloc: not enough size in buffer");

--- a/src/rdkafka_lz4.c
+++ b/src/rdkafka_lz4.c
@@ -229,7 +229,7 @@ rd_kafka_lz4_decompress (rd_kafka_broker_t *rkb, int proper_hc, int64_t Offset,
         if (!out) {
                 rd_rkb_log(rkb, LOG_WARNING, "LZ4DEC",
                            "Unable to allocate decompression "
-                           "buffer of %zd bytes: %s",
+                           "buffer of %"PRIusz" bytes: %s",
                            estimated_uncompressed_size, rd_strerror(errno));
                 err = RD_KAFKA_RESP_ERR__CRIT_SYS_RESOURCE;
                 goto done;
@@ -276,7 +276,7 @@ rd_kafka_lz4_decompress (rd_kafka_broker_t *rkb, int proper_hc, int64_t Offset,
                         if (!(tmp = rd_realloc(out, outlen + extra))) {
                                 rd_rkb_log(rkb, LOG_WARNING, "LZ4DEC",
                                            "Unable to grow decompression "
-                                           "buffer to %zd+%zd bytes: %s",
+                                           "buffer to %"PRIusz"+%"PRIusz" bytes: %s",
                                            outlen, extra,rd_strerror(errno));
                                 err = RD_KAFKA_RESP_ERR__CRIT_SYS_RESOURCE;
                                 goto done;

--- a/tests/0004-conf.c
+++ b/tests/0004-conf.c
@@ -90,7 +90,7 @@ static void conf_cmp (const char *desc,
 	int i;
 
 	if (acnt != bcnt)
-		TEST_FAIL("%s config compare: count %zd != %zd mismatch",
+		TEST_FAIL("%s config compare: count %"PRIusz" != %"PRIusz" mismatch",
 			  desc, acnt, bcnt);
 
 	for (i = 0 ; i < (int)acnt ; i += 2) {

--- a/tests/0039-event.c
+++ b/tests/0039-event.c
@@ -131,7 +131,7 @@ int main_0039_event_dr (int argc, char **argv) {
 		switch (rd_kafka_event_type(rkev))
 		{
 		case RD_KAFKA_EVENT_DR:
-                        TEST_SAYL(3, "%s event with %zd messages\n",
+                        TEST_SAYL(3, "%s event with %"PRIusz" messages\n",
                                   rd_kafka_event_name(rkev),
                                   rd_kafka_event_message_count(rkev));
 			handle_drs(rkev);

--- a/tests/0072-headers_ut.c
+++ b/tests/0072-headers_ut.c
@@ -275,13 +275,13 @@ static rd_kafka_resp_err_t on_send1 (rd_kafka_t *rk,
 
         header_cnt = rd_kafka_header_cnt(hdrs);
         TEST_ASSERT(header_cnt == 7,
-                    "Expected 7 length got %zd", header_cnt);
+                    "Expected 7 length got %"PRIusz"", header_cnt);
 
         rd_kafka_header_add(hdrs, "multi", -1, "multi4", -1);
 
         header_cnt = rd_kafka_header_cnt(hdrs);
         TEST_ASSERT(header_cnt == 8,
-                    "Expected 8 length got %zd", header_cnt);
+                    "Expected 8 length got %"PRIusz"", header_cnt);
 
         /* test iter() */
         expect_iter(__FUNCTION__, hdrs, "multi", expect_iter_multi, 4);
@@ -292,19 +292,19 @@ static rd_kafka_resp_err_t on_send1 (rd_kafka_t *rk,
 
         header_cnt = rd_kafka_header_cnt(hdrs);
         TEST_ASSERT(header_cnt == 9,
-                    "Expected 9 length got %zd", header_cnt);
+                    "Expected 9 length got %"PRIusz"", header_cnt);
 
         rd_kafka_header_remove(hdrs, "multi");
 
         header_cnt = rd_kafka_header_cnt(hdrs);
         TEST_ASSERT(header_cnt == 5,
-                    "Expected 5 length got %zd", header_cnt);
+                    "Expected 5 length got %"PRIusz"", header_cnt);
 
         rd_kafka_header_add(hdrs, "multi", -1, "multi5", -1);
 
         header_cnt = rd_kafka_header_cnt(hdrs);
         TEST_ASSERT(header_cnt == 6,
-                    "Expected 6 length got %zd", header_cnt);
+                    "Expected 6 length got %"PRIusz"", header_cnt);
 
         /* test get_last() */
         err = rd_kafka_header_get_last(hdrs, "multi", &value, &size);
@@ -388,7 +388,7 @@ int main_0072_headers_ut (int argc, char **argv) {
 
                         header_cnt = rd_kafka_header_cnt(hdrs);
                         TEST_ASSERT(header_cnt == 0,
-                                    "Expected 0 length got %zd", header_cnt);
+                                    "Expected 0 length got %"PRIusz"", header_cnt);
 
                         rd_kafka_headers_t *copied;
 
@@ -404,7 +404,7 @@ int main_0072_headers_ut (int argc, char **argv) {
 
                         header_cnt = rd_kafka_header_cnt(hdrs);
                         TEST_ASSERT(header_cnt == 6,
-                                    "Expected 6 length got %zd", header_cnt);
+                                    "Expected 6 length got %"PRIusz"", header_cnt);
 
                         rd_kafka_headers_destroy(hdrs);
 


### PR DESCRIPTION
 size_t being an unsigned type, '%zu' is the correct format specifier.
 Using '%zd' is technically undefined behaviour (due to sign mismatch).