### PR TITLE
Fix incorrect cmake Module path for submodule use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ parseversion("src/rdkafka.h")
 
 project(RdKafka VERSION ${RDKAFKA_VERSION})
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/packaging/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/packaging/cmake/Modules/")
 
 # Options. No 'RDKAFKA_' prefix to match old C++ code. {
 


### PR DESCRIPTION
When librdkafka is added to a project using `add_subdirectory`, the
include path for CMake modules that is added is incorrect, since it uses
`CMAKE_SOURCE_DIR` - which is the source directory of the root of the
project instead of `CMAKE_CURRENT_SOURCE_DIR`.

This matters not when librdkafka is built standalone (since the two
directories are the same), but when built as a submodule, it prevents
CMake from finding the bundled modules, like FindLibLZ4.cmake.