### PR TITLE
Added rd_kafka_message_broker_id() (#2952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ librdkafka.
  * Added `rd_kafka_produceva()` which takes an array of produce arguments
    for situations where the existing `rd_kafka_producev()` va-arg approach
    can't be used.
+ * Added `rd_kafka_message_broker_id()` to see the broker that a message
+   was produced or fetched from, or an error was associated with.
  * Added RTT/delay simulation to mock brokers.
 
 

--- a/examples/rdkafka_example.c
+++ b/examples/rdkafka_example.c
@@ -107,15 +107,18 @@ static void logger (const rd_kafka_t *rk, int level,
 static void msg_delivered (rd_kafka_t *rk,
                            const rd_kafka_message_t *rkmessage, void *opaque) {
         if (rkmessage->err)
-		fprintf(stderr, "%% Message delivery failed: %s\n",
+                fprintf(stderr,
+                        "%% Message delivery failed (broker %"PRId32"): %s\n",
+                        rd_kafka_message_broker_id(rkmessage),
                         rd_kafka_err2str(rkmessage->err));
-	else if (!quiet)
-		fprintf(stderr,
+        else if (!quiet)
+                fprintf(stderr,
                         "%% Message delivered (%zd bytes, offset %"PRId64", "
-                        "partition %"PRId32"): %.*s\n",
+                        "partition %"PRId32", broker %"PRId32"): %.*s\n",
                         rkmessage->len, rkmessage->offset,
-			rkmessage->partition,
-			(int)rkmessage->len, (const char *)rkmessage->payload);
+                        rkmessage->partition,
+                        rd_kafka_message_broker_id(rkmessage),
+                        (int)rkmessage->len, (const char *)rkmessage->payload);
 }
 
 
@@ -153,8 +156,11 @@ static void msg_consume (rd_kafka_message_t *rkmessage,
 		int64_t timestamp;
                 rd_kafka_headers_t *hdrs;
 
-		fprintf(stdout, "%% Message (offset %"PRId64", %zd bytes):\n",
-			rkmessage->offset, rkmessage->len);
+                fprintf(stdout,
+                        "%% Message (offset %"PRId64", %zd bytes, "
+                        "broker %"PRId32"):\n",
+                        rkmessage->offset, rkmessage->len,
+                        rd_kafka_message_broker_id(rkmessage));
 
 		timestamp = rd_kafka_message_timestamp(rkmessage, &tstype);
 		if (tstype != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2216,6 +2216,10 @@ class RD_EXPORT Message {
    *
    * @remark The lifetime of the Headers are the same as the Message. */
   virtual RdKafka::Headers   *headers (RdKafka::ErrorCode *err) = 0;
+
+  /** @returns the broker id of the broker the message was produced to or
+   *           fetched from, or -1 if not known/applicable. */
+  virtual int32_t broker_id () const = 0;
 };
 
 /**@}*/

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -437,6 +437,11 @@ class MessageImpl : public Message {
     return headers_;
   }
 
+  int32_t broker_id () const {
+    return rd_kafka_message_broker_id(rkmessage_);
+  }
+
+
   RdKafka::Topic *topic_;
   rd_kafka_message_t *rkmessage_;
   bool free_rkmessage_;

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -832,11 +832,12 @@ int rd_kafka_set_fatal_error0 (rd_kafka_t *rk, rd_dolock_t do_lock,
          * while for all other client types (the producer) we propagate to
          * the standard error handler (typically error_cb). */
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp)
-                rd_kafka_q_op_err(rk->rk_cgrp->rkcg_q,
-                                  RD_KAFKA_OP_CONSUMER_ERR,
-                                  RD_KAFKA_RESP_ERR__FATAL, 0, NULL, 0,
-                                  "Fatal error: %s: %s",
-                                  rd_kafka_err2str(err), rk->rk_fatal.errstr);
+                rd_kafka_consumer_err(rk->rk_cgrp->rkcg_q, RD_KAFKA_NODEID_UA,
+                                      RD_KAFKA_RESP_ERR__FATAL, 0, NULL, NULL,
+                                      RD_KAFKA_OFFSET_INVALID,
+                                      "Fatal error: %s: %s",
+                                      rd_kafka_err2str(err),
+                                      rk->rk_fatal.errstr);
         else
                 rd_kafka_op_err(rk, RD_KAFKA_RESP_ERR__FATAL,
                                 "Fatal error: %s: %s",

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1414,6 +1414,16 @@ int64_t rd_kafka_message_latency (const rd_kafka_message_t *rkmessage);
 
 
 /**
+ * @brief Returns the broker id of the broker the message was produced to
+ *        or fetched from.
+ *
+ * @returns a broker id if known, else -1.
+ */
+RD_EXPORT
+int32_t rd_kafka_message_broker_id (const rd_kafka_message_t *rkmessage);
+
+
+/**
  * @brief Get the message header list.
  *
  * The returned pointer in \p *hdrsp is associated with the \p rkmessage and

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -487,8 +487,7 @@ static void rd_kafka_broker_set_error (rd_kafka_broker_t *rkb, int level,
                              "%s: %s", rkb->rkb_name, errstr);
 
                 /* Send ERR op to application for processing. */
-                rd_kafka_q_op_err(rkb->rkb_rk->rk_rep, RD_KAFKA_OP_ERR,
-                                  err, 0, NULL, 0, "%s: %s",
+                rd_kafka_q_op_err(rkb->rkb_rk->rk_rep, err, "%s: %s",
                                   rkb->rkb_name, errstr);
         }
 }
@@ -4447,14 +4446,14 @@ rd_kafka_fetch_reply_handle (rd_kafka_broker_t *rkb,
 				case RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE:
 				default: /* and all other errors */
 					rd_dassert(tver->version > 0);
-					rd_kafka_q_op_err(
-						rktp->rktp_fetchq,
-						RD_KAFKA_OP_CONSUMER_ERR,
-						hdr.ErrorCode, tver->version,
-						rktp,
-						rktp->rktp_offsets.fetch_offset,
-						"Fetch failed: %s",
-						rd_kafka_err2str(hdr.ErrorCode));
+                                        rd_kafka_consumer_err(
+                                                rktp->rktp_fetchq,
+                                                rd_kafka_broker_id(rkb),
+                                                hdr.ErrorCode, tver->version,
+                                                NULL, rktp,
+                                                rktp->rktp_offsets.fetch_offset,
+                                                "Fetch failed: %s",
+                                                rd_kafka_err2str(hdr.ErrorCode));
 					break;
 				}
 

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -79,7 +79,8 @@ typedef struct rd_kafka_broker_monitor_s {
 struct rd_kafka_broker_s { /* rd_kafka_broker_t */
 	TAILQ_ENTRY(rd_kafka_broker_s) rkb_link;
 
-	int32_t             rkb_nodeid;
+        int32_t             rkb_nodeid;  /**< Broker Node Id.
+                                          *   @locks rkb_lock */
 #define RD_KAFKA_NODEID_UA -1
 
 	rd_sockaddr_list_t *rkb_rsal;
@@ -517,6 +518,7 @@ void msghdr_print (rd_kafka_t *rk,
 		   const char *what, const struct msghdr *msg,
 		   int hexdump);
 
+int32_t rd_kafka_broker_id (rd_kafka_broker_t *rkb);
 const char *rd_kafka_broker_name (rd_kafka_broker_t *rkb);
 void rd_kafka_broker_wakeup (rd_kafka_broker_t *rkb);
 int rd_kafka_all_brokers_wakeup (rd_kafka_t *rk,

--- a/src/rdkafka_msg.h
+++ b/src/rdkafka_msg.h
@@ -100,6 +100,8 @@ typedef struct rd_kafka_msg_s {
                                            *   the ProduceResponse handler:
                                            *   this value is always up to date.
                                            */
+        int32_t rkm_broker_id;            /**< Broker message was produced to
+                                           *   or fetched from. */
 
         union {
                 struct {
@@ -494,7 +496,7 @@ rd_kafka_msg_t *rd_kafka_msgq_find_pos (const rd_kafka_msgq_t *rkmq,
                                                     const void *),
                                         int *cntp, int64_t *bytesp);
 
-void rd_kafka_msgq_set_metadata (rd_kafka_msgq_t *rkmq,
+void rd_kafka_msgq_set_metadata (rd_kafka_msgq_t *rkmq, int32_t broker_id,
                                  int64_t base_offset, int64_t timestamp,
                                  rd_kafka_msg_status_t status);
 

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -165,6 +165,7 @@ typedef struct rd_kafka_msgset_reader_s {
         const struct rd_kafka_toppar_ver *msetr_tver; /**< Toppar op version of
                                                        *   request. */
 
+        int32_t            msetr_broker_id; /**< Broker id (of msetr_rkb) */
         rd_kafka_broker_t *msetr_rkb;    /* @warning Not a refcounted
                                           *          reference! */
         rd_kafka_toppar_t *msetr_rktp;   /* @warning Not a refcounted
@@ -224,6 +225,7 @@ rd_kafka_msgset_reader_init (rd_kafka_msgset_reader_t *msetr,
         memset(msetr, 0, sizeof(*msetr));
 
         msetr->msetr_rkb        = rkbuf->rkbuf_rkb;
+        msetr->msetr_broker_id  = rd_kafka_broker_id(msetr->msetr_rkb);
         msetr->msetr_rktp       = rktp;
         msetr->msetr_aborted_txns = aborted_txns;
         msetr->msetr_tver       = tver;
@@ -677,6 +679,8 @@ rd_kafka_msgset_reader_msg_v0_1 (rd_kafka_msgset_reader_t *msetr) {
                                         RD_KAFKAP_BYTES_IS_NULL(&Value) ?
                                         NULL : Value.data);
 
+        rkm->rkm_broker_id = msetr->msetr_broker_id;
+
         /* Assign message timestamp.
          * If message was in a compressed MessageSet and the outer/wrapper
          * Message.Attribute had a LOG_APPEND_TIME set, use the
@@ -893,6 +897,8 @@ unexpected_abort_txn:
                                         (size_t)RD_KAFKAP_BYTES_LEN(&hdr.Value),
                                         RD_KAFKAP_BYTES_IS_NULL(&hdr.Value) ?
                                         NULL : hdr.Value.data);
+
+        rkm->rkm_broker_id = msetr->msetr_broker_id;
 
         /* Store pointer to unparsed message headers, they will
          * be parsed on the first access.

--- a/src/rdkafka_offset.c
+++ b/src/rdkafka_offset.c
@@ -772,14 +772,9 @@ void rd_kafka_offset_reset (rd_kafka_toppar_t *rktp, int64_t err_offset,
 
 	if (offset == RD_KAFKA_OFFSET_INVALID) {
 		/* Error, auto.offset.reset tells us to error out. */
-		rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
-
-		rko->rko_err               = err;
-		rko->rko_u.err.offset      = err_offset;
-		rko->rko_u.err.errstr      = rd_strdup(reason);
-                rko->rko_rktp              = rd_kafka_toppar_keep(rktp);
-
-		rd_kafka_q_enq(rktp->rktp_fetchq, rko);
+                rd_kafka_consumer_err(rktp->rktp_fetchq, RD_KAFKA_NODEID_UA,
+                                      err, 0, NULL, rktp, err_offset,
+                                      "%s", reason);
                 rd_kafka_toppar_set_fetch_state(
 			rktp, RD_KAFKA_TOPPAR_FETCH_NONE);
 

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -529,17 +529,15 @@ int rd_kafka_op_reply (rd_kafka_op_t *rko, rd_kafka_resp_err_t err);
 			rd_kafka_log(rk, LOG_ERR, "ERROR", __VA_ARGS__); \
 			break;						\
 		}							\
-		rd_kafka_q_op_err((rk)->rk_rep, RD_KAFKA_OP_ERR, err, 0, \
-				  NULL, 0, __VA_ARGS__);		\
+		rd_kafka_q_op_err((rk)->rk_rep, err, __VA_ARGS__);      \
 	} while (0)
 
-void rd_kafka_q_op_err (rd_kafka_q_t *rkq, rd_kafka_op_type_t optype,
-                        rd_kafka_resp_err_t err, int32_t version,
-                        rd_kafka_toppar_t *rktp, int64_t offset,
-			const char *fmt, ...);
- void rd_kafka_q_op_topic_err (rd_kafka_q_t *rkq, rd_kafka_op_type_t optype,
-                               rd_kafka_resp_err_t err, int32_t version,
-                               const char *topic, const char *fmt, ...);
+void rd_kafka_q_op_err (rd_kafka_q_t *rkq, rd_kafka_resp_err_t err,
+                        const char *fmt, ...);
+void rd_kafka_consumer_err (rd_kafka_q_t *rkq, int32_t broker_id,
+                            rd_kafka_resp_err_t err, int32_t version,
+                            const char *topic, rd_kafka_toppar_t *rktp,
+                            int64_t offset, const char *fmt, ...);
 rd_kafka_op_t *rd_kafka_op_req0 (rd_kafka_q_t *destq,
                                  rd_kafka_q_t *recvq,
                                  rd_kafka_op_t *rko,

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -3186,6 +3186,7 @@ rd_kafka_msgbatch_handle_Produce_result (
         if (likely(rd_kafka_msgq_len(&batch->msgq) > 0)) {
                 /* Set offset, timestamp and status for each message. */
                 rd_kafka_msgq_set_metadata(&batch->msgq,
+                                           rkb->rkb_nodeid,
                                            presult->offset,
                                            presult->timestamp,
                                            status);

--- a/tests/0039-event.c
+++ b/tests/0039-event.c
@@ -48,15 +48,17 @@ static void handle_drs (rd_kafka_event_t *rkev) {
 	const rd_kafka_message_t *rkmessage;
 
 	while ((rkmessage = rd_kafka_event_message_next(rkev))) {
+                int32_t broker_id = rd_kafka_message_broker_id(rkmessage);
 		int msgid = *(int *)rkmessage->_private;
-
 		free(rkmessage->_private);
 
-		TEST_SAYL(3,"Got rkmessage %s [%"PRId32"] @ %"PRId64": %s\n",
+		TEST_SAYL(3,"Got rkmessage %s [%"PRId32"] @ %"PRId64": "
+                          "from broker %"PRId32": %s\n",
 			  rd_kafka_topic_name(rkmessage->rkt),
 			  rkmessage->partition, rkmessage->offset,
+                          broker_id,
 			  rd_kafka_err2str(rkmessage->err));
-			 
+
 
 		if (rkmessage->err != RD_KAFKA_RESP_ERR_NO_ERROR)
 			TEST_FAIL("Message delivery failed: %s\n",
@@ -68,6 +70,9 @@ static void handle_drs (rd_kafka_event_t *rkev) {
 				  msgid, msgid_next);
 			return;
 		}
+
+                TEST_ASSERT(broker_id >= 0,
+                            "Message %d has no broker id set", msgid);
 
 		msgid_next = msgid+1;
 	}

--- a/tests/0077-compaction.c
+++ b/tests/0077-compaction.c
@@ -253,7 +253,7 @@ static void do_test_compaction (int msgs_per_key, const char *compression) {
                                                       rd_kafka_name(rk),
                                                       &mv_correct, testid,
                                                       topic, partition,
-                                                      offset,  -1, 0, cnt);
+                                                      offset, -1, -1, 0, cnt);
                         }
 
 

--- a/tests/test.h
+++ b/tests/test.h
@@ -294,6 +294,7 @@ struct test_mv_m {
         int64_t offset;    /* Message offset */
         int     msgid;     /* Message id */
         int64_t timestamp; /* Message timestamp */
+        int32_t broker_id; /* Message broker id */
 };
 
 
@@ -323,6 +324,9 @@ struct test_mv_vs {
         int64_t timestamp_min;
         int64_t timestamp_max;
 
+        /* used by verify_broker_id */
+        int32_t broker_id;
+
 	struct test_mv_mvec mvec;
 
         /* Correct msgver for comparison */
@@ -336,7 +340,7 @@ int test_msgver_add_msg00 (const char *func, int line, const char *clientname,
                            test_msgver_t *mv,
                            uint64_t testid,
                            const char *topic, int32_t partition,
-                           int64_t offset, int64_t timestamp,
+                           int64_t offset, int64_t timestamp, int32_t broker_id,
                            rd_kafka_resp_err_t err, int msgnum);
 int test_msgver_add_msg0 (const char *func, int line, const char *clientname,
                           test_msgver_t *mv, rd_kafka_message_t *rkm,
@@ -357,6 +361,7 @@ int test_msgver_add_msg0 (const char *func, int line, const char *clientname,
 #define TEST_MSGVER_BY_MSGID  0x10000 /* Verify by msgid (unique in testid) */
 #define TEST_MSGVER_BY_OFFSET 0x20000 /* Verify by offset (unique in partition)*/
 #define TEST_MSGVER_BY_TIMESTAMP 0x40000 /* Verify by timestamp range */
+#define TEST_MSGVER_BY_BROKER_ID 0x80000 /* Verify by broker id */
 
 #define TEST_MSGVER_SUBSET 0x100000  /* verify_compare: allow correct mv to be
                                       * a subset of mv. */


### PR DESCRIPTION
This also refactors and cleans up OP_ERR and OP_CONSUMER_ERR calls.


The broker_id is also useful in our tests.