### PR TITLE
Added --disable-option-checking (autoconf compat no-op)

### DIFF
--- a/configure
+++ b/configure
@@ -105,7 +105,7 @@ while [[ ! -z $@ ]]; do
             arg="$1"
             shift
 
-            if [[ -z $arg ]]; then
+            if [[ -z $arg && $reqarg != '\*' ]]; then
                 mkl_err "Missing argument to option --$name $reqarg"
                 exit 1
             fi

--- a/mklove/modules/configure.base
+++ b/mklove/modules/configure.base
@@ -2173,11 +2173,13 @@ $1"
 # Arguments:
 #  option group ("Standard", "Cross-Compilation", etc..)
 #  variable name
-#  option ("--foo=feh")
+#  option ("--foo", "--foo=*", "--foo=args_required")
 #  help
 #  default (optional)
 #  assignvalue (optional, default:"y")
 #  function block (optional)
+#
+# If option takes the form --foo=* then arguments are optional.
 function mkl_option {
     local optgroup=$1
     local varname=$2
@@ -2209,6 +2211,10 @@ function mkl_option {
     if [[ $3 == *=* ]]; then
         optname="${optname%=*}"
         optval="${3#*=}"
+        if [[ $optval == '*' ]]; then
+            # Avoid globbing of --foo=* optional arguments
+            optval='\*'
+        fi
     fi
 
     safeopt=$(mkl_env_esc $optname)
@@ -2285,7 +2291,7 @@ function mkl_option {
 # Arguments:
 #  option group   ("Standard", ..)
 #  variable name  (WITH_FOO)
-#  option         (--enable-foo)
+#  option         (--enable-foo, --enable-foo=*, or --enable-foo=req)
 #  help           ("foo.." ("Enable" and "Disable" will be prepended))
 #  default        (y or n)
 

--- a/mklove/modules/configure.builtin
+++ b/mklove/modules/configure.builtin
@@ -50,6 +50,7 @@ mkl_option "Compatibility" "mk:COMPAT_DISABLE_DEP_TRACK" "--disable-dependency-t
 mkl_option "Compatibility" "mk:COMPAT_DISABLE_SILENT_RULES" "--disable-silent-rules" "Verbose build output (no-op)"
 mkl_option "Compatibility" "mk:COMPAT_SILENT" "--silent" "Less verbose build output (no-op)"
 mkl_toggle_option "Compatibility" "mk:COMPAT_ENABLE_SHARED" "--enable-shared" "Build shared library (no-op)"
+mkl_toggle_option "Compatibility" "mk:COMPAT_DISABLE_OPT_CHECK" '--enable-option-checking=*' "Disable configure option checking (no-op)"
 
 
 mkl_option "Dependency"  env:MKL_INSTALL_DEPS "--install-deps" "Attempt to install missing dependencies"


### PR DESCRIPTION
This is for compatibility with autoconf and is required to not break debian packaging builds.
Reported by @vincentbernat 