### PR TITLE
Txn producer must bump epoch through broker, not locally.

### DIFF
--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -164,9 +164,12 @@ rd_tmpabuf_write_str0 (const char *func, int line,
 			rd_kafka_assert(NULL, rkbuf->rkbuf_rkb);	\
                         rd_rkb_log(rkbuf->rkbuf_rkb, log_decode_errors, \
                                    "PROTOERR",                          \
-                                   "Protocol parse failure "            \
+                                   "Protocol parse failure for %s v%hd " \
                                    "at %"PRIusz"/%"PRIusz" (%s:%i) "    \
                                    "(incorrect broker.version.fallback?)", \
+                                   rd_kafka_ApiKey2str(rkbuf->rkbuf_reqhdr. \
+                                                       ApiKey),         \
+                                   rkbuf->rkbuf_reqhdr.ApiVersion,      \
                                    rd_slice_offset(&rkbuf->rkbuf_reader), \
                                    rd_slice_size(&rkbuf->rkbuf_reader), \
                                    __FUNCTION__, __LINE__);             \

--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -550,6 +550,14 @@ void rd_kafka_idemp_drain_epoch_bump (rd_kafka_t *rk, const char *fmt, ...) {
         rd_vsnprintf(buf, sizeof(buf), fmt, ap);
         va_end(ap);
 
+        if (rd_kafka_is_transactional(rk)) {
+                /* Only the Idempotent Producer is allowed to bump its own
+                 * epoch, the Transactional Producer needs to ask the broker
+                 * to bump it. */
+                rd_kafka_idemp_drain_reset(rk, buf);
+                return;
+        }
+
         rd_kafka_wrlock(rk);
         rd_kafka_dbg(rk, EOS, "DRAIN",
                      "Beginning partition drain for %s epoch bump "


### PR DESCRIPTION
Bump the epoch locally, which is okay for the idempotent producer, is not allowed for the transactional producer since the broker needs to track state of each pid+epoch.
However, this is not yet enforced by the broker which leads to inconsistent state and transactional.id states that go into a blocked unusable state.
