### PR TITLE
Use vcpkgs for dependencies on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,24 +1,33 @@
-version: 1.0.0-R-post{build}
+version: 1.8.0-R-post{build}
 pull_requests:
   do_not_increment_build_number: true
-image: Visual Studio 2013
+image: Visual Studio 2015
 configuration: Release
 environment:
+  runtime: v140
   matrix:
   - platform: x64
+    arch: x64
   - platform: win32
+    arch: x86
 install:
-- ps: "& .\\win32\\install-openssl.ps1"
 - ps: "& .\\win32\\install-coapp.ps1"
+  # Update vcpkg (is outdated on the VS 2015 image)
+- cmd: |
+    cd "C:\Tools\vcpkg"
+    git pull
+    .\bootstrap-vcpkg.bat
+    cd %appveyor_build_folder%
 cache:
-- c:\OpenSSL-Win32 -> win32\install-openssl.ps1
-- c:\OpenSSL-Win64 -> win32\install-openssl.ps1
+ - c:\tools\vcpkg\installed
+ - C:\Users\appveyor\AppData\Local\vcpkg\archives
+ - C:\Users\appveyor\AppData\Local\vcpkg\installed
 nuget:
   account_feed: true
   project_feed: true
   disable_publish_on_pr: true
 before_build:
-- cmd: nuget restore win32/librdkafka.sln
+ - cmd: vcpkg install zstd zlib openssl --triplet %arch%-windows
 build:
   project: win32/librdkafka.sln
   publish_nuget: true
@@ -27,7 +36,7 @@ build:
   parallel: true
   verbosity: normal
 test_script:
-- cmd: cd tests && ..\win32\outdir\v120\%PLATFORM%\%CONFIGURATION%\tests.exe -l -Q -p1 && cd ..
+- cmd: cd tests && ..\win32\outdir\%runtime%\%PLATFORM%\%CONFIGURATION%\tests.exe -l -Q -p1 && cd ..
 artifacts:
 - path: test_report*.json
   name: Test report
@@ -41,7 +50,8 @@ artifacts:
   name: Libraries
 - path: '**\*.exe'
   name: Executables
-before_deploy:
+#before_deploy:
+after_test:
 - ps: >-
     # FIXME: Add to Deployment condition above:
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ install:
   # Update vcpkg (is outdated on the VS 2015 image)
 - cmd: |
     cd "C:\Tools\vcpkg"
-    git pull
+    git pull -q
     .\bootstrap-vcpkg.bat
     cd %appveyor_build_folder%
 cache:
@@ -27,7 +27,7 @@ nuget:
   project_feed: true
   disable_publish_on_pr: true
 before_build:
- - cmd: vcpkg install zstd zlib openssl --triplet %arch%-windows
+ - cmd: vcpkg --feature-flags=versions install --triplet %arch%-windows
 build:
   project: win32/librdkafka.sln
   publish_nuget: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,18 @@ librdkafka v1.7.0 is feature release:
  * The binary librdkafka artifacts for Alpine are now using Alpine 3.12.
    OpenSSL 1.1.1k.
  * Improved static librdkafka Windows builds using MinGW (@neptoess, #3130).
+ * The `librdkafka.redist` NuGet package now has updated zlib, zstd and
+   OpenSSL versions (from vcpkg).
 
+
+## Security considerations
+
+ * The zlib version bundled with the `librdkafka.redist` NuGet package has now been upgraded
+   from zlib 1.2.8 to 1.2.11, fixing the following CVEs:
+   * CVE-2016-9840: undefined behaviour (compiler dependent) in inflate (decompression) code: this is used by the librdkafka consumer. Risk of successfully exploitation through consumed messages is eastimated very low.
+   * CVE-2016-9841: undefined behaviour (compiler dependent) in inflate code: this is used by the librdkafka consumer. Risk of successfully exploitation through consumed messages is eastimated very low.
+   * CVE-2016-9842: undefined behaviour in inflateMark(): this API is not used by librdkafka.
+   * CVE-2016-9843: issue in crc32_big() which is called from crc32_z(): this API is not used by librdkafka.
 
 ## Upgrade considerations
 
@@ -79,6 +90,8 @@ librdkafka v1.7.0 is feature release:
    This is more correct than the previous `consumer_lag` which was using
    either `committed_offset` or `app_offset` (last message passed
    to application).
+ * The `librdkafka.redist` NuGet package is now built with MSVC runtime v140
+   (VS 2015). Previous versions were built with MSVC runtime v120 (VS 2013).
 
 
 ## Fixes

--- a/packaging/RELEASE.md
+++ b/packaging/RELEASE.md
@@ -98,9 +98,10 @@ Release candidates start at 200, thus 0xAABBCCc9 is RC1, 0xAABBCCca is RC2, etc.
 Change the `RD_KAFKA_VERSION` defines in both `src/rdkafka.h` and
 `src-cpp/rdkafkacpp.h` to the version to build, such as 0x000b01c9
 for v0.11.1-RC1, or 0x000b01ff for the final v0.11.1 release.
+Update the librdkafka version in `vcpkg.json`.
 
    # Update defines
-   $ $EDITOR src/rdkafka.h src-cpp/rdkafkacpp.h
+   $ $EDITOR src/rdkafka.h src-cpp/rdkafkacpp.h vcpkg.json
 
    # Reconfigure and build
    $ ./configure

--- a/packaging/nuget/packaging.py
+++ b/packaging/nuget/packaging.py
@@ -327,19 +327,19 @@ class NugetPackage (Package):
                                               a.info.get('arch'),
                                               a.info.get('bldtype'))
             if 'toolset' not in a.info:
-                a.info['toolset'] = 'v120'
+                a.info['toolset'] = 'v140'
 
         mappings = [
-            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafka.h', 'build/native/include/librdkafka/rdkafka.h'],
-            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafkacpp.h', 'build/native/include/librdkafka/rdkafkacpp.h'],
-            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafka_mock.h', 'build/native/include/librdkafka/rdkafka_mock.h'],
+            [{'arch': 'x64', 'plat': 'linux', 'lnk': 'std', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafka.h', 'build/native/include/librdkafka/rdkafka.h'],
+            [{'arch': 'x64', 'plat': 'linux', 'lnk': 'std', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafkacpp.h', 'build/native/include/librdkafka/rdkafkacpp.h'],
+            [{'arch': 'x64', 'plat': 'linux', 'lnk': 'std', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './include/librdkafka/rdkafka_mock.h', 'build/native/include/librdkafka/rdkafka_mock.h'],
 
             # Travis OSX build
             [{'arch': 'x64', 'plat': 'osx', 'fname_glob': 'librdkafka-clang.tar.gz'}, './lib/librdkafka.dylib', 'runtimes/osx-x64/native/librdkafka.dylib'],
             # Travis Manylinux build
             [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-manylinux*x86_64.tgz'}, './lib/librdkafka.so.1', 'runtimes/linux-x64/native/centos6-librdkafka.so'],
             # Travis Ubuntu 14.04 build
-            [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/librdkafka.so.1', 'runtimes/linux-x64/native/librdkafka.so'],
+            [{'arch': 'x64', 'plat': 'linux', 'lnk': 'std', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/librdkafka.so.1', 'runtimes/linux-x64/native/librdkafka.so'],
             # Travis CentOS 7 RPM build
             [{'arch': 'x64', 'plat': 'linux', 'fname_glob': 'librdkafka1*el7.x86_64.rpm'}, './usr/lib64/librdkafka.so.1', 'runtimes/linux-x64/native/centos7-librdkafka.so'],
             # Travis Alpine build
@@ -348,32 +348,37 @@ class NugetPackage (Package):
             [{'arch': 'arm64', 'plat': 'linux', 'fname_glob': 'librdkafka-gcc.tar.gz'}, './lib/librdkafka.so.1', 'runtimes/linux-arm64/native/librdkafka.so'],
 
             # Common Win runtime
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'msvcr120.zip'}, 'msvcr120.dll', 'runtimes/win-x64/native/msvcr120.dll'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'msvcr120.zip'}, 'msvcp120.dll', 'runtimes/win-x64/native/msvcp120.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'msvcr140.zip'}, 'vcruntime140.dll', 'runtimes/win-x64/native/vcruntime140.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'msvcr140.zip'}, 'msvcp140.dll', 'runtimes/win-x64/native/msvcp140.dll'],
             # matches librdkafka.redist.{VER}.nupkg
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/x64/Release/librdkafka.dll', 'runtimes/win-x64/native/librdkafka.dll'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/x64/Release/librdkafkacpp.dll', 'runtimes/win-x64/native/librdkafkacpp.dll'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/x64/Release/zlib.dll', 'runtimes/win-x64/native/zlib.dll'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/x64/Release/libzstd.dll', 'runtimes/win-x64/native/libzstd.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/librdkafka.dll', 'runtimes/win-x64/native/librdkafka.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/librdkafkacpp.dll', 'runtimes/win-x64/native/librdkafkacpp.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/libcrypto-1_1-x64.dll', 'runtimes/win-x64/native/libcrypto-1_1-x64.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/libssl-1_1-x64.dll', 'runtimes/win-x64/native/libssl-1_1-x64.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/zlib1.dll', 'runtimes/win-x64/native/zlib1.dll'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/x64/Release/zstd.dll', 'runtimes/win-x64/native/zstd.dll'],
             # matches librdkafka.{VER}.nupkg
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka*', 'fname_excludes': ['redist', 'symbols']},
-             'build/native/lib/v120/x64/Release/librdkafka.lib', 'build/native/lib/win/x64/win-x64-Release/v120/librdkafka.lib'],
-            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka*', 'fname_excludes': ['redist', 'symbols']},
-             'build/native/lib/v120/x64/Release/librdkafkacpp.lib', 'build/native/lib/win/x64/win-x64-Release/v120/librdkafkacpp.lib'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka*.nupkg', 'fname_excludes': ['redist', 'symbols']},
+             'build/native/lib/v140/x64/Release/librdkafka.lib', 'build/native/lib/win/x64/win-x64-Release/v140/librdkafka.lib'],
+            [{'arch': 'x64', 'plat': 'win', 'fname_glob': 'librdkafka*.nupkg', 'fname_excludes': ['redist', 'symbols']},
+             'build/native/lib/v140/x64/Release/librdkafkacpp.lib', 'build/native/lib/win/x64/win-x64-Release/v140/librdkafkacpp.lib'],
 
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'msvcr120.zip'}, 'msvcr120.dll', 'runtimes/win-x86/native/msvcr120.dll'],
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'msvcr120.zip'}, 'msvcp120.dll', 'runtimes/win-x86/native/msvcp120.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'msvcr140.zip'}, 'vcruntime140.dll', 'runtimes/win-x86/native/vcruntime140.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'msvcr140.zip'}, 'msvcp140.dll', 'runtimes/win-x86/native/msvcp140.dll'],
             # matches librdkafka.redist.{VER}.nupkg
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/Win32/Release/librdkafka.dll', 'runtimes/win-x86/native/librdkafka.dll'],
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/Win32/Release/librdkafkacpp.dll', 'runtimes/win-x86/native/librdkafkacpp.dll'],
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/Win32/Release/zlib.dll', 'runtimes/win-x86/native/zlib.dll'],
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v120/Win32/Release/libzstd.dll', 'runtimes/win-x86/native/libzstd.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/librdkafka.dll', 'runtimes/win-x86/native/librdkafka.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/librdkafkacpp.dll', 'runtimes/win-x86/native/librdkafkacpp.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/libcrypto-1_1.dll', 'runtimes/win-x86/native/libcrypto-1_1.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/libssl-1_1.dll', 'runtimes/win-x86/native/libssl-1_1.dll'],
+
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/zlib1.dll', 'runtimes/win-x86/native/zlib1.dll'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka.redist*'}, 'build/native/bin/v140/Win32/Release/zstd.dll', 'runtimes/win-x86/native/zstd.dll'],
 
             # matches librdkafka.{VER}.nupkg
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka*', 'fname_excludes': ['redist', 'symbols']},
-            'build/native/lib/v120/Win32/Release/librdkafka.lib', 'build/native/lib/win/x86/win-x86-Release/v120/librdkafka.lib'],
-            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka*', 'fname_excludes': ['redist', 'symbols']},
-            'build/native/lib/v120/Win32/Release/librdkafkacpp.lib', 'build/native/lib/win/x86/win-x86-Release/v120/librdkafkacpp.lib']
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka*.nupkg', 'fname_excludes': ['redist', 'symbols']},
+            'build/native/lib/v140/Win32/Release/librdkafka.lib', 'build/native/lib/win/x86/win-x86-Release/v140/librdkafka.lib'],
+            [{'arch': 'x86', 'plat': 'win', 'fname_glob': 'librdkafka*.nupkg', 'fname_excludes': ['redist', 'symbols']},
+            'build/native/lib/v140/Win32/Release/librdkafkacpp.lib', 'build/native/lib/win/x86/win-x86-Release/v140/librdkafkacpp.lib']
         ]
 
         for m in mappings:
@@ -385,36 +390,36 @@ class NugetPackage (Package):
                 fname_excludes = attributes['fname_excludes']
                 del attributes['fname_excludes']
 
-            artifact = None
-            for a in self.arts.artifacts:
-                found = True
+            outf = os.path.join(self.stpath, m[2])
+            member = m[1]
 
+            found = False
+            # Try all matching artifacts until we find the wanted file (member)
+            for a in self.arts.artifacts:
                 for attr in attributes:
-                    if a.info[attr] != attributes[attr]:
-                        found = False
-                        break
+                    if a.info.get(attr, None) != attributes[attr]:
+                        continue
 
                 if not fnmatch(a.fname, fname_glob):
-                    found = False
+                    continue
 
                 for exclude in fname_excludes:
                     if exclude in a.fname:
-                        found = False
-                        break
+                        continue
 
-                if found:
-                    artifact = a
-                    break
+                try:
+                    zfile.ZFile.extract(a.lpath, member, outf)
+                except KeyError as e:
+                    continue
+                except Exception as e:
+                    raise Exception('file not found in archive %s: %s. Files in archive are: %s' % (a.lpath, e, zfile.ZFile(a.lpath).getnames()))
 
-            if artifact is None:
-                raise MissingArtifactError('unable to find artifact with tags %s matching "%s"' % (str(attributes), fname_glob))
+                found = True
+                break
 
-            outf = os.path.join(self.stpath, m[2])
-            member = m[1]
-            try:
-                zfile.ZFile.extract(artifact.lpath, member, outf)
-            except KeyError as e:
-                raise Exception('file not found in archive %s: %s. Files in archive are: %s' % (artifact.lpath, e, zfile.ZFile(artifact.lpath).getnames()))
+            if not found:
+                raise MissingArtifactError('unable to find artifact with tags %s matching "%s" for file "%s"' % (str(attributes), fname_glob, member))
+
 
         print('Tree extracted to %s' % self.stpath)
 
@@ -437,28 +442,34 @@ class NugetPackage (Package):
             "build/native/include/librdkafka/rdkafka.h",
             "build/native/include/librdkafka/rdkafkacpp.h",
             "build/native/include/librdkafka/rdkafka_mock.h",
-            "build/native/lib/win/x64/win-x64-Release/v120/librdkafka.lib",
-            "build/native/lib/win/x64/win-x64-Release/v120/librdkafkacpp.lib",
-            "build/native/lib/win/x86/win-x86-Release/v120/librdkafka.lib",
-            "build/native/lib/win/x86/win-x86-Release/v120/librdkafkacpp.lib",
+            "build/native/lib/win/x64/win-x64-Release/v140/librdkafka.lib",
+            "build/native/lib/win/x64/win-x64-Release/v140/librdkafkacpp.lib",
+            "build/native/lib/win/x86/win-x86-Release/v140/librdkafka.lib",
+            "build/native/lib/win/x86/win-x86-Release/v140/librdkafkacpp.lib",
             "runtimes/linux-x64/native/centos7-librdkafka.so",
             "runtimes/linux-x64/native/centos6-librdkafka.so",
             "runtimes/linux-x64/native/alpine-librdkafka.so",
             "runtimes/linux-x64/native/librdkafka.so",
             "runtimes/linux-arm64/native/librdkafka.so",
             "runtimes/osx-x64/native/librdkafka.dylib",
+            # win x64
             "runtimes/win-x64/native/librdkafka.dll",
             "runtimes/win-x64/native/librdkafkacpp.dll",
-            "runtimes/win-x64/native/msvcr120.dll",
-            "runtimes/win-x64/native/msvcp120.dll",
-            "runtimes/win-x64/native/zlib.dll",
-            "runtimes/win-x64/native/libzstd.dll",
+            "runtimes/win-x64/native/vcruntime140.dll",
+            "runtimes/win-x64/native/msvcp140.dll",
+            "runtimes/win-x64/native/libcrypto-1_1-x64.dll",
+            "runtimes/win-x64/native/libssl-1_1-x64.dll",
+            "runtimes/win-x64/native/zlib1.dll",
+            "runtimes/win-x64/native/zstd.dll",
+            # win x86
             "runtimes/win-x86/native/librdkafka.dll",
             "runtimes/win-x86/native/librdkafkacpp.dll",
-            "runtimes/win-x86/native/msvcr120.dll",
-            "runtimes/win-x86/native/msvcp120.dll",
-            "runtimes/win-x86/native/zlib.dll",
-            "runtimes/win-x86/native/libzstd.dll"]
+            "runtimes/win-x86/native/vcruntime140.dll",
+            "runtimes/win-x86/native/msvcp140.dll",
+            "runtimes/win-x86/native/libcrypto-1_1.dll",
+            "runtimes/win-x86/native/libssl-1_1.dll",
+            "runtimes/win-x86/native/zlib1.dll",
+            "runtimes/win-x86/native/zstd.dll"]
 
         missing = list()
         with zfile.ZFile(path, 'r') as zf:

--- a/packaging/nuget/templates/librdkafka.redist.targets
+++ b/packaging/nuget/templates/librdkafka.redist.targets
@@ -1,10 +1,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win\x64\win-x64-Release\v120\librdkafka.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win\x86\win-x86-Release\v120\librdkafka.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win\x64\win-x64-Release\v120;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win\x86\win-x86-Release\v120;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win\x64\win-x64-Release\v140\librdkafka.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win\x86\win-x86-Release\v140\librdkafka.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win\x64\win-x64-Release\v140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win\x86\win-x86-Release\v140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -39,6 +39,8 @@
 #ifdef _WIN32
 #include <wincrypt.h>
 #pragma comment (lib, "crypt32.lib")
+#pragma comment (lib, "libcrypto.lib")
+#pragma comment (lib, "libssl.lib")
 #endif
 
 #include <openssl/x509.h>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,19 @@
+{
+    "name": "librdkafka",
+    "version": "1.8.0",
+    "dependencies": [
+        {
+            "name": "zstd",
+            "version>=": "1.4.9"
+        },
+        {
+            "name": "zlib",
+            "version>=": "1.2.11"
+        },
+        {
+            "name": "openssl",
+            "version>=": "1.1.1k"
+        }
+    ],
+    "builtin-baseline": "cf03dac5c25dd5a8d207d0b7d546f24424898418"
+}

--- a/win32/librdkafka.autopkg.template
+++ b/win32/librdkafka.autopkg.template
@@ -1,7 +1,7 @@
 configurations {
     Toolset { 
         key : "PlatformToolset"; 
-        choices: { v120, v140 };  
+        choices: { v120, v140, v142 };
  
         // Explicitly Not including pivot variants:  "WindowsKernelModeDriver8.0", "WindowsApplicationForDrivers8.0", "WindowsUserModeDriver8.0" 
 
@@ -25,7 +25,7 @@ nuget {
         summary: "The Apache Kafka C/C++ client library";
 		description:"The Apache Kafka C/C++ client library";
         releaseNotes: "Release of librdkafka";
-        copyright: "Copyright 2016";
+        copyright: "Copyright 2012-2021";
         tags: { native, kafka, librdkafka, C, C++ };
  };
 
@@ -39,7 +39,7 @@ nuget {
 	};
 	docs: { ${TOPDIR}README.md, ${TOPDIR}CONFIGURATION.md, ${TOPDIR}LICENSES.txt };
 
-        ("v120,v140", "Win32,x64", "Release,Debug") => {
+        ("v120,v140,v142", "Win32,x64", "Release,Debug") => {
            [${0},${1},${2}] {
 		lib: { outdir\${0}\${1}\${2}\librdkafka*.lib };
 		symbols: { outdir\${0}\${1}\${2}\librdkafka*.pdb };

--- a/win32/librdkafka.sln
+++ b/win32/librdkafka.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "librdkafka", "librdkafka.vcxproj", "{4BEBB59C-477B-4F7A-8AE8-4228D0861E54}"
 EndProject
@@ -219,5 +219,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6FC23A9-9ED2-4E8F-AC27-BF023227C588}
 	EndGlobalSection
 EndGlobal

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -12,8 +12,8 @@
   <Import Project="$(SolutionDir)common.vcxproj" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Platform)'=='Win32'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);C:\OpenSSL-Win32\include</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);C:\OpenSSL-Win32\lib\VC\static</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);C:\OpenSSL-Win64\include</IncludePath>
@@ -33,7 +33,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -50,7 +50,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -70,7 +70,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalOptions>/SAFESEH:NO</AdditionalOptions>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -89,7 +89,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libeay32MT.lib;ssleay32MT.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -246,18 +246,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\README.win32" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="packages\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.targets" Condition="Exists('packages\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.targets')" />
-    <Import Project="packages\confluent.libzstd.redist.1.3.8-g9f9630f4-test1\build\native\confluent.libzstd.redist.targets" Condition="Exists('packages\confluent.libzstd.redist.1.3.8-g9f9630f4-test1\build\native\confluent.libzstd.redist.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.1.2.8.8\build\native\zlib.$(PlatformToolset).windesktop.msvcstl.dyn.rt-dyn.targets'))" />
-    <Error Condition="!Exists('packages\confluent.libzstd.redist.1.3.8-g9f9630f4-test1\build\native\confluent.libzstd.redist.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\confluent.libzstd.redist.1.3.8-g9f9630f4-test1\build\native\confluent.libzstd.redist.targets'))" />
-  </Target>
 </Project>

--- a/win32/packages.config
+++ b/win32/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="confluent.libzstd.redist" version="1.3.8-g9f9630f4-test1" targetFramework="native" />
-  <package id="zlib" version="1.2.8.8" targetFramework="Native" />
-  <package id="zlib.v120.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="Native" />
-  <package id="zlib.v140.windesktop.msvcstl.dyn.rt-dyn" version="1.2.8.8" targetFramework="Native" />
-</packages>


### PR DESCRIPTION
This addresses the zlib upgrade in #2934 and makes sure we'll have up-to-date dependencies going forward.

It also makes adding additional dependencies easier.