### PR TITLE
Fix test 0052 and rename test executable generated with CMake

### DIFF
--- a/tests/0052-msg_timestamps.c
+++ b/tests/0052-msg_timestamps.c
@@ -32,11 +32,6 @@
 /**
  * Verify message timestamp behaviour on supporting brokers (>=0.10.0.0).
  * Issue #858
- *
- * FIXME: Intermittent failures:
- *  "consume.easy: consumer_poll() timeout (1/-1 eof, 0/20 msgs)"
- * are due to the really old timestamps being used (my_timestamp, 1234)
- * causing the offset retention cleaner on the broker to kick in.
  */
 struct timestamp_range {
         int64_t min;
@@ -44,12 +39,19 @@ struct timestamp_range {
 };
 
 const struct timestamp_range invalid_timestamp = { -1, -1 };
-const struct timestamp_range broker_timestamp = {
-        946684800000/* 2000-01-01 */, 1577836800000 /* 2020-01-01 */
-};
-const struct timestamp_range my_timestamp = { 1234, 1234 };
+struct timestamp_range broker_timestamp;
+struct timestamp_range my_timestamp;
 
+static void prepare_timestamps() {
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
 
+        /* broker timestamps expected to be within 120 seconds */
+        broker_timestamp.min = ((int64_t)ts.tv_sec * 1000LLU);
+        broker_timestamp.max = broker_timestamp.min + 120 * 1000LLU;
+
+        my_timestamp.min = my_timestamp.max = ((int64_t)ts.tv_sec * 1000LLU);
+}
 
 /**
  * @brief Produce messages according to compress \p codec
@@ -187,6 +189,8 @@ int main_0052_msg_timestamps (int argc, char **argv) {
          *
          * Any other option should honour the producer create timestamps.
          */
+        prepare_timestamps();
+
         test_timestamps("CreateTime",    "0.10.1.0", "none", &my_timestamp);
         test_timestamps("LogAppendTime", "0.10.1.0", "none", &broker_timestamp);
         test_timestamps("CreateTime",    "0.9.0.0",  "none", &invalid_timestamp);

--- a/tests/0052-msg_timestamps.c
+++ b/tests/0052-msg_timestamps.c
@@ -38,19 +38,22 @@ struct timestamp_range {
         int64_t max;
 };
 
-const struct timestamp_range invalid_timestamp = { -1, -1 };
-struct timestamp_range broker_timestamp;
-struct timestamp_range my_timestamp;
+const static struct timestamp_range invalid_timestamp = { -1, -1 };
+static struct timestamp_range broker_timestamp;
+static struct timestamp_range my_timestamp;
 
 static void prepare_timestamps() {
         struct timeval ts;
         rd_gettimeofday(&ts, NULL);
 
-        /* broker timestamps expected to be within 120 seconds */
+        /* broker timestamps expected to be within 600 seconds */
         broker_timestamp.min = ((int64_t)ts.tv_sec * 1000LLU);
-        broker_timestamp.max = broker_timestamp.min + 120 * 1000LLU;
+        broker_timestamp.max = broker_timestamp.min + 600 * 1000LLU;
 
-        my_timestamp.min = my_timestamp.max = ((int64_t)ts.tv_sec * 1000LLU);
+        /* client timestamps: set in the future (24 hours)
+         * to be outside of broker timestamps */
+        my_timestamp.min = my_timestamp.max = (((int64_t)ts.tv_sec + 24*3600LLU)
+        									  * 1000LLU);
 }
 
 /**

--- a/tests/0052-msg_timestamps.c
+++ b/tests/0052-msg_timestamps.c
@@ -38,22 +38,22 @@ struct timestamp_range {
         int64_t max;
 };
 
-const static struct timestamp_range invalid_timestamp = { -1, -1 };
+static const struct timestamp_range invalid_timestamp = { -1, -1 };
 static struct timestamp_range broker_timestamp;
 static struct timestamp_range my_timestamp;
 
-static void prepare_timestamps() {
+static void prepare_timestamps (void) {
         struct timeval ts;
         rd_gettimeofday(&ts, NULL);
 
         /* broker timestamps expected to be within 600 seconds */
-        broker_timestamp.min = ((int64_t)ts.tv_sec * 1000LLU);
-        broker_timestamp.max = broker_timestamp.min + 600 * 1000LLU;
+        broker_timestamp.min = (int64_t)ts.tv_sec * 1000LLU;
+        broker_timestamp.max = broker_timestamp.min + (600 * 1000LLU);
 
         /* client timestamps: set in the future (24 hours)
          * to be outside of broker timestamps */
-        my_timestamp.min = my_timestamp.max = (((int64_t)ts.tv_sec + 24*3600LLU)
-        									  * 1000LLU);
+        my_timestamp.min = my_timestamp.max =
+                ((int64_t)ts.tv_sec + (24 * 3600 * 1000LLU);
 }
 
 /**

--- a/tests/0052-msg_timestamps.c
+++ b/tests/0052-msg_timestamps.c
@@ -53,7 +53,7 @@ static void prepare_timestamps (void) {
         /* client timestamps: set in the future (24 hours)
          * to be outside of broker timestamps */
         my_timestamp.min = my_timestamp.max =
-                ((int64_t)ts.tv_sec + (24 * 3600 * 1000LLU);
+                (int64_t)ts.tv_sec + (24 * 3600 * 1000LLU);
 }
 
 /**

--- a/tests/0052-msg_timestamps.c
+++ b/tests/0052-msg_timestamps.c
@@ -43,8 +43,8 @@ struct timestamp_range broker_timestamp;
 struct timestamp_range my_timestamp;
 
 static void prepare_timestamps() {
-        struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
+        struct timeval ts;
+        rd_gettimeofday(&ts, NULL);
 
         /* broker timestamps expected to be within 120 seconds */
         broker_timestamp.min = ((int64_t)ts.tv_sec * 1000LLU);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,12 +107,12 @@ else()
     list(APPEND sources ../src/tinycthread.c ../src/tinycthread_extra.c)
 endif()
 
-add_executable(rdkafka_test ${sources})
-target_link_libraries(rdkafka_test PUBLIC rdkafka++)
+add_executable(test-runner ${sources})
+target_link_libraries(test-runner PUBLIC rdkafka++)
 
-add_test(NAME RdKafkaTestInParallel COMMAND rdkafka_test -p5)
-add_test(NAME RdKafkaTestSequentially COMMAND rdkafka_test -p1)
-add_test(NAME RdKafkaTestBrokerLess COMMAND rdkafka_test -p5 -l)
+add_test(NAME RdKafkaTestInParallel COMMAND test-runner -p5)
+add_test(NAME RdKafkaTestSequentially COMMAND test-runner -p1)
+add_test(NAME RdKafkaTestBrokerLess COMMAND test-runner -p5 -l)
 
 if(NOT WIN32 AND NOT APPLE)
   set(tests_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Test 0052 is broken since 01JAN2020 - fix test by generating dynamically expected timestamps

Test executable generated by CMake was rdkafka_test while when generated through configure is test-runner. Rename rdkafka_test to test-runner to be consistent