### PR TITLE
Fix regex crash on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
 
 matrix:
  include:
- - name: "Linux GCC: +Debian packages"
+ - name: "Linux GCC: +Debian packages +BuiltinRegex"
    os: linux
    compiler: gcc
    env: ADDITIONAL_BUILDS="debian" LINKAGE=std
    before_script:
-    - ./configure --install-deps --disable-lz4-ext --prefix="$PWD/dest"
+    - ./configure --install-deps --disable-lz4-ext --disable-regex-ext --prefix="$PWD/dest"
  - name: "RPM packages"
    os: linux
    compiler: gcc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ librdkafka.
  * Initial consumer group joins should now be a couple of seconds quicker
    thanks expedited query intervals (@benesch).
  * Don't propagate temporary offset lookup errors to application
+ * Fix crash and/or inconsistent subscriptions when using multiple consumers
+   (in the same process) with wildcard topics on Windows.
+
 
 ### Producer fixes
 

--- a/configure.self
+++ b/configure.self
@@ -36,6 +36,8 @@ mkl_toggle_option "Development" ENABLE_REFCNT_DEBUG "--enable-refcnt-debug" "Ena
 mkl_toggle_option "Feature" ENABLE_LZ4_EXT "--enable-lz4-ext" "Enable external LZ4 library support (builtin version 1.9.2)" "y"
 mkl_toggle_option "Feature" ENABLE_LZ4_EXT "--enable-lz4" "Deprecated: alias for --enable-lz4-ext" "y"
 
+mkl_toggle_option "Feature" ENABLE_REGEX_EXT "--enable-regex-ext" "Enable external (libc) regex (else use builtin)" "y"
+
 # librdkafka with TSAN won't work with glibc C11 threads on Ubuntu 19.04.
 # This option allows disabling libc-based C11 threads and instead
 # use the builtin tinycthread alternative.
@@ -176,7 +178,8 @@ void foo (void) {
 
 
     # Check for libc regex
-    mkl_compile_check "regex" "HAVE_REGEX" disable CC "" \
+    if [[ $ENABLE_REGEX_EXT == y ]]; then
+        mkl_compile_check "regex" "HAVE_REGEX" disable CC "" \
 "
 #include <stddef.h>
 #include <regex.h>
@@ -186,7 +189,7 @@ void foo (void) {
    regerror(0, NULL, NULL, 0);
    regfree(NULL);
 }"
-
+    fi
 
     # Older g++ (<=4.1?) gives invalid warnings for the C++ code.
     mkl_mkvar_append CXXFLAGS CXXFLAGS "-Wno-non-virtual-dtor"

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ SRCS_y += rdkafka_lz4.c $(SRCS_LZ4)
 SRCS_$(WITH_LIBDL) += rddl.c
 SRCS_$(WITH_PLUGINS) += rdkafka_plugin.c
 
-ifeq ($(HAVE_REGEX), n)
+ifneq ($(HAVE_REGEX), y)
 SRCS_y += regexp.c
 endif
 


### PR DESCRIPTION
The regex code we use on Windows was using global variables and thus either bugged out or was crashed when multiple consumers with wildcard subscriptions were running in the same instance, as reported in numerous .NET issues.

This fix moves the global `g` variable (g for global!) to the `Reprog` object.