### PR TITLE
CMake: Remove Libs.private entries from rdkafka-static.pc and rdkafka++-static.pc

### DIFF
--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
   set(PKG_CONFIG_CFLAGS "-I\${includedir} -DLIBRDKAFKA_STATICLIB")
   set(PKG_CONFIG_LIBS "-L\${libdir} \${libdir}/librdkafka++.a")
   if(WIN32)
-    set(PKG_CONFIG_LIBS_PRIVATE "-lws2_32 -lsecur32 -lcrypt32")
+    string(APPEND PKG_CONFIG_LIBS " -lws2_32 -lsecur32 -lcrypt32")
   endif()
 
   configure_file(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -315,6 +315,8 @@ else()
   set(PKG_CONFIG_DESCRIPTION "The Apache Kafka C/C++ library (static)")
   set(PKG_CONFIG_CFLAGS "-I\${includedir} -DLIBRDKAFKA_STATICLIB")
   set(PKG_CONFIG_LIBS "-L\${libdir} \${libdir}/librdkafka.a")
+  string(APPEND PKG_CONFIG_LIBS " ${PKG_CONFIG_LIBS_PRIVATE}")
+  set(PKG_CONFIG_LIBS_PRIVATE "")
   configure_file(
     "../packaging/cmake/rdkafka.pc.in"
     "${GENERATED_DIR}/rdkafka-static.pc"


### PR DESCRIPTION
Per @edenhill comment [here](https://github.com/confluentinc/confluent-kafka-go/pull/564#discussion_r614670205), when building static pkg-config files, add any additional linker flags for dynamic dependencies, e.g. `-ldl` on *nix, `-lws2_32` on Windows, to `Libs`, not `Libs.private`. As this only affects CMake static builds, the risk is minimal (nothing uses these builds yet, but the hope is that confluent-kafka-go will be able to use static MinGW-built artifacts to provide Windows support)