### PR TITLE
Incremental rebalancing fixes

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1838,6 +1838,14 @@ void rd_kafka_conf_set_consume_cb (rd_kafka_conf_t *conf,
  * such as fetching offsets from an alternate location (on assign)
  * or manually committing offsets (on revoke).
  *
+ * rebalance_cb is always triggered exactly once when a rebalance completes
+ * with a new assignment, even if that assignment is empty. If an
+ * eager/non-cooperative assignor is configured, there will eventually be
+ * exactly one corresponding call to rebalance_cb to revoke these partitions
+ * (even if empty), whether this is due to a group rebalance or lost
+ * partitions. In the cooperative case, rebalance_cb will never be called if
+ * the set of partitions being revoked is empty (whether or not lost).
+ *
  * The callback's \p opaque argument is the opaque set with
  * rd_kafka_conf_set_opaque().
  *

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3886,9 +3886,8 @@ static void rd_kafka_cgrp_revoke_all_rejoin (rd_kafka_cgrp_t *rkcg,
                            "current assignment and rebalance");
         }
 
-
-        if (rkcg->rkcg_group_assignment) {
-
+        if (rkcg->rkcg_group_assignment &&
+            rkcg->rkcg_group_assignment->cnt > 0) {
                 if (assignment_lost)
                         rd_kafka_cgrp_assignment_set_lost(
                                 rkcg,

--- a/tests/0113-cooperative_rebalance.cpp
+++ b/tests/0113-cooperative_rebalance.cpp
@@ -2094,7 +2094,7 @@ static void poll_all_consumers (RdKafka::KafkaConsumer **consumers,
  * TODO: incorporate committing offsets.
  */
 
-static void u_complex (bool use_rebalance_cb, int subscription_variation) {
+static void u_multiple_subscription_changes (bool use_rebalance_cb, int subscription_variation) {
   const int N_CONSUMERS = 8;
   const int N_TOPICS = 2;
   const int N_PARTS_PER_TOPIC = N_CONSUMERS * N_TOPICS;
@@ -2792,8 +2792,8 @@ extern "C" {
       t_max_poll_interval_exceeded(i);
     /* Run all 2*3 variations of the u_.. test */
     for (i = 0 ; i < 3 ; i++) {
-      u_complex(true/*with rebalance_cb*/, i);
-      u_complex(false/*without rebalance_cb*/, i);
+      u_multiple_subscription_changes(true/*with rebalance_cb*/, i);
+      u_multiple_subscription_changes(false/*without rebalance_cb*/, i);
     }
 
     return 0;


### PR DESCRIPTION
- partitions revoked events should never be emitted in the incremental rebalancing case when the assignment is empty.
- in the n_wildcard test it is valid for either one rebalance or two rebalances to be required for the consumers subscription to be updated.
