### PR TITLE
main thread should keep polling while cgrp is alive (#3127)

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1966,7 +1966,8 @@ static int rd_kafka_thread_main (void *arg) {
         mtx_unlock(&rk->rk_init_lock);
 
 	while (likely(!rd_kafka_terminating(rk) ||
-		      rd_kafka_q_len(rk->rk_ops))) {
+		      rd_kafka_q_len(rk->rk_ops) ||
+                      (rk->rk_cgrp && (rk->rk_cgrp->rkcg_state != RD_KAFKA_CGRP_STATE_TERM)))) {
                 rd_ts_t sleeptime = rd_kafka_timers_next(
                         &rk->rk_timers, 1000*1000/*1s*/, 1/*lock*/);
                 rd_kafka_q_serve(rk->rk_ops, (int)(sleeptime / 1000), 0,


### PR DESCRIPTION
During termination, the main thread's loop continues as long
as there are ops left to poll, but is also responsible for
terminating the cgrp via `rd_kafka_cgrp_serve`. It is possible
for the loop to exit before the cgrp is terminated if you
unsubscribe and then immediately destroy the rdkafka handle,
which leaves some stray refcnts and hangs.

The solution is to keep the polling loop going as long as
there are remaining ops OR until the cgrp is terminated.

I also discovered a data race while investigating this issue.
TSAN should occasionally catch the race while running the
updated test 0116, but unfortunately it's pretty non-deterministic..

fixes #3127 