### PR TITLE
Added a first fuzzer with purpose of integrating to OSS-Fuzz

### DIFF
--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -1,5 +1,5 @@
 # Fuzzing
-Librdkafka supports fuzzing by way of Libfuzzer and OSS-Fuzz. This is ongoing work.
+librdkafka supports fuzzing by way of Libfuzzer and OSS-Fuzz. This is ongoing work.
 
 ## Launching the fuzzers
 The easiest way to launch the fuzzers are to go through OSS-Fuzz. The only prerequisite to this is having Docker installed.
@@ -9,8 +9,10 @@ With Docker installed, the following commands will build and run the fuzzers in 
 ```
 git clone https://github.com/google/oss-fuzz
 cd oss-fuzz
-sudo python3 infra/helper.py build_image librdkafka
-sudo python3 infra/helper.py build_fuzzers librdkafka
-sudo python3 infra/helper.py run_fuzzer librdkafka FUZZ_NAME
+python3 infra/helper.py build_image librdkafka
+python3 infra/helper.py build_fuzzers librdkafka
+python3 infra/helper.py run_fuzzer librdkafka FUZZ_NAME
 ```
 where FUZZ_NAME references the name of the fuzzer. Currently the only fuzzer we have is fuzz_regex
+
+Notice that the OSS-Fuzz `helper.py` script above will create a Docker image in which the code of librdkafka will be built. As such, depending on how you installed Docker, you may be asked to have root access (i.e. run with `sudo`).

--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -1,0 +1,16 @@
+# Fuzzing
+Librdkafka supports fuzzing by way of Libfuzzer and OSS-Fuzz. This is ongoing work.
+
+## Launching the fuzzers
+The easiest way to launch the fuzzers are to go through OSS-Fuzz. The only prerequisite to this is having Docker installed.
+
+With Docker installed, the following commands will build and run the fuzzers in this directory:
+
+```
+git clone https://github.com/google/oss-fuzz
+cd oss-fuzz
+sudo python3 infra/helper.py build_image librdkafka
+sudo python3 infra/helper.py build_fuzzers librdkafka
+sudo python3 infra/helper.py run_fuzzer librdkafka FUZZ_NAME
+```
+where FUZZ_NAME references the name opf the fuzzer. Currently the only fuzzer wave is fuzz_regex

--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -13,4 +13,4 @@ sudo python3 infra/helper.py build_image librdkafka
 sudo python3 infra/helper.py build_fuzzers librdkafka
 sudo python3 infra/helper.py run_fuzzer librdkafka FUZZ_NAME
 ```
-where FUZZ_NAME references the name opf the fuzzer. Currently the only fuzzer wave is fuzz_regex
+where FUZZ_NAME references the name of the fuzzer. Currently the only fuzzer we have is fuzz_regex

--- a/tests/fuzzers/fuzz_regex.c
+++ b/tests/fuzzers/fuzz_regex.c
@@ -1,0 +1,26 @@
+#include "rd.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <setjmp.h>
+#include <stdio.h>
+
+#include "regexp.h"
+
+int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+    /* wrap random data in a null-terminated string */
+    char *null_terminated = malloc(size+1);
+    memcpy(null_terminated, data, size);
+    null_terminated[size] = '\0';
+
+    const char *error;
+    Reprog *p = re_regcomp(null_terminated, 0, &error);
+    if (p != NULL) {
+            re_regfree(p);
+    }
+
+    /* cleanup */
+    free(null_terminated);
+
+    return 0;
+}


### PR DESCRIPTION
Hi!

I have been doing some work on fuzzing Librdkafka and also integrating it into OSS-Fuzz (https://github.com/google/oss-fuzz). OSS-Fuzz is service from Google that performs continuous fuzzing of important open source projects. It's completely free and I would be happy to supply fuzzers to Librdkafka to help with the security of the project. By integrating into OSS-Fuzz you will receive bug reports, coverage reports and more from OSS-Fuzz, and all I need is an email(s) from you that will receive the reports. 

I started with a simple fuzzer for a portion of the regex code, but would be happy to extend with more fuzzers if you would like to integrate. 