### PR TITLE
Fix consumer stall when partitions are reassigned (#2955)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ v1.4.4 is a maintenance release with the following fixes and enhancements:
  * Fix crash on transactional coordinator FindCoordinator request failure.
  * Minimize broker re-connect delay when broker's connection is needed to
    send requests.
+ * Proper locking for transaction state in EndTxn handler.
  * `socket.timeout.ms` was ignored when `transactional.id` was set.
  * Added RTT/delay simulation to mock brokers.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ librdkafka.
    supported (by @sky92zwq).
  * `./configure` arguments now take precedence over cached `configure` variables
    from previous invocation.
- * Fix theoeretical crash on coord request failure.
+ * Fix theoretical crash on coord request failure.
 
 
 ### Consumer fixes
@@ -76,9 +76,11 @@ librdkafka.
    for partitions that were not being consumed (#2826).
  * Initial consumer group joins should now be a couple of seconds quicker
    thanks expedited query intervals (@benesch).
- * Don't propagate temporary offset lookup errors to application
  * Fix crash and/or inconsistent subscriptions when using multiple consumers
    (in the same process) with wildcard topics on Windows.
+ * Don't propagate temporary offset lookup errors to application.
+ * Immediately refresh topic metadata when partitions are reassigned to other
+   brokers, avoiding a fetch stall of up to `topic.metadata.refresh.interval.ms`. (#2955)
 
 
 ### Producer fixes

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4361,6 +4361,9 @@ rd_kafka_fetch_reply_handle (rd_kafka_broker_t *rkb,
 				case RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE:
 				case RD_KAFKA_RESP_ERR_NOT_LEADER_FOR_PARTITION:
 				case RD_KAFKA_RESP_ERR_BROKER_NOT_AVAILABLE:
+                                case RD_KAFKA_RESP_ERR_REPLICA_NOT_AVAILABLE:
+                                case RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR:
+                                case RD_KAFKA_RESP_ERR_FENCED_LEADER_EPOCH:
                                         /* Request metadata information update*/
                                         rd_kafka_toppar_leader_unavailable(
                                                 rktp, "fetch", hdr.ErrorCode);
@@ -4452,7 +4455,9 @@ rd_kafka_fetch_reply_handle (rd_kafka_broker_t *rkb,
                                                 hdr.ErrorCode, tver->version,
                                                 NULL, rktp,
                                                 rktp->rktp_offsets.fetch_offset,
-                                                "Fetch failed: %s",
+                                                "Fetch from broker %"PRId32
+                                                " failed: %s",
+                                                rd_kafka_broker_id(rkb),
                                                 rd_kafka_err2str(hdr.ErrorCode));
 					break;
 				}

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -142,6 +142,18 @@ RD_EXPORT
 void rd_kafka_mock_push_request_errors (rd_kafka_mock_cluster_t *mcluster,
                                         int16_t ApiKey, size_t cnt, ...);
 
+
+/**
+ * @brief Same as rd_kafka_mock_push_request_errors() but for a specific broker.
+ *
+ * @remark The broker errors take precedence over the cluster errors.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_mock_broker_push_request_errors (rd_kafka_mock_cluster_t *mcluster,
+                                          int32_t broker_id,
+                                          int16_t ApiKey, size_t cnt, ...);
+
+
 /**
  * @brief Set the topic error to return in protocol requests.
  *

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -67,7 +67,7 @@ static int rd_kafka_mock_handle_Produce (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, TopicsCnt);
 
         /* Inject error, if any */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         while (TopicsCnt-- > 0) {
@@ -197,7 +197,7 @@ static int rd_kafka_mock_handle_Fetch (rd_kafka_mock_connection_t *mconn,
 
 
         /* Inject error, if any */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (rkbuf->rkbuf_reqhdr.ApiVersion >= 7) {
@@ -418,7 +418,7 @@ static int rd_kafka_mock_handle_ListOffset (rd_kafka_mock_connection_t *mconn,
 
 
         /* Inject error, if any */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         rd_kafka_buf_read_i32(rkbuf, &TopicsCnt);
@@ -551,7 +551,7 @@ static int rd_kafka_mock_handle_OffsetFetch (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_read_str(rkbuf, &GroupId);
 
         /* Inject error, if any */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         mrkb = rd_kafka_mock_cluster_get_coord(mcluster, RD_KAFKA_COORD_GROUP,
@@ -689,7 +689,7 @@ static int rd_kafka_mock_handle_OffsetCommit (rd_kafka_mock_connection_t *mconn,
 
 
         /* Inject error, if any */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         mrkb = rd_kafka_mock_cluster_get_coord(mcluster, RD_KAFKA_COORD_GROUP,
@@ -1045,7 +1045,7 @@ rd_kafka_mock_handle_FindCoordinator (rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err && RD_KAFKAP_STR_LEN(&Key) > 0) {
@@ -1147,7 +1147,7 @@ rd_kafka_mock_handle_JoinGroup (rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err) {
@@ -1235,7 +1235,7 @@ rd_kafka_mock_handle_Heartbeat (rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
         if (!err) {
                 mrkb = rd_kafka_mock_cluster_get_coord(mcluster,
@@ -1307,7 +1307,7 @@ rd_kafka_mock_handle_LeaveGroup (rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
         if (!err) {
                 mrkb = rd_kafka_mock_cluster_get_coord(mcluster,
@@ -1386,7 +1386,7 @@ rd_kafka_mock_handle_SyncGroup (rd_kafka_mock_connection_t *mconn,
         }
 
         /* Inject error, if any */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
         if (!err) {
                 mrkb = rd_kafka_mock_cluster_get_coord(mcluster,
@@ -1509,7 +1509,7 @@ rd_kafka_mock_handle_InitProducerId (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, 0);
 
         /* Inject error */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err &&
@@ -1573,7 +1573,7 @@ rd_kafka_mock_handle_AddPartitionsToTxn (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, TopicsCnt);
 
         /* Inject error */
-        all_err = rd_kafka_mock_next_request_error(mcluster,
+        all_err = rd_kafka_mock_next_request_error(mconn,
                                                    rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!all_err &&
@@ -1655,7 +1655,7 @@ rd_kafka_mock_handle_AddOffsetsToTxn (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, 0);
 
         /* Inject error */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err &&
@@ -1709,7 +1709,7 @@ rd_kafka_mock_handle_TxnOffsetCommit (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, TopicsCnt);
 
         /* Inject error */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err &&
@@ -1802,7 +1802,7 @@ rd_kafka_mock_handle_EndTxn (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_write_i32(resp, 0);
 
         /* Inject error */
-        err = rd_kafka_mock_next_request_error(mcluster,
+        err = rd_kafka_mock_next_request_error(mconn,
                                                rkbuf->rkbuf_reqhdr.ApiKey);
 
         if (!err &&

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -138,6 +138,10 @@ typedef struct rd_kafka_mock_broker_s {
 
         TAILQ_HEAD(, rd_kafka_mock_connection_s) connections;
 
+        /**< Per-protocol request error stack.
+         *   @locks mcluster->lock */
+        rd_kafka_mock_error_stack_head_t errstacks;
+
         struct rd_kafka_mock_cluster_s *cluster;
 } rd_kafka_mock_broker_t;
 
@@ -362,7 +366,7 @@ rd_kafka_mock_msgset_find (const rd_kafka_mock_partition_t *mpart,
                            int64_t offset, rd_bool_t on_follower);
 
 rd_kafka_resp_err_t
-rd_kafka_mock_next_request_error (rd_kafka_mock_cluster_t *mcluster,
+rd_kafka_mock_next_request_error (rd_kafka_mock_connection_t *mconn,
                                   int16_t ApiKey);
 
 rd_kafka_resp_err_t

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -451,6 +451,9 @@ rd_kafka_resp_err_t rd_kafka_handle_Offset (rd_kafka_t *rk,
                 RD_KAFKA_ERR_ACTION_REFRESH,
                 RD_KAFKA_RESP_ERR_NOT_LEADER_FOR_PARTITION,
 
+                RD_KAFKA_ERR_ACTION_REFRESH,
+                RD_KAFKA_RESP_ERR_REPLICA_NOT_AVAILABLE,
+
                 RD_KAFKA_ERR_ACTION_REFRESH|RD_KAFKA_ERR_ACTION_RETRY,
                 RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE,
 

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -1937,13 +1937,17 @@ static void rd_kafka_txn_handle_EndTxn (rd_kafka_t *rk,
                 is_commit = rd_false;
         else
                 err = RD_KAFKA_RESP_ERR__OUTDATED;
+
+        if (!err) {
+                /* EndTxn successful: complete the transaction */
+                rd_kafka_txn_complete(rk);
+        }
+
         rd_kafka_wrunlock(rk);
 
         switch (err)
         {
         case RD_KAFKA_RESP_ERR_NO_ERROR:
-                /* EndTxn successful: complete the transaction */
-                rd_kafka_txn_complete(rk);
                 break;
 
         case RD_KAFKA_RESP_ERR__DESTROY:

--- a/src/rdkafka_txnmgr.h
+++ b/src/rdkafka_txnmgr.h
@@ -54,10 +54,10 @@ static RD_INLINE RD_UNUSED rd_bool_t
 rd_kafka_txn_may_send_msg (rd_kafka_t *rk) {
         rd_bool_t ret;
 
-        rd_kafka_wrlock(rk);
+        rd_kafka_rdlock(rk);
         ret = (rk->rk_eos.txn_state == RD_KAFKA_TXN_STATE_IN_TRANSACTION ||
                rk->rk_eos.txn_state == RD_KAFKA_TXN_STATE_BEGIN_COMMIT);
-        rd_kafka_wrunlock(rk);
+        rd_kafka_rdunlock(rk);
 
         return ret;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -2613,6 +2613,29 @@ void test_consumer_assign_partition (const char *what, rd_kafka_t *rk,
 }
 
 
+void test_consumer_pause_resume_partition (rd_kafka_t *rk,
+                                           const char *topic, int32_t partition,
+                                           rd_bool_t pause) {
+        rd_kafka_topic_partition_list_t *part;
+        rd_kafka_resp_err_t err;
+
+        part = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(part, topic, partition);
+
+        if (pause)
+                err = rd_kafka_pause_partitions(rk, part);
+        else
+                err = rd_kafka_resume_partitions(rk, part);
+
+        TEST_ASSERT(!err, "Failed to %s %s [%"PRId32"]: %s",
+                    pause ? "pause":"resume",
+                    topic, partition,
+                    rd_kafka_err2str(err));
+
+        rd_kafka_topic_partition_list_destroy(part);
+}
+
+
 /**
  * Message verification services
  *

--- a/tests/test.h
+++ b/tests/test.h
@@ -520,6 +520,9 @@ void test_consumer_unassign (const char *what, rd_kafka_t *rk);
 void test_consumer_assign_partition (const char *what, rd_kafka_t *rk,
                                      const char *topic, int32_t partition,
                                      int64_t offset);
+void test_consumer_pause_resume_partition (rd_kafka_t *rk,
+                                           const char *topic, int32_t partition,
+                                           rd_bool_t pause);
 
 void test_consumer_close (rd_kafka_t *rk);
 


### PR DESCRIPTION
.. and a locking fix for transactions.