### PR TITLE
Stats: Fix consumer_lag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ librdkafka v1.7.0 is feature release:
    argument that has now been added. This is a breaking change but the original
    function signature is considered a bug.
    This change only affects C++ OAuth developers.
- * Statistics: `consumer_lag` is now using the committed_offset, while the
-   new `consumer_lag_stored` is using `stored_offset` (to be committed).
+ * Statistics: `consumer_lag` is now using the `committed_offset`,
+   while the new `consumer_lag_stored` is using `stored_offset`
+   (offset to be committed).
    This is more correct than the previous `consumer_lag` which was either
    `committed_offset` or `app_offset` (last message passed to application).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ librdkafka v1.7.0 is feature release:
    argument that has now been added. This is a breaking change but the original
    function signature is considered a bug.
    This change only affects C++ OAuth developers.
+ * Statistics: `consumer_lag` is now using the committed_offset, while the
+   new `consumer_lag_stored` is using `stored_offset` (to be committed).
+   This is more correct than the previous `consumer_lag` which was either
+   `committed_offset` or `app_offset` (last message passed to application).
 
 ## Enhancements
 

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -183,7 +183,8 @@ eof_offset | int gauge | | Last PARTITION_EOF signaled offset
 lo_offset | int gauge | | Partition's low watermark offset on broker
 hi_offset | int gauge | | Partition's high watermark offset on broker
 ls_offset | int gauge | | Partition's last stable offset on broker, or same as hi_offset is broker version is less than 0.11.0.0.
-consumer_lag | int gauge | | Difference between (hi_offset or ls_offset) - max(app_offset, committed_offset). hi_offset is used when isolation.level=read_uncommitted, otherwise ls_offset.
+consumer_lag | int gauge | | Difference between (hi_offset or ls_offset) - committed_offset). hi_offset is used when isolation.level=read_uncommitted, otherwise ls_offset.
+consumer_lag_stored | int gauge | | Difference between (hi_offset or ls_offset) - stored_offset. See consumer_lag and stored_offset.
 txmsgs | int | | Total number of messages transmitted (produced)
 txbytes | int | | Total number of bytes transmitted for txmsgs
 rxmsgs | int | | Total number of messages consumed, not including ignored messages (due to offset, etc).

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -183,8 +183,8 @@ eof_offset | int gauge | | Last PARTITION_EOF signaled offset
 lo_offset | int gauge | | Partition's low watermark offset on broker
 hi_offset | int gauge | | Partition's high watermark offset on broker
 ls_offset | int gauge | | Partition's last stable offset on broker, or same as hi_offset is broker version is less than 0.11.0.0.
-consumer_lag | int gauge | | Difference between (hi_offset or ls_offset) - committed_offset). hi_offset is used when isolation.level=read_uncommitted, otherwise ls_offset.
-consumer_lag_stored | int gauge | | Difference between (hi_offset or ls_offset) - stored_offset. See consumer_lag and stored_offset.
+consumer_lag | int gauge | | Difference between (hi_offset or ls_offset) and committed_offset). hi_offset is used when isolation.level=read_uncommitted, otherwise ls_offset.
+consumer_lag_stored | int gauge | | Difference between (hi_offset or ls_offset) and stored_offset. See consumer_lag and stored_offset.
 txmsgs | int | | Total number of messages transmitted (produced)
 txbytes | int | | Total number of bytes transmitted for txmsgs
 rxmsgs | int | | Total number of messages consumed, not including ignored messages (due to offset, etc).

--- a/src/statistics_schema.json
+++ b/src/statistics_schema.json
@@ -315,6 +315,9 @@
                                       "consumer_lag": {
                                           "type": "integer"
                                       },
+                                      "consumer_lag_stored": {
+                                          "type": "integer"
+                                      },
                                       "txmsgs": {
                                           "type": "integer"
                                       },

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -123,9 +123,9 @@ clean:
 	rm -f *.test $(OBJS) $(BIN)
 	$(MAKE) -C interceptor_test clean
 
+# Remove test reports, temporary test files, crash dumps, etc.
 clean-output:
-	# Clean test output files
-	rm -f stats_*.json *.offset
+	rm -f *.offset stats_*.json core vgcore.* _until_fail_*.log gdbrun??????
 
 realclean: clean clean-output
 	rm -f test_report_*.json
@@ -173,8 +173,6 @@ release-test: | asan tsan pristine-full scenarios compat
 rusage:
 	./run-test.sh -R bare
 
-# Remove test reports, temporary test files, crash dumps, etc.
-clean-reports:
-	rm -f *.offset stats_*.json core vgcore.*
+
 
 -include $(DEPS)


### PR DESCRIPTION
This makes consumer_lag show the committed consumer lag, i.e., the same thing as what existing consumer_lag monitoring applications will see (but without querying the coordinator), and adds a consumer_lag_stored which is the consumer lag based on the stored offset (the to-be-committed offset) which is the lag from the application's point of view.