### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,15 @@ On Windows, reference [librdkafka.redist](https://www.nuget.org/packages/librdka
 For other platforms, follow the source building instructions below.
 
 
-## Building librdkafka - Using vcpkg
+## Installing librdkafka - Using vcpkg
 
 You can download and install librdkafka using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install librdkafka
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ vcpkg install librdkafka
 
 The librdkafka port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ For other platforms, follow the source building instructions below.
 ## Installing librdkafka - Using vcpkg
 
 You can download and install librdkafka using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
+    ```bash
     $ git clone https://github.com/Microsoft/vcpkg.git
     $ cd vcpkg
     $ ./bootstrap-vcpkg.sh
     $ ./vcpkg integrate install
     $ vcpkg install librdkafka
-
+    ```
 The librdkafka port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ On Windows, reference [librdkafka.redist](https://www.nuget.org/packages/librdka
 For other platforms, follow the source building instructions below.
 
 
+## Building librdkafka - Using vcpkg
+
+You can download and install librdkafka using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install librdkafka
+
+The librdkafka port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 ## Build from source
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -72,17 +72,23 @@ On Windows, reference [librdkafka.redist](https://www.nuget.org/packages/librdka
 For other platforms, follow the source building instructions below.
 
 
-## Installing librdkafka - Using vcpkg
+## Installing librdkafka using vcpkg
 
 You can download and install librdkafka using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-    ```bash
-    $ git clone https://github.com/Microsoft/vcpkg.git
-    $ cd vcpkg
-    $ ./bootstrap-vcpkg.sh
-    $ ./vcpkg integrate install
-    $ vcpkg install librdkafka
-    ```
-The librdkafka port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+```bash
+# Install vcpkg if not already installed
+$ git clone https://github.com/Microsoft/vcpkg.git
+$ cd vcpkg
+$ ./bootstrap-vcpkg.sh
+$ ./vcpkg integrate install
+
+# Install librdkafka
+$ vcpkg install librdkafka
+```
+
+The librdkafka paackage in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 
 ## Build from source


### PR DESCRIPTION
librdkafka is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for librdkafka and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build librdkafka, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/librdkafka/portfile.cmake). We try to keep the library maintained as close as possible to the original library.