### PR TITLE
mock: Make rdkafka_mock.h c++ compatible (#2885)

### DIFF
--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -33,6 +33,12 @@
 #error "rdkafka_mock.h must be included after rdkafka.h"
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#if 0
+} /* Restore indent */
+#endif
+#endif
 
 
 /**
@@ -265,4 +271,7 @@ rd_kafka_mock_set_apiversion (rd_kafka_mock_cluster_t *mcluster,
 
 /**@}*/
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _RDKAFKA_MOCK_H_ */


### PR DESCRIPTION
Allow rdkafka_mock.h to be included from c and c++ programs.