### PR TITLE
Improve compression codec error message

### DIFF
--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -262,7 +262,7 @@ enum ErrorCode {
         ERR__STATE = -172,
 	/** Unknown protocol */
         ERR__UNKNOWN_PROTOCOL = -171,
-	/** Not implemented */
+	/** Compression Codec not implemented */
         ERR__NOT_IMPLEMENTED = -170,
 	/** Authentication failure*/
 	ERR__AUTHENTICATION = -169,

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -438,7 +438,7 @@ static const struct rd_kafka_err_desc rd_kafka_err_descs[] = {
         _ERR_DESC(RD_KAFKA_RESP_ERR__UNKNOWN_PROTOCOL,
 		  "Local: Unknown protocol"),
         _ERR_DESC(RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-		  "Local: Not implemented"),
+		  "Local: Compression Codec not implemented"),
 	_ERR_DESC(RD_KAFKA_RESP_ERR__AUTHENTICATION,
 		  "Local: Authentication failure"),
 	_ERR_DESC(RD_KAFKA_RESP_ERR__NO_OFFSET,


### PR DESCRIPTION
Currently the error message: `Not implemented` is pretty cryptic since it lacks any context. 

This PR addresses that, by specifying this is about a missing compression codec.