### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -555,9 +555,9 @@ static void rd_kafka_cgrp_handle_FindCoordinator (rd_kafka_t *rk,
                                                   void *opaque) {
         const int log_decode_errors = LOG_ERR;
         int16_t ErrorCode = 0;
-        int32_t CoordId;
+        int32_t CoordId = 0;
         rd_kafkap_str_t CoordHost = RD_ZERO_INIT;
-        int32_t CoordPort;
+        int32_t CoordPort = 0;
         rd_kafka_cgrp_t *rkcg = opaque;
         struct rd_kafka_metadata_broker mdb = RD_ZERO_INIT;
         char *errstr = NULL;

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4090,7 +4090,7 @@ int unittest_conf (void) {
                         char tmp[64];
                         int odd = cnt & 1;
                         int do_set = iteration == 3 || (iteration == 1 && odd);
-                        rd_bool_t is_modified;
+                        rd_bool_t is_modified = rd_false;
                         int exp_is_modified = !prop->unsupported &&
                                 (iteration >= 3 ||
                                  (iteration > 0 && (do_set || odd)));


### PR DESCRIPTION
 - V614 [CWE-457] Potentially uninitialized variable 'CoordId' used. rdkafka_cgrp.c 589
 - V614 [CWE-457] Potentially uninitialized variable 'CoordPort' used. rdkafka_cgrp.c 591
 - V614 [CWE-457] Potentially uninitialized variable 'is_modified' used. rdkafka_conf.c 4207