### PR TITLE
Don't rely on LastStableOffset for old brokers

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4164,9 +4164,10 @@ rd_kafka_fetch_reply_handle (rd_kafka_broker_t *rkb,
                                                           * (8+8));
                                         }
                                 } else {
-                                        if (rd_kafka_buf_ApiVersion(request) > 8) {
+					/* Older brokers may return LSO -1,
+					 * in which case we use the HWM. */
+                                        if (hdr.LastStableOffset >= 0)
                                                 end_offset = hdr.LastStableOffset;
-                                        }
 
                                         if (AbortedTxnCnt > 0) {
                                                 int k;

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4164,7 +4164,9 @@ rd_kafka_fetch_reply_handle (rd_kafka_broker_t *rkb,
                                                           * (8+8));
                                         }
                                 } else {
-                                        end_offset = hdr.LastStableOffset;
+                                        if (rd_kafka_buf_ApiVersion(request) > 8) {
+                                                end_offset = hdr.LastStableOffset;
+                                        }
 
                                         if (AbortedTxnCnt > 0) {
                                                 int k;


### PR DESCRIPTION
Old kafka brokers(<2.1.0) always reports -1 as LastStableOffset.
This prevents librdkafka from emitting EOF messages. Use
HighwaterMarkOffset instead as before.