### PR TITLE
Clean buffer after rebalancing for batch queue

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3854,7 +3854,8 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                 rd_assert(thrd_is_current(rk->rk_thread));
                 res = rd_kafka_op_call(rk, rkq, rko);
                 break;
-
+        case RD_KAFKA_OP_BARRIER:
+                break;
         case RD_KAFKA_OP_PURGE:
                 rd_kafka_purge(rk, rko->rko_u.purge.flags);
                 break;

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2951,7 +2951,7 @@ rd_kafka_consume_cb (rd_kafka_t *rk,
 	struct consume_ctx *ctx = opaque;
 	rd_kafka_message_t *rkmessage;
 
-        if (unlikely(rd_kafka_op_version_outdated(rko, 0))) {
+        if (unlikely(rd_kafka_op_version_outdated(rko, 0)) || rko->rko_type == RD_KAFKA_OP_BARRIER) {
                 rd_kafka_op_destroy(rko);
                 return RD_KAFKA_OP_RES_HANDLED;
         }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2951,7 +2951,8 @@ rd_kafka_consume_cb (rd_kafka_t *rk,
 	struct consume_ctx *ctx = opaque;
 	rd_kafka_message_t *rkmessage;
 
-        if (unlikely(rd_kafka_op_version_outdated(rko, 0)) || rko->rko_type == RD_KAFKA_OP_BARRIER) {
+        if (unlikely(rd_kafka_op_version_outdated(rko, 0)) ||
+            rko->rko_type == RD_KAFKA_OP_BARRIER) {
                 rd_kafka_op_destroy(rko);
                 return RD_KAFKA_OP_RES_HANDLED;
         }
@@ -3854,8 +3855,10 @@ rd_kafka_poll_cb (rd_kafka_t *rk, rd_kafka_q_t *rkq, rd_kafka_op_t *rko,
                 rd_assert(thrd_is_current(rk->rk_thread));
                 res = rd_kafka_op_call(rk, rkq, rko);
                 break;
+
         case RD_KAFKA_OP_BARRIER:
                 break;
+
         case RD_KAFKA_OP_PURGE:
                 rd_kafka_purge(rk, rko->rko_u.purge.flags);
                 break;

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1405,7 +1405,8 @@ rd_kafka_message_t *rd_kafka_message_get (rd_kafka_op_t *rko) {
                         strlen(rkmessage->payload) : 0;
                 rkmessage->offset  = rko->rko_u.err.offset;
                 break;
-
+        case RD_KAFKA_OP_BARRIER:
+                break;
         default:
                 rd_kafka_assert(NULL, !*"unhandled optype");
                 RD_NOTREACHED();

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1405,8 +1405,6 @@ rd_kafka_message_t *rd_kafka_message_get (rd_kafka_op_t *rko) {
                         strlen(rkmessage->payload) : 0;
                 rkmessage->offset  = rko->rko_u.err.offset;
                 break;
-        case RD_KAFKA_OP_BARRIER:
-                return NULL;
         default:
                 rd_kafka_assert(NULL, !*"unhandled optype");
                 RD_NOTREACHED();

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1406,7 +1406,7 @@ rd_kafka_message_t *rd_kafka_message_get (rd_kafka_op_t *rko) {
                 rkmessage->offset  = rko->rko_u.err.offset;
                 break;
         case RD_KAFKA_OP_BARRIER:
-                break;
+                return NULL;
         default:
                 rd_kafka_assert(NULL, !*"unhandled optype");
                 RD_NOTREACHED();

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1405,6 +1405,7 @@ rd_kafka_message_t *rd_kafka_message_get (rd_kafka_op_t *rko) {
                         strlen(rkmessage->payload) : 0;
                 rkmessage->offset  = rko->rko_u.err.offset;
                 break;
+
         default:
                 rd_kafka_assert(NULL, !*"unhandled optype");
                 RD_NOTREACHED();

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -238,7 +238,7 @@ rd_kafka_op_t *rd_kafka_op_new0 (const char *source, rd_kafka_op_type_t type) {
                 [RD_KAFKA_OP_GET_REBALANCE_PROTOCOL] =
                 sizeof(rko->rko_u.rebalance_protocol),
                 [RD_KAFKA_OP_LEADERS] = sizeof(rko->rko_u.leaders),
-                [RD_KAFKA_OP_BARRIER] = sizeof(rko->rko_u.barrier),
+                [RD_KAFKA_OP_BARRIER] = sizeof(rko->rko_version),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 
@@ -412,6 +412,7 @@ void rd_kafka_op_destroy (rd_kafka_op_t *rko) {
                 RD_IF_FREE(rko->rko_u.leaders.partitions,
                            rd_kafka_topic_partition_list_destroy);
                 break;
+
 	default:
 		break;
 	}

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -238,7 +238,7 @@ rd_kafka_op_t *rd_kafka_op_new0 (const char *source, rd_kafka_op_type_t type) {
                 [RD_KAFKA_OP_GET_REBALANCE_PROTOCOL] =
                 sizeof(rko->rko_u.rebalance_protocol),
                 [RD_KAFKA_OP_LEADERS] = sizeof(rko->rko_u.leaders),
-                [RD_KAFKA_OP_BARRIER] = sizeof(_RD_KAFKA_OP_EMPTY),
+                [RD_KAFKA_OP_BARRIER] = _RD_KAFKA_OP_EMPTY,
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -238,7 +238,7 @@ rd_kafka_op_t *rd_kafka_op_new0 (const char *source, rd_kafka_op_type_t type) {
                 [RD_KAFKA_OP_GET_REBALANCE_PROTOCOL] =
                 sizeof(rko->rko_u.rebalance_protocol),
                 [RD_KAFKA_OP_LEADERS] = sizeof(rko->rko_u.leaders),
-                [RD_KAFKA_OP_BARRIER] = sizeof(rko->rko_version),
+                [RD_KAFKA_OP_BARRIER] = sizeof(_RD_KAFKA_OP_EMPTY),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -413,7 +413,7 @@ void rd_kafka_op_destroy (rd_kafka_op_t *rko) {
                            rd_kafka_topic_partition_list_destroy);
                 break;
         case RD_KAFKA_OP_BARRIER:
-            break;
+                break;
 	default:
 		break;
 	}

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -95,6 +95,7 @@ const char *rd_kafka_op2str (rd_kafka_op_type_t type) {
                 [RD_KAFKA_OP_GET_REBALANCE_PROTOCOL] =
                 "REPLY:GET_REBALANCE_PROTOCOL",
                 [RD_KAFKA_OP_LEADERS] = "REPLY:LEADERS",
+                [RD_KAFKA_OP_BARRIER] = "REPLY:BARRIER",
         };
 
         if (type & RD_KAFKA_OP_REPLY)
@@ -237,6 +238,7 @@ rd_kafka_op_t *rd_kafka_op_new0 (const char *source, rd_kafka_op_type_t type) {
                 [RD_KAFKA_OP_GET_REBALANCE_PROTOCOL] =
                 sizeof(rko->rko_u.rebalance_protocol),
                 [RD_KAFKA_OP_LEADERS] = sizeof(rko->rko_u.leaders),
+                [RD_KAFKA_OP_BARRIER] = sizeof(rko->rko_u.barrier),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 
@@ -410,7 +412,8 @@ void rd_kafka_op_destroy (rd_kafka_op_t *rko) {
                 RD_IF_FREE(rko->rko_u.leaders.partitions,
                            rd_kafka_topic_partition_list_destroy);
                 break;
-
+        case RD_KAFKA_OP_BARRIER:
+            break;
 	default:
 		break;
 	}

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -412,8 +412,6 @@ void rd_kafka_op_destroy (rd_kafka_op_t *rko) {
                 RD_IF_FREE(rko->rko_u.leaders.partitions,
                            rd_kafka_topic_partition_list_destroy);
                 break;
-        case RD_KAFKA_OP_BARRIER:
-                break;
 	default:
 		break;
 	}

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -136,7 +136,7 @@ typedef enum {
         RD_KAFKA_OP_TXN,             /**< Transaction command */
         RD_KAFKA_OP_GET_REBALANCE_PROTOCOL, /**< Get rebalance protocol */
         RD_KAFKA_OP_LEADERS,         /**< Partition leader query */
-        RD_KAFKA_OP_BARRIER,
+        RD_KAFKA_OP_BARRIER,         /**< Version barrier bump */
         RD_KAFKA_OP__END
 } rd_kafka_op_type_t;
 
@@ -612,10 +612,6 @@ struct rd_kafka_op_s {
                         void *opaque;
 
                 } leaders;
-
-                struct {
-                        int32_t version;
-                } barrier;
 
         } rko_u;
 };

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -614,7 +614,7 @@ struct rd_kafka_op_s {
                 } leaders;
 
                 struct {
-                    int32_t version;
+                        int32_t version;
                 } barrier;
 
         } rko_u;

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -136,6 +136,7 @@ typedef enum {
         RD_KAFKA_OP_TXN,             /**< Transaction command */
         RD_KAFKA_OP_GET_REBALANCE_PROTOCOL, /**< Get rebalance protocol */
         RD_KAFKA_OP_LEADERS,         /**< Partition leader query */
+        RD_KAFKA_OP_BARRIER,
         RD_KAFKA_OP__END
 } rd_kafka_op_type_t;
 
@@ -611,6 +612,10 @@ struct rd_kafka_op_s {
                         void *opaque;
 
                 } leaders;
+
+                struct {
+                    int32_t version;
+                } barrier;
 
         } rko_u;
 };

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -197,8 +197,8 @@ void rd_kafka_toppar_op_version_bump (rd_kafka_q_t *rktp_fetchq,
         rd_kafka_op_t *rko;
 
         rko = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
-	    rko->rko_version = version;
-	    rd_kafka_q_enq(rktp_fetchq, rko);
+        rko->rko_version = version;
+        rd_kafka_q_enq(rktp_fetchq, rko);
 }
 
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -188,7 +188,7 @@ static void rd_kafka_toppar_consumer_lag_tmr_cb (rd_kafka_timers_t *rkts,
 
 /**
  * @brief Enqueue an RD_KAFKA_OP_BARRIER type of operation
- *         when the op_version is updated.
+ *        when the op_version is updated.
  *
  * @locality Toppar handler thread
  */

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -187,9 +187,11 @@ static void rd_kafka_toppar_consumer_lag_tmr_cb (rd_kafka_timers_t *rkts,
 }
 
 /**
- * @brief Enqueue an RD_KAFKA_OP_BARRIER type of operation
+ * @brief Update rktp_op_version.
+ *        Enqueue an RD_KAFKA_OP_BARRIER type of operation
  *        when the op_version is updated.
  *
+ * @locks_required rd_kafka_toppar_lock() must be held.
  * @locality Toppar handler thread
  */
 void rd_kafka_toppar_op_version_bump (rd_kafka_toppar_t *rktp,

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1684,6 +1684,7 @@ void rd_kafka_toppar_fetch_stopped (rd_kafka_toppar_t *rktp,
  */
 void rd_kafka_toppar_fetch_stop (rd_kafka_toppar_t *rktp,
 				 rd_kafka_op_t *rko_orig) {
+		rd_kafka_op_t *rko;
         int32_t version = rko_orig->rko_version;
 
 	rd_kafka_toppar_lock(rktp);
@@ -1695,7 +1696,7 @@ void rd_kafka_toppar_fetch_stop (rd_kafka_toppar_t *rktp,
                      rd_kafka_fetch_states[rktp->rktp_fetch_state], version);
 
 	rktp->rktp_op_version = version;
-	rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
+	rko = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
 	rko->rko_version = version;
 	rd_kafka_q_enq(rktp->rktp_fetchq, rko);
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1695,6 +1695,9 @@ void rd_kafka_toppar_fetch_stop (rd_kafka_toppar_t *rktp,
                      rd_kafka_fetch_states[rktp->rktp_fetch_state], version);
 
 	rktp->rktp_op_version = version;
+	rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
+	rko->rko_version = version;
+	rd_kafka_q_enq(rktp->rktp_fetchq, rko);
 
 	/* Abort pending offset lookups. */
 	if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_QUERY)

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -187,18 +187,19 @@ static void rd_kafka_toppar_consumer_lag_tmr_cb (rd_kafka_timers_t *rkts,
 }
 
 /**
- * Enqueue an RD_KAFKA_OP_BARRIER type of operation
- * when the op_version is updated.
+ * @brief Enqueue an RD_KAFKA_OP_BARRIER type of operation
+ *         when the op_version is updated.
  *
- * Locality: toppar handler thread
+ * @locality Toppar handler thread
  */
-void rd_kafka_toppar_op_version_bump (rd_kafka_q_t *rktp_fetchq,
-		                             int32_t version) {
+void rd_kafka_toppar_op_version_bump (rd_kafka_toppar_t *rktp,
+                                      int32_t version) {
         rd_kafka_op_t *rko;
 
+        rktp->rktp_op_version = version;
         rko = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
         rko->rko_version = version;
-        rd_kafka_q_enq(rktp_fetchq, rko);
+        rd_kafka_q_enq(rktp->rktp_fetchq, rko);
 }
 
 
@@ -254,7 +255,6 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0 (rd_kafka_topic_t *rkt,
         rktp->rktp_ops->rkq_opaque = rktp;
         rd_atomic32_init(&rktp->rktp_version, 1);
 	rktp->rktp_op_version = rd_atomic32_get(&rktp->rktp_version);
-        rd_kafka_toppar_op_version_bump(rktp->rktp_fetchq, rktp->rktp_op_version);
 
         rd_atomic32_init(&rktp->rktp_msgs_inflight, 0);
         rd_kafka_pid_reset(&rktp->rktp_eos.pid);
@@ -1601,8 +1601,7 @@ static void rd_kafka_toppar_fetch_start (rd_kafka_toppar_t *rktp,
                 goto err_reply;
         }
 
-	rktp->rktp_op_version = version;
-        rd_kafka_toppar_op_version_bump(rktp->rktp_fetchq, version);
+        rd_kafka_toppar_op_version_bump(rktp, version);
 
         if (rkcg) {
                 rd_kafka_assert(rktp->rktp_rkt->rkt_rk, !rktp->rktp_cgrp);
@@ -1711,8 +1710,7 @@ void rd_kafka_toppar_fetch_stop (rd_kafka_toppar_t *rktp,
                      rktp->rktp_partition,
                      rd_kafka_fetch_states[rktp->rktp_fetch_state], version);
 
-	rktp->rktp_op_version = version;
-        rd_kafka_toppar_op_version_bump(rktp->rktp_fetchq, version);
+        rd_kafka_toppar_op_version_bump(rktp, version);
 
 	/* Abort pending offset lookups. */
 	if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_QUERY)
@@ -1772,8 +1770,7 @@ void rd_kafka_toppar_seek (rd_kafka_toppar_t *rktp,
 		goto err_reply;
 	}
 
-	rktp->rktp_op_version = version;
-        rd_kafka_toppar_op_version_bump(rktp->rktp_fetchq, version);
+        rd_kafka_toppar_op_version_bump(rktp, version);
 
 	/* Abort pending offset lookups. */
 	if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_QUERY)
@@ -1828,8 +1825,7 @@ static void rd_kafka_toppar_pause_resume (rd_kafka_toppar_t *rktp,
 
 	rd_kafka_toppar_lock(rktp);
 
-	rktp->rktp_op_version = version;
-        rd_kafka_toppar_op_version_bump(rktp->rktp_fetchq, version);
+        rd_kafka_toppar_op_version_bump(rktp, version);
 
         if (!pause && (rktp->rktp_flags & flag) != flag) {
                 rd_kafka_dbg(rk, TOPIC, "RESUME",

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -610,7 +610,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                         cnt = rd_kafka_purge_outdated_messages(
                                 rko->rko_version,
                                 rkmessages,
-								cnt);
+                                cnt);
                 }
 
                 /* Serve non-FETCH callbacks */

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -605,15 +605,12 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                                        RD_KAFKA_Q_CB_RETURN, NULL);
                 if (res == RD_KAFKA_OP_RES_KEEP ||
                     res == RD_KAFKA_OP_RES_HANDLED) {
-
                         if (rko->rko_type == RD_KAFKA_OP_BARRIER) {
                                 /* Clean outdated messages if rebalancing happens. */
                                 rk_valid_messages = malloc(rkmessages_size * sizeof(rd_kafka_message_t *));
                                 cnt = rd_kafka_purge_outdated_messages(rko->rko_version, rkmessages, rk_valid_messages, cnt);
                                 memcpy(rkmessages, rk_valid_messages, rkmessages_size);
-                                rd_kafka_op_destroy(rko);
                         }
-
                         /* Callback served, rko is destroyed (if HANDLED). */
                         continue;
                 } else if (unlikely(res == RD_KAFKA_OP_RES_YIELD ||

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -517,7 +517,35 @@ int rd_kafka_q_serve (rd_kafka_q_t *rkq, int timeout_ms,
 }
 
 
+int invalid_all_old_msgs_in_array(rd_kafka_op_t **rkos,
+                                  int32_t version,
+                                  rd_kafka_message_t **rkmessages,
+                                  int cnt,
+                                  size_t rkmessages_size) {
+    TAILQ_HEAD(, rd_kafka_op_s) tmpq = TAILQ_HEAD_INITIALIZER(tmpq);
+    rd_kafka_op_t *rko, *next;
+    rd_kafka_message_t *tmp[rkmessages_size];
 
+    int valid_count = 0;
+    for(int i = 0; i < cnt; i++) {
+        if(rd_kafka_op_version_outdated(rkos[i], version)) {
+            TAILQ_INSERT_TAIL(&tmpq, rkos[i], rko_link);
+        } else {
+            tmp[valid_count++] = rd_kafka_message_get(rkos[i]);
+        }
+    }
+
+    /* Discard non-desired and already handled ops */
+    next = TAILQ_FIRST(&tmpq);
+    while (next) {
+        rko = next;
+        next = TAILQ_NEXT(next, rko_link);
+        rd_kafka_op_destroy(rko);
+    }
+
+    rkmessages = tmp;
+    return valid_count;
+}
 
 
 /**
@@ -537,6 +565,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
         rd_kafka_t *rk = rkq->rkq_rk;
         rd_kafka_q_t *fwdq;
         struct timespec timeout_tspec;
+        rd_kafka_op_t *rkos[rkmessages_size];
 
 	mtx_lock(&rkq->rkq_lock);
         if ((fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
@@ -587,6 +616,10 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                                        RD_KAFKA_Q_CB_RETURN, NULL);
                 if (res == RD_KAFKA_OP_RES_KEEP ||
                     res == RD_KAFKA_OP_RES_HANDLED) {
+                    if(rko->rko_type == RD_KAFKA_OP_BARRIER) {
+                        // For EAGER rebalancing, clean the whole buffer
+                        cnt = invalid_all_old_msgs_in_array(rkos, rko->rko_version, rkmessages, cnt, rkmessages_size);
+                    }
                         /* Callback served, rko is destroyed (if HANDLED). */
                         continue;
                 } else if (unlikely(res == RD_KAFKA_OP_RES_YIELD ||
@@ -609,6 +642,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                 }
 
 		/* Get rkmessage from rko and append to array. */
+		rkos[cnt] = rko;
 		rkmessages[cnt++] = rd_kafka_message_get(rko);
 	}
 

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -605,12 +605,15 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                                        RD_KAFKA_Q_CB_RETURN, NULL);
                 if (res == RD_KAFKA_OP_RES_KEEP ||
                     res == RD_KAFKA_OP_RES_HANDLED) {
+
                         if (rko->rko_type == RD_KAFKA_OP_BARRIER) {
                                 /* Clean outdated messages if rebalancing happens. */
                                 rk_valid_messages = malloc(rkmessages_size * sizeof(rd_kafka_message_t *));
                                 cnt = rd_kafka_purge_outdated_messages(rko->rko_version, rkmessages, rk_valid_messages, cnt);
                                 memcpy(rkmessages, rk_valid_messages, rkmessages_size);
+                                rd_kafka_op_destroy(rko);
                         }
+
                         /* Callback served, rko is destroyed (if HANDLED). */
                         continue;
                 } else if (unlikely(res == RD_KAFKA_OP_RES_YIELD ||

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -655,6 +655,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
         }
 
         rd_kafka_app_polled(rk);
+
 	return cnt;
 }
 

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -585,6 +585,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
         rd_kafka_yield_thread = 0;
 	while (cnt < rkmessages_size) {
                 rd_kafka_op_res_t res;
+
                 mtx_lock(&rkq->rkq_lock);
 
                 while (!(rko = TAILQ_FIRST(&rkq->rkq_q)) &&
@@ -607,6 +608,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                         TAILQ_INSERT_TAIL(&tmpq, rko, rko_link);
                         continue;
                 }
+
                 /* Serve non-FETCH callbacks */
                 res = rd_kafka_poll_cb(rk, rkq, rko,
                                        RD_KAFKA_Q_CB_RETURN, NULL);
@@ -648,6 +650,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                 next = TAILQ_NEXT(next, rko_link);
                 rd_kafka_op_destroy(rko);
         }
+
         rd_kafka_app_polled(rk);
 
 	return cnt;

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -605,12 +605,14 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                         TAILQ_INSERT_TAIL(&tmpq, rko, rko_link);
                         continue;
                 }
+
                 if (unlikely(rko->rko_type == RD_KAFKA_OP_BARRIER)) {
                         cnt = rd_kafka_purge_outdated_messages(
                                 rko->rko_version,
                                 rkmessages,
 								cnt);
                 }
+
                 /* Serve non-FETCH callbacks */
                 res = rd_kafka_poll_cb(rk, rkq, rko,
                                        RD_KAFKA_Q_CB_RETURN, NULL);

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -524,10 +524,9 @@ int rd_kafka_q_serve (rd_kafka_q_t *rkq, int timeout_ms,
  * @locality Any thread.
  */
 static size_t rd_kafka_purge_outdated_messages (int32_t version,
-                                  rd_kafka_message_t **rkmessages,
-                                  int cnt) {
+        rd_kafka_message_t **rkmessages, size_t cnt) {
         size_t valid_count = 0;
-        int i;
+        size_t i;
 
         for (i = 0; i < cnt; i++) {
                 rd_kafka_op_t *rko;
@@ -535,7 +534,7 @@ static size_t rd_kafka_purge_outdated_messages (int32_t version,
                 if (rd_kafka_op_version_outdated(rko, version)) {
                         /* This also destroys the corresponding rkmessage. */
                         rd_kafka_op_destroy(rko);
-                } else if ((size_t)i > valid_count) {
+                } else if (i > valid_count) {
                         rkmessages[valid_count++] = rkmessages[i];
                 } else {
                         valid_count++;
@@ -608,7 +607,7 @@ int rd_kafka_q_serve_rkmessages (rd_kafka_q_t *rkq, int timeout_ms,
                 }
 
                 if (unlikely(rko->rko_type == RD_KAFKA_OP_BARRIER)) {
-                        cnt = rd_kafka_purge_outdated_messages(
+                        cnt = (unsigned int)rd_kafka_purge_outdated_messages(
                                 rko->rko_version,
                                 rkmessages,
                                 cnt);

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -32,178 +32,123 @@
  * is built from within the librdkafka source tree and thus differs. */
 #include "rdkafka.h"  /* for Kafka driver */
 
-static rd_kafka_t *c1, *c2;
-//static uint64_t testid;
-//static char *topic;
+static rd_kafka_t *c1;
 
-
-typedef struct _consumer_s {
-        const char *what;
+typedef struct rd_kafka_consumer_s {
+        char *what;
         rd_kafka_queue_t *rkq;
         int timeout_ms;
         int consumemsgcnt;
         rd_kafka_t *rk;
-        char *topic;
         uint64_t testid;
-} _consumer_t;
+} rd_kafka_consumer_t;
 
-//static int test_consumer_batch_queue(_consumer_t *args) {
-static int test_consumer_batch_queue(const _consumer_t *arguments) {
-//static int test_consumer_batch_queue (const char *what, rd_kafka_queue_t *rkq, int timeout_ms, rd_kafka_message_t **rkmessage, int consumemsgcnt, rd_kafka_t *rk) {
-        //_consumer_t *args = (struct _consumer_t *)arguments;
-        _consumer_t *args = (struct _consumer_t *)arguments;
-        int cnt = 0;
+static void test_consumer_batch_queue(const rd_kafka_consumer_t *arguments) {
+	    rd_kafka_consumer_t *args = (struct rd_kafka_consumer_t *)arguments;
         int eof_cnt = 0;
-        int i = 0;
+        int i;
+        int correct;
         test_timing_t t_cons;
         test_msgver_t mv;
-        rd_kafka_queue_t *rkq = args->rkq;
-        //rd_kafka_message_t **rkmessage = args->rkmessage;
 
+        rd_kafka_queue_t *rkq = args->rkq;
         int timeout_ms = args->timeout_ms;
         int consumemsgcnt = args->consumemsgcnt;
-        rd_kafka_message_t **rkmessage = malloc(consumemsgcnt * sizeof(rd_kafka_message_t *));
-
-        int correct;
         rd_kafka_t *rk = args->rk;
-        char *topic = args->topic;
         uint64_t testid = args->testid;
+        char *what = args->what;
+
+        rd_kafka_message_t **rkmessage = malloc(consumemsgcnt * sizeof(rd_kafka_message_t *));
         test_msgver_init(&mv, testid);
-        //mv.p_cnt = 4;
-        TEST_SAY("Jing Liu Consumer1 testid %"PRId64"\n", testid);
-        TEST_SAY("Jing Liu Consumer1 tmv estid %"PRId64"\n", mv.testid);
-
-        const char *what = args->what;
-
-
-        TEST_SAY(" %s Consumer\n", what);
-
-        //TEST_SAY("%s: consume %d messages\n", what, exp_cnt);
 
         TIMING_START(&t_cons, "CONSUME");
 
         while (eof_cnt == 0) {
-                //TEST_SAY("Jing Liu Consumer2 %s\n", what);
-                //rd_kafka_message_t *rkmessage;
-
                 eof_cnt = rd_kafka_consume_batch_queue(rkq, timeout_ms, rkmessage, consumemsgcnt);
-                if (eof_cnt == 0) {
+                if (eof_cnt == 0)
                         continue;
+
+                for (i = 0; i < eof_cnt; i++) {
+                       correct = test_msgver_add_msg(rk, &mv, rkmessage[i]);
+                       if (correct == 0)
+                               TEST_FAIL("The message is not from testid %"PRId64" \n", testid);
                 }
-
-                for(i = 0; i < eof_cnt; i++) {
-                   correct = test_msgver_add_msg(rk, &mv, rkmessage[i]);
-                   if (correct == 0) {
-                	   TEST_FAIL("The message is not from testid %"PRId64" \n", testid);
-                   }
-
-                   //TEST_SAY("Jing Liu Consumer verify %s result %d\n", what, mv.p_cnt);
-                }
-
 
                 test_msgver_verify(what, &mv, TEST_MSGVER_ORDER|TEST_MSGVER_DUP, 0, eof_cnt);
                 test_msgver_clear(&mv);
+        }
+        for (i = 0; i < eof_cnt; i++)
+                rd_kafka_message_destroy(rkmessage[i]);
 
-                TEST_SAY("Jing Liu Consumer %d %s \n", eof_cnt, what);
-
-                //rd_kafka_message_destroy(rkmessage);
-        //}
-}
-        free(rkmessage);
-        TEST_SAY("Jing Liu Consumer2 %d %s\n", eof_cnt, what);
         TIMING_STOP(&t_cons);
-
-        //TEST_SAY("%s: consumed %d/%d messages (%d/%d EOFs)\n",
-        //         what, cnt, exp_cnt, eof_cnt, exp_eof_cnt);
-       /*
-        if (exp_cnt == 0)
-                TEST_ASSERT(cnt == 0 && eof_cnt == exp_eof_cnt,
-                            "%s: expected no messages and %d EOFs: "
-                            "got %d messages and %d EOFs",
-                            what, exp_eof_cnt, cnt, eof_cnt);*/
-        return cnt;
 }
 
-static void rebalance_cb (rd_kafka_t *rk, rd_kafka_resp_err_t err,
-                          rd_kafka_topic_partition_list_t *parts,
+static void rebalance_cb (rd_kafka_t *rk,
+                          rd_kafka_resp_err_t err,
+                          rd_kafka_topic_partition_list_t *partitions,
                           void *opaque) {
+        rd_kafka_error_t *error = NULL;
+        rd_kafka_resp_err_t ret_err = RD_KAFKA_RESP_ERR_NO_ERROR;
 
-        TEST_SAY("Rebalance for %s: %s: %d partition(s)\n",
-                 rd_kafka_name(rk), rd_kafka_err2name(err), parts->cnt);
+        switch (err) {
+        case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
+                TEST_SAY("Group rebalanced (%s): "
+                         "%d new partition(s) assigned\n",
+                         rd_kafka_rebalance_protocol(rk), partitions->cnt);
 
-        if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
-        TEST_SAY("Rebalance for 1");
-                TEST_CALL_ERR__(rd_kafka_assign(rk, parts));
+                if (!strcmp(rd_kafka_rebalance_protocol(rk), "COOPERATIVE"))
+                        error = rd_kafka_incremental_assign(rk, partitions);
+                else
+                        ret_err = rd_kafka_assign(rk, partitions);
 
-        } else if (err == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
-        TEST_SAY("Rebalance for 2");
-                rd_kafka_resp_err_t commit_err;
+                break;
+        case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
+                TEST_SAY("(%s): %d partition(s) revoked\n",
+                         rd_kafka_rebalance_protocol(rk), partitions->cnt);
 
-                TEST_CALL_ERR__(rd_kafka_position(rk, parts));
+                if (!strcmp(rd_kafka_rebalance_protocol(rk), "COOPERATIVE"))
+                        error = rd_kafka_incremental_unassign(rk, partitions);
+                else
+                        ret_err = rd_kafka_assign(rk, NULL);
+                break;
 
-                TEST_CALL_ERR__(rd_kafka_assign(rk, NULL));
-
-                if (rk == c1)
-                        return;
-
-                /* Give the closing consumer some time to handle the
-                 * unassignment and leave so that the coming commit fails. */
-                rd_sleep(5);
-
-                /* Committing after unassign will trigger an
-                 * Illegal generation error from the broker, which would
-                 * previously cause the cgrp to not properly transition
-                 * the next assigned state to fetching.
-                 * The closing consumer's commit is denied by the consumer
-                 * since it will have started to shut down after the assign
-                 * call. */
-                TEST_SAY("%s: Committing\n", rd_kafka_name(rk));
-                commit_err = rd_kafka_commit(rk, parts, 0/*sync*/);
-                TEST_SAY("%s: Commit result: %s\n",
-                         rd_kafka_name(rk), rd_kafka_err2name(commit_err));
-
-                TEST_ASSERT(commit_err,
-                            "Expected closing consumer %s's commit to "
-                            "fail, but got %s",
-                            rd_kafka_name(rk),
-                            rd_kafka_err2name(commit_err));
-
-        } else {
-                TEST_SAY("Rebalance for 3");
-                TEST_FAIL("Unhandled event: %s", rd_kafka_err2name(err));
+        default:
+                break;
         }
 
+        if (error) {
+                TEST_FAIL("%% incremental assign failure: %s\n",
+                          rd_kafka_error_string(error));
+                rd_kafka_error_destroy(error);
+        } else if (ret_err) {
+                TEST_FAIL( "%% assign failure: %s\n",
+                rd_kafka_err2str(ret_err));
+        }
 }
 
 /**
  * Consume with batch + queue interface
  *
  */
-static int do_test_consume_batch (void) {
-        //const char *topic;
-        const int partition_cnt = 4;
-        const rd_kafka_queue_t *rkq1, *rkq2;
-        const rd_kafka_topic_t *rkt;
-	    const rd_kafka_resp_err_t err;
-        const int producemsgcnt = 4000;
+static int do_test_consume_batch (char *strategy) {
+        int partition_cnt = 4;
+        rd_kafka_queue_t *rkq1, *rkq2;
+        int producemsgcnt = 400;
         const char *topic;
-        test_msgver_t mv;
-        int i, p;
-        int batch_cnt = 0;
-        int remains;
-        int timeout_ms = 30;
+        rd_kafka_t *c2;
+        int p;
+        int timeout_ms = 30000;
         uint64_t testid;
-        const int consumemsgcnt = 5000;
+        int consumemsgcnt = 500;
         rd_kafka_conf_t *conf;
         pthread_t thread_id;
         pthread_t thread_id2;
-        _consumer_t *c1_args = (_consumer_t *) malloc(sizeof(_consumer_t));
-        _consumer_t *c2_args = (_consumer_t *) malloc(sizeof(_consumer_t));
+        rd_kafka_consumer_t *c1_args = (rd_kafka_consumer_t *) malloc(sizeof(rd_kafka_consumer_t));
+        rd_kafka_consumer_t *c2_args = (rd_kafka_consumer_t *) malloc(sizeof(rd_kafka_consumer_t));
 
         test_conf_init(&conf, NULL, 60);
         test_conf_set(conf, "enable.auto.commit", "false");
         test_conf_set(conf, "auto.offset.reset", "earliest");
-        rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
 
         testid = test_id_generate();
 
@@ -215,15 +160,18 @@ static int do_test_consume_batch (void) {
                                        testid,
                                        p,
                                        producemsgcnt / partition_cnt);
-
         /* Create simple consumer */
+        if(strcmp(strategy, "cooperative-sticky") == 0)
+                test_conf_set(conf, "partition.assignment.strategy", "cooperative-sticky");
+
+        rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
+
         c1 = test_create_consumer(topic, rebalance_cb,
                                   rd_kafka_conf_dup(conf), NULL);
         c2 = test_create_consumer(topic, NULL, conf, NULL);
 
         test_consumer_subscribe(c1, topic);
         test_consumer_subscribe(c2, topic);
-        rd_sleep(2);
 
         /* Create generic consume queue */
         rkq1 = rd_kafka_queue_get_consumer(c1);
@@ -235,47 +183,42 @@ static int do_test_consume_batch (void) {
         c1_args->consumemsgcnt = consumemsgcnt;
         c1_args->rk = c1;
         c1_args->testid = testid;
-        c1_args->topic = topic;
 
         pthread_create(&thread_id, NULL, test_consumer_batch_queue, c1_args);
 
-        TEST_SAY("Jing Liu c2_args\n");
         c2_args->what = "C2.PRE";
         c2_args->rkq = rkq2;
         c2_args->timeout_ms = timeout_ms;
         c2_args->consumemsgcnt = consumemsgcnt;
         c2_args->rk = c2;
         c2_args->testid = testid;
-        c2_args->topic = topic;
-        TEST_SAY("Jing Liu c2_args\n");
 
         pthread_create(&thread_id2, NULL, test_consumer_batch_queue, c2_args);
         pthread_join(thread_id, NULL);
         pthread_join(thread_id2, NULL);
 
-
         rd_free(c1_args);
         rd_free(c2_args);
+
         rd_kafka_queue_destroy(rkq1);
         rd_kafka_queue_destroy(rkq2);
 
         test_consumer_close(c1);
         test_consumer_close(c2);
-        //rd_kafka_destroy(c2);
 
-        //rd_kafka_destroy(c1);
-        //rd_kafka_destroy(c2);
+        rd_kafka_destroy(c1);
+        rd_kafka_destroy(c2);
 
         return 0;
 }
 
 
-
-
 int main_0122_buffer_cleaning_after_rebalance (int argc, char **argv) {
         int fails = 0;
 
-        fails += do_test_consume_batch();
+        fails += do_test_consume_batch("eager-rebalance");
+
+        fails += do_test_consume_batch("cooperative-sticky");
 
         if (fails > 0)
                 TEST_FAIL("See %d previous error(s)\n", fails);

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -27,7 +27,6 @@
  */
 
 #include "test.h"
-#include <pthread.h>
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is built from within the librdkafka source tree and thus differs. */
 #include "rdkafka.h"  /* for Kafka driver */
@@ -41,10 +40,10 @@ typedef struct rd_kafka_consumer_s {
         int consumemsgcnt;
         rd_kafka_t *rk;
         uint64_t testid;
-} rd_kafka_consumer_t;
+} consumer_t;
 
-static void test_consumer_batch_queue(const rd_kafka_consumer_t *arguments) {
-	    rd_kafka_consumer_t *args = (struct rd_kafka_consumer_t *)arguments;
+static void test_consumer_batch_queue(const consumer_t *arguments) {
+	    consumer_t *args = (struct consumer_t *)arguments;
         int eof_cnt = 0;
         int i;
         int correct;
@@ -141,10 +140,10 @@ static int do_test_consume_batch (char *strategy) {
         uint64_t testid;
         int consumemsgcnt = 500;
         rd_kafka_conf_t *conf;
-        pthread_t thread_id;
-        pthread_t thread_id2;
-        rd_kafka_consumer_t *c1_args = (rd_kafka_consumer_t *) malloc(sizeof(rd_kafka_consumer_t));
-        rd_kafka_consumer_t *c2_args = (rd_kafka_consumer_t *) malloc(sizeof(rd_kafka_consumer_t));
+        thrd_t thread_id;
+        thrd_t thread_id2;
+        consumer_t *c1_args = (consumer_t *) malloc(sizeof(consumer_t));
+        consumer_t *c2_args = (consumer_t *) malloc(sizeof(consumer_t));
 
         test_conf_init(&conf, NULL, 60);
         test_conf_set(conf, "enable.auto.commit", "false");
@@ -184,7 +183,7 @@ static int do_test_consume_batch (char *strategy) {
         c1_args->rk = c1;
         c1_args->testid = testid;
 
-        pthread_create(&thread_id, NULL, test_consumer_batch_queue, c1_args);
+        thrd_create(&thread_id, test_consumer_batch_queue, c1_args);
 
         c2_args->what = "C2.PRE";
         c2_args->rkq = rkq2;
@@ -193,9 +192,9 @@ static int do_test_consume_batch (char *strategy) {
         c2_args->rk = c2;
         c2_args->testid = testid;
 
-        pthread_create(&thread_id2, NULL, test_consumer_batch_queue, c2_args);
-        pthread_join(thread_id, NULL);
-        pthread_join(thread_id2, NULL);
+        thrd_create(&thread_id2, test_consumer_batch_queue, c2_args);
+        thrd_join(thread_id, NULL);
+        thrd_join(thread_id2, NULL);
 
         rd_free(c1_args);
         rd_free(c2_args);

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -120,7 +120,9 @@ static void do_test_consume_batch (const char *strategy) {
                                        produce_msg_cnt / partition_cnt);
         /* Create simple consumer */
         if (!strcmp(strategy, "cooperative-sticky"))
-                test_conf_set(conf, "partition.assignment.strategy", "cooperative-sticky");
+                test_conf_set(conf,
+                              "partition.assignment.strategy",
+                              "cooperative-sticky");
 
         c1 = test_create_consumer(topic, NULL,
                                   rd_kafka_conf_dup(conf), NULL);

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -59,7 +59,6 @@ static int consumer_batch_queue (void *arg) {
 
         msg_cnt = rd_kafka_consume_batch_queue(rkq,
                 timeout_ms, rkmessage, consume_msg_cnt);
-        TEST_SAY("Jing Liu received %d\n", msg_cnt);
 
         TIMING_STOP(&t_cons);
 
@@ -75,9 +74,9 @@ static int consumer_batch_queue (void *arg) {
 
 
 /**
- * @brief Produce 400 messages and consume 500 messages totally by 2 consumers,
- *        verify if there isn't any missed or duplicate messages received
- *        by the two consumers.
+ * @brief Produce 400 messages and consume 500 messages totally by 2 consumers
+ *        using batch queue method, verify if there isn't any missed or
+ *        duplicate messages received by the two consumers.
  *        The reasons for setting the consume messages number is higher than
  *        or equal to the produce messages number are:
  *        1) Make sure each consumer can at most receive half of the produced

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -1,0 +1,284 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2012-2015, Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+#include <pthread.h>
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is built from within the librdkafka source tree and thus differs. */
+#include "rdkafka.h"  /* for Kafka driver */
+
+static rd_kafka_t *c1, *c2;
+//static uint64_t testid;
+//static char *topic;
+
+
+typedef struct _consumer_s {
+        const char *what;
+        rd_kafka_queue_t *rkq;
+        int timeout_ms;
+        int consumemsgcnt;
+        rd_kafka_t *rk;
+        char *topic;
+        uint64_t testid;
+} _consumer_t;
+
+//static int test_consumer_batch_queue(_consumer_t *args) {
+static int test_consumer_batch_queue(const _consumer_t *arguments) {
+//static int test_consumer_batch_queue (const char *what, rd_kafka_queue_t *rkq, int timeout_ms, rd_kafka_message_t **rkmessage, int consumemsgcnt, rd_kafka_t *rk) {
+        //_consumer_t *args = (struct _consumer_t *)arguments;
+        _consumer_t *args = (struct _consumer_t *)arguments;
+        int cnt = 0;
+        int eof_cnt = 0;
+        int i = 0;
+        test_timing_t t_cons;
+        test_msgver_t mv;
+        rd_kafka_queue_t *rkq = args->rkq;
+        //rd_kafka_message_t **rkmessage = args->rkmessage;
+
+        int timeout_ms = args->timeout_ms;
+        int consumemsgcnt = args->consumemsgcnt;
+        rd_kafka_message_t **rkmessage = malloc(consumemsgcnt * sizeof(rd_kafka_message_t *));
+
+        int correct;
+        rd_kafka_t *rk = args->rk;
+        char *topic = args->topic;
+        uint64_t testid = args->testid;
+        test_msgver_init(&mv, testid);
+        //mv.p_cnt = 4;
+        TEST_SAY("Jing Liu Consumer1 testid %"PRId64"\n", testid);
+        TEST_SAY("Jing Liu Consumer1 tmv estid %"PRId64"\n", mv.testid);
+
+        const char *what = args->what;
+
+
+        TEST_SAY(" %s Consumer\n", what);
+
+        //TEST_SAY("%s: consume %d messages\n", what, exp_cnt);
+
+        TIMING_START(&t_cons, "CONSUME");
+
+        while (eof_cnt == 0) {
+                //TEST_SAY("Jing Liu Consumer2 %s\n", what);
+                //rd_kafka_message_t *rkmessage;
+
+                eof_cnt = rd_kafka_consume_batch_queue(rkq, timeout_ms, rkmessage, consumemsgcnt);
+                if (eof_cnt == 0) {
+                        continue;
+                }
+
+                for(i = 0; i < eof_cnt; i++) {
+                   correct = test_msgver_add_msg(rk, &mv, rkmessage[i]);
+                   if (correct == 0) {
+                	   TEST_FAIL("The message is not from testid %"PRId64" \n", testid);
+                   }
+
+                   //TEST_SAY("Jing Liu Consumer verify %s result %d\n", what, mv.p_cnt);
+                }
+
+
+                test_msgver_verify(what, &mv, TEST_MSGVER_ORDER|TEST_MSGVER_DUP, 0, eof_cnt);
+                test_msgver_clear(&mv);
+
+                TEST_SAY("Jing Liu Consumer %d %s \n", eof_cnt, what);
+
+                //rd_kafka_message_destroy(rkmessage);
+        //}
+}
+        free(rkmessage);
+        TEST_SAY("Jing Liu Consumer2 %d %s\n", eof_cnt, what);
+        TIMING_STOP(&t_cons);
+
+        //TEST_SAY("%s: consumed %d/%d messages (%d/%d EOFs)\n",
+        //         what, cnt, exp_cnt, eof_cnt, exp_eof_cnt);
+       /*
+        if (exp_cnt == 0)
+                TEST_ASSERT(cnt == 0 && eof_cnt == exp_eof_cnt,
+                            "%s: expected no messages and %d EOFs: "
+                            "got %d messages and %d EOFs",
+                            what, exp_eof_cnt, cnt, eof_cnt);*/
+        return cnt;
+}
+
+static void rebalance_cb (rd_kafka_t *rk, rd_kafka_resp_err_t err,
+                          rd_kafka_topic_partition_list_t *parts,
+                          void *opaque) {
+
+        TEST_SAY("Rebalance for %s: %s: %d partition(s)\n",
+                 rd_kafka_name(rk), rd_kafka_err2name(err), parts->cnt);
+
+        if (err == RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS) {
+        TEST_SAY("Rebalance for 1");
+                TEST_CALL_ERR__(rd_kafka_assign(rk, parts));
+
+        } else if (err == RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS) {
+        TEST_SAY("Rebalance for 2");
+                rd_kafka_resp_err_t commit_err;
+
+                TEST_CALL_ERR__(rd_kafka_position(rk, parts));
+
+                TEST_CALL_ERR__(rd_kafka_assign(rk, NULL));
+
+                if (rk == c1)
+                        return;
+
+                /* Give the closing consumer some time to handle the
+                 * unassignment and leave so that the coming commit fails. */
+                rd_sleep(5);
+
+                /* Committing after unassign will trigger an
+                 * Illegal generation error from the broker, which would
+                 * previously cause the cgrp to not properly transition
+                 * the next assigned state to fetching.
+                 * The closing consumer's commit is denied by the consumer
+                 * since it will have started to shut down after the assign
+                 * call. */
+                TEST_SAY("%s: Committing\n", rd_kafka_name(rk));
+                commit_err = rd_kafka_commit(rk, parts, 0/*sync*/);
+                TEST_SAY("%s: Commit result: %s\n",
+                         rd_kafka_name(rk), rd_kafka_err2name(commit_err));
+
+                TEST_ASSERT(commit_err,
+                            "Expected closing consumer %s's commit to "
+                            "fail, but got %s",
+                            rd_kafka_name(rk),
+                            rd_kafka_err2name(commit_err));
+
+        } else {
+                TEST_SAY("Rebalance for 3");
+                TEST_FAIL("Unhandled event: %s", rd_kafka_err2name(err));
+        }
+
+}
+
+/**
+ * Consume with batch + queue interface
+ *
+ */
+static int do_test_consume_batch (void) {
+        //const char *topic;
+        const int partition_cnt = 4;
+        const rd_kafka_queue_t *rkq1, *rkq2;
+        const rd_kafka_topic_t *rkt;
+	    const rd_kafka_resp_err_t err;
+        const int producemsgcnt = 4000;
+        const char *topic;
+        test_msgver_t mv;
+        int i, p;
+        int batch_cnt = 0;
+        int remains;
+        int timeout_ms = 30;
+        uint64_t testid;
+        const int consumemsgcnt = 5000;
+        rd_kafka_conf_t *conf;
+        pthread_t thread_id;
+        pthread_t thread_id2;
+        _consumer_t *c1_args = (_consumer_t *) malloc(sizeof(_consumer_t));
+        _consumer_t *c2_args = (_consumer_t *) malloc(sizeof(_consumer_t));
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
+
+        testid = test_id_generate();
+
+        /* Produce messages */
+        topic = test_mk_topic_name(__FUNCTION__, 1);
+
+        for (p = 0 ; p < partition_cnt ; p++)
+                test_produce_msgs_easy(topic,
+                                       testid,
+                                       p,
+                                       producemsgcnt / partition_cnt);
+
+        /* Create simple consumer */
+        c1 = test_create_consumer(topic, rebalance_cb,
+                                  rd_kafka_conf_dup(conf), NULL);
+        c2 = test_create_consumer(topic, NULL, conf, NULL);
+
+        test_consumer_subscribe(c1, topic);
+        test_consumer_subscribe(c2, topic);
+        rd_sleep(2);
+
+        /* Create generic consume queue */
+        rkq1 = rd_kafka_queue_get_consumer(c1);
+        rkq2 = rd_kafka_queue_get_consumer(c2);
+
+        c1_args->what = "C1.PRE";
+        c1_args->rkq = rkq1;
+        c1_args->timeout_ms = timeout_ms;
+        c1_args->consumemsgcnt = consumemsgcnt;
+        c1_args->rk = c1;
+        c1_args->testid = testid;
+        c1_args->topic = topic;
+
+        pthread_create(&thread_id, NULL, test_consumer_batch_queue, c1_args);
+
+        TEST_SAY("Jing Liu c2_args\n");
+        c2_args->what = "C2.PRE";
+        c2_args->rkq = rkq2;
+        c2_args->timeout_ms = timeout_ms;
+        c2_args->consumemsgcnt = consumemsgcnt;
+        c2_args->rk = c2;
+        c2_args->testid = testid;
+        c2_args->topic = topic;
+        TEST_SAY("Jing Liu c2_args\n");
+
+        pthread_create(&thread_id2, NULL, test_consumer_batch_queue, c2_args);
+        pthread_join(thread_id, NULL);
+        pthread_join(thread_id2, NULL);
+
+
+        rd_free(c1_args);
+        rd_free(c2_args);
+        rd_kafka_queue_destroy(rkq1);
+        rd_kafka_queue_destroy(rkq2);
+
+        test_consumer_close(c1);
+        test_consumer_close(c2);
+        //rd_kafka_destroy(c2);
+
+        //rd_kafka_destroy(c1);
+        //rd_kafka_destroy(c2);
+
+        return 0;
+}
+
+
+
+
+int main_0122_buffer_cleaning_after_rebalance (int argc, char **argv) {
+        int fails = 0;
+
+        fails += do_test_consume_batch();
+
+        if (fails > 0)
+                TEST_FAIL("See %d previous error(s)\n", fails);
+
+        return 0;
+}

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -88,7 +88,6 @@ static int test_consumer_batch_queue (void *arguments) {
 static void do_test_consume_batch (const char *strategy) {
         const int partition_cnt = 4;
         rd_kafka_queue_t *rkq1, *rkq2;
-        //int produce_msg_cnt = 400;
         const char *topic;
         rd_kafka_t *c1;
         rd_kafka_t *c2;

--- a/tests/0122-buffer_cleaning_after_rebalance.c
+++ b/tests/0122-buffer_cleaning_after_rebalance.c
@@ -69,7 +69,11 @@ static int test_consumer_batch_queue (consumer_t *arguments) {
                         TEST_FAIL("The message is not from testid "
                                   "%"PRId64" \n", testid);
         }
-        test_msgver_verify(what, &mv, TEST_MSGVER_ORDER|TEST_MSGVER_DUP, 0, produce_msg_cnt/2);
+        test_msgver_verify(what,
+                           &mv,
+                           TEST_MSGVER_ORDER|TEST_MSGVER_DUP,
+                           0,
+                           produce_msg_cnt/2);
         test_msgver_clear(&mv);
 
         for (i = 0; i < msg_cnt; i++)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ set(
     0119-consumer_auth.cpp
     0120-asymmetric_subscription.c
     0121-clusterid.c
+    0122-buffer_cleaning_after_rebalance.c
     0123-connections_max_idle.c
     8000-idle.cpp
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -230,6 +230,7 @@ _TEST_DECL(0118_commit_rebalance);
 _TEST_DECL(0119_consumer_auth);
 _TEST_DECL(0120_asymmetric_subscription);
 _TEST_DECL(0121_clusterid);
+_TEST_DECL(0122_buffer_cleaning_after_rebalance);
 _TEST_DECL(0123_connections_max_idle);
 
 /* Manual tests */
@@ -432,6 +433,7 @@ struct test tests[] = {
         _TEST(0119_consumer_auth, 0, TEST_BRKVER(2,1,0,0)),
         _TEST(0120_asymmetric_subscription, TEST_F_LOCAL),
         _TEST(0121_clusterid, TEST_F_LOCAL),
+		_TEST(0122_buffer_cleaning_after_rebalance, TEST_F_LOCAL),
         _TEST(0123_connections_max_idle, 0),
 
         /* Manual tests */

--- a/tests/test.c
+++ b/tests/test.c
@@ -433,7 +433,7 @@ struct test tests[] = {
         _TEST(0119_consumer_auth, 0, TEST_BRKVER(2,1,0,0)),
         _TEST(0120_asymmetric_subscription, TEST_F_LOCAL),
         _TEST(0121_clusterid, TEST_F_LOCAL),
-		_TEST(0122_buffer_cleaning_after_rebalance, TEST_BRKVER(2,4,0,0)),
+        _TEST(0122_buffer_cleaning_after_rebalance, TEST_BRKVER(2,4,0,0)),
         _TEST(0123_connections_max_idle, 0),
 
         /* Manual tests */

--- a/tests/test.c
+++ b/tests/test.c
@@ -433,7 +433,7 @@ struct test tests[] = {
         _TEST(0119_consumer_auth, 0, TEST_BRKVER(2,1,0,0)),
         _TEST(0120_asymmetric_subscription, TEST_F_LOCAL),
         _TEST(0121_clusterid, TEST_F_LOCAL),
-		_TEST(0122_buffer_cleaning_after_rebalance, TEST_F_LOCAL),
+		_TEST(0122_buffer_cleaning_after_rebalance, TEST_BRKVER(2,4,0,0)),
         _TEST(0123_connections_max_idle, 0),
 
         /* Manual tests */

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="..\..\tests\0119-consumer_auth.cpp" />
     <ClCompile Include="..\..\tests\0120-asymmetric_subscription.c" />
     <ClCompile Include="..\..\tests\0121-clusterid.c" />
+    <ClCompile Include="..\..\tests\0122-buffer_cleaning_after_rebalance.c" />
     <ClCompile Include="..\..\tests\0123-connections_max_idle.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
Summary: This is bug fix for https://github.com/confluentinc/confluent-kafka-python/issues/1013

Issue: Buffer is not cleaned after rebalance if messages are polled using the batch queue method, so the consumer will still get old messages.

Solution: when assign happens, a new op event with type RD_KAFKA_OP_BARRIER will be created, a new version is been created at mean time. If the consumer met this event, will clean the buffer by comparing the version of msgs and the new version just created.

Test passed in local test:
Testing:
[0122_buffer_cleaning_after_rebalance/ 62.283s] ================= Test 0122_buffer_cleaning_after_rebalance PASSED =================
[<MAIN>                      / 63.161s] ALL-TESTS: duration 63160.668ms
TEST 20210224223610 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |  63.161s |
| 0122_buffer_cleaning_after_rebalance     |     PASSED |  62.283s |
#==================================================================#
[<MAIN>                      / 63.163s] 0 thread(s) in use by librdkafka
[<MAIN>                      / 63.163s] 
============== ALL TESTS PASSED ==============
###
###  ./test-runner in bare mode PASSED! ###
###
