### PR TITLE
Shave another 1s off cgrp initialization

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -529,6 +529,9 @@ void rd_kafka_cgrp_coord_query (rd_kafka_cgrp_t *rkcg,
 	rd_kafka_rdunlock(rkcg->rkcg_rk);
 
 	if (!rkb) {
+		/* Reset the interval because there were no brokers. When a
+		 * broker becomes available, we want to query it immediately. */
+		rd_interval_reset(&rkcg->rkcg_coord_query_intvl);
 		rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "CGRPQUERY",
 			     "Group \"%.*s\": "
 			     "no broker available for coordinator query: %s",


### PR DESCRIPTION
Querying for the cgrp coordinator does not need to back off when there
are no brokers connected, as no requests were sent. This avoids an
accident of timing that would cause cgrp initialization to wait an extra
turn of the main rdkafka thread loop, which would add an unnecessary
second of latency.

Inspired by c64b652689.

----

Details follow.

The logs that inspired this change are here: https://gist.github.com/benesch/787791fa96cc75660ecb29cd37d49ddc. Warning: there are some additional debugging log lines that I patched in myself.

The relevant lines are these:

```
May 03 00:40:46.553 DEBUG librdkafka: librdkafka: BRKMAIN [thrd:marmoset:9092/0]: marmoset:9092/0: Enter main broker thread
May 03 00:40:47.542 DEBUG librdkafka: librdkafka: CGRPQUERY [thrd:main]: localhost:9092/bootstrap: Group "materialize-kafka-u1/u2": querying for coordinator: intervaled in state query-coord    
```

Notice the nearly 1s gap between when the broker is connected, and when the cgrp actually starts querying for the coordinator! This turned out to be a really unfortunate artifact of timing.

The cgrp is created first, when there are no brokers. This request understandably fails:

```
May 03 00:40:46.544 DEBUG librdkafka: librdkafka: CGRPQUERY [thrd:main]: Group "materialize-kafka-u1/u2": no broker available for coordinator query: intervaled in state query-coord
```

The broker connection happens just milliseconds later:

```
May 03 00:40:46.551 DEBUG librdkafka: librdkafka: STATE [thrd:localhost:9092/bootstrap]: localhost:9092/bootstrap: Broker changed state APIVERSION_QUERY -> UP    
```

This immediately triggers a call to `rd_kafka_cgrp_serve` (log line is something.I added myself)

```
May 03 00:40:46.552 DEBUG librdkafka: librdkafka: CGRPLOG [thrd:main]: serving state query-coord  
```

but that call doesn't actually query for the coordinator, because we queried for the coordinator less than 500ms ago! We're then forced to wait not just 500ms, but a full 1000ms, because we need to wait out a full turn of the main rdkafka thread loop, and there are no events that wake it up before it hits the 1000ms max timeout.

The fix here is to reset the coord-query interval if there were no brokers available—that operation wasn't expensive at all, so might as well try it again ASAP. And indeed, in combination with c64b652689, this brings the consumer initialization time down to ~150ms, which is much more pleasant than the 5s+ we were seeing before.