### PR TITLE
Fix lintian-detected misspellings

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -1759,7 +1759,7 @@ rd_kafka_mock_cluster_cmd (rd_kafka_mock_cluster_t *mcluster,
 
                 rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
                              "Set %s [%"PRId32"] follower "
-                             "watermark offets to %"PRId64"..%"PRId64,
+                             "watermark offsets to %"PRId64"..%"PRId64,
                              rko->rko_u.mock.name, rko->rko_u.mock.partition,
                              rko->rko_u.mock.lo, rko->rko_u.mock.hi);
 

--- a/src/rdkafka_sasl_scram.c
+++ b/src/rdkafka_sasl_scram.c
@@ -699,7 +699,7 @@ rd_kafka_sasl_scram_handle_server_final_message (
                  * but we need to verify the ServerSignature too. */
                 rd_rkb_dbg(rktrans->rktrans_rkb, SECURITY | RD_KAFKA_DBG_BROKER,
                            "SCRAMAUTH",
-                           "SASL SCRAM authentication succesful on server: "
+                           "SASL SCRAM authentication successful on server: "
                            "verifying ServerSignature");
 
                 if (strcmp(attr_v, state->ServerSignatureB64)) {


### PR DESCRIPTION
Just a minor fixup :) These misspellings generate [warnings](https://lintian.debian.org/tags/spelling-error-in-binary.html) in `lintian` (Debian's package linter).

```
I: librdkafka1: spelling-error-in-binary usr/lib/x86_64-linux-gnu/librdkafka.so.1 offets offsets
I: librdkafka1: spelling-error-in-binary usr/lib/x86_64-linux-gnu/librdkafka.so.1 succesful successful
```