### PR TITLE
Remove offset.store.method=broker from the examples/ directory.

### DIFF
--- a/examples/rdkafka_complex_consumer_example.c
+++ b/examples/rdkafka_complex_consumer_example.c
@@ -477,15 +477,6 @@ int main (int argc, char **argv) {
                         exit(1);
                 }
 
-                /* Consumer groups always use broker based offset storage */
-                if (rd_kafka_topic_conf_set(topic_conf, "offset.store.method",
-                                            "broker",
-                                            errstr, sizeof(errstr)) !=
-                    RD_KAFKA_CONF_OK) {
-                        fprintf(stderr, "%% %s\n", errstr);
-                        exit(1);
-                }
-
                 /* Set default topic config for pattern-matched topics. */
                 rd_kafka_conf_set_default_topic_conf(conf, topic_conf);
 


### PR DESCRIPTION
This config option is deprecated and should no longer be used in examples.

The non-deprecated behavior is implicitly "offset.store.method=broker".
Trying to set "offset.store.method=broker" explicitly gives a warning, and
trying to set "offset.store.method" to anything else is deprecated AND gives
a warning.

However, "offset.store.method=file" is still supported in src/,
and therefore tested. I didn't touch tests/.

Addresses #3016.