### PR TITLE
Correctly handle empty aborted transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ librdkafka v1.7.0 is feature release:
  * Fix balancing and reassignment issues with the cooperative-sticky assignor.
    #3306.
  * Fix incorrect detection of first rebalance in sticky assignor (@hallfox).
+ * Aborted transactions with no messages produced to a partition could
+   cause further successfully committed messages in the same Fetch response to
+   be ignored, resulting in consumer-side message loss.
+   A log message along the lines `Abort txn ctrl msg bad order at offset
+   7501: expected before or at 7702: messages in aborted transactions may be delivered to the application`
+   would be seen.
+   This is a rare occurrence where a transactional producer would register with
+   the partition but not produce any messages before aborting the transaction.
  * The consumer group deemed cached metadata up to date by checking
    `topic.metadata.refresh.interval.ms`: if this property was set too low
    it would cause cached metadata to be unusable and new metadata to be fetched,


### PR DESCRIPTION
Seems like there is a case where aborted transactions will have an
ABORT ctrl message marker, but not be included in the aborted transactions
list.
This would cause the next aborted-transaction-offset to be popped from the
aborted transaction list even though it did not match the aborted transaction
marker. This in turn could lead to aborted messages for subsequent aborted
transactions in the same MessageSet to not be skipped and instead delivered
to the application.

The fix is to silently (unless debug) ignore these unsolicited abort markers
if they're not in the aborted transaction list and not pop off the next
non-matching offset from the aborted transaction list.