### PR TITLE
max.poll.interval.ms should only be enforced when using subscribe()

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2036,7 +2036,7 @@ rd_kafka_t *rd_kafka_new (rd_kafka_type_t type, rd_kafka_conf_t *app_conf,
         rd_interval_init(&rk->rk_suppress.sparse_connect_random);
         mtx_init(&rk->rk_suppress.sparse_connect_lock, mtx_plain);
 
-        rd_atomic64_init(&rk->rk_ts_last_poll, INT64_MAX);
+        rd_atomic64_init(&rk->rk_ts_last_poll, rd_clock());
 
 	rk->rk_rep = rd_kafka_q_new(rk);
 	rk->rk_ops = rd_kafka_q_new(rk);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -1884,18 +1884,21 @@ rd_kafka_cgrp_partitions_fetch_start0 (rd_kafka_cgrp_t *rkcg,
 		rd_kafka_cgrp_set_join_state(rkcg,
 					     RD_KAFKA_CGRP_JOIN_STATE_STARTED);
 
-                /* Start a timer to enforce `max.poll.interval.ms`.
-                 * Instead of restarting the timer on each ...poll() call,
-                 * which would be costly (once per message), set up an
-                 * intervalled timer that checks a timestamp
-                 * (that is updated on ..poll()).
-                 * The timer interval is 2 hz. */
-
-                rd_kafka_timer_start(&rkcg->rkcg_rk->rk_timers,
-                             &rkcg->rkcg_max_poll_interval_tmr,
-                             500 * 1000ll /* 500ms */,
-                             rd_kafka_cgrp_max_poll_interval_check_tmr_cb,
-                             rkcg);
+                if (rkcg->rkcg_subscription) {
+                        /* If using subscribe(), start a timer to enforce
+                         * `max.poll.interval.ms`.
+                         * Instead of restarting the timer on each ...poll()
+                         * call, which would be costly (once per message),
+                         * set up an intervalled timer that checks a timestamp
+                         * (that is updated on ..poll()).
+                         * The timer interval is 2 hz. */
+                        rd_kafka_timer_start(
+                                &rkcg->rkcg_rk->rk_timers,
+                                &rkcg->rkcg_max_poll_interval_tmr,
+                                500 * 1000ll /* 500ms */,
+                                rd_kafka_cgrp_max_poll_interval_check_tmr_cb,
+                                rkcg);
+                }
 
                 for (i = 0 ; i < assignment->cnt ; i++) {
                         rd_kafka_topic_partition_t *rktpar =


### PR DESCRIPTION
For https://github.com/confluentinc/confluent-kafka-dotnet/issues/1220

This needs to go into v1.4