### PR TITLE
make: don't depend on linker script if not enabled

### DIFF
--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -72,6 +72,12 @@ man6dir?=	$(mandir)/man6
 man7dir?=	$(mandir)/man7
 man8dir?=	$(mandir)/man8
 
+# An application Makefile should set DISABLE_LDS=y prior to
+# including Makefile.base if it does not wish to have a linker-script.
+ifeq ($(WITH_LDS)-$(DISABLE_LDS),y-)
+# linker-script file
+LIBNAME_LDS?=$(LIBNAME).lds
+endif
 
 # Checks that mklove is set up and ready for building
 mklove-check:
@@ -89,9 +95,10 @@ mklove-check:
 
 lib: $(LIBFILENAME) $(LIBNAME).a $(LIBNAME)-static.a $(LIBFILENAMELINK) lib-gen-pkg-config
 
-$(LIBNAME).lds: #overridable
+# Linker-script (if WITH_LDS=y): overridable by application Makefile
+$(LIBNAME_LDS):
 
-$(LIBFILENAME): $(OBJS) $(LIBNAME).lds
+$(LIBFILENAME): $(OBJS) $(LIBNAME_LDS)
 	@printf "$(MKL_YELLOW)Creating shared library $@$(MKL_CLR_RESET)\n"
 	$(CC) $(LDFLAGS) $(LIB_LDFLAGS) $(OBJS) -o $@ $(LIBS)
 
@@ -277,7 +284,7 @@ generic-clean:
 
 lib-clean: generic-clean lib-clean-pkg-config
 	rm -f $(LIBNAME)*.a $(LIBFILENAME) $(LIBFILENAMELINK) \
-		$(LIBNAME).lds
+		$(LIBNAME_LDS)
 
 bin-clean: generic-clean
 	rm -f $(BIN)

--- a/src-cpp/Makefile
+++ b/src-cpp/Makefile
@@ -15,11 +15,11 @@ OBJS=		$(CXXSRCS:%.cpp=%.o)
 
 all: lib check
 
+# No linker script/symbol hiding for C++ library
+DISABLE_LDS=y
+
 MKL_NO_SELFCONTAINED_STATIC_LIB=y
 include ../mklove/Makefile.base
-
-# No linker script/symbol hiding for C++ library
-WITH_LDS=n
 
 # OSX and Cygwin requires linking required libraries
 ifeq ($(_UNAME_S),Darwin)

--- a/src/Makefile
+++ b/src/Makefile
@@ -82,9 +82,9 @@ $(SRCS_LZ4:.c=.o): CFLAGS:=$(CFLAGS) -O3
 
 ifeq ($(WITH_LDS),y)
 # Enable linker script if supported by platform
-LIB_LDFLAGS+= $(LDFLAG_LINKERSCRIPT)$(LIBNAME).lds
+LIB_LDFLAGS+= $(LDFLAG_LINKERSCRIPT)$(LIBNAME_LDS)
 
-$(LIBNAME).lds: $(HDRS)
+$(LIBNAME_LDS): $(HDRS)
 	@(printf "$(MKL_YELLOW)Generating linker script $@ from $(HDRS)$(MKL_CLR_RESET)\n" ; \
 	  cat $(HDRS) | ../lds-gen.py > $@)
 endif


### PR DESCRIPTION
This prevents the shared libs to be re-generated on each 'make',
including 'make install', even if there were no changes, which in the case
of 'sudo make install' would create shared libs as the root user messing up the build dir permissions.