### PR TITLE
fix: Don't leak messages created by rd_kafka_message_new

### DIFF
--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1045,6 +1045,7 @@ void rd_kafka_message_destroy (rd_kafka_message_t *rkmessage) {
 
 rd_kafka_message_t *rd_kafka_message_new (void) {
         rd_kafka_msg_t *rkm = rd_calloc(1, sizeof(*rkm));
+        rkm->rkm_flags      = RD_KAFKA_MSG_F_FREE_RKM;
         return (rd_kafka_message_t *)rkm;
 }
 


### PR DESCRIPTION
Since `RD_KAFKA_MSG_F_FREE_RKM` is not set, the message would not be
freed when `rd_kafka_msg_destroy`.

https://github.com/edenhill/librdkafka/blob/2e53c0f439e7d5ac4ba0b0c772b56308fee8cfa0/src/rdkafka_msg.c#L103-L104

I might very well be missing something about this, but it definitely looks like any messages created with `rd_kafka_message_new` will leak even if `rd_kafka_message_destroy` is called.