### PR TITLE
Fix static windows build artifacts, and a CI test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
  - name: "Windows MinGW-w64 Dynamic"
    os: windows
    env:
+    - LINKAGE=std
     - SKIP_MAKE=y
    before_install:
     - source ./packaging/mingw-w64/travis-before-install.sh
@@ -64,6 +65,7 @@ matrix:
  - name: "Windows MinGW-w64 Static"
    os: windows
    env:
+    - LINKAGE=static
     - SKIP_MAKE=y
    before_install:
     - source ./packaging/mingw-w64/travis-before-install.sh

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -513,9 +513,9 @@ class StaticPackage (Package):
             [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/librdkafka-static.a', 'librdkafka_darwin.a'],
             [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/pkgconfig/rdkafka-static.pc', 'librdkafka_darwin.pc'],
 
-            # win static lib and pkg-config file
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka-mingw.tar.gz'}, './lib/librdkafka-static.a', 'librdkafka_windows.a'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka-mingw.tar.gz'}, './lib/pkgconfig/rdkafka-static.pc', 'librdkafka_windows.pc'],
+            # win static lib and pkg-config file (mingw)
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/librdkafka-static.a', 'librdkafka_windows.a'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/pkgconfig/rdkafka-static.pc', 'librdkafka_windows.pc'],
         ]
 
         for m in mappings:


### PR DESCRIPTION
That CI test failure has been bugging me for ages, but not being able to reproduce locally until today with a hefty dose of valgrind and cpulimit. Time-based tests are crap.