### PR TITLE
Const correctness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ parseversion("src/rdkafka.h")
 
 project(RdKafka VERSION ${RDKAFKA_VERSION})
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/packaging/cmake/Modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/packaging/cmake/Modules/")
 
 # Options. No 'RDKAFKA_' prefix to match old C++ code. {
 

--- a/src-cpp/ConsumerImpl.cpp
+++ b/src-cpp/ConsumerImpl.cpp
@@ -35,10 +35,10 @@
 
 RdKafka::Consumer::~Consumer () {}
 
-RdKafka::Consumer *RdKafka::Consumer::create (RdKafka::Conf *conf,
+RdKafka::Consumer *RdKafka::Consumer::create (const RdKafka::Conf *conf,
                                               std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  const RdKafka::ConfImpl *confimpl = dynamic_cast<const RdKafka::ConfImpl *>(conf);
   RdKafka::ConsumerImpl *rkc = new RdKafka::ConsumerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
 

--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -259,7 +259,7 @@ offset_commit_cb_trampoline (
 }
 
 
-void RdKafka::HandleImpl::set_common_config (RdKafka::ConfImpl *confimpl) {
+void RdKafka::HandleImpl::set_common_config (const RdKafka::ConfImpl *confimpl) {
 
   rd_kafka_conf_set_opaque(confimpl->rk_conf_, this);
 

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -33,10 +33,10 @@
 
 RdKafka::KafkaConsumer::~KafkaConsumer () {}
 
-RdKafka::KafkaConsumer *RdKafka::KafkaConsumer::create (RdKafka::Conf *conf,
+RdKafka::KafkaConsumer *RdKafka::KafkaConsumer::create (const RdKafka::Conf *conf,
                                                         std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  const RdKafka::ConfImpl *confimpl = dynamic_cast<const RdKafka::ConfImpl *>(conf);
   RdKafka::KafkaConsumerImpl *rkc = new RdKafka::KafkaConsumerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
   size_t grlen;

--- a/src-cpp/ProducerImpl.cpp
+++ b/src-cpp/ProducerImpl.cpp
@@ -49,10 +49,10 @@ static void dr_msg_cb_trampoline (rd_kafka_t *rk,
 
 
 
-RdKafka::Producer *RdKafka::Producer::create (RdKafka::Conf *conf,
+RdKafka::Producer *RdKafka::Producer::create (const RdKafka::Conf *conf,
                                               std::string &errstr) {
   char errbuf[512];
-  RdKafka::ConfImpl *confimpl = dynamic_cast<RdKafka::ConfImpl *>(conf);
+  const RdKafka::ConfImpl *confimpl = dynamic_cast<const RdKafka::ConfImpl *>(conf);
   RdKafka::ProducerImpl *rkp = new RdKafka::ProducerImpl();
   rd_kafka_conf_t *rk_conf = NULL;
 

--- a/src-cpp/TopicImpl.cpp
+++ b/src-cpp/TopicImpl.cpp
@@ -76,9 +76,9 @@ static int32_t partitioner_kp_cb_trampoline (const rd_kafka_topic_t *rkt,
 
 RdKafka::Topic *RdKafka::Topic::create (Handle *base,
 					const std::string &topic_str,
-					Conf *conf,
+					const Conf *conf,
 					std::string &errstr) {
-  RdKafka::ConfImpl *confimpl = static_cast<RdKafka::ConfImpl *>(conf);
+  const RdKafka::ConfImpl *confimpl = static_cast<const RdKafka::ConfImpl *>(conf);
   rd_kafka_topic_t *rkt;
   rd_kafka_topic_conf_t *rkt_conf;
   rd_kafka_t *rk = dynamic_cast<HandleImpl*>(base)->rk_;

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1604,7 +1604,7 @@ class RD_EXPORT Handle {
    * @returns ERR_NO_ERROR if no fatal error has been raised, else
    *          any other error code.
    */
-  virtual ErrorCode fatal_error (std::string &errstr) = 0;
+  virtual ErrorCode fatal_error (std::string &errstr) const = 0;
 
   /**
    * @brief Set SASL/OAUTHBEARER token and metadata

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -1765,7 +1765,7 @@ class RD_EXPORT Topic {
    * @returns the new topic handle or NULL on error (see \p errstr).
    */
   static Topic *create (Handle *base, const std::string &topic_str,
-                        Conf *conf, std::string &errstr);
+                        const Conf *conf, std::string &errstr);
 
   virtual ~Topic () = 0;
 
@@ -2348,7 +2348,7 @@ public:
    * @sa CONFIGURATION.md for \c group.id, \c session.timeout.ms,
    *     \c partition.assignment.strategy, etc.
    */
-  static KafkaConsumer *create (Conf *conf, std::string &errstr);
+  static KafkaConsumer *create (const Conf *conf, std::string &errstr);
 
   virtual ~KafkaConsumer () = 0;
 
@@ -2662,7 +2662,7 @@ class RD_EXPORT Consumer : public virtual Handle {
    * @returns the new handle on success or NULL on error in which case
    * \p errstr is set to a human readable error message.
    */
-  static Consumer *create (Conf *conf, std::string &errstr);
+  static Consumer *create (const Conf *conf, std::string &errstr);
 
   virtual ~Consumer () = 0;
 
@@ -2839,7 +2839,7 @@ class RD_EXPORT Producer : public virtual Handle {
    * @returns the new handle on success or NULL on error in which case
    *          \p errstr is set to a human readable error message.
    */
-  static Producer *create (Conf *conf, std::string &errstr);
+  static Producer *create (const Conf *conf, std::string &errstr);
 
 
   virtual ~Producer () = 0;

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -936,7 +936,7 @@ class HandleImpl : virtual public Handle {
           return rd_kafka_controllerid(rk_, timeout_ms);
   }
 
-  ErrorCode fatal_error (std::string &errstr) {
+  ErrorCode fatal_error (std::string &errstr) const {
           char errbuf[512];
           RdKafka::ErrorCode err =
                   static_cast<RdKafka::ErrorCode>(

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -875,7 +875,7 @@ class HandleImpl : virtual public Handle {
   int poll (int timeout_ms) { return rd_kafka_poll(rk_, timeout_ms); };
   int outq_len () { return rd_kafka_outq_len(rk_); };
 
-  void set_common_config (RdKafka::ConfImpl *confimpl);
+  void set_common_config (const RdKafka::ConfImpl *confimpl);
 
   RdKafka::ErrorCode metadata (bool all_topics,const Topic *only_rkt,
             Metadata **metadatap, int timeout_ms);


### PR DESCRIPTION
Improve const correctness by allowing Conf pointers to be const-qualified when constructing Handles. fatal_error member functions are now also const-qualified.