### PR TITLE
fix producer header option

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -863,7 +863,7 @@ int main (int argc, char **argv) {
 	while ((opt =
 		getopt(argc, argv,
 		       "PCG:t:p:b:s:k:c:fi:MDd:m:S:x:"
-                       "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNHH:")) != -1) {
+                       "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNhH:")) != -1) {
 		switch (opt) {
 		case 'G':
 			if (rd_kafka_conf_set(conf, "group.id", optarg,
@@ -962,37 +962,35 @@ int main (int argc, char **argv) {
 		case 'd':
 			debug = optarg;
 			break;
-                case 'H':
-                {
-                        char *name, *val;
-                        size_t name_sz = -1;
+        case 'h':
+            read_hdrs = 1;
+            break;
+        case 'H':
+            {
+                char *name, *val;
+                size_t name_sz = -1;
 
-                        if (!optarg) {
-                                read_hdrs = 1;
-                                break;
-                        }
-
-                        name = optarg;
-                        val = strchr(name, '=');
-                        if (val) {
-                                name_sz = (size_t)(val-name);
-                                val++; /* past the '=' */
-                        }
-
-                        if (!hdrs)
-                                hdrs = rd_kafka_headers_new(8);
-
-                        err = rd_kafka_header_add(hdrs, name, name_sz, val, -1);
-                        if (err) {
-                                fprintf(stderr,
-                                        "%% Failed to add header %s: %s\n",
-                                        name, rd_kafka_err2str(err));
-                                exit(1);
-                        }
-
-                        read_hdrs = 1;
+                name = optarg;
+                val = strchr(name, '=');
+                if (val) {
+                        name_sz = (size_t)(val-name);
+                        val++; /* past the '=' */
                 }
-                break;
+
+                if (!hdrs)
+                        hdrs = rd_kafka_headers_new(8);
+
+                err = rd_kafka_header_add(hdrs, name, name_sz, val, -1);
+                if (err) {
+                        fprintf(stderr,
+                                "%% Failed to add header %s: %s\n",
+                                name, rd_kafka_err2str(err));
+                        exit(1);
+                }
+
+                read_hdrs = 1;
+            }
+            break;
 		case 'X':
 		{
 			char *name, *val;
@@ -1131,8 +1129,8 @@ int main (int argc, char **argv) {
 			"  -b <brokers> Broker address list (host[:port],..)\n"
 			"  -s <size>    Message size (producer)\n"
 			"  -k <key>     Message key (producer)\n"
-                        "  -H <name[=value]> Add header to message (producer)\n"
-                        "  -H           Read message headers (consumer)\n"
+            "  -H <name[=value]> Add header to message (producer)\n"
+            "  -h           Read message headers (consumer)\n"
 			"  -c <cnt>     Messages to transmit/receive\n"
 			"  -x <cnt>     Hard exit after transmitting <cnt> messages (producer)\n"
 			"  -D           Copy/Duplicate data buffer (producer)\n"

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -863,7 +863,7 @@ int main (int argc, char **argv) {
 	while ((opt =
 		getopt(argc, argv,
 		       "PCG:t:p:b:s:k:c:fi:MDd:m:S:x:"
-                       "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNhH:")) != -1) {
+                       "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNH:")) != -1) {
 		switch (opt) {
 		case 'G':
 			if (rd_kafka_conf_set(conf, "group.id", optarg,
@@ -966,7 +966,7 @@ int main (int argc, char **argv) {
             read_hdrs = 1;
             break;
         case 'H':
-            {
+            if (mode == 'P') {
                 char *name, *val;
                 size_t name_sz = -1;
 
@@ -989,6 +989,12 @@ int main (int argc, char **argv) {
                 }
 
                 read_hdrs = 1;
+            } else if (!strcmp(optarg, "parse")) {
+                read_hdrs = 1;
+            } else {
+                fprintf(stderr, "%% expected "
+                        "-H parse, not -H %s for consumer\n", optarg);
+                exit(1);
             }
             break;
 		case 'X':
@@ -1130,7 +1136,7 @@ int main (int argc, char **argv) {
 			"  -s <size>    Message size (producer)\n"
 			"  -k <key>     Message key (producer)\n"
             "  -H <name[=value]> Add header to message (producer)\n"
-            "  -h           Read message headers (consumer)\n"
+            "  -H parse     Read message headers (consumer)\n"
 			"  -c <cnt>     Messages to transmit/receive\n"
 			"  -x <cnt>     Hard exit after transmitting <cnt> messages (producer)\n"
 			"  -D           Copy/Duplicate data buffer (producer)\n"

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -963,7 +963,9 @@ int main (int argc, char **argv) {
 			debug = optarg;
 			break;
         case 'H':
-            if (mode == 'P') {
+            if (!strcmp(optarg, "parse"))
+                read_hdrs = 1;
+            else {
                 char *name, *val;
                 size_t name_sz = -1;
 
@@ -984,14 +986,6 @@ int main (int argc, char **argv) {
                                 name, rd_kafka_err2str(err));
                         exit(1);
                 }
-
-                read_hdrs = 1;
-            } else if (!strcmp(optarg, "parse")) {
-                read_hdrs = 1;
-            } else {
-                fprintf(stderr, "%% expected "
-                        "-H parse, not -H %s for consumer\n", optarg);
-                exit(1);
             }
             break;
 		case 'X':
@@ -1294,6 +1288,15 @@ int main (int argc, char **argv) {
         if (mode == 'C' || mode == 'G')
                 rd_kafka_conf_set(conf, "enable.partition.eof", "true",
                                   NULL, 0);
+    if (read_hdrs && mode == 'P') {
+        fprintf(stderr, "%% producer can not read headers\n");
+        exit(1);
+    }
+    
+    if (hdrs && mode != 'P') {
+        fprintf(stderr, "%% consumer can not add headers\n");
+        exit(1);
+    }
 
 	if (mode == 'P') {
 		/*

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -962,9 +962,6 @@ int main (int argc, char **argv) {
 		case 'd':
 			debug = optarg;
 			break;
-        case 'h':
-            read_hdrs = 1;
-            break;
         case 'H':
             if (mode == 'P') {
                 char *name, *val;


### PR DESCRIPTION
Currently, the ability to test producing messages with a header in `rdkafka_performance` is broken because of a subtle `getopt` error.  Although the intent is to give the option `-H` an optional argument, what is happening is optarg is always discarding an option even if present since the format string looks like `...HH:` - it never parses the latter part.

There are a couple of considerations:
* [GNU optarg supports optional arguments with a double colon in the format string](https://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html) (would use `H::`) but not all platforms use GNU.
* [the POSIX standard actually forbids GNU-style optional arguments](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02).

Thus IMHO the best approach is to just make them different options: `-H <argument>` for the producer, and `-h` for the consumer.