### PR TITLE
Destroy control messages in batch mode

### DIFF
--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -602,8 +602,10 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
 
                         /* If this is a control messages, don't return
                          * message to application, only store the offset */
-                        if (unlikely(rd_kafka_op_is_ctrl_msg(rko)))
+                        if (unlikely(rd_kafka_op_is_ctrl_msg(rko))) {
+                                rd_kafka_op_destroy(rko);
                                 continue;
+                        }
                 }
 
 		/* Get rkmessage from rko and append to array. */


### PR DESCRIPTION
If there are control messages in the topic, rd_kafka_destroy will
hang if only rd_kafka_consume_batch is used, rd_kafka_consume and
rd_kafka_consume_callback don't have this issue.

Release these messages before returning to the application.