### PR TITLE
Honour array size in rd_kafka_event_message_array() to avoid overflow…

### DIFF
--- a/src/rdkafka_event.c
+++ b/src/rdkafka_event.c
@@ -131,11 +131,12 @@ rd_kafka_event_message_next (rd_kafka_event_t *rkev) {
 
 
 size_t rd_kafka_event_message_array (rd_kafka_event_t *rkev,
-				     const rd_kafka_message_t **rkmessages, size_t size) {
+				     const rd_kafka_message_t **rkmessages,
+                                     size_t size) {
 	size_t cnt = 0;
 	const rd_kafka_message_t *rkmessage;
 
-	while ((rkmessage = rd_kafka_event_message_next(rkev)))
+	while (cnt < size && (rkmessage = rd_kafka_event_message_next(rkev)))
 		rkmessages[cnt++] = rkmessage;
 
 	return cnt;


### PR DESCRIPTION
… (#2773)