### PR TITLE
add recent additions to kafka broker error codes

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -486,11 +486,7 @@ enum ErrorCode {
         /** Broker failed to validate record */
         ERR_INVALID_RECORD = 87,
         /** There are unstable offsets that need to be cleared */
-        ERR_UNSTABLE_OFFSET_COMMIT = 88,
-        /** The throttling quota has been exceeded */
-        ERR_THROTTLING_QUOTA_EXCEEDED = 89,
-        /** Producer has been fenced by another producer with the same transaction.id */
-        ERR_PRODUCER_FENCED = 90
+        ERR_UNSTABLE_OFFSET_COMMIT = 88
 };
 
 

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -475,6 +475,22 @@ enum ErrorCode {
         /** Static consumer fenced by other consumer with same
          * group.instance.id. */
         ERR_FENCED_INSTANCE_ID = 82,
+        /** Eligible partition leaders are not available */
+        ERR_ELIGIBLE_LEADERS_NOT_AVAILABLE = 83,
+        /** Leader election not needed for topic partition */
+        ERR_ELECTION_NOT_NEEDED = 84,
+        /** No partition reassignment is in progress */
+        ERR_NO_REASSIGNMENT_IN_PROGRESS = 85,
+        /** Deleting offsets of a topic while the consumer group is subscribed to it */
+        ERR_GROUP_SUBSCRIBED_TO_TOPIC = 86,
+        /** Broker failed to validate record */
+        ERR_INVALID_RECORD = 87,
+        /** There are unstable offsets that need to be cleared */
+        ERR_UNSTABLE_OFFSET_COMMIT = 88,
+        /** The throttling quota has been exceeded */
+        ERR_THROTTLING_QUOTA_EXCEEDED = 89,
+        /** Producer has been fenced by another producer with the same transaction.id */
+        ERR_PRODUCER_FENCED = 90
 };
 
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -676,6 +676,22 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
         _ERR_DESC(RD_KAFKA_RESP_ERR_FENCED_INSTANCE_ID,
                   "Broker: Static consumer fenced by other consumer with same "
                   "group.instance.id"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_ELIGIBLE_LEADERS_NOT_AVAILABLE,
+                  "Broker: Eligible topic partition leaders are not available"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_ELECTION_NOT_NEEDED,
+                  "Broker: Leader election not needed for topic partition"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_NO_REASSIGNMENT_IN_PROGRESS,
+                  "Broker: No partition reassignment is in progress"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_GROUP_SUBSCRIBED_TO_TOPIC,
+                  "Broker: Deleting offsets of a topic while the consumer group is subscribed to it"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_INVALID_RECORD,
+                  "Broker: Broker failed to validate record"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_UNSTABLE_OFFSET_COMMIT,
+                  "Broker: There are unstable offsets that need to be cleared"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED,
+                  "Broker: The throttling quota has been exceeded"),
+        _ERR_DESC(RD_KAFKA_RESP_ERR_PRODUCER_FENCED,
+                  "Broker: Producer has been fenced by another with the same transaction.id"),
 
 	_ERR_DESC(RD_KAFKA_RESP_ERR__END, NULL)
 };

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3,24 +3,24 @@
  *
  * Copyright (c) 2012-2013, Magnus Edenhill
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met: 
- * 
+ * modification, are permitted provided that the following conditions are met:
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer. 
+ *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution. 
- * 
+ *    and/or other materials provided with the distribution.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
@@ -677,7 +677,7 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
                   "Broker: Static consumer fenced by other consumer with same "
                   "group.instance.id"),
         _ERR_DESC(RD_KAFKA_RESP_ERR_ELIGIBLE_LEADERS_NOT_AVAILABLE,
-                  "Broker: Eligible topic partition leaders are not available"),
+                  "Broker: Eligible partition leaders are not available"),
         _ERR_DESC(RD_KAFKA_RESP_ERR_ELECTION_NOT_NEEDED,
                   "Broker: Leader election not needed for topic partition"),
         _ERR_DESC(RD_KAFKA_RESP_ERR_NO_REASSIGNMENT_IN_PROGRESS,
@@ -691,7 +691,7 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
         _ERR_DESC(RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED,
                   "Broker: The throttling quota has been exceeded"),
         _ERR_DESC(RD_KAFKA_RESP_ERR_PRODUCER_FENCED,
-                  "Broker: Producer has been fenced by another with the same transaction.id"),
+                  "Broker: Producer has been fenced by another producer with the same transaction.id"),
 
 	_ERR_DESC(RD_KAFKA_RESP_ERR__END, NULL)
 };

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -688,10 +688,6 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
                   "Broker: Broker failed to validate record"),
         _ERR_DESC(RD_KAFKA_RESP_ERR_UNSTABLE_OFFSET_COMMIT,
                   "Broker: There are unstable offsets that need to be cleared"),
-        _ERR_DESC(RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED,
-                  "Broker: The throttling quota has been exceeded"),
-        _ERR_DESC(RD_KAFKA_RESP_ERR_PRODUCER_FENCED,
-                  "Broker: Producer has been fenced by another producer with the same transaction.id"),
 
 	_ERR_DESC(RD_KAFKA_RESP_ERR__END, NULL)
 };

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -566,6 +566,22 @@ typedef enum {
         /** Static consumer fenced by other consumer with same
          *  group.instance.id. */
         RD_KAFKA_RESP_ERR_FENCED_INSTANCE_ID = 82,
+        /** Eligible topic partition leaders are not available */
+        RD_KAFKA_RESP_ERR_ELIGIBLE_LEADERS_NOT_AVAILABLE = 83,
+        /** Leader election not needed for topic partition */
+        RD_KAFKA_RESP_ERR_ELECTION_NOT_NEEDED = 84,
+        /** No partition reassignment is in progress */
+        RD_KAFKA_RESP_ERR_NO_REASSIGNMENT_IN_PROGRESS = 85,
+        /** Deleting offsets of a topic while the consumer group is subscribed to it */
+        RD_KAFKA_RESP_ERR_GROUP_SUBSCRIBED_TO_TOPIC = 86,
+        /** Broker failed to validate record */
+        RD_KAFKA_RESP_ERR_INVALID_RECORD = 87,
+        /** There are unstable offsets that need to be cleared */
+        RD_KAFKA_RESP_ERR_UNSTABLE_OFFSET_COMMIT = 88,
+        /** The throttling quota has been exceeded */
+        RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED = 89,
+        /** Producer has been fenced by another with the same transaction.id */
+        RD_KAFKA_RESP_ERR_PRODUCER_FENCED = 90,
 
         RD_KAFKA_RESP_ERR_END_ALL,
 } rd_kafka_resp_err_t;

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -566,7 +566,7 @@ typedef enum {
         /** Static consumer fenced by other consumer with same
          *  group.instance.id. */
         RD_KAFKA_RESP_ERR_FENCED_INSTANCE_ID = 82,
-        /** Eligible topic partition leaders are not available */
+        /** Eligible partition leaders are not available */
         RD_KAFKA_RESP_ERR_ELIGIBLE_LEADERS_NOT_AVAILABLE = 83,
         /** Leader election not needed for topic partition */
         RD_KAFKA_RESP_ERR_ELECTION_NOT_NEEDED = 84,
@@ -580,7 +580,7 @@ typedef enum {
         RD_KAFKA_RESP_ERR_UNSTABLE_OFFSET_COMMIT = 88,
         /** The throttling quota has been exceeded */
         RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED = 89,
-        /** Producer has been fenced by another with the same transaction.id */
+        /** Producer has been fenced by another producer with the same transaction.id */
         RD_KAFKA_RESP_ERR_PRODUCER_FENCED = 90,
 
         RD_KAFKA_RESP_ERR_END_ALL,

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -578,10 +578,6 @@ typedef enum {
         RD_KAFKA_RESP_ERR_INVALID_RECORD = 87,
         /** There are unstable offsets that need to be cleared */
         RD_KAFKA_RESP_ERR_UNSTABLE_OFFSET_COMMIT = 88,
-        /** The throttling quota has been exceeded */
-        RD_KAFKA_RESP_ERR_THROTTLING_QUOTA_EXCEEDED = 89,
-        /** Producer has been fenced by another producer with the same transaction.id */
-        RD_KAFKA_RESP_ERR_PRODUCER_FENCED = 90,
 
         RD_KAFKA_RESP_ERR_END_ALL,
 } rd_kafka_resp_err_t;


### PR DESCRIPTION
See https://github.com/apache/kafka/blob/b937ec75677f8af13bf6fda686f07e9c62cdd20f/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java#L317-L328 for the upstream error code names and descriptions. It looks like `THROTTLING_QUOTA_EXCEEDED ` and `PRODUCER_FENCED ` have not made it into a released broker yet, so we may want to hold off on them until they're released. But the others are documented at https://kafka.apache.org/protocol.html#protocol_error_codes already, and `INVALID_RECORD` in particular is being returned for messages with no keys that are produced to compacted topics.