### PR TITLE
Don't destroy metadata cache until brokers are destroyed (#3279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# librdkafka NEXT
+
+## Fixes
+
+### General fixes
+
+ * Fix accesses to freed metadata cache mutexes on client termination (#3279)
+
+
 # librdkafka v1.6.1
 
 librdkafka v1.6.1 is a maintenance release.

--- a/src/rdkafka_metadata.h
+++ b/src/rdkafka_metadata.h
@@ -184,6 +184,7 @@ void rd_kafka_metadata_fast_leader_query (rd_kafka_t *rk);
 
 void rd_kafka_metadata_cache_init (rd_kafka_t *rk);
 void rd_kafka_metadata_cache_destroy (rd_kafka_t *rk);
+void rd_kafka_metadata_cache_purge (rd_kafka_t *rk, rd_bool_t purge_observers);
 int  rd_kafka_metadata_cache_wait_change (rd_kafka_t *rk, int timeout_ms);
 void rd_kafka_metadata_cache_dump (FILE *fp, rd_kafka_t *rk);
 


### PR DESCRIPTION
As ops on broker queues may have references to the metadata cache's mutex