### PR TITLE
fix 'apis' pointer was used after the memory was releaase

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -2414,9 +2414,10 @@ rd_kafka_broker_handle_ApiVersion (rd_kafka_t *rk,
                 retry_ApiVersion = 0;
         }
 
-        if (err && apis)
+        if (err && apis) {
                 rd_free(apis);
-
+                apis = NULL;
+        }
         if (retry_ApiVersion != -1) {
                 /* Retry request with a lower version */
                 rd_rkb_dbg(rkb,


### PR DESCRIPTION
V774 [CWE-416] The 'apis' pointer was used after the memory was released. rdkafka_broker.c 2450