### PR TITLE
stdarg.h included for va_start macro use

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -41,7 +41,7 @@
 #include "rdunittest.h"
 
 #include <ctype.h>
-
+#include <stdarg.h>
 
 static void rd_kafka_cgrp_offset_commit_tmr_cb (rd_kafka_timers_t *rkts,
                                                 void *arg);


### PR DESCRIPTION
stdarg.h must included explicitly for va_start and va_end use in old compilers.

Resolve issue:
 [https://github.com/edenhill/librdkafka/issues/3115](url)
