### PR TITLE
fix ssize_t definition in mingw32

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -60,7 +60,10 @@
 #ifndef _BASETSD_H_
 #include <basetsd.h>
 #endif
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
+#endif
 #endif
 #undef RD_EXPORT
 #ifdef LIBRDKAFKA_STATICLIB

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -61,7 +61,10 @@ extern "C" {
 #define WIN32_MEAN_AND_LEAN
 #endif
 #include <winsock2.h>  /* for sockaddr, .. */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
+#endif
 #define RD_UNUSED
 #define RD_INLINE __inline
 #define RD_DEPRECATED __declspec(deprecated)

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -47,7 +47,10 @@
 /**
  * Types
  */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
+#endif
 typedef int socklen_t;
 
 struct iovec {


### PR DESCRIPTION
Building librdkafka with msys2 for win32 (i686) target failed with:

```
librdkafka\src\rdwin32.h:50:17: error: conflicting types for 'ssize_t'
   50 | typedef SSIZE_T ssize_t;
      |                 ^~~~~~~
In file included from C:/msys64/mingw32/i686-w64-mingw32/include/corecrt_stdio_config.h:10,
                 from C:/msys64/mingw32/i686-w64-mingw32/include/stdio.h:9,
                 from C:\workspace\librdkafka\src\rd.h:48,
                 from C:\workspace\librdkafka\src\crc32c.c:48:
C:/msys64/mingw32/i686-w64-mingw32/include/corecrt.h:52:13: note: previous declaration of 'ssize_t' was here
   52 | typedef int ssize_t;
      |             ^~~~~~~
```

this patch will fix this issue.