### PR TITLE
sticky_assignor: Fix incorrect access of map entry

### DIFF
--- a/src/rdkafka_sticky_assignor.c
+++ b/src/rdkafka_sticky_assignor.c
@@ -977,7 +977,7 @@ balance (rd_kafka_t *rk,
         rd_bool_t initializing =
                 ((const rd_kafka_topic_partition_list_t *)
                  ((const rd_map_elem_t *)rd_list_last(
-                         sortedCurrentSubscriptions))->key)->cnt == 0;
+                         sortedCurrentSubscriptions))->value)->cnt == 0;
         rd_bool_t reassignmentPerformed = rd_false;
 
         map_str_toppar_list_t fixedAssignments =


### PR DESCRIPTION
The balance function accesses a key (typed as a `const char*`) instead of
the likely intended value, based on the type actually being casted. This
seems to mean that initializing is always set to false, and it is
causing a unaligned memory access on Solaris 64-bit builds.