### PR TITLE
transactions example: minor bug fixes (#3257)

### DIFF
--- a/examples/transactions.c
+++ b/examples/transactions.c
@@ -193,8 +193,8 @@ static void rewind_consumer (rd_kafka_t *consumer) {
          * committed offset is available. */
         for (i = 0 ; i < offsets->cnt ; i++) {
                 /* No committed offset, start from beginning */
-                if (offsets->elems[0].offset < 0)
-                        offsets->elems[0].offset =
+                if (offsets->elems[i].offset < 0)
+                        offsets->elems[i].offset =
                                 RD_KAFKA_OFFSET_BEGINNING;
         }
 
@@ -378,7 +378,7 @@ consumer_group_rebalance_cb (rd_kafka_t *consumer,
                 break;
 
         case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-                if (!rd_kafka_assignment_lost(consumer)) {
+                if (rd_kafka_assignment_lost(consumer)) {
                         fprintf(stdout,
                                 "Consumer group rebalanced: assignment lost: "
                                 "aborting current transaction\n");


### PR DESCRIPTION
1. Abort transcation if partitions are lost and commit if they are revoked. 
2. Correctly iterate over all the offsets in the list