### PR TITLE
Fix possible corrupted decompression of snappy format

### DIFF
--- a/src/snappy.c
+++ b/src/snappy.c
@@ -67,6 +67,35 @@
 #define inline __inline
 #endif
 
+static inline u64 get_unaligned64(const void *b)
+{
+	u64 ret;
+	memcpy(&ret, b, sizeof(u64));
+	return ret;
+}
+static inline u32 get_unaligned32(const void *b)
+{
+	u32 ret;
+	memcpy(&ret, b, sizeof(u32));
+	return ret;
+}
+#define get_unaligned_le32(x) (le32toh(get_unaligned32((u32 *)(x))))
+
+static inline void put_unaligned64(u64 v, void *b)
+{
+	memcpy(b, &v, sizeof(v));
+}
+static inline void put_unaligned32(u32 v, void *b)
+{
+	memcpy(b, &v, sizeof(v));
+}
+static inline void put_unaligned16(u16 v, void *b)
+{
+	memcpy(b, &v, sizeof(v));
+}
+#define put_unaligned_le16(v,x) (put_unaligned16(htole16(v), (u16 *)(x)))
+
+
 #define CRASH_UNLESS(x) BUG_ON(!(x))
 #define CHECK(cond) CRASH_UNLESS(cond)
 #define CHECK_LE(a, b) CRASH_UNLESS((a) <= (b))
@@ -76,12 +105,11 @@
 #define CHECK_LT(a, b) CRASH_UNLESS((a) < (b))
 #define CHECK_GT(a, b) CRASH_UNLESS((a) > (b))
 
-#define UNALIGNED_LOAD16(_p) get_unaligned((u16 *)(_p))
-#define UNALIGNED_LOAD32(_p) get_unaligned((u32 *)(_p))
+#define UNALIGNED_LOAD32(_p) get_unaligned32((u32 *)(_p))
 #define UNALIGNED_LOAD64(_p) get_unaligned64((u64 *)(_p))
 
-#define UNALIGNED_STORE16(_p, _val) put_unaligned(_val, (u16 *)(_p))
-#define UNALIGNED_STORE32(_p, _val) put_unaligned(_val, (u32 *)(_p))
+#define UNALIGNED_STORE16(_p, _val) put_unaligned16(_val, (u16 *)(_p))
+#define UNALIGNED_STORE32(_p, _val) put_unaligned32(_val, (u32 *)(_p))
 #define UNALIGNED_STORE64(_p, _val) put_unaligned64(_val, (u64 *)(_p))
 
 /*

--- a/src/snappy_compat.h
+++ b/src/snappy_compat.h
@@ -74,22 +74,6 @@ struct iovec {
 };
 #endif
 
-#define get_unaligned_memcpy(x) ({ \
-		typeof(*(x)) _ret; \
-		memcpy(&_ret, (x), sizeof(*(x))); \
-		_ret; })
-#define put_unaligned_memcpy(v,x) ({ \
-		typeof((v)) _v = (v); \
-		memcpy((x), &_v, sizeof(*(x))); })
-
-#define get_unaligned get_unaligned_memcpy
-#define put_unaligned put_unaligned_memcpy
-#define get_unaligned64 get_unaligned_memcpy
-#define put_unaligned64 put_unaligned_memcpy
-
-#define get_unaligned_le32(x) (le32toh(get_unaligned((u32 *)(x))))
-#define put_unaligned_le16(v,x) (put_unaligned(htole16(v), (u16 *)(x)))
-
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned u32;

--- a/src/snappy_compat.h
+++ b/src/snappy_compat.h
@@ -82,57 +82,10 @@ struct iovec {
 		typeof((v)) _v = (v); \
 		memcpy((x), &_v, sizeof(*(x))); })
 
-#define get_unaligned_direct(x) (*(x))
-#define put_unaligned_direct(v,x) (*(x) = (v))
-
-// Potentially unaligned loads and stores.
-// x86, PowerPC, and ARM64 can simply do these loads and stores native.
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || \
-	defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || \
-	defined(__aarch64__)
-
-#define get_unaligned get_unaligned_direct
-#define put_unaligned put_unaligned_direct
-#define get_unaligned64 get_unaligned_direct
-#define put_unaligned64 put_unaligned_direct
-
-// ARMv7 and newer support native unaligned accesses, but only of 16-bit
-// and 32-bit values (not 64-bit); older versions either raise a fatal signal,
-// do an unaligned read and rotate the words around a bit, or do the reads very
-// slowly (trip through kernel mode). There's no simple #define that says just
-// “ARMv7 or higher”, so we have to filter away all ARMv5 and ARMv6
-// sub-architectures.
-//
-// This is a mess, but there's not much we can do about it.
-#elif defined(__arm__) && \
-	!defined(__ARM_ARCH_4__) &&		\
-	!defined(__ARM_ARCH_4T__) &&		\
-	!defined(__ARM_ARCH_5__) &&		\
-	!defined(__ARM_ARCH_5T__) &&		\
-	!defined(__ARM_ARCH_5TE__) &&		\
-	!defined(__ARM_ARCH_5TEJ__) &&		\
-	!defined(__ARM_ARCH_6__) &&		\
-	!defined(__ARM_ARCH_6J__) &&		\
-	!defined(__ARM_ARCH_6K__) &&		\
-	!defined(__ARM_ARCH_6Z__) &&		\
-	!defined(__ARM_ARCH_6ZK__) &&		\
-	!defined(__ARM_ARCH_6T2__)
-
-#define get_unaligned get_unaligned_direct
-#define put_unaligned put_unaligned_direct
-#define get_unaligned64 get_unaligned_memcpy
-#define put_unaligned64 put_unaligned_memcpy
-
-// These macroses are provided for architectures that don't support
-// unaligned loads and stores.
-#else
-
 #define get_unaligned get_unaligned_memcpy
 #define put_unaligned put_unaligned_memcpy
 #define get_unaligned64 get_unaligned_memcpy
 #define put_unaligned64 put_unaligned_memcpy
-
-#endif
 
 #define get_unaligned_le32(x) (le32toh(get_unaligned((u32 *)(x))))
 #define put_unaligned_le16(v,x) (put_unaligned(htole16(v), (u16 *)(x)))


### PR DESCRIPTION
In incremental_copy_fast_path there is undefined behavior (and in some
other places too).

And under this circumstances gcc10 with -O1 -ftree-loop-vectorize (or
simply -O3), due to loop unroll, generates code that do copy by 16 bytes
at a time for the second loop (MOVDQU+MOVUPS), while this is not correct
since the memory may be overlapped and may be changed in the previous
iteration.

Fix this by eliminating those UB, by using memcpy over direct store/load
since these days direct store/loads looks redundant. Even on ARM [1].

  [1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67366

Upstream patch: https://github.com/andikleen/snappy-c/pull/22

*NOTE: clang is fine, and other older versions of gcc too*

This bug was found by [ClickHouse](https://github.com/ClickHouse/ClickHouse) test suite.