### PR TITLE
Fix a small error due to the unreleased lock before program exit

### DIFF
--- a/tests/sockem.c
+++ b/tests/sockem.c
@@ -428,6 +428,7 @@ static void *sockem_run (void *arg) {
                 }
                 fprintf(stderr, "%% sockem: accept(%d) failed: %s\n",
                         ls, strerror(socket_errno()));
+                mtx_unlock(&skm->lock);
                 assert(cs != -1);
         }
 


### PR DESCRIPTION
Fix a small error due to the unreleased lock skm->lock before program exit.