### PR TITLE
the configure script does not work correctly when configuration is  like "--LDFLAGS='-Wl,--build-id=none'"

### DIFF
--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ while [[ ! -z $@ ]]; do
     shift
 
     if [[ $opt = *=* ]]; then
-        name="${opt%=*}"
+        name="${opt%%=*}"
         arg="${opt#*=}"
         eqarg=1
     else


### PR DESCRIPTION
`./configure --LDFLAGS='-Wl,--build-id=none'`

there are two '=' in a configration, then ` name="${opt%=*}"` will Intercept `LDFLAGS=-Wl,--build-id` as `name`. 

so ` name="${opt%%=*}"`may be a good choice to Intercept LDFLAGS out.
