### PR TITLE
Update va_list reference to match the other functions and fix an embedded compile issue.

### DIFF
--- a/src/rdkafka_error.h
+++ b/src/rdkafka_error.h
@@ -30,6 +30,8 @@
 #ifndef _RDKAFKA_ERROR_H_
 #define _RDKAFKA_ERROR_H_
 
+#include <stdarg.h>
+
 /**
  * @name Public API complex error type implementation.
  *


### PR DESCRIPTION
Some embedded toolchains (uClibc MIPS in this case) will not define va_list before the rdkafka_error.h is loaded. A va_list undefined error stops the compile. Mimicking the other functions in the header, using the "..." syntax, resolves the compile issue with these toolchains, while not breaking other platforms. 