### PR TITLE
wchar_t -> CHAR

### DIFF
--- a/src/rdkafka_sasl_win32.c
+++ b/src/rdkafka_sasl_win32.c
@@ -62,7 +62,7 @@
 typedef struct rd_kafka_sasl_win32_state_s {
         CredHandle *cred;
         CtxtHandle *ctx;
-        wchar_t principal[512];  /* Broker service principal and hostname */
+        CHAR principal[1024];  /* Broker service principal and hostname */
 } rd_kafka_sasl_win32_state_t;
 
 


### PR DESCRIPTION
fix librdkafka\src\rdkafka_sasl_win32.c(182,58):
warning C4133: 'function': incompatible types - from 'wchar_t [512]' to 'SEC_CHAR *'