### PR TITLE
Centos 8 RPMs for 1.4.x

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -5,7 +5,7 @@
       "buildenv": "xenial-amd64",
       "builddeps": [
         "build-essential",
-        "python",
+        "python3",
         "zlib1g-dev",
         "libssl-dev",
         "libsasl2-dev",
@@ -26,7 +26,7 @@
       "buildenv": "xenial-i386",
       "builddeps": [
         "build-essential",
-        "python",
+        "python3",
         "zlib1g-dev",
         "libssl-dev",
         "libsasl2-dev",
@@ -48,7 +48,7 @@
       "buildenv": "xenial-armhf",
       "builddeps": [
         "build-essential",
-        "python",
+        "python3",
         "zlib1g-dev",
         "libssl-dev",
         "libsasl2-dev",
@@ -71,7 +71,7 @@
       "buildenv": "stretch-mips",
       "builddeps": [
         "build-essential",
-        "python",
+        "python3",
         "zlib1g-dev",
         "libssl-dev",
         "libsasl2-dev",
@@ -94,7 +94,7 @@
       "buildenv": "xenial-amd64",
       "builddeps": [
         "build-essential",
-        "python",
+        "python3",
         "zlib1g-dev",
         "libssl-dev",
         "libsasl2-dev",

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,9 @@ install:
 
 before_script:
 script:
-- make -j2 all examples check && make -j2 -C tests build
-- if [[ $RUN_INTEGRATION_TESTS != y ]]; then make -C tests run_local_quick ; fi
-- make install
+- if [[ $SKIP_MAKE != y ]]; then make -j2 all examples check && make -j2 -C tests build ; fi
+- if [[ $SKIP_MAKE != y && $RUN_INTEGRATION_TESTS != y ]]; then make -C tests run_local_quick ; fi
+- if [[ $SKIP_MAKE != y ]]; then make install ; fi
 - if [[ -z $NO_ARTIFACTS ]]; then (cd dest && tar cvzf ../artifacts/librdkafka-${CC}.tar.gz .) ; fi
 - for distro in $ADDITIONAL_BUILDS ; do packaging/tools/distro-build.sh $distro || exit 1 ; done
 - if [[ $COPYRIGHT_CHECK == y ]]; then make copyright-check ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
 addons:
   apt:
     packages:
+    - python3
+    - python3-pip
+    - python3-setuptools
     # required by openssl installer
     - perl
 
@@ -56,7 +59,7 @@ matrix:
    before_script:
     - wget -O rapidjson-dev.deb https://launchpad.net/ubuntu/+archive/primary/+files/rapidjson-dev_1.1.0+dfsg2-3_all.deb
     - sudo dpkg -i rapidjson-dev.deb
-    - sudo pip install -r tests/requirements.txt
+    - sudo pip3 install -r tests/requirements.txt
     - sudo apt update
     - sudo apt install -y doxygen graphviz gdb
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,16 @@ addons:
 
 matrix:
  include:
- - name: "Linux GCC: +centos +debian"
+ - name: "Linux GCC: +Debian packages"
    os: linux
    compiler: gcc
-   env: ADDITIONAL_BUILDS="centos debian" LINKAGE=std
+   env: ADDITIONAL_BUILDS="debian" LINKAGE=std
    before_script:
     - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
+ - name: "RPM packages"
+   os: linux
+   compiler: gcc
+   env: ADDITIONAL_BUILDS="centos" SKIP_MAKE=y
  - name: "Linux clang: +alpine"
    os: linux
    compiler: clang

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOC_FILES+=	LICENSE LICENSES.txt INTRODUCTION.md README.md \
 		CONFIGURATION.md STATISTICS.md
 
 PKGNAME?=	librdkafka
-VERSION?=	$(shell python packaging/get_version.py src/rdkafka.h)
+VERSION?=	$(shell python3 packaging/get_version.py src/rdkafka.h)
 
 # Jenkins CI integration
 BUILD_NUMBER ?= 1

--- a/configure.self
+++ b/configure.self
@@ -266,10 +266,10 @@ void foo (void) {
 	mkl_mkvar_set SYMDUMPER SYMDUMPER 'echo'
     fi
 
-    # The linker-script generator (lds-gen.py) requires python
+    # The linker-script generator (lds-gen.py) requires python3
     if [[ $WITH_LDS == y ]]; then
-        if ! mkl_command_check python "HAVE_PYTHON" "disable" "python -V"; then
-            mkl_err "disabling linker-script since python is not available"
+        if ! mkl_command_check python3 "HAVE_PYTHON" "disable" "python3 -V"; then
+            mkl_err "disabling linker-script since python3 is not available"
             mkl_mkvar_set WITH_LDS WITH_LDS "n"
         fi
     fi

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: librdkafka
 Priority: optional
 Maintainer: Faidon Liambotis <paravoid@debian.org>
 Uploaders: Christos Trochalakis <ctrochalakis@debian.org>
-Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, liblz4-dev, python
+Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, liblz4-dev, python3
 Standards-Version: 3.9.7
 Section: libs
 Homepage: https://github.com/edenhill/librdkafka

--- a/lds-gen.py
+++ b/lds-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # librdkafka - Apache Kafka C library
 #

--- a/packaging/RELEASE.md
+++ b/packaging/RELEASE.md
@@ -138,7 +138,7 @@ On a Linux host with docker installed, this will also require S3 credentials
 to be set up.
 
     $ cd packaging/nuget
-    $ pip install -r requirements.txt  # if necessary
+    $ pip3 install -r requirements.txt  # if necessary
     $ ./release.py v0.11.1-RC1
 
 Test the generated librdkafka.redist.0.11.1-RC1.nupkg and

--- a/packaging/alpine/build-alpine.sh
+++ b/packaging/alpine/build-alpine.sh
@@ -9,7 +9,7 @@ if [ "$1" = "--in-docker" ]; then
     # Runs in docker, performs the actual build.
     shift
 
-    apk add bash curl gcc g++ make musl-dev bsd-compat-headers git python perl
+    apk add bash curl gcc g++ make musl-dev bsd-compat-headers git python3 perl
 
     git clone /v /librdkafka
 

--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -8,7 +8,7 @@ arch=('x86_64')
 source=('git+https://github.com/edenhill/librdkafka#branch=master')
 sha256sums=('SKIP')
 depends=(glibc libsasl lz4 openssl zlib zstd)
-makedepends=(bash git python)
+makedepends=(bash git python3)
 
 pkgver() {
 	cd "$pkgname"

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,7 +1,7 @@
 Source: librdkafka
 Priority: optional
 Maintainer: Faidon Liambotis <paravoid@debian.org>
-Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, python
+Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, python3
 Standards-Version: 3.9.6
 Section: libs
 Homepage: https://github.com/edenhill/librdkafka

--- a/packaging/debian/librdkafka.dsc
+++ b/packaging/debian/librdkafka.dsc
@@ -8,7 +8,7 @@ Homepage: https://github.com/edenhill/librdkafka
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/edenhill/librdkafka/tree/master
 Vcs-Git: git://github.com/edenhill/librdkafka.git -b master
-Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, python
+Build-Depends: debhelper (>= 9), zlib1g-dev, libssl-dev, libsasl2-dev, python3
 Package-List:
  librdkafka-dev deb libdevel optional arch=any
  librdkafka1 deb libs optional arch=any

--- a/packaging/get_version.py
+++ b/packaging/get_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 
@@ -18,4 +18,4 @@ minor = int(version[4:6], 16)
 patch = int(version[6:8], 16)
 version = '.'.join(str(item) for item in (major, minor, patch))
 
-print version
+print(version)

--- a/packaging/nuget/artifact.py
+++ b/packaging/nuget/artifact.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # Collects CI artifacts from S3 storage, downloading them

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # NuGet packaging script.
 # Assembles a NuGet package using CI artifacts in S3

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -336,7 +336,7 @@ class NugetPackage (Package):
             # Travis Ubuntu 14.04 build
             [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/librdkafka.so.1', 'runtimes/linux-x64/native/librdkafka.so'],
             # Travis CentOS 7 RPM build
-            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka1*.x86_64.rpm'}, './usr/lib64/librdkafka.so.1', 'runtimes/linux-x64/native/centos7-librdkafka.so'],
+            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka1*el7.x86_64.rpm'}, './usr/lib64/librdkafka.so.1', 'runtimes/linux-x64/native/centos7-librdkafka.so'],
             # Alpine build
             [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'alpine-librdkafka.tgz'}, 'librdkafka.so.1', 'runtimes/linux-x64/native/alpine-librdkafka.so'],
 

--- a/packaging/nuget/release.py
+++ b/packaging/nuget/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # NuGet release packaging tool.

--- a/packaging/nuget/zfile/zfile.py
+++ b/packaging/nuget/zfile/zfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import tarfile

--- a/packaging/rpm/.gitignore
+++ b/packaging/rpm/.gitignore
@@ -1,3 +1,7 @@
 *.log
 available_pkgs
 installed_pkgs
+pkgs-*
+arts-*
+cache
+output

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -8,6 +8,9 @@ MOCK_CONFIG?=default
 
 RESULT_DIR?=pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
 
+# Where built packages are copied with `make copy-artifacts`
+ARTIFACTS_DIR?=../../artifacts
+
 all: rpm
 
 
@@ -30,8 +33,10 @@ srpm: build_prepare
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)" \
 		--define "__release $(BUILD_NUMBER)" \
+		--enable-network \
 		--resultdir=$(RESULT_DIR) \
 		--no-clean --no-cleanup-after \
+		--install epel-release \
 		--buildsrpm \
 		--spec=librdkafka.spec \
 		--sources=SOURCES || \
@@ -43,6 +48,7 @@ rpm: srpm
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)"\
 		--define "__release $(BUILD_NUMBER)"\
+		--enable-network \
 		--resultdir=$(RESULT_DIR) \
 		--no-clean --no-cleanup-after \
 		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm || \
@@ -50,7 +56,7 @@ rpm: srpm
 	@echo "======= Binary RPMs now available in $(RESULT_DIR) ======="
 
 copy-artifacts:
-	cp $(RESULT_DIR)/*rpm ../../artifacts/
+	cp $(RESULT_DIR)/*rpm $(ARTIFACTS_DIR)
 
 clean:
 	rm -rf SOURCES
@@ -74,7 +80,10 @@ prepare_ubuntu:
 	addgroup --system mock || true
 	adduser $$(whoami) mock
 	/usr/bin/mock -r $(MOCK_CONFIG) --init
-	/usr/bin/mock -r $(MOCK_CONFIG) --no-cleanup-after --install epel-release shadow-utils
+	/usr/bin/mock -r $(MOCK_CONFIG) \
+		--enable-network \
+		--no-cleanup-after \
+		--install epel-release shadow-utils
 
 prepare_centos:
 	yum install -y -q mock make git

--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -31,6 +31,7 @@ build_prepare: archive
 srpm: build_prepare
 	/usr/bin/mock \
 		-r $(MOCK_CONFIG) \
+		$(MOCK_OPTIONS) \
 		--define "__version $(VERSION)" \
 		--define "__release $(BUILD_NUMBER)" \
 		--enable-network \
@@ -46,6 +47,7 @@ srpm: build_prepare
 rpm: srpm
 	/usr/bin/mock \
 		-r $(MOCK_CONFIG) \
+		$(MOCK_OPTIONS) \
 		--define "__version $(VERSION)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--enable-network \

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,5 +1,14 @@
 # RPM packages for librdkafka
 
+On a system with RPM mock installed, simply run make to create RPM packages:
+
+    $ make
+
+Additional mock options may be specified using MOCK_OPTIONS:
+
+    $ make MOCK_OPTIONS='--bootstrap-chroot'
+
+
 ## Build with Mock on docker
 
 From the librdkafka top-level directory:

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,14 @@
+# RPM packages for librdkafka
+
+## Build with Mock on docker
+
+From the librdkafka top-level directory:
+
+    $ packaging/rpm/mock-on-docker.sh
+
+Wait for packages to build, they will be copied to top-level dir artifacts/
+
+Test the packages:
+
+    $ packaging/rpm/tests/test-on-docker.sh
+

--- a/packaging/rpm/librdkafka.spec
+++ b/packaging/rpm/librdkafka.spec
@@ -9,7 +9,7 @@ License: BSD-2-Clause
 URL:     https://github.com/edenhill/librdkafka
 Source:	 librdkafka-%{version}.tar.gz
 
-BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ openssl-devel cyrus-sasl-devel python3
+BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ openssl-devel cyrus-sasl-devel
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %define _source_payload w9.gzdio
@@ -26,8 +26,12 @@ Requires: zlib libstdc++ cyrus-sasl
 # openssl libraries were extract to openssl-libs in RHEL7
 %if 0%{?rhel} >= 7
 Requires: openssl-libs
+BuildRequires: python3
 %else
 Requires: openssl
+# python34 is provided from epel-release, but that package needs to be installed
+# prior to rpmbuild working out these dependencies (such as from mock).
+BuildRequires: python34
 %endif
 
 %description -n %{name}%{soname}

--- a/packaging/rpm/librdkafka.spec
+++ b/packaging/rpm/librdkafka.spec
@@ -9,7 +9,7 @@ License: BSD-2-Clause
 URL:     https://github.com/edenhill/librdkafka
 Source:	 librdkafka-%{version}.tar.gz
 
-BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ openssl-devel cyrus-sasl-devel python
+BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ openssl-devel cyrus-sasl-devel python3
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %define _source_payload w9.gzdio

--- a/packaging/rpm/librdkafka.spec
+++ b/packaging/rpm/librdkafka.spec
@@ -9,7 +9,7 @@ License: BSD-2-Clause
 URL:     https://github.com/edenhill/librdkafka
 Source:	 librdkafka-%{version}.tar.gz
 
-BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ openssl-devel cyrus-sasl-devel
+BuildRequires: zlib-devel libstdc++-devel gcc >= 4.1 gcc-c++ cyrus-sasl-devel
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %define _source_payload w9.gzdio
@@ -25,13 +25,13 @@ Group:   Development/Libraries/C and C++
 Requires: zlib libstdc++ cyrus-sasl
 # openssl libraries were extract to openssl-libs in RHEL7
 %if 0%{?rhel} >= 7
-Requires: openssl-libs
-BuildRequires: python3
+Requires: openssl-libs >= 1.0.2
+BuildRequires: openssl-devel >= 1.0.2 python3
 %else
 Requires: openssl
 # python34 is provided from epel-release, but that package needs to be installed
 # prior to rpmbuild working out these dependencies (such as from mock).
-BuildRequires: python34
+BuildRequires: openssl-devel python34
 %endif
 
 %description -n %{name}%{soname}

--- a/packaging/rpm/mock-on-docker.sh
+++ b/packaging/rpm/mock-on-docker.sh
@@ -1,17 +1,35 @@
 #!/bin/bash
 #
 #
-
-# Run mock in docker
+#
+# Run mock in docker to create RPM packages of librdkafka.
+#
+# Usage:
+#   packaging/rpm/mock-on-docker.sh [<mock configs ..>]
+#
 
 set -ex
 
-_DOCKER_IMAGE=centos:7
-export MOCK_CONFIG=epel-7-x86_64
+_DOCKER_IMAGE=fedora:33
+_MOCK_CONFIGS="epel-6-x86_64 epel-7-x86_64 epel-8-x86_64"
 
-if [[ ! -f /.dockerenv ]]; then
+if [[ $1 == "--build" ]]; then
+    on_builder=1
+    shift
+else
+    on_builder=0
+fi
+
+
+if [[ -n $* ]]; then
+    _MOCK_CONFIGS="$*"
+fi
+
+
+if [[ $on_builder == 0 ]]; then
     #
-    # Running on host, fire up a docker container a run it.
+    # Running on host, fire up a docker container and run the latter
+    # part of this script in docker.
     #
 
     if [[ ! -f configure.self ]]; then
@@ -19,23 +37,58 @@ if [[ ! -f /.dockerenv ]]; then
         exit 1
     fi
 
-    docker run --privileged=true -t -v $(pwd):/io \
-          $_DOCKER_IMAGE /io/packaging/rpm/mock-on-docker.sh
+    mkdir -p ${PWD}/packaging/rpm/cache/mock
 
-    pushd packaging/rpm
-    make copy-artifacts
-    popd
+    docker run --cap-add=SYS_ADMIN \
+           --privileged \
+           -t \
+           -v ${PWD}/packaging/rpm/cache/mock:/var/cache/mock \
+           -v ${PWD}:/io \
+           $_DOCKER_IMAGE \
+           /io/packaging/rpm/mock-on-docker.sh --build $_MOCK_CONFIGS
+
+    mkdir -p artifacts
+    for MOCK_CONFIG in $_MOCK_CONFIGS ; do
+        cp -vr --no-preserve=ownership packaging/rpm/arts-${MOCK_CONFIG}/*rpm artifacts/
+    done
+
+    echo "All Done"
 
 else
+    #
+    # Running in docker container.
+    #
 
-    yum install -y python3 mock make git
+    dnf install -y -q mock mock-core-configs make git
 
-    cfg_file=/etc/mock/${MOCK_CONFIG}.cfg
-    ls -la /etc/mock
-    echo "config_opts['plugin_conf']['bind_mount_enable'] = False" >> $cfg_file
-    echo "config_opts['package_manager'] = 'yum'" >> $cfg_file
-    cat $cfg_file
+    echo "%_netsharedpath /sys:/proc" >> /etc/rpm/macros.netshared
+
     pushd /io/packaging/rpm
-    make all
+
+    for MOCK_CONFIG in $_MOCK_CONFIGS ; do
+        cfg_file=/etc/mock/${MOCK_CONFIG}.cfg
+        if [[ ! -f $cfg_file ]]; then
+            echo "Error: Mock config $cfg_file does not exist"
+            exit 1
+        fi
+
+        echo "config_opts['plugin_conf']['bind_mount_enable'] = False" >> $cfg_file
+        echo "config_opts['docker_unshare_warning'] = False" >> $cfg_file
+        echo "Building $MOCK_CONFIG in $PWD"
+        cat $cfg_file
+
+        export MOCK_CONFIG=$MOCK_CONFIG
+        make all
+
+        echo "Done building $MOCK_CONFIG: copying artifacts"
+        artdir="arts-$MOCK_CONFIG"
+        mkdir -p "$artdir"
+        make ARTIFACTS_DIR="$artdir" copy-artifacts
+
+    done
+
     popd
+    echo "Done"
 fi
+
+exit 0

--- a/packaging/rpm/mock-on-docker.sh
+++ b/packaging/rpm/mock-on-docker.sh
@@ -28,7 +28,7 @@ if [[ ! -f /.dockerenv ]]; then
 
 else
 
-    yum install -y python mock make git
+    yum install -y python3 mock make git
 
     cfg_file=/etc/mock/${MOCK_CONFIG}.cfg
     ls -la /etc/mock

--- a/packaging/rpm/mock-on-docker.sh
+++ b/packaging/rpm/mock-on-docker.sh
@@ -39,7 +39,7 @@ if [[ $on_builder == 0 ]]; then
 
     mkdir -p ${PWD}/packaging/rpm/cache/mock
 
-    docker run --cap-add=SYS_ADMIN \
+    docker run \
            --privileged \
            -t \
            -v ${PWD}/packaging/rpm/cache/mock:/var/cache/mock \

--- a/packaging/rpm/tests/.gitignore
+++ b/packaging/rpm/tests/.gitignore
@@ -1,0 +1,2 @@
+test
+testcpp

--- a/packaging/rpm/tests/Makefile
+++ b/packaging/rpm/tests/Makefile
@@ -1,0 +1,12 @@
+
+all: test testcpp
+
+test: test.c
+	$(CC) -O2 -Werror -Wall $^ -o $@ $$(pkg-config --libs rdkafka)
+
+testcpp: test.cpp
+	$(CXX) -O2 -Werror -Wall $^ -o $@ $$(pkg-config --libs rdkafka++)
+
+
+clean:
+	rm -f test testcpp

--- a/packaging/rpm/tests/README.md
+++ b/packaging/rpm/tests/README.md
@@ -1,0 +1,8 @@
+# Test librdkafka RPMs using docker
+
+After building the RPMs (see README.md in parent directory) test
+the RPMs on the supported CentOS/RHEL versions using:
+
+    $ packaging/rpm/tests/test-on-docker.sh
+
+

--- a/packaging/rpm/tests/run-test.sh
+++ b/packaging/rpm/tests/run-test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# This script runs in the docker container, performing:
+# * install build toolchain
+# * install librdkafka rpms
+# * builds test apps
+# * runs test apps
+#
+# Usage: $0 <docker-image-name>
+
+set -ex
+
+pushd /v
+
+_IMG=$1
+
+echo "Testing on $_IMG"
+
+if [[ $_IMG == "centos:6" ]]; then
+    _EL=6
+    _INST="yum install -y -q"
+elif [[ $_IMG == "centos:7" ]]; then
+    _EL=7
+    _INST="yum install -y -q"
+    # centos:7 ships with openssl-libs 1.0.1 which is outdated and not
+    # ABI-compatible with 1.0.2 (which we build with).
+    # Upgrade openssl-libs, as users would, to prevent missing symbols.
+    _UPG="yum upgrade -y openssl-libs"
+else
+    _EL=8
+    _INST="dnf install -y -q"
+fi
+
+$_INST gcc gcc-c++ make pkg-config
+
+if [[ -n $_UPG ]]; then
+    $_UPG
+fi
+
+$_INST /rpms/librdkafka1-*el${_EL}.x86_64.rpm /rpms/librdkafka-devel-*el${_EL}.x86_64.rpm
+
+make clean all
+
+./test
+
+./testcpp
+
+make clean
+
+echo "$_IMG is all good!"
+

--- a/packaging/rpm/tests/test-on-docker.sh
+++ b/packaging/rpm/tests/test-on-docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+#
+# Test librdkafka packages in <rpmdirectory> using docker.
+# Must be executed from the librdkafka top-level directory.
+#
+# Usage:
+#   packaging/rpm/test-on-docker.sh [<rpm-dir>]
+
+set -ex
+
+if [[ ! -f configure.self ]]; then
+    echo "Must be executed from the librdkafka top-level directory"
+    exit 1
+fi
+
+_DOCKER_IMAGES="centos:6 centos:7 centos:8"
+_RPMDIR=artifacts
+
+if [[ -n $1 ]]; then
+    _RPMDIR="$1"
+    echo "Usage: $0 <path/to/rpmdirectory>"
+    exit 1
+fi
+
+_RPMDIR=$(readlink -f $_RPMDIR)
+
+if [[ ! -d $_RPMDIR ]]; then
+    echo "$_RPMDIR does not exist"
+    exit 1
+fi
+
+
+fails=""
+for _IMG in $_DOCKER_IMAGES ; do
+    if ! docker run \
+         -t \
+         -v $_RPMDIR:/rpms \
+         -v $(readlink -f packaging/rpm/tests):/v \
+         $_IMG \
+         /v/run-test.sh $_IMG ; then
+        echo "ERROR: $_IMG FAILED"
+        fails="${fails}$_IMG "
+    fi
+done
+
+if [[ -n $fails ]]; then
+    echo "##################################################"
+    echo "# Package verification failed for:"
+    echo "# $fails"
+    echo "# See previous errors"
+    echo "##################################################"
+    exit 1
+fi
+
+exit 0
+
+

--- a/packaging/rpm/tests/test.c
+++ b/packaging/rpm/tests/test.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <string.h>
+#include <librdkafka/rdkafka.h>
+
+int main (int argc, char **argv) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+        char features[256];
+        size_t fsize = sizeof(features);
+        char errstr[512];
+        const char *exp_features[] = {
+                "gzip",
+                "snappy",
+                "ssl",
+                "sasl",
+                "regex",
+                "lz4",
+                "sasl_gssapi",
+                "sasl_plain",
+                "sasl_scram",
+                "plugins",
+                "zstd",
+                "sasl_oauthbearer",
+                NULL,
+        };
+        const char **exp;
+        int missing = 0;
+
+
+        printf("librdkafka %s\n", rd_kafka_version_str());
+
+        conf = rd_kafka_conf_new();
+        if (rd_kafka_conf_get(conf, "builtin.features", features, &fsize) !=
+            RD_KAFKA_CONF_OK) {
+                fprintf(stderr, "conf_get failed\n");
+                return 1;
+        }
+
+        printf("builtin.features %s\n", features);
+
+        /* Verify that expected features are enabled. */
+        for (exp = exp_features ; *exp ; exp++) {
+                const char *t = features;
+                size_t elen = strlen(*exp);
+                int match = 0;
+
+                while ((t = strstr(t, *exp))) {
+                        if (t[elen] == ',' ||
+                            t[elen] == '\0') {
+                                match = 1;
+                                break;
+                        }
+                        t += elen;
+                }
+
+                if (match)
+                        continue;
+
+                fprintf(stderr, "ERROR: feature %s not found\n", *exp);
+                missing++;
+        }
+
+        if (rd_kafka_conf_set(conf, "security.protocol", "SASL_SSL",
+                              errstr, sizeof(errstr)) ||
+            rd_kafka_conf_set(conf, "sasl.mechanism", "PLAIN",
+                              errstr, sizeof(errstr)) ||
+            rd_kafka_conf_set(conf, "sasl.username", "username",
+                              errstr, sizeof(errstr)) ||
+            rd_kafka_conf_set(conf, "sasl.password", "password",
+                              errstr, sizeof(errstr)) ||
+            rd_kafka_conf_set(conf, "debug", "security",
+                              errstr, sizeof(errstr))) {
+                fprintf(stderr, "conf_set failed: %s\n", errstr);
+                return 1;
+        }
+
+        rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        if (!rk) {
+                fprintf(stderr, "rd_kafka_new failed: %s\n", errstr);
+                return 1;
+        }
+
+        printf("client name %s\n", rd_kafka_name(rk));
+
+        rd_kafka_destroy(rk);
+
+        return missing ? 1 : 0;
+}

--- a/packaging/rpm/tests/test.cpp
+++ b/packaging/rpm/tests/test.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <librdkafka/rdkafkacpp.h>
+
+
+int main () {
+  std::cout << "librdkafka++ " << RdKafka::version_str() << std::endl;
+
+  RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+
+  std::string features;
+
+  if (conf->get("builtin.features", features) != RdKafka::Conf::CONF_OK) {
+    std::cerr << "conf_get failed" << std::endl;
+    return 1;
+  }
+
+  std::cout << "builtin.features " << features << std::endl;
+
+  std::string errstr;
+  RdKafka::Producer *producer = RdKafka::Producer::create(conf, errstr);
+  if (!producer) {
+    std::cerr << "Producer::create failed: " << errstr << std::endl;
+    return 1;
+  }
+
+  delete conf;
+
+  std::cout << "client name " << producer->name() << std::endl;
+
+
+  delete producer;
+
+  return 0;
+}

--- a/packaging/tools/build-debian.sh
+++ b/packaging/tools/build-debian.sh
@@ -25,7 +25,7 @@ fi
 set -u
 
 apt-get update
-apt-get install -y gcc g++ zlib1g-dev python2.7 git-core make
+apt-get install -y gcc g++ zlib1g-dev python3 git-core make
 
 
 # Copy the librdkafka git archive to a new location to avoid messing

--- a/packaging/tools/distro-build.sh
+++ b/packaging/tools/distro-build.sh
@@ -11,6 +11,7 @@ distro=$1
 case $distro in
     centos)
         packaging/rpm/mock-on-docker.sh
+        packaging/rpm/tests/test-on-docker.sh
         ;;
     debian)
         docker run -it -v "$PWD:/v" microsoft/dotnet:2-sdk /v/packaging/tools/build-debian.sh /v /v/artifacts/librdkafka-debian9.tgz

--- a/packaging/tools/gh-release-checksums.py
+++ b/packaging/tools/gh-release-checksums.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Calculate checksums for GitHub release artifacts/assets.
 #

--- a/tests/LibrdkafkaTestApp.py
+++ b/tests/LibrdkafkaTestApp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # librdkafka test trivup app module
 #

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ to alternate directory, e.g., `TRIVUP_ROOT=$HOME/trivup make full`.
 
 First install trivup:
 
-    $ pip install trivup
+    $ pip3 install trivup
 
 Bring up a Kafka cluster (with the specified version) and start an interactive
 shell, when the shell is exited the cluster is brought down and deleted.

--- a/tests/autotest.sh
+++ b/tests/autotest.sh
@@ -21,7 +21,7 @@ pushd tests
 source _venv/bin/activate
 
 # Install trivup that is used to bring up a cluster.
-pip install -U trivup
+pip3 install -U trivup
 
 # Run tests that automatically spin up their clusters
 export KAFKA_VERSION

--- a/tests/broker_version_tests.py
+++ b/tests/broker_version_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # Run librdkafka regression tests on with different SASL parameters

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # Cluster testing helper

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # Run librdkafka regression tests on different supported broker versions.

--- a/tests/performance_plot.py
+++ b/tests/performance_plot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
 import sys, json

--- a/tests/sasl_test.py
+++ b/tests/sasl_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #
 # Run librdkafka regression tests on with different SASL parameters
@@ -11,9 +11,6 @@
 from cluster_testing import LibrdkafkaTestCluster, print_report_summary, print_test_report_summary, read_scenario_conf
 from LibrdkafkaTestApp import LibrdkafkaTestApp
 
-
-import time
-import tempfile
 import os
 import sys
 import argparse
@@ -225,7 +222,7 @@ if __name__ == '__main__':
             else:
                 tests_to_run = tests
             report = test_it(version, tests=tests_to_run, conf=_conf, rdkconf=_rdkconf,
-                             debug=args.debug, scenario=scenario)
+                             debug=args.debug, scenario=args.scenario)
 
             # Handle test report
             report['version'] = version


### PR DESCRIPTION
This is a backport of the work on master which also brings in Python3 support (since `python` is not a valid python2 executable on Centos 8).