### PR TITLE
Fix build break

### DIFF
--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -31,6 +31,8 @@
  *
  */
 
+#include <stdarg.h>
+
 #include "rd.h"
 #include "rdkafka_int.h"
 #include "rdkafka_txnmgr.h"


### PR DESCRIPTION
Fixing build errors on `debian:stretch`
```
rdkafka_txnmgr.c: In function 'rd_kafka_txn_set_fatal_error':
rdkafka_txnmgr.c:245:9: warning: implicit declaration of function 'va_start' [-Wimplicit-function-declaration]
         va_start(ap, fmt);
         ^~~~~~~~
rdkafka_txnmgr.c:247:9: warning: implicit declaration of function 'va_end' [-Wimplicit-function-declaration]
         va_end(ap);
         ^~~~~~
```
which breaks the build
```
Creating shared library librdkafka++.so.1
gcc  -shared -Wl,-soname,librdkafka++.so.1 RdKafka.o ConfImpl.o HandleImpl.o ConsumerImpl.o ProducerImpl.o KafkaConsumerImpl.o TopicImpl.o TopicPartitionImpl.o MessageImpl.o HeadersImpl.o QueueImpl.o MetadataImpl.o -o librdkafka++.so.1 -L../src -lrdkafka -lstdc++
Creating static library librdkafka++.a
ar rcs librdkafka++.a RdKafka.o ConfImpl.o HandleImpl.o ConsumerImpl.o ProducerImpl.o KafkaConsumerImpl.o TopicImpl.o TopicPartitionImpl.o MessageImpl.o HeadersImpl.o QueueImpl.o MetadataImpl.o
Creating librdkafka++.so symlink
rm -f "librdkafka++.so" && ln -s "librdkafka++.so.1" "librdkafka++.so"
Generating pkg-config file rdkafka++.pc
Generating pkg-config file rdkafka++-static.pc
Checking librdkafka++ integrity
librdkafka++.so.1              OK
librdkafka++.a                 OK
make[1]: Leaving directory '/go/librdkafka/src-cpp'
make -C examples
make[1]: Entering directory '/go/librdkafka/examples'
gcc -g -O2 -fPIC -Wall -Wsign-compare -Wfloat-equal -Wpointer-arith -Wcast-align -I../src rdkafka_example.c -o rdkafka_example  \
	../src/librdkafka.a -lm -ldl -lpthread -lrt
../src/librdkafka.a(rdkafka_txnmgr.o): In function `rd_kafka_txn_coord_set':
/go/librdkafka/src/rdkafka_txnmgr.c:2486: undefined reference to `va_start'
/go/librdkafka/src/rdkafka_txnmgr.c:2488: undefined reference to `va_end'
../src/librdkafka.a(rdkafka_txnmgr.o): In function `rd_kafka_txn_curr_api_reply':
/go/librdkafka/src/rdkafka_txnmgr.c:365: undefined reference to `va_start'
/go/librdkafka/src/rdkafka_txnmgr.c:367: undefined reference to `va_end'
../src/librdkafka.a(rdkafka_txnmgr.o): In function `rd_kafka_txn_set_fatal_error':
/go/librdkafka/src/rdkafka_txnmgr.c:245: undefined reference to `va_start'
/go/librdkafka/src/rdkafka_txnmgr.c:247: undefined reference to `va_end'
../src/librdkafka.a(rdkafka_txnmgr.o): In function `rd_kafka_txn_set_abortable_error':
/go/librdkafka/src/rdkafka_txnmgr.c:298: undefined reference to `va_start'
/go/librdkafka/src/rdkafka_txnmgr.c:300: undefined reference to `va_end'
collect2: error: ld returned 1 exit status
Makefile:18: recipe for target 'rdkafka_example' failed
make[1]: Leaving directory '/go/librdkafka/examples'
make[1]: *** [rdkafka_example] Error 1
make: *** [examples] Error 2
Makefile:44: recipe for target 'examples' failed
ERROR: Service 'xxxx-xxxxx' failed to build: The command '/bin/sh -c git clone https://github.com/edenhill/librdkafka.git && cd librdkafka && ./configure --prefix /usr && make && make install' returned a non-zero code: 2
Failed with exit code: 1

Exited with code exit status 1
```