### PR TITLE
Include sys/wait.h for OpenBSD

### DIFF
--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -33,7 +33,7 @@
 #include "rdkafka_sasl_int.h"
 #include "rdstring.h"
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <sys/wait.h>  /* For WIF.. */
 #endif
 


### PR DESCRIPTION
Like FreeBSD, OpenBSD needs to include `sys/wait.h` for macros like `WIFSIGNALED`.