### PR TITLE
Improve nuget release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
-# librdkafka v1.9.0
+# librdkafka v1.8.2
+
+librdkafka v1.8.2 is a maintenance release.
+
+## Fixes
+
+ * The `librdkafka.redist` 1.8.0 package had two flaws:
+   - the linux-arm64 .so build was a linux-x64 build.
+   - the included MSVC 140 runtimes for x64 were infact x86.
+   The release script has been updated to verify the architectures of
+   provided artifacts to avoid this happening in the future.
 
 ## Enhancements
 
  * Added `ssl.ca.pem` to add CA certificate by PEM string. (#2380)
+
+*Note: there was no v1.8.1 librdkafka release*
 
 
 # librdkafka v1.8.0

--- a/packaging/nuget/requirements.txt
+++ b/packaging/nuget/requirements.txt
@@ -1,2 +1,3 @@
-boto3
-rpmfile
+boto3==1.18.45
+rpmfile==1.0.8
+filemagic==1.6

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -111,7 +111,7 @@ namespace RdKafka {
  * @remark This value should only be used during compile time,
  *         for runtime checks of version use RdKafka::version()
  */
-#define RD_KAFKA_VERSION  0x010800ff
+#define RD_KAFKA_VERSION  0x010802ff
 
 /**
  * @brief Returns the librdkafka version as integer.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -158,7 +158,7 @@ typedef SSIZE_T ssize_t;
  * @remark This value should only be used during compile time,
  *         for runtime checks of version use rd_kafka_version()
  */
-#define RD_KAFKA_VERSION  0x010800ff
+#define RD_KAFKA_VERSION  0x010802ff
 
 /**
  * @brief Returns the librdkafka version as integer.


### PR DESCRIPTION
 - Verify artifact file contents and architectures.
 - Verify that artifact attributes match.
 - Get README, CONFIG,.. etc, from artifacts instead of local source tree
   (which may not match the released version).