### PR TITLE
mklove: make zlib test program compilable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ librdkafka v1.8.0 is a security release:
 
 ### General fixes
 
+ * Correctly detect presence of zlib via compilation check. (Chris Novakovic)
  * `ERR__ALL_BROKERS_DOWN` is no longer emitted when the coordinator
    connection goes down, only when all standard named brokers have been tried.
    This fixes the issue with `ERR__ALL_BROKERS_DOWN` being triggered on

--- a/mklove/modules/configure.zlib
+++ b/mklove/modules/configure.zlib
@@ -23,6 +23,7 @@ function manual_checks {
     mkl_meta_set "zlib" "static" "libz.a"
     mkl_lib_check "zlib" "WITH_ZLIB" $action CC "-lz" \
                   "
+#include <stddef.h>
 #include <zlib.h>
 
 void foo (void) {


### PR DESCRIPTION
The test program that is used at compile-time to detect whether zlib is available fails to compile due to `NULL` being undefined:

```
_mkltmpyos55w.c:5:20: error: use of undeclared identifier 'NULL'
     z_stream *p = NULL;
                   ^
1 error generated.
```

This means that zlib availability is only automatically detected when using pkg-config.

Import `stddef.h` (which defines `NULL`) in the test program, allowing zlib to be automatically detected via a compilation check.