### PR TITLE
move note about transaction.timeout.ms to begin_transaction

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -6951,14 +6951,6 @@ rd_kafka_oauthbearer_set_token_failure (rd_kafka_t *rk, const char *errstr);
  * will acquire the internal producer id and epoch, used in all future
  * transactional messages issued by this producer instance.
  *
- * Upon successful return from this function the application has to perform at
- * least one of the following operations within \c transaction.timeout.ms to
- * avoid timing out the transaction on the broker:
- *   * rd_kafka_produce() (et.al)
- *   * rd_kafka_send_offsets_to_transaction()
- *   * rd_kafka_commit_transaction()
- *   * rd_kafka_abort_transaction()
- *
  * @param rk Producer instance.
  * @param timeout_ms The maximum time to block. On timeout the operation
  *                   may continue in the background, depending on state,
@@ -7006,6 +6998,14 @@ rd_kafka_init_transactions (rd_kafka_t *rk, int timeout_ms);
  *
  * rd_kafka_init_transactions() must have been called successfully (once)
  * before this function is called.
+ *
+ * Upon successful return from this function the application has to perform at
+ * least one of the following operations within \c transaction.timeout.ms to
+ * avoid timing out the transaction on the broker:
+ *   * rd_kafka_produce() (et.al)
+ *   * rd_kafka_send_offsets_to_transaction()
+ *   * rd_kafka_commit_transaction()
+ *   * rd_kafka_abort_transaction()
  *
  * Any messages produced, offsets sent (rd_kafka_send_offsets_to_transaction()),
  * etc, after the successful return of this function will be part of


### PR DESCRIPTION
As far as I can tell, there is no broker-side requirement to perform transactional operations after calling `rd_kafka_init_transactions`, and the client in `examples/transactions.c` works just fine if I insert arbitrary delays between `init_transactions` and `begin_transaction`. It would also be strange if this requirement did exist, because `init_transactions` is meant to be called once at startup and we can't necessarily control the rate of outgoing messages.