### PR TITLE
fix: produce thread block and never wakeup

### DIFF
--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -506,6 +506,7 @@ struct rd_kafka_s {
 		size_t size;      /* Current message size sum */
 	        unsigned int max_cnt; /* Max limit */
 		size_t max_size; /* Max limit */
+        char blocked;    /* Produce thread has blocked */
 	} rk_curr_msgs;
 
         rd_kafka_timers_t rk_timers;
@@ -627,6 +628,7 @@ rd_kafka_curr_msgs_add (rd_kafka_t *rk, unsigned int cnt, size_t size,
                 if (rdlock)
                         rwlock_rdunlock(rdlock);
 
+        rk->rk_curr_msgs.blocked = 1;
 		cnd_wait(&rk->rk_curr_msgs.cnd, &rk->rk_curr_msgs.lock);
 
                 if (rdlock)
@@ -661,12 +663,12 @@ rd_kafka_curr_msgs_sub (rd_kafka_t *rk, unsigned int cnt, size_t size) {
 
         /* If the subtraction would pass one of the thresholds
          * broadcast a wake-up to any waiting listeners. */
-        if ((rk->rk_curr_msgs.cnt - cnt == 0) ||
-            (rk->rk_curr_msgs.cnt >= rk->rk_curr_msgs.max_cnt &&
-             rk->rk_curr_msgs.cnt - cnt < rk->rk_curr_msgs.max_cnt) ||
-            (rk->rk_curr_msgs.size >= rk->rk_curr_msgs.max_size &&
-             rk->rk_curr_msgs.size - size < rk->rk_curr_msgs.max_size))
-                broadcast = 1;
+        if (rk->rk_curr_msgs.blocked)
+            if ((rk->rk_curr_msgs.cnt - cnt < rk->rk_curr_msgs.max_cnt) ||
+                (rk->rk_curr_msgs.size - size < rk->rk_curr_msgs.max_size)) {
+                    broadcast = 1;
+                    rk->rk_curr_msgs.blocked = 0;
+            }
 
 	rk->rk_curr_msgs.cnt  -= cnt;
 	rk->rk_curr_msgs.size -= size;


### PR DESCRIPTION
Porudcer may blocked and never waked up when flag RdKafka::Producer::RK_MSG_BLOCK is set to produce.

Here is two contition in code:
- conditionA:
(rk->rk_curr_msgs.cnt + cnt >rk->rk_curr_msgs.max_cnt ||
			(unsigned long long)(rk->rk_curr_msgs.size + size) >(unsigned long long)rk->rk_curr_msgs.max_size)

- conditionB:
(rk->rk_curr_msgs.cnt - cnt == 0) ||
            (rk->rk_curr_msgs.cnt >= rk->rk_curr_msgs.max_cnt &&
             rk->rk_curr_msgs.cnt - cnt < rk->rk_curr_msgs.max_cnt) ||
            (rk->rk_curr_msgs.size >= rk->rk_curr_msgs.max_size &&
             rk->rk_curr_msgs.size - size < rk->rk_curr_msgs.max_size

Produce thread would block when conditionA==true, and wakeup when conditionB==true.

But we found, when the produce thread is blocked, the conditionB will not always wake up the blocked thread.This is because, when the produce thread blocked, rk->rk_curr_msgs.cnt may less than rk->rk_curr_msgs.max_cnt, and  rk->rk_curr_msgs.size may less than rk->rk_curr_msgs.max_size eigher. 

This fix solved this problem by change wakeup condition. When produce thread is blocked, and the space is enough, we should always awake them. 