### PR TITLE
cooperative-sticky consumer unsubscribe() now leaves the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ librdkafka v1.7.0 is feature release:
  * A consumer configured with the `cooperative-sticky` assignor did
    not actively Leave the group on unsubscribe(). This delayed the
    rebalance for the remaining group members by up to `session.timeout.ms`.
+ * The current subscription list was sometimes leaked when unsubscribing.
 
 ### Producer fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ librdkafka v1.7.0 is feature release:
    (introduced in v1.6.0).
  * Fix unaligned access and possibly corrupted snappy decompression when
    building with MSVC (@azat)
+ * A consumer configured with the `cooperative-sticky` assignor did
+   not actively Leave the group on unsubscribe(). This delayed the
+   rebalance for the remaining group members by up to `session.timeout.ms`.
 
 ### Producer fixes
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -4271,6 +4271,9 @@ rd_kafka_cgrp_modify_subscription (rd_kafka_cgrp_t *rkcg,
                      revoking ? revoking->cnt : 0,
                      rd_kafka_cgrp_join_state_names[rkcg->rkcg_join_state]);
 
+        if (unsubscribing_topics)
+                rd_kafka_topic_partition_list_destroy(unsubscribing_topics);
+
         /* Create a list of the topics in metadata that matches the new
          * subscription */
         tinfos = rd_list_new(rkcg->rkcg_subscription->cnt,
@@ -4315,9 +4318,6 @@ rd_kafka_cgrp_modify_subscription (rd_kafka_cgrp_t *rkcg,
 
                 rd_kafka_topic_partition_list_destroy(revoking);
         }
-
-        if (unsubscribing_topics)
-                rd_kafka_topic_partition_list_destroy(unsubscribing_topics);
 
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }

--- a/tests/0113-cooperative_rebalance.cpp
+++ b/tests/0113-cooperative_rebalance.cpp
@@ -107,6 +107,7 @@ static void produce_msgs (vector<pair<Toppar,int> > partitions) {
   RdKafka::Producer *p = RdKafka::Producer::create(conf, errstr);
   if (!p)
     Test::Fail("Failed to create producer: " + errstr);
+  delete conf;
 
   for (vector<pair<Toppar,int> >::iterator it = partitions.begin() ;
        it != partitions.end() ; it++) {


### PR DESCRIPTION
The increase in session.timeout.ms surfaced the fact that we don't leave the group on unsubscribe in the incremental case.