### PR TITLE
Use sig_atomic_t for vars modified in signal handlers

### DIFF
--- a/examples/consumer.c
+++ b/examples/consumer.c
@@ -44,7 +44,7 @@
 #include "rdkafka.h"
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 
 /**
  * @brief Signal termination of program

--- a/examples/idempotent_producer.c
+++ b/examples/idempotent_producer.c
@@ -50,7 +50,7 @@
 #include "rdkafka.h"
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 
 /**
  * @brief Signal termination of program

--- a/examples/producer.c
+++ b/examples/producer.c
@@ -42,7 +42,7 @@
 #include "rdkafka.h"
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 
 /**
  * @brief Signal termination of program

--- a/examples/producer.cpp
+++ b/examples/producer.cpp
@@ -50,10 +50,10 @@
 #include "rdkafkacpp.h"
 
 
-static bool run = true;
+static volatile sig_atomic_t run = 1;
 
 static void sigterm (int sig) {
-  run = false;
+  run = 0;
 }
 
 

--- a/examples/rdkafka_complex_consumer_example.c
+++ b/examples/rdkafka_complex_consumer_example.c
@@ -47,7 +47,7 @@
 #include "rdkafka.h"  /* for Kafka driver */
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 static rd_kafka_t *rk;
 static int exit_eof = 0;
 static int wait_eof = 0;  /* number of partitions awaiting EOF */

--- a/examples/rdkafka_complex_consumer_example.cpp
+++ b/examples/rdkafka_complex_consumer_example.cpp
@@ -61,7 +61,7 @@
 
 
 
-static bool run = true;
+static volatile sig_atomic_t run = 1;
 static bool exit_eof = false;
 static int eof_cnt = 0;
 static int partition_cnt = 0;
@@ -69,7 +69,7 @@ static int verbosity = 1;
 static long msg_cnt = 0;
 static int64_t msg_bytes = 0;
 static void sigterm (int sig) {
-  run = false;
+  run = 0;
 }
 
 
@@ -99,7 +99,7 @@ class ExampleEventCb : public RdKafka::EventCb {
       case RdKafka::Event::EVENT_ERROR:
         if (event.fatal()) {
           std::cerr << "FATAL ";
-          run = false;
+          run = 0;
         }
         std::cerr << "ERROR (" << RdKafka::err2str(event.err()) << "): " <<
             event.str() << std::endl;
@@ -195,20 +195,20 @@ void msg_consume(RdKafka::Message* message, void* opaque) {
       if (exit_eof && ++eof_cnt == partition_cnt) {
         std::cerr << "%% EOF reached for all " << partition_cnt <<
             " partition(s)" << std::endl;
-        run = false;
+        run = 0;
       }
       break;
 
     case RdKafka::ERR__UNKNOWN_TOPIC:
     case RdKafka::ERR__UNKNOWN_PARTITION:
       std::cerr << "Consume failed: " << message->errstr() << std::endl;
-      run = false;
+      run = 0;
       break;
 
     default:
       /* Errors */
       std::cerr << "Consume failed: " << message->errstr() << std::endl;
-      run = false;
+      run = 0;
   }
 }
 

--- a/examples/rdkafka_consume_batch.cpp
+++ b/examples/rdkafka_consume_batch.cpp
@@ -66,10 +66,10 @@
 
 
 
-static bool run = true;
+static volatile sig_atomic_t run = 1;
 
 static void sigterm (int sig) {
-  run = false;
+  run = 0;
 }
 
 
@@ -116,7 +116,7 @@ consume_batch (RdKafka::KafkaConsumer *consumer, size_t batch_size, int batch_tm
 
     default:
       std::cerr << "%% Consumer error: " << msg->errstr() << std::endl;
-      run = false;
+      run = 0;
       delete msg;
       return msgs;
     }

--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -47,7 +47,7 @@
 #include "rdkafka.h"  /* for Kafka driver */
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 static rd_kafka_t *rk;
 static int exit_eof = 0;
 static int quiet = 0;

--- a/examples/rdkafka_example.cpp
+++ b/examples/rdkafka_example.cpp
@@ -116,11 +116,11 @@ static void metadata_print (const std::string &topic,
   }
 }
 
-static bool run = true;
+static volatile sig_atomic_t run = 1;
 static bool exit_eof = false;
 
 static void sigterm (int sig) {
-  run = false;
+  run = 0;
 }
 
 
@@ -159,7 +159,7 @@ class ExampleEventCb : public RdKafka::EventCb {
       case RdKafka::Event::EVENT_ERROR:
         if (event.fatal()) {
           std::cerr << "FATAL ";
-          run = false;
+          run = 0;
         }
         std::cerr << "ERROR (" << RdKafka::err2str(event.err()) << "): " <<
             event.str() << std::endl;
@@ -237,20 +237,20 @@ void msg_consume(RdKafka::Message* message, void* opaque) {
     case RdKafka::ERR__PARTITION_EOF:
       /* Last message */
       if (exit_eof) {
-        run = false;
+        run = 0;
       }
       break;
 
     case RdKafka::ERR__UNKNOWN_TOPIC:
     case RdKafka::ERR__UNKNOWN_PARTITION:
       std::cerr << "Consume failed: " << message->errstr() << std::endl;
-      run = false;
+      run = 0;
       break;
 
     default:
       /* Errors */
       std::cerr << "Consume failed: " << message->errstr() << std::endl;
-      run = false;
+      run = 0;
   }
 }
 
@@ -551,7 +551,7 @@ int main (int argc, char **argv) {
 
       producer->poll(0);
     }
-    run = true;
+    run = 1;
 
     while (run && producer->outq_len() > 0) {
       std::cerr << "Waiting for " << producer->outq_len() << std::endl;

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -58,7 +58,7 @@
 #endif
 
 
-static int run = 1;
+static volatile sig_atomic_t run = 1;
 static int forever = 1;
 static rd_ts_t dispintvl = 1000;
 static int do_seq = 0;

--- a/tests/test.c
+++ b/tests/test.c
@@ -48,7 +48,7 @@ int test_level = 2;
 int test_seed = 0;
 
 char test_mode[64] = "bare";
-static int  test_exit = 0;
+static volatile sig_atomic_t test_exit = 0;
 static char test_topic_prefix[128] = "rdkafkatest";
 static int  test_topic_random = 0;
 int          tests_running_cnt = 0;


### PR DESCRIPTION
Another minor tweak to a type:
For proper atomicity (with respect to signal handler), the type of variables modified in signal handlers should be 'sig_atomic_t' with 'volatile' qualifier (modifying other types such as a plain 'int' is undefined behaviour even if it works as expected on most platforms). This is atomicity between main code & signal handler i.e. required even in single-threaded program.

In C++ files, used 0 for false and 1 for true respectively just to avoid any confusion and implicit conversions (which is otherwise fine).

sig_atomic_t type is available since C89, so should be reasonably portable.