### PR TITLE
Export rd_kafka_message_errstr() as proper symbol, not inline (#2822)

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1331,18 +1331,8 @@ void rd_kafka_message_destroy(rd_kafka_message_t *rkmessage);
  *
  * @remark This function MUST NOT be used with the producer.
  */
-static RD_INLINE const char *
-RD_UNUSED
-rd_kafka_message_errstr(const rd_kafka_message_t *rkmessage) {
-	if (!rkmessage->err)
-		return NULL;
-
-	if (rkmessage->payload)
-		return (const char *)rkmessage->payload;
-
-	return rd_kafka_err2str(rkmessage->err);
-}
-
+RD_EXPORT
+const char *rd_kafka_message_errstr (const rd_kafka_message_t *rkmessage);
 
 
 /**

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -46,6 +46,17 @@
 #include <stdarg.h>
 
 
+const char *rd_kafka_message_errstr (const rd_kafka_message_t *rkmessage) {
+        if (!rkmessage->err)
+                return NULL;
+
+        if (rkmessage->payload)
+                return (const char *)rkmessage->payload;
+
+        return rd_kafka_err2str(rkmessage->err);
+}
+
+
 /**
  * @brief Check if producing is allowed.
  *


### PR DESCRIPTION
This allows non-C languages (like .NET!) to use it without the need of a C compiler.