### PR TITLE
Add rd_kafka_produceva() using a vtype array as an alternative to va-args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ librdkafka.
  * Added MinGW-w64 builds (@ed-alertedh, #2553)
  * `./configure --enable-XYZ` now requires the XYZ check to pass,
    and `--disable-XYZ` disables the feature altogether (@benesch)
+ * Added `rd_kafka_produceva()` which takes an array of produce arguments
+   for situations where the existing `rd_kafka_producev()` va-arg approach
+   can't be used.
 
 
 ## Upgrade considerations

--- a/src/rd.h
+++ b/src/rd.h
@@ -145,7 +145,7 @@ static RD_INLINE RD_UNUSED char *rd_strndup(const char *s, size_t len) {
 	char *n = strndup(s, len);
 	rd_assert(n);
 #else
-	char *n = malloc(len + 1);
+	char *n = (char *)malloc(len + 1);
 	rd_assert(n);
 	memcpy(n, s, len);
 	n[len] = '\0';


### PR DESCRIPTION
It is problematic to construct va-arg lists for calling C in some high-level languages that wrap librdkafka, erlang in the case of #2895. 
This new method allows constructing an array of structs instead.