### PR TITLE
Timed auto commits did not work when using only assign() and not subscribe()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
  * Automatically retry offset commits on `ERR_REQUEST_TIMED_OUT`,
    `ERR_COORDINATOR_NOT_AVAILABLE`, and `ERR_NOT_COORDINATOR` (#3398).
    Offset commits will be retried twice.
+ * Timed auto commits did not work when only using assign() and not subscribe().
+   This regression was introduced in v1.7.0.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
    `isolation.level` and will return the Last Stable Offset (LSO)
    when `isolation.level` is set to `read_committed` (default), rather than
    the uncommitted high-watermark when it is set to `read_uncommitted`. (#3423)
+ * SASL GSSAPI is now usable when `sasl.kerberos.min.time.before.relogin`
+   is set to 0 - which disables ticket refreshes (by @mpekalski, #3431).
 
 
 ### Consumer fixes

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3107,7 +3107,8 @@ static void rd_kafka_cgrp_offset_commit_tmr_cb (rd_kafka_timers_t *rkts,
 
         /* Don't attempt auto commit when rebalancing or initializing since
          * the rkcg_generation_id is most likely in flux. */
-        if (rkcg->rkcg_join_state != RD_KAFKA_CGRP_JOIN_STATE_STEADY)
+        if (rkcg->rkcg_subscription &&
+            rkcg->rkcg_join_state != RD_KAFKA_CGRP_JOIN_STATE_STEADY)
                 return;
 
         rd_kafka_cgrp_assigned_offsets_commit(rkcg, NULL,


### PR DESCRIPTION


This regression was introduced in v1.7.0