### PR TITLE
Add some error message when failed in decompressing kafka message in gzip

### DIFF
--- a/src/rdgz.c
+++ b/src/rdgz.c
@@ -32,7 +32,6 @@
 #include "rdgz.h"
 
 #include <zlib.h>
-#include "rdbuf.h"
 
 #define RD_GZ_CHUNK  262144
 

--- a/src/rdgz.h
+++ b/src/rdgz.h
@@ -39,7 +39,7 @@
  *
  * The decompressed length is returned in '*decompressed_lenp'.
  */
-void *rd_gz_decompress (const void *compressed, int compressed_len,
+void *rd_gz_decompress (rd_kafka_broker_t *rkb, const void *compressed, int compressed_len,
 			uint64_t *decompressed_lenp);
 
 #endif /* _RDGZ_H_ */

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -277,7 +277,7 @@ rd_kafka_msgset_reader_decompress (rd_kafka_msgset_reader_t *msetr,
                 uint64_t outlenx = 0;
 
                 /* Decompress Message payload */
-                iov.iov_base = rd_gz_decompress(compressed, (int)compressed_size,
+                iov.iov_base = rd_gz_decompress(msetr->msetr_rkb, compressed, (int)compressed_size,
                                                 &outlenx);
                 if (unlikely(!iov.iov_base)) {
                         rd_rkb_dbg(msetr->msetr_rkb, MSG, "GZIP",


### PR DESCRIPTION
In AWS Lambda enviroment, sometimes rd_kafka_msgset_reader_decompress will fail in decompressing kafka messages in gzip because of no enough memory. But from existing logs, you couldn't find any clue about it--instead the system will tell you an invalid compressed data.