### PR TITLE
Travis s390x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,16 @@ matrix:
     - sudo apt install -y gdb
     - ./configure --enable-devel --disable-lz4-ext --prefix="$PWD/dest"
     - ./packaging/tools/rdutcoverage.sh
-
+ - name: "Linux GCC s390x: +devel"
+   os: linux
+   arch: s390x   
+   dist: bionic
+   compiler: gcc
+   env: NO_ARTIFACTS=y
+   before_script:
+    - sudo apt update
+    - sudo apt install -y gdb
+    - ./configure --enable-devel --disable-lz4-ext --prefix="$PWD/dest"
 install:
  - ccache -s || echo "CCache is not available."
  - rm -rf artifacts dest


### PR DESCRIPTION
Travis CI [officially](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) supports s390x builds, adding support for same.