### PR TITLE
Ensure known toppars do not wind up in desired partitions list

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -569,8 +569,8 @@ void rd_kafka_toppar_desired_unlink (rd_kafka_toppar_t *rktp) {
 
 /**
  * @brief If rktp is not already desired:
- *  - mark as DESIRED|UNKNOWN
- *  - add to desired list
+ *  - mark as DESIRED|~REMOVE
+ *  - add to desired list if unknown
  *
  * @remark toppar_lock() MUST be held
  */
@@ -579,10 +579,21 @@ void rd_kafka_toppar_desired_add0 (rd_kafka_toppar_t *rktp) {
                 return;
 
         rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "DESIRED",
+                     "%s [%"PRId32"]: marking as DESIRED",
+                     rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
+
+        /* If toppar was marked for removal this is no longer
+         * the case since the partition is now desired. */
+        rktp->rktp_flags &= ~RD_KAFKA_TOPPAR_F_REMOVE;
+
+        rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_DESIRED;
+
+        if (rktp->rktp_flags & RD_KAFKA_TOPPAR_F_UNKNOWN) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "DESIRED",
                      "%s [%"PRId32"]: adding to DESIRED list",
                      rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
-	rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_DESIRED;
-        rd_kafka_toppar_desired_link(rktp);
+                rd_kafka_toppar_desired_link(rktp);
+        }
 }
 
 
@@ -596,37 +607,19 @@ rd_kafka_toppar_t *rd_kafka_toppar_desired_add (rd_kafka_topic_t *rkt,
                                                 int32_t partition) {
         rd_kafka_toppar_t *rktp;
 
-	if ((rktp = rd_kafka_toppar_get(rkt,
-                                          partition, 0/*no_ua_on_miss*/))) {
-		rd_kafka_toppar_lock(rktp);
-                if (unlikely(!(rktp->rktp_flags & RD_KAFKA_TOPPAR_F_DESIRED))) {
-                        rd_kafka_dbg(rkt->rkt_rk, TOPIC, "DESP",
-                                     "Setting topic %s [%"PRId32"] partition "
-                                     "as desired",
-                                     rkt->rkt_topic->str, rktp->rktp_partition);
-                        rktp->rktp_flags |= RD_KAFKA_TOPPAR_F_DESIRED;
-                }
-                /* If toppar was marked for removal this is no longer
-                 * the case since the partition is now desired. */
-                rktp->rktp_flags &= ~RD_KAFKA_TOPPAR_F_REMOVE;
-		rd_kafka_toppar_unlock(rktp);
-		return rktp;
-	}
+        rktp = rd_kafka_toppar_get(rkt, partition, 0/*no_ua_on_miss*/);
 
-	if ((rktp = rd_kafka_toppar_desired_get(rkt, partition)))
-		return rktp;
+        if (!rktp)
+                rktp = rd_kafka_toppar_desired_get(rkt, partition);
 
-	rktp = rd_kafka_toppar_new(rkt, partition);
+        if (!rktp)
+                rktp = rd_kafka_toppar_new(rkt, partition);
 
         rd_kafka_toppar_lock(rktp);
         rd_kafka_toppar_desired_add0(rktp);
         rd_kafka_toppar_unlock(rktp);
 
-	rd_kafka_dbg(rkt->rkt_rk, TOPIC, "DESP",
-		     "Adding desired topic %s [%"PRId32"]",
-		     rkt->rkt_topic->str, rktp->rktp_partition);
-
-	return rktp; /* Callers refcount */
+        return rktp; /* Callers refcount */
 }
 
 

--- a/tests/0112-assign_unknown_part.c
+++ b/tests/0112-assign_unknown_part.c
@@ -1,0 +1,95 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2012-2015, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+#include "rdkafka.h"
+
+/**
+ * Assign consumer to single partition topic and consume a message.
+ * Then add a new partition to the topic (i.e., one that will not
+ * be in the consumer's metadata) and assign the consumer to it.
+ * Verify that partition 0 is not incorrectly reported as missing.
+ * See #2915.
+ */
+
+int main_0112_assign_unknown_part (int argc, char **argv) {
+        const char *topic = test_mk_topic_name(__FUNCTION__ + 5, 1);
+        int64_t offset = RD_KAFKA_OFFSET_BEGINNING;
+        uint64_t testid = test_id_generate();
+        rd_kafka_t *c;
+        rd_kafka_topic_t *rkt;
+        rd_kafka_topic_partition_list_t *tpl;
+        rd_kafka_resp_err_t err;
+        const struct rd_kafka_metadata *md;
+
+        test_conf_init(NULL, NULL, 60);
+
+        TEST_SAY("Creating consumer\n");
+        c = test_create_consumer(topic, NULL, NULL, NULL);
+
+        TEST_SAY("Creating topic %s with 1 partition\n", topic);
+        test_create_topic(c, topic, 1, 1);
+        test_wait_topic_exists(c, topic, 10*1000);
+
+        TEST_SAY("Producing message to partition 0\n");
+        test_produce_msgs_easy(topic, testid, 0, 1);
+
+        TEST_SAY("Assigning partition 0\n");
+        tpl = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(tpl, topic, 0)->offset = offset;
+        test_consumer_assign("ASSIGN", c, tpl);
+
+        TEST_SAY("Waiting for message");
+        rkt = rd_kafka_topic_new(c, topic, NULL);
+        test_consume_msgs("CONSUME", rkt, testid, 0, TEST_NO_SEEK, 0, 1, 1);
+
+        TEST_SAY("Changing partition count for topic %s\n", topic);
+        test_create_partitions(NULL, topic, 2);
+
+        TEST_SAY("Producing message to partition 1\n");
+        test_produce_msgs_easy(topic, testid, 1, 1);
+
+        TEST_SAY("Assigning partitions 1\n");
+        rd_kafka_topic_partition_list_add(tpl, topic, 1)->offset = offset;
+        test_consumer_assign("ASSIGN", c, tpl);
+
+        TEST_SAY("Updating metadata\n");
+        err = rd_kafka_metadata(c, 0, rkt, &md, tmout_multip(2000));
+        TEST_ASSERT(!err, "metadata failed: %s", rd_kafka_err2str(err));
+        rd_kafka_metadata_destroy(md);
+
+        TEST_SAY("Waiting for messages");
+        test_consume_msgs("CONSUME", rkt, testid, 0, TEST_NO_SEEK, 0, 1, 0);
+        test_consume_msgs("CONSUME", rkt, testid, 1, TEST_NO_SEEK, 0, 1, 0);
+
+        rd_kafka_topic_partition_list_destroy(tpl);
+        test_consumer_close(c);
+        rd_kafka_destroy(c);
+
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ set(
     0109-auto_create_topics.cpp
     0110-batch_size.cpp
     0111-delay_create_topics.cpp
+    0112-assign_unknown_part.c
     8000-idle.cpp
     test.c
     testcpp.cpp

--- a/tests/test.c
+++ b/tests/test.c
@@ -217,6 +217,7 @@ _TEST_DECL(0107_topic_recreate);
 _TEST_DECL(0109_auto_create_topics);
 _TEST_DECL(0110_batch_size);
 _TEST_DECL(0111_delay_create_topics);
+_TEST_DECL(0112_assign_unknown_part);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -403,6 +404,7 @@ struct test tests[] = {
         _TEST(0110_batch_size, 0),
         _TEST(0111_delay_create_topics, 0, TEST_BRKVER_TOPIC_ADMINAPI,
               .scenario = "noautocreate"),
+        _TEST(0112_assign_unknown_part, 0),
 
         /* Manual tests */
         _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="..\..\tests\0109-auto_create_topics.cpp" />
     <ClCompile Include="..\..\tests\0110-batch_size.cpp" />
     <ClCompile Include="..\..\tests\0111-delay_create_topics.cpp" />
+    <ClCompile Include="..\..\tests\0112-assign_unknown_part.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\test.c" />
     <ClCompile Include="..\..\tests\testcpp.cpp" />


### PR DESCRIPTION
rd_kafka_cgrp_assign calls rd_kafka_toppar_desired_add0 rather than its
wrapper rd_kafka_toppar_desired_add. The "add" wrapper preserves the
invariant that a known topic should never get added to the desired
partitions queue, while the "add0" function does not.

Maintaining this invariant is important for
rd_kafka_topic_partition_cnt_update, which assumes that a toppar is in
either the list of known partitions or the list of desired partitions,
but not both. Violating this invariant results in the situation
described in #2915, where updating assignments can trigger incorrect
"unknown partition" errors.

This patch rearranges rd_kafka_toppar_desired_add/add0 so that add0, in
addition to add, will avoid adding known partitions to the desired
partition list. The enclosed test correctly fails if run against the
current master (for the reasons described above).

Fix #2915.