### PR TITLE
Consumer assignors could ignore topics if topic_cnt > member_cnt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ librdkafka.
  * The roundrobin partition assignor could crash if subscriptions
    where asymmetrical (different sets from different members of the group).
    Thanks to @ankon and @wilmai for identifying the root cause (#2121).
+ * The consumer assignors could ignore some topics if there were more subscribed
+   topics than consumers in taking part in the assignment.
  * The consumer would connect to all partition leaders of a topic even
    for partitions that were not being consumed (#2826).
  * Initial consumer group joins should now be a couple of seconds quicker

--- a/src/rdkafka_assignor.c
+++ b/src/rdkafka_assignor.c
@@ -232,12 +232,11 @@ rd_kafka_member_subscriptions_map (rd_kafka_cgrp_t *rkcg,
         /* For each topic in the cluster, scan through the member list
          * to find matching subscriptions. */
         for (ti = 0 ; ti < metadata->topic_cnt ; ti++) {
-                int complete_cnt = 0;
                 int i;
 
                 /* Ignore topics in blacklist */
                 if (rkcg->rkcg_rk->rk_conf.topic_blacklist &&
-		    rd_kafka_pattern_match(rkcg->rkcg_rk->rk_conf.
+                    rd_kafka_pattern_match(rkcg->rkcg_rk->rk_conf.
                                            topic_blacklist,
                                            metadata->topics[ti].topic)) {
                         rd_kafka_dbg(rkcg->rkcg_rk, TOPIC, "BLACKLIST",
@@ -256,10 +255,9 @@ rd_kafka_member_subscriptions_map (rd_kafka_cgrp_t *rkcg,
                 for (i = 0 ; i < member_cnt ; i++) {
                         /* Match topic against existing metadata,
                            incl regex matching. */
-                        if (rd_kafka_member_subscription_match(
-                                    rkcg, &members[i], &metadata->topics[ti],
-                                    eligible_topic))
-                                complete_cnt++;
+                        rd_kafka_member_subscription_match(
+                                rkcg, &members[i], &metadata->topics[ti],
+                                eligible_topic);
                 }
 
                 if (rd_list_empty(&eligible_topic->members)) {
@@ -270,9 +268,6 @@ rd_kafka_member_subscriptions_map (rd_kafka_cgrp_t *rkcg,
                 eligible_topic->metadata = &metadata->topics[ti];
                 rd_list_add(eligible_topics, eligible_topic);
                 eligible_topic = NULL;
-
-                if (complete_cnt == (int)member_cnt)
-                        break;
         }
 
         if (eligible_topic)


### PR DESCRIPTION
This is a backport from the kip-54 PR which I believe you've already reviewed.