### PR TITLE
Fix for use-of-uninitialized-value in rdaddr.c

### DIFF
--- a/src/rdaddr.c
+++ b/src/rdaddr.c
@@ -148,10 +148,13 @@ rd_sockaddr_list_t *rd_getaddrinfo (const char *nodesvc, const char *defsvc,
 				    int flags, int family,
 				    int socktype, int protocol,
 				    const char **errstr) {
-	struct addrinfo hints = { .ai_family = family,
-				  .ai_socktype = socktype,
-				  .ai_protocol = protocol,
-				  .ai_flags = flags };
+	struct addrinfo hints;
+    	memset(&hints, 0, sizeof(hints));
+    	hints.ai_family = family;
+	hints.ai_socktype = socktype;
+	hints.ai_protocol = protocol;
+	hints.ai_flags = flags;
+
 	struct addrinfo *ais, *ai;
 	char *node, *svc;
 	int r;


### PR DESCRIPTION
Fix error reported by Memory sanitizer, see https://github.com/ClickHouse/ClickHouse/issues/12990
Backporting fix by @alexey-milovidov from https://github.com/ClickHouse-Extras/librdkafka/pull/1