### PR TITLE
Support finding LZ4 from installed package

### DIFF
--- a/packaging/cmake/Config.cmake.in
+++ b/packaging/cmake/Config.cmake.in
@@ -24,6 +24,7 @@ if(@WITH_SSL@)
 endif()
 
 if(@WITH_LZ4_EXT@)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
   find_dependency(LZ4)
 endif()
 


### PR DESCRIPTION
When built with ENABLE_LZ4_EXT=ON, consuming RdKafka via
find_package also requires lz4. Since lz4 doesn't bring an
LZ4Config.cmake, this package is found using RdKafka's custom
FindLZ4.cmake. But this "find module" isn't searched in
RdKafka's install target by default [1].

Attempting to do so results in
  By not providing "FindLZ4.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "LZ4", but
  CMake did not find one.
  [...]
with current releases.

This is why extending the CMAKE_MODULE_PATH to the RdKafka
install target is necessary. This is actually common practice
e.g. [2].

[1]: https://cmake.org/cmake/help/latest/command/find_package.html?highlight=find%20package#search-procedure
[2]: https://github.com/grpc/grpc/blob/master/cmake/gRPCConfig.cmake.in#L2