### PR TITLE
Fix SSL handshake busy-loop due to POLLOUT being set in CONNECT state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ librdkafka v1.7.0 is feature release:
    `rd_kafka_new()` which made this call blocking if the refresh command
    was taking long. The refresh is now performed by the background rdkafka
    main thread.
+ * Fix busy-loop (100% CPU on the broker threads) during the handshake phase
+   of an SSL connection.
 
 ### Consumer fixes
 

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -82,6 +82,7 @@ const char *rd_kafka_broker_state_names[] = {
 	"DOWN",
         "TRY_CONNECT",
 	"CONNECT",
+        "SSL_HANDSHAKE",
 	"AUTH_LEGACY",
 	"UP",
         "UPDATE",
@@ -5303,6 +5304,7 @@ static int rd_kafka_broker_thread_main (void *arg) {
 			break;
 
 		case RD_KAFKA_BROKER_STATE_CONNECT:
+                case RD_KAFKA_BROKER_STATE_SSL_HANDSHAKE:
 		case RD_KAFKA_BROKER_STATE_AUTH_LEGACY:
                 case RD_KAFKA_BROKER_STATE_AUTH_REQ:
 		case RD_KAFKA_BROKER_STATE_AUTH_HANDSHAKE:

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -44,6 +44,7 @@ typedef	enum {
         RD_KAFKA_BROKER_STATE_DOWN,
         RD_KAFKA_BROKER_STATE_TRY_CONNECT,
         RD_KAFKA_BROKER_STATE_CONNECT,
+        RD_KAFKA_BROKER_STATE_SSL_HANDSHAKE,
         RD_KAFKA_BROKER_STATE_AUTH_LEGACY,
 
         /* Any state >= STATE_UP means the Kafka protocol layer


### PR DESCRIPTION
.. by adding a new SSL_HANDSHAKE broker state specific to this state of
the connection establishment.