### PR TITLE
cmake: Fix using absolute path in include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ if(MINGW)
 endif(MINGW)
 
 # Support '#include <rdkafka.h>'
-target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
+target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>")
 target_compile_definitions(rdkafka PUBLIC ${rdkafka_compile_definitions})
 if(RDKAFKA_BUILD_STATIC)
   target_compile_definitions(rdkafka PUBLIC LIBRDKAFKA_STATICLIB)


### PR DESCRIPTION
* LIST_DIR was problematic with cmake target files. It produces
  absolute paths and that crashs build on yocto. SOURCE_DIR has the
  same abilities without path mixes.