### PR TITLE
rdkafka_mock: fix message v2 overhead sanity check

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -207,7 +207,7 @@ rd_kafka_mock_partition_log_append (rd_kafka_mock_partition_t *mpart,
 
         if (RecordCount < 1 ||
             (size_t)RecordCount >
-            RD_KAFKAP_BYTES_LEN(bytes) / RD_KAFKAP_MESSAGE_V2_OVERHEAD) {
+            RD_KAFKAP_BYTES_LEN(bytes) / RD_KAFKAP_MESSAGE_V2_MIN_OVERHEAD) {
                 err = RD_KAFKA_RESP_ERR_INVALID_MSG_SIZE;
                 goto err;
         }

--- a/src/rdkafka_msg.h
+++ b/src/rdkafka_msg.h
@@ -150,7 +150,7 @@ size_t rd_kafka_msg_wire_size (const rd_kafka_msg_t *rkm, int MsgVersion) {
         static const size_t overheads[] = {
                 [0] = RD_KAFKAP_MESSAGE_V0_OVERHEAD,
                 [1] = RD_KAFKAP_MESSAGE_V1_OVERHEAD,
-                [2] = RD_KAFKAP_MESSAGE_V2_OVERHEAD
+                [2] = RD_KAFKAP_MESSAGE_V2_MAX_OVERHEAD
         };
         size_t size;
         rd_dassert(MsgVersion >= 0 && MsgVersion <= 2);
@@ -172,7 +172,7 @@ size_t rd_kafka_msg_wire_size (const rd_kafka_msg_t *rkm, int MsgVersion) {
 static RD_INLINE RD_UNUSED
 size_t rd_kafka_msg_max_wire_size (size_t keylen, size_t valuelen,
                                    size_t hdrslen) {
-        return RD_KAFKAP_MESSAGE_V2_OVERHEAD +
+        return RD_KAFKAP_MESSAGE_V2_MAX_OVERHEAD +
                 keylen + valuelen + hdrslen;
 }
 

--- a/src/rdkafka_msgset_writer.c
+++ b/src/rdkafka_msgset_writer.c
@@ -313,7 +313,7 @@ rd_kafka_msgset_writer_alloc_buf (rd_kafka_msgset_writer_t *msetw) {
 
         case 2:
                 /* MsgVer2 uses varints, we calculate for the worst-case. */
-                msg_overhead += RD_KAFKAP_MESSAGE_V2_OVERHEAD;
+                msg_overhead += RD_KAFKAP_MESSAGE_V2_MAX_OVERHEAD;
 
                 /* MessageSet header fields */
                 msgsetsize +=

--- a/src/rdkafka_proto.h
+++ b/src/rdkafka_proto.h
@@ -505,7 +505,7 @@ typedef struct rd_kafka_buf_s rd_kafka_buf_t;
 /**
  * MsgVersion v2
  */
-#define RD_KAFKAP_MESSAGE_V2_OVERHEAD                                  \
+#define RD_KAFKAP_MESSAGE_V2_MAX_OVERHEAD                              \
         (                                                              \
         /* Length (varint) */                                          \
         RD_UVARINT_ENC_SIZEOF(int32_t) +                               \
@@ -523,6 +523,23 @@ typedef struct rd_kafka_buf_s rd_kafka_buf_t;
         RD_UVARINT_ENC_SIZEOF(int32_t)                                 \
         )
 
+#define RD_KAFKAP_MESSAGE_V2_MIN_OVERHEAD                              \
+        (                                                              \
+        /* Length (varint) */                                          \
+        RD_UVARINT_ENC_SIZE_0() +                                      \
+        /* Attributes */                                               \
+        1 +                                                            \
+        /* TimestampDelta (varint) */                                  \
+        RD_UVARINT_ENC_SIZE_0() +                                      \
+        /* OffsetDelta (varint) */                                     \
+        RD_UVARINT_ENC_SIZE_0() +                                      \
+        /* KeyLen (varint) */                                          \
+        RD_UVARINT_ENC_SIZE_0() +                                      \
+        /* ValueLen (varint) */                                        \
+        RD_UVARINT_ENC_SIZE_0() +                                      \
+        /* HeaderCnt (varint): */                                      \
+        RD_UVARINT_ENC_SIZE_0()                                        \
+        )
 
 
 /**

--- a/src/rdvarint.h
+++ b/src/rdvarint.h
@@ -150,7 +150,7 @@ size_t rd_varint_dec_i64 (const char *src, size_t srcsize, int64_t *nump) {
 /**
  * @returns the encoding size of the value 0
  */
-#define RD_UVARINT_ENC_SIZE_0() 1
+#define RD_UVARINT_ENC_SIZE_0() ((size_t)1)
 
 
 int unittest_rdvarint (void);

--- a/tests/0009-mock_cluster.c
+++ b/tests/0009-mock_cluster.c
@@ -72,6 +72,10 @@ int main_0009_mock_cluster (int argc, char **argv) {
         test_produce_msgs(p, rkt, 0, RD_KAFKA_PARTITION_UA, 0, msgcnt,
                           NULL, 0);
 
+        /* Produce tiny messages */
+        test_produce_msgs(p, rkt, 0, RD_KAFKA_PARTITION_UA, 0, msgcnt,
+                          "hello", 5);
+
         rd_kafka_topic_destroy(rkt);
 
         /* Assign */


### PR DESCRIPTION
The Message V2 API uses VARINTs, which means we have to use the
*minimal* overhead to sanity check the size of a ProduceRequest.