### PR TITLE
Remove CMAKE_FIND_LIBRARY_SUFFIXES From MinGW Build Script

### DIFF
--- a/packaging/mingw-w64/configure-build-msys2-mingw-static.sh
+++ b/packaging/mingw-w64/configure-build-msys2-mingw-static.sh
@@ -4,7 +4,6 @@ set -e
 
 cmake \
     -G "MinGW Makefiles" \
-    -D CMAKE_FIND_LIBRARY_SUFFIXES=".a" \
     -D CMAKE_INSTALL_PREFIX="$PWD/dest/" \
     -D RDKAFKA_BUILD_STATIC=ON \
     .


### PR DESCRIPTION
Remove CMAKE_FIND_LIBRARY_SUFFIXES from packaging/mingw-w64/configure-build-msys2-mingw-static.sh
It turns out that this will not cause any issues with the static bundle

Thanks to @SpaceIm for initially pointing it out.
