### PR TITLE
Fixes and updates for building with VS 2019 on Win10

### DIFF
--- a/README.win32
+++ b/README.win32
@@ -4,9 +4,9 @@ Native win32 build instructions using Microsoft Visual Studio 2015 (MSVC).
 Requirements:
  * zlib is installed automatically from NuGet,
    but probably requires the NuGet VS extension.
- * OpenSSL-win32 must be installed in C:\OpenSSL-win32 and C:\OpenSSL-Win64
-   depending on your architecture.
-   Download and install the latest v1.0.2 non-light package from:
+ * OpenSSL-win32 must be installed in C:\OpenSSL-win32 and OpenSSL-win64
+   in C:\OpenSSL-Win64 depending on your architecture.
+   Download and install the latest v1.1.1 non-light package from:
    https://slproweb.com/products/Win32OpenSSL.html
    (This would be using NuGet too but the current
     OpenSSL packages are outdated and with broken

--- a/win32/build.bat
+++ b/win32/build.bat
@@ -2,11 +2,13 @@
 
 SET TOOLCHAIN=v140
 
+nuget restore librdkafka.sln
+
 FOR %%C IN (Debug,Release) DO (
   FOR %%P IN (Win32,x64) DO (
      @echo Building %%C %%P
-     msbuild librdkafka.sln /p:Configuration=%%C /p:Platform=%%P /target:Clean
-     msbuild librdkafka.sln /p:Configuration=%%C /p:Platform=%%P || goto :error
+     msbuild librdkafka.sln /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=v140 /target:Clean
+     msbuild librdkafka.sln /p:Configuration=%%C /p:Platform=%%P /p:PlatformToolset=v140 || goto :error
 
 
   )

--- a/win32/install-openssl.ps1
+++ b/win32/install-openssl.ps1
@@ -1,33 +1,36 @@
-$OpenSSLVersion = "1_0_2r"
+$OpenSSLVersion = "1_1_1g"
 $OpenSSLExe = "OpenSSL-$OpenSSLVersion.exe"
+$OpenSSLUriBase = "https://slproweb.com/download"
 
 if (!(Test-Path("C:\OpenSSL-Win32"))) {
-   instDir = "C:\OpenSSL-Win32"
+   $instDir = "C:\OpenSSL-Win32"
    $exeFull = "Win32$OpenSSLExe"
    $exePath = "$($env:USERPROFILE)\$exeFull"
+   $uri     = "$OpenSSLUriBase/$exeFull"
 
-   Write-Host "Downloading and installing OpenSSL v1.0 32-bit ..." -ForegroundColor Cyan
-   (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/$exeFull', $exePath)
+   Write-Host "Downloading and installing OpenSSL v$OpenSSLVersion 32-bit via $uri ..." -ForegroundColor Cyan
+   (New-Object Net.WebClient).DownloadFile($uri, $exePath)
 
    Write-Host "Installing to $instDir..."
-   cmd /c start /wait $exePath /silent /verysilent /sp- /suppressmsgboxes /DIR=$instDir
+   Start-Process -FilePath $exePath -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes /DIR=`"$instDir`""
    Write-Host "Installed" -ForegroundColor Green
 } else {
-   echo "OpenSSL-Win32 already exists: not downloading"
+   Write-Output "OpenSSL-Win32 already exists: not downloading"
 }
 
 
 if (!(Test-Path("C:\OpenSSL-Win64"))) {
-   instDir = "C:\OpenSSL-Win64"
+   $instDir = "C:\OpenSSL-Win64"
    $exeFull = "Win64$OpenSSLExe"
    $exePath = "$($env:USERPROFILE)\$exeFull"
+   $uri     = "$OpenSSLUriBase/$exeFull"
 
-   Write-Host "Downloading and installing OpenSSL v1.0 64-bit ..." -ForegroundColor Cyan
-   (New-Object Net.WebClient).DownloadFile('https://slproweb.com/download/$exeFull', $exePath)
+   Write-Host "Downloading and installing OpenSSL v$OpenSSLVersion 64-bit via $uri ..." -ForegroundColor Cyan
+   (New-Object Net.WebClient).DownloadFile($uri, $exePath)
 
    Write-Host "Installing to $instDir..."
-   cmd /c start /wait $exePath /silent /verysilent /sp- /suppressmsgboxes /DIR=$instDir
+   Start-Process -FilePath $exePath -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes /DIR=`"$instDir`""
    Write-Host "Installed" -ForegroundColor Green
 } else {
-   echo "OpenSSL-Win64 already exists: not downloading"
+   Write-Output "OpenSSL-Win64 already exists: not downloading"
 }

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -5,6 +5,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>librdkafka</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <PlatformToolset>Visual Studio 2013 (v120)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -33,7 +34,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libcrypto32MT.lib;libssl32MT.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -50,7 +51,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libcrypto64MT.lib;libssl64MT.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -70,7 +71,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalOptions>/SAFESEH:NO</AdditionalOptions>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libcrypto32MT.lib;libssl32MT.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -89,7 +90,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libcrypto64MT.lib;libssl64MT.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -5,7 +5,6 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>librdkafka</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
-    <PlatformToolset>Visual Studio 2013 (v120)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>


### PR DESCRIPTION
I was trying to build with Visual Studio 2019 on Win10 and had a lot of challenges as others have mentioned (see Issue #2816) 

This PR makes the following changes:

- Fixes the `build.bat` script to explicitly set the `PlatformToolset`
- Call `nuget restore` in `build.bat` to make sure dependencies are fetched prior to building
- Bump OpenSSL version to the latest LTS on win32 (1.1.1g) by updating the vcxproj to use the newer library names (and setting appropriate version based on win32 vs x64 target)
- Updates the powershell script for installing openssl (`install-openssl.ps1`) to use the newer version as well as resolve issues running it in newer PowerShell environments by using `Start-Process` instead of `cmd`
- Updates the win32 readme to mention latest OpenSSL version is 1.1.1 and clarify it expects you to install 

I'm no Visual Studio expert and still cannot get the project to build using the VS2019 gui application...only via the msbuild tool on the command line. (I don't have access to VS2015 tooling to make and test the proper changes.)

I realize this PR combines both a dependency bump as well as some tooling changes, so if you'd like me to split it up into two different PRs, let me know.