### PR TITLE
Return added broker in rd_kafka_broker_update

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -5958,9 +5958,9 @@ rd_kafka_broker_update (rd_kafka_t *rk, rd_kafka_secproto_t proto,
                  * update the nodeid. */
                 needs_update = 1;
 
-        } else {
-		rd_kafka_broker_add(rk, RD_KAFKA_LEARNED,
-				    proto, mdb->host, mdb->port, mdb->id);
+        } else if ((rkb = rd_kafka_broker_add(rk, RD_KAFKA_LEARNED, proto,
+					      mdb->host, mdb->port, mdb->id))){
+		rd_kafka_broker_keep(rkb);
 	}
 
 	rd_kafka_wrunlock(rk);


### PR DESCRIPTION
Based on the doxygen comment, a newly added broker should probably be returned via the `rkbp` parameter.