### PR TITLE
Add a new C++ client in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Questions and discussions are also welcome on the [Confluent Community slack](ht
 
   * C#/.NET: [confluent-kafka-dotnet](https://github.com/confluentinc/confluent-kafka-dotnet) (based on [rdkafka-dotnet](https://github.com/ah-/rdkafka-dotnet))
   * C++: [cppkafka](https://github.com/mfontanini/cppkafka)
+  * C++: [modern-cpp-kafka](https://github.com/Morgan-Stanley/modern-cpp-kafka)
   * Common Lisp: [cl-rdkafka](https://github.com/SahilKang/cl-rdkafka)
   * D (C-like): [librdkafka](https://github.com/DlangApache/librdkafka/)
   * D (C++-like): [librdkafkad](https://github.com/tamediadigital/librdkafka-d)


### PR DESCRIPTION
@edenhill Glad the `c++ API` is finally ready. And welcome to review and comment. 😊
https://github.com/Morgan-Stanley/modern-cpp-kafka