### PR TITLE
[Windows] VC++ fix potentially uninitialized local pointer variable

### DIFF
--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -1210,7 +1210,7 @@ rd_kafka_mock_handle_Heartbeat (rd_kafka_mock_connection_t *mconn,
         rd_kafkap_str_t GroupInstanceId = RD_KAFKAP_STR_INITIALIZER;
         int32_t GenerationId;
         rd_kafka_resp_err_t err;
-        rd_kafka_mock_cgrp_t *mcgrp;
+        rd_kafka_mock_cgrp_t *mcgrp = NULL;
         rd_kafka_mock_cgrp_member_t *member = NULL;
 
         rd_kafka_buf_read_str(rkbuf, &GroupId);
@@ -1283,7 +1283,7 @@ rd_kafka_mock_handle_LeaveGroup (rd_kafka_mock_connection_t *mconn,
         rd_kafka_buf_t *resp = rd_kafka_mock_buf_new_response(rkbuf);
         rd_kafkap_str_t GroupId, MemberId;
         rd_kafka_resp_err_t err;
-        rd_kafka_mock_cgrp_t *mcgrp;
+        rd_kafka_mock_cgrp_t *mcgrp = NULL;
         rd_kafka_mock_cgrp_member_t *member = NULL;
 
         rd_kafka_buf_read_str(rkbuf, &GroupId);

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -83,7 +83,7 @@ static void rd_kafka_toppar_lag_handle_Offset (rd_kafka_t *rk,
 					       void *opaque) {
         rd_kafka_toppar_t *rktp = opaque;
         rd_kafka_topic_partition_list_t *offsets;
-        rd_kafka_topic_partition_t *rktpar;
+        rd_kafka_topic_partition_t *rktpar = NULL;
 
         offsets = rd_kafka_topic_partition_list_new(1);
 
@@ -1325,7 +1325,7 @@ static void rd_kafka_toppar_handle_Offset (rd_kafka_t *rk,
 					   void *opaque) {
         rd_kafka_toppar_t *rktp = opaque;
         rd_kafka_topic_partition_list_t *offsets;
-        rd_kafka_topic_partition_t *rktpar;
+        rd_kafka_topic_partition_t *rktpar = NULL;
         int64_t Offset;
 
 	rd_kafka_toppar_lock(rktp);

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -155,7 +155,7 @@ int rd_kafka_sasl_recv (rd_kafka_transport_t *rktrans,
  */
 int rd_kafka_sasl_io_event (rd_kafka_transport_t *rktrans, int events,
                             char *errstr, size_t errstr_size) {
-        rd_kafka_buf_t *rkbuf;
+        rd_kafka_buf_t *rkbuf = NULL;
         int r;
         const void *buf;
         size_t len;

--- a/src/rdkafka_sticky_assignor.c
+++ b/src/rdkafka_sticky_assignor.c
@@ -923,7 +923,7 @@ performReassignments (
  * FIXME: should be called imbalance score then?
  */
 static int getBalanceScore (map_str_toppar_list_t *assignment) {
-        const char *consumer;
+        const char *consumer = NULL;
         const rd_kafka_topic_partition_list_t *partitions;
         int *sizes;
         int cnt = 0;
@@ -1004,7 +1004,7 @@ balance (rd_kafka_t *rk,
         int newScore, oldScore;
         /* Iterator variables */
         const rd_kafka_topic_partition_t *partition;
-        const void *ignore;
+        const void *ignore = NULL;
         const rd_map_elem_t *elem;
         int i;
 
@@ -1381,7 +1381,7 @@ static void populatePotentialMaps (
 static rd_bool_t areSubscriptionsIdentical (
         map_toppar_list_t *partition2AllPotentialConsumers,
         map_str_toppar_list_t *consumer2AllPotentialPartitions) {
-        const void *ignore;
+        const void *ignore = NULL;
         const rd_list_t *lcurr, *lprev = NULL;
         const rd_kafka_topic_partition_list_t *pcurr, *pprev = NULL;
 

--- a/src/regexp.c
+++ b/src/regexp.c
@@ -656,7 +656,7 @@ static Reinst *emit(Reprog *prog, int opcode)
 
 static void compile(Reprog *prog, Renode *node)
 {
-	Reinst *inst, *split, *jump;
+	Reinst *inst = NULL, *split, *jump;
 	unsigned int i;
 
 	if (!node)


### PR DESCRIPTION
Error	C4703	potentially uninitialized local pointer variable 'mcgrp' used	librdkafka	\librdkafka\src\rdkafka_mock_handlers.c	1250
Error	C4703	potentially uninitialized local pointer variable 'mcgrp' used	librdkafka	\librdkafka\src\rdkafka_mock_handlers.c	1321
Error	C4703	potentially uninitialized local pointer variable 'ignore' used	librdkafka	\librdkafka\src\rdkafka_sticky_assignor.c	1045
Error	C4703	potentially uninitialized local pointer variable 'ignore' used	librdkafka	\librdkafka\src\rdkafka_sticky_assignor.c	1401
Error	C4703	potentially uninitialized local pointer variable 'consumer' used	librdkafka	\librdkafka\src\rdkafka_sticky_assignor.c	948
Error	C4703	potentially uninitialized local pointer variable 'rktpar' used	librdkafka	\librdkafka\src\rdkafka_partition.c	1428
Error	C4703	potentially uninitialized local pointer variable 'rktpar' used	librdkafka	\librdkafka\src\rdkafka_partition.c	105
Error	C4703	potentially uninitialized local pointer variable 'inst' used	librdkafka	\librdkafka\src\regexp.c	715