### PR TITLE
Mark sasl ready if relogin disabled

### DIFF
--- a/src/rdkafka_sasl_cyrus.c
+++ b/src/rdkafka_sasl_cyrus.c
@@ -573,7 +573,8 @@ static int rd_kafka_sasl_cyrus_client_new (rd_kafka_transport_t *rktrans,
  */
 static rd_bool_t rd_kafka_sasl_cyrus_ready (rd_kafka_t *rk) {
         rd_kafka_sasl_cyrus_handle_t *handle = rk->rk_sasl.handle;
-
+        if (!rk->rk_conf.sasl.relogin_min_time)
+                return rd_true;
         if (!handle)
                 return rd_false;
 


### PR DESCRIPTION
It fixes the issue https://github.com/edenhill/librdkafka/issues/3430

Basically if one has a cached kerberos ticket and disables relogin then sasl should be marked as ready and there should be no first attempt to refresh the ticket.