### PR TITLE
lost partition notification for EAGER rebalance protocol

### DIFF
--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -144,7 +144,7 @@ RdKafka::KafkaConsumerImpl::assignment (std::vector<RdKafka::TopicPartition*> &p
 
 bool
 RdKafka::KafkaConsumerImpl::assignment_lost () {
-  return rd_kafka_assignment_lost(rk_);
+  return rd_kafka_assignment_lost(rk_) ? true : false;
 }
 
 

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -141,6 +141,14 @@ RdKafka::KafkaConsumerImpl::assignment (std::vector<RdKafka::TopicPartition*> &p
 }
 
 
+
+bool
+RdKafka::KafkaConsumerImpl::assignment_lost () {
+  return rd_kafka_assignment_lost(rk_);
+}
+
+
+
 RdKafka::ErrorCode
 RdKafka::KafkaConsumerImpl::subscription (std::vector<std::string> &topics) {
   rd_kafka_topic_partition_list_t *c_topics;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2365,21 +2365,6 @@ public:
   virtual ErrorCode assignment (std::vector<RdKafka::TopicPartition*> &partitions) = 0;
 
 
-  /** @brief Check whether the consumer considers the current assignment to
-   *         have been lost involuntarily. This method is only applicable for
-   *         use with a subscribing consumer. Assignments are revoked
-   *         immediately when determined to have been lost, so this method is
-   *         only useful within a rebalance callback.
-   *
-   * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
-   *         rd_kafka_incremental_unassign() resets this flag.
-   *
-   * @returns Returns true if the current partition assignment is considered
-   *          lost, false otherwise.
-   */
-  virtual bool assignment_lost () = 0;
-
-
   /** @brief Returns the current subscription as set by
    *         RdKafka::KafkaConsumer::subscribe() */
   virtual ErrorCode subscription (std::vector<std::string> &topics) = 0;
@@ -2655,6 +2640,22 @@ public:
    */
   virtual ConsumerGroupMetadata *groupMetadata () = 0;
 
+
+  /** @brief Check whether the consumer considers the current assignment to
+   *         have been lost involuntarily. This method is only applicable for
+   *         use with a subscribing consumer. Assignments are revoked
+   *         immediately when determined to have been lost, so this method is
+   *         only useful within a rebalance callback. Partitions that have
+   *         been lost may already be owned by other members in the group and
+   *         therefore commiting offsets, for example, may fail.
+   *
+   * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
+   *         rd_kafka_incremental_unassign() resets this flag.
+   *
+   * @returns Returns true if the current partition assignment is considered
+   *          lost, false otherwise.
+   */
+  virtual bool assignment_lost () = 0;
 
 };
 

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2364,6 +2364,22 @@ public:
    *         RdKafka::KafkaConsumer::assign() */
   virtual ErrorCode assignment (std::vector<RdKafka::TopicPartition*> &partitions) = 0;
 
+
+  /** @brief Check whether the consumer considers the current assignment to
+   *         have been lost involuntarily. This method is only applicable for
+   *         use with a subscribing consumer. Assignments are revoked
+   *         immediately when determined to have been lost, so this method is
+   *         only useful within a rebalance callback.
+   *
+   * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
+   *         rd_kafka_incremental_unassign() resets this flag.
+   *
+   * @returns Returns true if the current partition assignment is considered
+   *          lost, false otherwise.
+   */
+  virtual bool assignment_lost () = 0;
+
+
   /** @brief Returns the current subscription as set by
    *         RdKafka::KafkaConsumer::subscribe() */
   virtual ErrorCode subscription (std::vector<std::string> &topics) = 0;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2364,7 +2364,6 @@ public:
    *         RdKafka::KafkaConsumer::assign() */
   virtual ErrorCode assignment (std::vector<RdKafka::TopicPartition*> &partitions) = 0;
 
-
   /** @brief Returns the current subscription as set by
    *         RdKafka::KafkaConsumer::subscribe() */
   virtual ErrorCode subscription (std::vector<std::string> &topics) = 0;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2649,8 +2649,8 @@ public:
    *         been lost may already be owned by other members in the group and
    *         therefore commiting offsets, for example, may fail.
    *
-   * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
-   *         rd_kafka_incremental_unassign() resets this flag.
+   * @remark Calling assign(), incremental_assign() or incremental_unassign()
+   *         resets this flag.
    *
    * @returns Returns true if the current partition assignment is considered
    *          lost, false otherwise.

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -1109,6 +1109,7 @@ public:
   static KafkaConsumer *create (Conf *conf, std::string &errstr);
 
   ErrorCode assignment (std::vector<TopicPartition*> &partitions);
+  bool assignment_lost ();
   ErrorCode subscription (std::vector<std::string> &topics);
   ErrorCode subscribe (const std::vector<std::string> &topics);
   ErrorCode unsubscribe ();

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3473,7 +3473,6 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                                      rko->rko_u.rebalance.partitions->cnt : 0);
                         rd_kafka_assign(rk, NULL);
                 }
-                rk->rk_cgrp->rkcg_assignment_lost = rd_false;
                 break;
 
         case RD_KAFKA_OP_OFFSET_COMMIT | RD_KAFKA_OP_REPLY:

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3458,15 +3458,16 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                 break;
 
         case RD_KAFKA_OP_REBALANCE:
-                /* If EVENT_REBALANCE is enabled but rebalance_cb isnt
+                /* If EVENT_REBALANCE is enabled but rebalance_cb isn't
                  * we need to perform a dummy assign for the application.
                  * This might happen during termination with consumer_close() */
-                if (rk->rk_conf.rebalance_cb)
+                if (rk->rk_conf.rebalance_cb) {
                         rk->rk_conf.rebalance_cb(
                                 rk, rko->rko_err,
                                 rko->rko_u.rebalance.partitions,
                                 rk->rk_conf.opaque);
-                else {
+                        rk->rk_cgrp->rkcg_assignment_lost = rd_false;
+                } else {
                         rd_kafka_dbg(rk, CGRP, "UNASSIGN",
                                      "Forcing unassign of %d partition(s)",
                                      rko->rko_u.rebalance.partitions ?

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3461,19 +3461,19 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                 /* If EVENT_REBALANCE is enabled but rebalance_cb isn't
                  * we need to perform a dummy assign for the application.
                  * This might happen during termination with consumer_close() */
-                if (rk->rk_conf.rebalance_cb) {
+                if (rk->rk_conf.rebalance_cb)
                         rk->rk_conf.rebalance_cb(
                                 rk, rko->rko_err,
                                 rko->rko_u.rebalance.partitions,
                                 rk->rk_conf.opaque);
-                        rk->rk_cgrp->rkcg_assignment_lost = rd_false;
-                } else {
+                else {
                         rd_kafka_dbg(rk, CGRP, "UNASSIGN",
                                      "Forcing unassign of %d partition(s)",
                                      rko->rko_u.rebalance.partitions ?
                                      rko->rko_u.rebalance.partitions->cnt : 0);
                         rd_kafka_assign(rk, NULL);
                 }
+                rk->rk_cgrp->rkcg_assignment_lost = rd_false;
                 break;
 
         case RD_KAFKA_OP_OFFSET_COMMIT | RD_KAFKA_OP_REPLY:

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3694,7 +3694,9 @@ rd_kafka_assignment (rd_kafka_t *rk,
  *        use with a high level subscribing consumer. Assignments are revoked
  *        immediately when determined to have been lost, so this method
  *        is only useful when reacting to a RD_KAFKA_EVENT_REBALANCE event
- *        or from within a rebalance_cb.
+ *        or from within a rebalance_cb. Partitions that have been lost may
+ *        already be owned by other members in the group and therefore
+ *        commiting offsets, for example, may fail.
  *
  * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
  *         rd_kafka_incremental_unassign() resets this flag.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3690,9 +3690,14 @@ rd_kafka_assignment (rd_kafka_t *rk,
 
 /**
  * @brief Check whether the consumer considers the current assignment to
- *        have been lost involuntarily. This method is only useful when
- *        called from within a group rebalance callback (rebalance_cb)
- *        because lost assignments are revoked immediately.
+ *        have been lost involuntarily. This method is only applicable for
+ *        use with a high level subscribing consumer. Assignments are revoked
+ *        immediately when determined to have been lost, so this method
+ *        is only useful when reacting to a RD_KAFKA_EVENT_REBALANCE event
+ *        or from within a rebalance_cb.
+ *
+ * @remark Calling rd_kafka_assign(), rd_kafka_incremental_assign() or
+ *         rd_kafka_incremental_unassign() resets this flag.
  *
  * @returns Returns 1 if the current partition assignment is considered
  *          lost, 0 otherwise.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3688,6 +3688,17 @@ rd_kafka_assignment (rd_kafka_t *rk,
                      rd_kafka_topic_partition_list_t **partitions);
 
 
+/**
+ * @brief Check whether the consumer considers the current assignment to
+ *        have been lost involuntarily. This method is only useful when
+ *        called from within a group rebalance callback (rebalance_cb)
+ *        because lost assignments are revoked immediately.
+ *
+ * @returns Returns 1 if the current partition assignment is considered
+ *          lost, 0 otherwise.
+ */
+RD_EXPORT int
+rd_kafka_assignment_lost (rd_kafka_t *rk);
 
 
 /**

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2650,6 +2650,7 @@ rd_kafka_cgrp_assign (rd_kafka_cgrp_t *rkcg,
         rkcg->rkcg_c.assignment_size = assignment ? assignment->cnt : 0;
         rd_kafka_wrunlock(rkcg->rkcg_rk);
 
+
         /* Remove existing assignment (async operation) */
 	if (rkcg->rkcg_assignment)
 		rd_kafka_cgrp_unassign(rkcg);

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -180,6 +180,9 @@ typedef struct rd_kafka_cgrp_s {
 
 	int                rkcg_assigned_cnt;       /* Assigned partitions */
 
+        rd_bool_t          rkcg_assignment_lost;    /* Assignment considered
+                                                     * lost */
+
         int32_t            rkcg_generation_id;      /* Current generation id */
 
         rd_kafka_assignor_t *rkcg_assignor;         /**< The current partition

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -180,7 +180,7 @@ typedef struct rd_kafka_cgrp_s {
 
 	int                rkcg_assigned_cnt;       /* Assigned partitions */
 
-        rd_bool_t          rkcg_assignment_lost;    /* Assignment considered
+        rd_atomic32_t      rkcg_assignment_lost;    /* Assignment considered
                                                      * lost */
 
         int32_t            rkcg_generation_id;      /* Current generation id */

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -119,7 +119,7 @@ rd_kafka_assignment_lost (rd_kafka_t *rk) {
         if (!(rkcg = rd_kafka_cgrp_get(rk)))
                 return 0;
 
-        return rkcg->rkcg_assignment_lost ? 1 : 0;
+        return rd_atomic32_get(&rkcg->rkcg_assignment_lost) ? 1 : 0;
 }
 
 rd_kafka_resp_err_t

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -112,6 +112,16 @@ rd_kafka_assign (rd_kafka_t *rk,
 
 
 
+int
+rd_kafka_assignment_lost (rd_kafka_t *rk) {
+        rd_kafka_cgrp_t *rkcg;
+
+        if (!(rkcg = rd_kafka_cgrp_get(rk)))
+                return 0;
+
+        return rkcg->rkcg_assignment_lost ? 1 : 0;
+}
+
 rd_kafka_resp_err_t
 rd_kafka_assignment (rd_kafka_t *rk,
                      rd_kafka_topic_partition_list_t **partitions) {


### PR DESCRIPTION
ok, let's see what you think of this.

many less lines of code and much cleaner than adding `RD_KAFKA_RESP_ERR__LOST_PARTITIONS`, which is a good indicator it's better.
