### PR TITLE
RD_KAFKA_RESP_ERR__PARTITION_EOF is not a broker error

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -396,7 +396,7 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
 	_ERR_DESC(RD_KAFKA_RESP_ERR__MSG_TIMED_OUT,
 		  "Local: Message timed out"),
 	_ERR_DESC(RD_KAFKA_RESP_ERR__PARTITION_EOF,
-		  "Broker: No more messages"),
+		  "Local: No more messages"),
 	_ERR_DESC(RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION,
 		  "Local: Unknown partition"),
 	_ERR_DESC(RD_KAFKA_RESP_ERR__FS,


### PR DESCRIPTION
i guess you've reasoned that what is here already is most correct, but i think there's a lot of value in differentiating whether an error is local or broker strictly on whether the error was generated on the broker or not. PR just a suggestion.