### PR TITLE
Fix crash on metadata update (regression in txns PR)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
 - for distro in $ADDITIONAL_BUILDS ; do packaging/tools/distro-build.sh $distro || exit 1 ; done
 - if [[ $COPYRIGHT_CHECK == y ]]; then make copyright-check ; fi
 - if [[ $DOC_CHECK == y ]]; then make docs ; fi
-- if [[ $RUN_INTEGRATION_TESTS == y ]]; then (cd tests && ./interactive_broker_version.py -c "make quick" 2.3.0) ; fi
+- if [[ $RUN_INTEGRATION_TESTS == y ]]; then (cd tests && ./interactive_broker_version.py -c "make quick" 2.4.0) ; fi
 - if [[ -f tests/core ]] && (which gdb >/dev/null); then (cd tests && LD_LIBRARY_PATH=../src:../src-cpp gdb ./test-runner core < backtrace.gdb) ; fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     - sudo dpkg -i rapidjson-dev.deb
     - sudo pip install -r tests/requirements.txt
     - sudo apt update
-    - sudo apt install -y doxygen graphviz
+    - sudo apt install -y doxygen graphviz gdb
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
  - name: "Linux GCC: +devel +code-cov"
    os: linux
@@ -65,6 +65,7 @@ script:
 - if [[ $COPYRIGHT_CHECK == y ]]; then make copyright-check ; fi
 - if [[ $DOC_CHECK == y ]]; then make docs ; fi
 - if [[ $RUN_INTEGRATION_TESTS == y ]]; then (cd tests && ./interactive_broker_version.py -c "make quick" 2.3.0) ; fi
+- if [[ -f tests/core ]] && (which gdb >/dev/null); then (cd tests && LD_LIBRARY_PATH=../src:../src-cpp gdb ./test-runner core < backtrace.gdb) ; fi
 
 deploy:
   provider: s3

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -5703,6 +5703,7 @@ rd_kafka_broker_update (rd_kafka_t *rk, rd_kafka_secproto_t proto,
 		rd_kafka_wrunlock(rk);
                 if (rkbp)
                         *rkbp = NULL;
+                return;
 	}
 
 	if ((rkb = rd_kafka_broker_find_by_nodeid(rk, mdb->id))) {

--- a/tests/backtrace.gdb
+++ b/tests/backtrace.gdb
@@ -1,0 +1,30 @@
+p *test
+bt full
+list
+
+p *rk
+p *rkb
+p *rkb.rkb_rk
+
+up
+p *rk
+p *rkb
+p *rkb.rkb_rk
+
+up
+p *rk
+p *rkb
+p *rkb.rkb_rk
+
+up
+p *rk
+p *rkb
+p *rkb.rkb_rk
+
+up
+p *rk
+p *rkb
+p *rkb.rkb_rk
+
+thread apply all bt
+quit


### PR DESCRIPTION
And bump travis integration tests to AK 2.4.0.
And attempt to get a backtrace if tests crash on travis.