### PR TITLE
Use native scheduler on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ test_report*.json
 cov-int
 gdbrun*.gdb
 TAGS
+vcpkg_installed

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -241,9 +241,6 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
         rd_socket_t         rkb_wakeup_fd[2];     /* Wake-up fds (r/w) to wake
                                                    * up from IO-wait when
                                                    * queues have content. */
-        rd_socket_t         rkb_toppar_wakeup_fd; /* Toppar msgq wakeup fd,
-                                                   * this is rkb_wakeup_fd[1]
-                                                   * if enabled. */
 
         /**< Current, exponentially increased, reconnect backoff. */
         int                 rkb_reconnect_backoff_ms;

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -1966,6 +1966,12 @@ rd_kafka_anyconf_set_prop (int scope, void *conf,
 	switch (prop->type)
 	{
 	case _RK_C_STR:
+                /* Left-trim string(likes) */
+                if (value)
+                        while (isspace((int)*value))
+                                value++;
+
+                /* FALLTHRU */
         case _RK_C_KSTR:
 		if (prop->s2i[0].str) {
 			int match;

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -3753,7 +3753,8 @@ static void rd_kafka_sw_str_sanitize_inplace (char *str) {
  *          on success. The array count is returned in \p cntp.
  *          The returned pointer must be freed with rd_free().
  */
-static char **rd_kafka_conf_kv_split (const char **input, size_t incnt,
+static RD_UNUSED
+char **rd_kafka_conf_kv_split (const char **input, size_t incnt,
                                       size_t *cntp) {
         size_t i;
         char **out, *p;

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -200,7 +200,7 @@ rd_kafka_transport_ssl_io_update (rd_kafka_transport_t *rktrans, int ret,
                 break;
 
         case SSL_ERROR_WANT_WRITE:
-        case SSL_ERROR_WANT_CONNECT:
+                rd_kafka_transport_set_blocked(rktrans, rd_true);
                 rd_kafka_transport_poll_set(rktrans, POLLOUT);
                 break;
 

--- a/src/rdkafka_transport.h
+++ b/src/rdkafka_transport.h
@@ -39,6 +39,7 @@
 typedef struct rd_kafka_transport_s rd_kafka_transport_t;
 
 int rd_kafka_transport_io_serve (rd_kafka_transport_t *rktrans,
+                                 rd_kafka_q_t *rkq,
                                  int timeout_ms);
 
 ssize_t rd_kafka_transport_send (rd_kafka_transport_t *rktrans,
@@ -71,7 +72,15 @@ void rd_kafka_transport_close(rd_kafka_transport_t *rktrans);
 void rd_kafka_transport_shutdown (rd_kafka_transport_t *rktrans);
 void rd_kafka_transport_poll_set(rd_kafka_transport_t *rktrans, int event);
 void rd_kafka_transport_poll_clear(rd_kafka_transport_t *rktrans, int event);
-int rd_kafka_transport_poll(rd_kafka_transport_t *rktrans, int tmout);
+
+#ifdef _WIN32
+void rd_kafka_transport_set_blocked (rd_kafka_transport_t *rktrans,
+        rd_bool_t blocked);
+#else
+/* no-op on other platforms */
+#define rd_kafka_transport_set_blocked(rktrans,blocked) do {} while (0)
+#endif
+
 
 void rd_kafka_transport_init (void);
 

--- a/src/rdkafka_transport_int.h
+++ b/src/rdkafka_transport_int.h
@@ -52,6 +52,16 @@ struct rd_kafka_transport_s {
 	SSL *rktrans_ssl;
 #endif
 
+#ifdef _WIN32
+        WSAEVENT *rktrans_wsaevent;
+        rd_bool_t rktrans_blocked;  /* Latest send() returned ..WOULDBLOCK.
+                                     * We need to poll for FD_WRITE which
+                                     * is edge-triggered rather than
+                                     * level-triggered.
+                                     * This behaviour differs from BSD
+                                     * sockets. */
+#endif
+
 	struct {
                 void *state;               /* SASL implementation
                                             * state handle */
@@ -75,7 +85,7 @@ struct rd_kafka_transport_s {
 
         /* Two pollable fds:
          * - TCP socket
-         * - wake-up fd
+         * - wake-up fd  (not used on Win32)
          */
         rd_pollfd_t rktrans_pfd[2];
         int rktrans_pfd_cnt;

--- a/src/tinycthread_extra.c
+++ b/src/tinycthread_extra.c
@@ -59,6 +59,23 @@ int thrd_is_current(thrd_t thr) {
 }
 
 
+#ifdef _WIN32
+void cnd_wait_enter (cnd_t *cond) {
+        /* Increment number of waiters */
+        EnterCriticalSection(&cond->mWaitersCountLock);
+        ++cond->mWaitersCount;
+        LeaveCriticalSection(&cond->mWaitersCountLock);
+}
+
+void cnd_wait_exit (cnd_t *cond) {
+        /* Increment number of waiters */
+        EnterCriticalSection(&cond->mWaitersCountLock);
+        --cond->mWaitersCount;
+        LeaveCriticalSection(&cond->mWaitersCountLock);
+}
+#endif
+
+
 
 
 int cnd_timedwait_ms(cnd_t *cnd, mtx_t *mtx, int timeout_ms) {

--- a/src/tinycthread_extra.h
+++ b/src/tinycthread_extra.h
@@ -54,6 +54,22 @@ int thrd_setname (const char *name);
 int thrd_is_current(thrd_t thr);
 
 
+#ifdef _WIN32
+/**
+ * @brief Mark the current thread as waiting on cnd.
+ *
+ * @remark This is to be used when the thread uses its own
+ * WaitForMultipleEvents() call rather than cnd_timedwait().
+ *
+ * @sa cnd_wait_exit()
+ */
+void cnd_wait_enter (cnd_t *cond);
+
+/**
+ * @brief Mark the current thread as no longer waiting on cnd.
+ */
+void cnd_wait_exit (cnd_t *cond);
+#endif
 
 
 /**


### PR DESCRIPTION
We've seen an increase in concerns about the internal localhost TCP connections that we use to wake up internal queue listeners.


This here PR changes the IO/queue scheduler to use WSAWaitForMultiplEvents() on Windows, allowing a single call
to wait for both socket IO and queue cond-var signals. Thanks to this the localhost TCP connections are no more.

Manual testing showed a 5-10% throughput increase for the producer.