### PR TITLE
Keep session alive during long consumer group rebalances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ librdkafka v1.7.1 is a maintenance release.
    `ERR_COORDINATOR_NOT_AVAILABLE`, and `ERR_NOT_COORDINATOR` (#3398).
    Offset commits will be retried twice.
 
+ * If a rebalance takes longer than a consumer's `session.timeout.ms`, the
+   consumer will remain in the group as long as it receives heartbeat responses
+   from the broker.
 
 
 # librdkafka v1.7.0

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -2333,6 +2333,8 @@ void rd_kafka_cgrp_handle_Heartbeat (rd_kafka_t *rk,
                 break;
 
         case RD_KAFKA_RESP_ERR_REBALANCE_IN_PROGRESS:
+                rd_kafka_cgrp_update_session_timeout(
+                        rkcg, rd_false/*don't update if session has expired*/);
                 /* No further action if already rebalancing */
                 if (RD_KAFKA_CGRP_WAIT_ASSIGN_CALL(rkcg))
                         return;


### PR DESCRIPTION
If a consumer group rebalance takes longer than `session.timeout.ms` (for example, one of the consumers is taking a long time to complete a batch of messages), then other consumers will fail their session timeout check after some time. This is because heartbeat responses from the broker with a `REBALANCE_IN_PROGRESS` error do not update the session timeout.

This PR simply updates the timer when `REBALANCE_IN_PROGRESS` is received in a heartbeat response.

There was a similar improvement in the Java client here: https://github.com/apache/kafka/pull/8834

That change modified the broker to send no error in response to heartbeats during a rebalance, but this PR should fix the issue for clients of older brokers.