### PR TITLE
Retrieve jwt token from token provider

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -54,6 +54,7 @@ librdkafka also provides a native C++ interface.
         - [Threads and callbacks](#threads-and-callbacks)
         - [Brokers](#brokers)
             - [SSL](#ssl)
+            - [OAUTHBEARER with Support for OIDC](#oauthbearer-oidc)
             - [Sparse connections](#sparse-connections)
                 - [Random broker selection](#random-broker-selection)
                 - [Persistent broker connections](#persistent-broker-connections)
@@ -1120,6 +1121,31 @@ The predefined system store names are:
 For example, to read both intermediate and root CAs, set
 `ssl.ca.certificate.stores=CA,Root`.
 
+
+#### OAUTHBEARER with Support for OIDC
+
+Oauthbearer with OIDC is another way for client to connect to a broker's
+SSL endpoints/listeners. If this way is used, the client needs to be
+configured with `security.protocol=SASL_SSL` for SASL authentication
+and SSL transport, `sasl.oauthbearer.method=OIDC` to use the
+OAUTHBEARER with OIDC method.
+
+The OAUTHBEARER with OIDC will also require the configuration of the
+following:
+
+  * `sasl.oauthbearer.token.endpoint.url` - OAUTH issuer token endpoint HTTP(S)
+    URI used to retrieve the token
+  * `sasl.oauthbearer.client.id` - A public identifier for the application
+    It must be unique across all clients that the authorization server handles
+  * `sasl.oauthbearer.client.secret` - This is only known to the application
+    and the authorization server. This should be a sufficiently random string
+    that are not guessable
+  * `sasl.oauthbearer.scope` - Client use this to specify the scope of the
+    access request to the broker
+  * `sasl.oauthbearer.extensions` - Allow additional information to be provided
+    to the broker. "It's comma-separated list of key=value pairs.
+    The example of the input is
+    `supportFeatureX=true,organizationId=sales-emea`
 
 
 #### Sparse connections

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -54,7 +54,7 @@ librdkafka also provides a native C++ interface.
         - [Threads and callbacks](#threads-and-callbacks)
         - [Brokers](#brokers)
             - [SSL](#ssl)
-            - [OAUTHBEARER with Support for OIDC](#oauthbearer-oidc)
+            - [OAUTHBEARER with Support for OIDC](#oauthbearer-with-support-for-oidc)
             - [Sparse connections](#sparse-connections)
                 - [Random broker selection](#random-broker-selection)
                 - [Persistent broker connections](#persistent-broker-connections)
@@ -1124,27 +1124,27 @@ For example, to read both intermediate and root CAs, set
 
 #### OAUTHBEARER with Support for OIDC
 
-Oauthbearer with OIDC is another way for client to connect to a broker's
-SSL endpoints/listeners. If this way is used, the client needs to be
+Oauthbearer with OIDC is another way for the client to connect to a broker's
+SASL endpoints/listeners. To use this method the client needs to be
 configured with `security.protocol=SASL_SSL` for SASL authentication
-and SSL transport, `sasl.oauthbearer.method=OIDC` to use the
-OAUTHBEARER with OIDC method.
+and SSL transport, and `sasl.oauthbearer.method=OIDC` to use
+OIDC with OAUTHBEARER.
 
-The OAUTHBEARER with OIDC will also require the configuration of the
-following:
+OAUTHBEARER with OIDC will also require configuration of the
+following configuration properties:
 
   * `sasl.oauthbearer.token.endpoint.url` - OAUTH issuer token endpoint HTTP(S)
-    URI used to retrieve the token
-  * `sasl.oauthbearer.client.id` - A public identifier for the application
-    It must be unique across all clients that the authorization server handles
+    URI used to retrieve the token.
+  * `sasl.oauthbearer.client.id` - A public identifier for the application.
+    It must be unique across all clients that the authorization server handles.
   * `sasl.oauthbearer.client.secret` - This is only known to the application
     and the authorization server. This should be a sufficiently random string
-    that are not guessable
+    that is not guessable.
   * `sasl.oauthbearer.scope` - Client use this to specify the scope of the
-    access request to the broker
+    access request to the broker.
   * `sasl.oauthbearer.extensions` - Allow additional information to be provided
-    to the broker. "It's comma-separated list of key=value pairs.
-    The example of the input is
+    to the broker. It's a comma-separated list of key=value pairs.
+    For example:
     `supportFeatureX=true,organizationId=sales-emea`
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,10 @@ if(WITH_SASL_OAUTHBEARER)
   list(APPEND sources rdkafka_sasl_oauthbearer.c)
 endif()
 
+if(WITH_CURL)
+  list(APPEND sources rdkafka_sasl_oauthbearer_oidc.c)
+endif()
+
 if(WITH_ZLIB)
   list(APPEND sources rdgz.c)
 endif()

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ SRCS_$(WITH_ZSTD) += rdkafka_zstd.c
 SRCS_$(WITH_HDRHISTOGRAM) += rdhdrhistogram.c
 SRCS_$(WITH_SSL) += rdkafka_ssl.c
 SRCS_$(WITH_CURL) += rdhttp.c
+SRCS_$(WITH_CURL) += rdkafka_sasl_oauthbearer_oidc.c
 
 SRCS_LZ4 = rdxxhash.c
 ifneq ($(WITH_LZ4_EXT), y)

--- a/src/rdhttp.c
+++ b/src/rdhttp.c
@@ -299,7 +299,7 @@ rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
                                           const struct curl_slist *headers,
                                           const char *post_fields,
                                           size_t post_fields_size,
-                                          rd_ts_t timeout_s,
+                                          int timeout_s,
                                           int retries,
                                           int retry_ms,
                                           cJSON **jsonp) {
@@ -351,12 +351,6 @@ rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
         }
 
         herr = rd_http_parse_json(&hreq, jsonp);
-
-        if (!cJSON_HasObjectItem(*jsonp, "access_token")) {
-                rd_kafka_op_err(rk, RD_KAFKA_RESP_ERR__AUTHENTICATION,
-                                "Expected JSON response with "
-                                "\"access_token\" field");
-        }
 
         rd_http_req_destroy(&hreq);
 

--- a/src/rdhttp.c
+++ b/src/rdhttp.c
@@ -222,54 +222,19 @@ rd_http_error_t *rd_http_get(const char *url, rd_buf_t **rbufp) {
         return NULL;
 }
 
-/**
- * @brief Extract the jwt from \p *cjson.
- *
- * @returns The token will be responsed in \p *res.
- *          Returns NULL on success or an error
- *          object on error - this error object must be destroyed
- *          by calling rd_http_error_destroy().
- */
-rd_http_error_t *rd_http_extract_jwt_from_json (cJSON **cjson,
-                                               char **res,
-                                               const char *key) {
-        char *token;
-        cJSON *jval;
-        cJSON *parsed_token = NULL;
-        rd_http_error_t *herr;
-
-        cJSON_ArrayForEach(jval, *cjson) {
-                parsed_token = cJSON_GetObjectItem(*cjson, key);
-                break;
-        }
-        if (parsed_token == NULL) {
-                herr = rd_http_error_new(-1,
-                        "Expected non-empty JSON response");
-                return herr;
-        }
-
-        token = cJSON_Print(parsed_token);
-        *res = rd_malloc(strlen(token) + 1);
-        strcpy(*res, token);
-        rd_free(token);
-        return NULL;
-}
-
 
 /**
- * @brief Extract the json string that includes jwt from \p hreq.
+ * @brief Extract the json string from \p hreq and returned it from \p *jsonp.
  *
- * @returns Returns the response (even if there's a HTTP error code returned)
- *          in \p *json.
+ * @returns Returns NULL on success, or an JSON parsing error - this
+ *          error object must be destroyed by calling rd_http_error_destroy().
  */
-rd_http_error_t *rd_http_parse_token_to_json (rd_http_req_t *hreq,
-                                              cJSON **jsonp) {
+rd_http_error_t *rd_http_parse_json (rd_http_req_t *hreq, cJSON **jsonp) {
         size_t len = 0;
         char *raw_json = NULL;
         const char *end = NULL;
         rd_slice_t slice;
         rd_http_error_t *herr = NULL;
-        *jsonp = NULL;
 
         /* cJSON requires the entire input to parse in contiguous memory. */
         rd_slice_init_full(&slice, hreq->hreq_buf);
@@ -280,73 +245,123 @@ rd_http_error_t *rd_http_parse_token_to_json (rd_http_req_t *hreq,
         raw_json[len] = '\0';
 
         /* Parse JSON */
-        end = NULL;
         *jsonp = cJSON_ParseWithOpts(raw_json, &end, 0);
 
-        if (!*jsonp && !herr)
+        if (!*jsonp)
                 herr = rd_http_error_new(hreq->hreq_code,
                                          "Failed to parse JSON response "
                                          "at %"PRIusz"/%"PRIusz,
                                          (size_t)(end - raw_json), len);
         rd_free(raw_json);
-        rd_http_req_destroy(hreq);
         return herr;
 }
 
 
 /**
- * @brief Perform a blocking HTTP(S) request to \p url with HTTP(S)
- *        headers and data with 20s timeout.
- *        If the HTTP(S) request fails, will retry another \p retry times.
+ * @brief Check if the error returned from HTTP(S) is tempoorary or not.
  *
- * @returns The result will be responsed in \p *jsonp.
+ * @returns If the \p error_code is temporary, return rd_true,
+ *          otherwise return rd_false.
+ *
+ * @locality Any thread.
+ */
+static rd_bool_t rd_http_is_failure_temporary (int error_code) {
+        switch (error_code)
+        {
+                case REQUEST_TIMEOUT:
+                case TOO_EARLY:
+                case INTERNAL_SERVER_ERROR:
+                case BAD_GATEWAY:
+                case SERVICE_UNAVAILABLE:
+                case GATEWAY_TIMEOUT:
+                     return rd_true;
+        }
+        return rd_false;
+}
+
+
+/**
+ * @brief Perform a blocking HTTP(S) request to token url from \p rk with
+ *        HTTP(S) headers and data with \p timeout.
+ *        If the HTTP(S) request fails, will retry another \p retries times
+ *        with multiplying backoff \p interval.
+ *
+ * @returns The result will be returned in \p *jsonp.
  *          Returns NULL on success (HTTP response code < 400), or an error
- *          object on transport or HTTP error - this error object must be
- *          destroyed by calling rd_http_error_destroy().
+ *          object on transport, HTTP error or a JSON parsing error - this
+ *          error object must be destroyed by calling rd_http_error_destroy().
  *
  * @locality Any thread.
  */
 rd_http_error_t
-*rd_http_post_json (const char *url,
-                    struct curl_slist **headers,
-                    const char *data_to_token,
-                    const size_t data_to_token_size,
-                    const long timeout,
-                    const size_t retry,
-                    cJSON **jsonp) {
+*rd_http_post_expect_json (rd_kafka_t *rk,
+                           const struct curl_slist *headers,
+                           const char *post_fields,
+                           size_t post_fields_size,
+                           long timeout,
+                           int retries,
+                           int interval,
+                           cJSON **jsonp) {
         rd_http_error_t *herr;
         rd_http_req_t hreq;
-        size_t i;
+        int i;
         size_t len;
         const char *content_type;
 
-        herr = rd_http_req_init(&hreq, url);
+        herr = rd_http_req_init(
+                &hreq,
+                rk->rk_conf.sasl.oauthbearer.token_endpoint_url);
         if (unlikely(herr != NULL))
                 return herr;
 
-        curl_easy_setopt(hreq.hreq_curl, CURLOPT_HTTPHEADER, *headers);
+        curl_easy_setopt(hreq.hreq_curl, CURLOPT_HTTPHEADER, headers);
         curl_easy_setopt(hreq.hreq_curl, CURLOPT_TIMEOUT, timeout);
 
         curl_easy_setopt(hreq.hreq_curl,
                          CURLOPT_POSTFIELDSIZE,
-                         data_to_token_size);
-        curl_easy_setopt(hreq.hreq_curl, CURLOPT_POSTFIELDS, data_to_token);
+                         post_fields_size);
+        curl_easy_setopt(hreq.hreq_curl, CURLOPT_POSTFIELDS, post_fields);
 
-        for (i = 0; i <= retry; i++) {
+        for (i = 0; i <= retries && !rd_kafka_terminating(rk); i++) {
                 herr = rd_http_req_perform_sync(&hreq);
                 len = rd_buf_len(hreq.hreq_buf);
-                if (!herr && len > 0) {
+
+                /* Break the for loop directly if HTTP(S) request is succeed,
+                   return with permanent error code or last retry. */
+                if ((!herr && len > 0) ||
+                    (herr && !rd_http_is_failure_temporary(herr->code))
+                    || i == retries)
                         break;
+                /* Empty response: should be retry */
+                else if (!herr && len == 0)
+                        rd_kafka_log(rk, LOG_WARNING, "HTTP",
+                                     "HTTP connection returns an empty "
+                                     "JSON string");
+                /* Retry if HTTP(S) request returns temporary error. */
+                else if (herr && rd_http_is_failure_temporary(herr->code)) {
+                        rd_kafka_log(rk, LOG_ERR, "HTTP",
+                                     "Failed to connect to HTTP server with "
+                                     "error code: %d, error string: %s",
+                                    herr->code, herr->errstr);
+                        rd_http_error_destroy(herr);
                 }
+
+                rd_usleep(interval * (i + 1), &rk->rk_terminate);
         }
 
-        if (herr && len == 0) {
+        if (herr) {
+                rd_kafka_log(rk, LOG_ERR, "HTTP",
+                             "Failed to connect to HTTP server with "
+                             "error code: %d, error string: %s",
+                             herr->code, herr->errstr);
                 rd_http_req_destroy(&hreq);
                 return herr;
         }
 
         if (len == 0) {
                 /* Empty response: create empty JSON object */
+                rd_kafka_log(rk, LOG_WARNING, "HTTP",
+                             "HTTP connection returns an empty JSON string");
                 *jsonp = cJSON_CreateObject();
                 rd_http_req_destroy(&hreq);
                 return NULL;
@@ -366,7 +381,8 @@ rd_http_error_t
                 return herr;
         }
 
-        herr = rd_http_parse_token_to_json(&hreq, &*jsonp);
+        herr = rd_http_parse_json(&hreq, jsonp);
+        rd_http_req_destroy(&hreq);
 
         return herr;
 }

--- a/src/rdhttp.h
+++ b/src/rdhttp.h
@@ -47,14 +47,7 @@ rd_http_error_t *rd_http_get_json(const char *url, cJSON **jsonp);
 
 void rd_http_global_init(void);
 
-typedef enum {
-  REQUEST_TIMEOUT = 408,
-  TOO_EARLY = 425,
-  INTERNAL_SERVER_ERROR = 500,
-  BAD_GATEWAY = 502,
-  SERVICE_UNAVAILABLE = 503,
-  GATEWAY_TIMEOUT = 504
-} rd_http_temporary_error;
+
 
 #ifdef LIBCURL_VERSION
 /* Advanced API that exposes the underlying CURL handle.
@@ -69,19 +62,19 @@ typedef struct rd_http_req_s {
                                                  *   write to. */
 } rd_http_req_t;
 
-rd_http_error_t *rd_http_req_init (rd_http_req_t *hreq, const char *url);
-rd_http_error_t *rd_http_req_perform_sync (rd_http_req_t *hreq);
-rd_http_error_t *rd_http_parse_json (rd_http_req_t *hreq, cJSON **jsonp);
-rd_http_error_t
-*rd_http_post_expect_json (rd_kafka_t *rk,
-                           const struct curl_slist *headers,
-                           const char *data_to_token,
-                           size_t data_to_token_size,
-                           long timeout,
-                           int retry,
-                           int interval,
-                           cJSON **jsonp);
-void rd_http_req_destroy (rd_http_req_t *hreq);
+rd_http_error_t *rd_http_req_init(rd_http_req_t *hreq, const char *url);
+rd_http_error_t *rd_http_req_perform_sync(rd_http_req_t *hreq);
+rd_http_error_t *rd_http_parse_json(rd_http_req_t *hreq, cJSON **jsonp);
+rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
+                                          const char *url,
+                                          const struct curl_slist *headers,
+                                          const char *data_to_token,
+                                          size_t data_to_token_size,
+                                          rd_ts_t timeout,
+                                          int retry,
+                                          int retry_ms,
+                                          cJSON **jsonp);
+void rd_http_req_destroy(rd_http_req_t *hreq);
 
 #endif
 

--- a/src/rdhttp.h
+++ b/src/rdhttp.h
@@ -47,7 +47,14 @@ rd_http_error_t *rd_http_get_json(const char *url, cJSON **jsonp);
 
 void rd_http_global_init(void);
 
-
+typedef enum {
+  REQUEST_TIMEOUT = 408,
+  TOO_EARLY = 425,
+  INTERNAL_SERVER_ERROR = 500,
+  BAD_GATEWAY = 502,
+  SERVICE_UNAVAILABLE = 503,
+  GATEWAY_TIMEOUT = 504
+} rd_http_temporary_error;
 
 #ifdef LIBCURL_VERSION
 /* Advanced API that exposes the underlying CURL handle.
@@ -64,19 +71,17 @@ typedef struct rd_http_req_s {
 
 rd_http_error_t *rd_http_req_init (rd_http_req_t *hreq, const char *url);
 rd_http_error_t *rd_http_req_perform_sync (rd_http_req_t *hreq);
-rd_http_error_t *rd_http_parse_token_to_json (rd_http_req_t *hreq,
-                                             cJSON **jsonp);
-rd_http_error_t *rd_http_extract_jwt_from_json (cJSON **cjson,
-                                               char **jwt_token,
-                                               const char *key);
+rd_http_error_t *rd_http_parse_json (rd_http_req_t *hreq, cJSON **jsonp);
 rd_http_error_t
-*rd_http_post_json (const char *url,
-                    struct curl_slist **headers,
-                    const char *data_to_token,
-                    const size_t data_to_token_size,
-                    const long timeout,
-                    const size_t retry,
-                    cJSON **jsonp);
+*rd_http_post_expect_json (rd_kafka_t *rk,
+                           const struct curl_slist *headers,
+                           const char *data_to_token,
+                           size_t data_to_token_size,
+                           long timeout,
+                           int retry,
+                           int interval,
+                           cJSON **jsonp);
+void rd_http_req_destroy (rd_http_req_t *hreq);
 
 #endif
 

--- a/src/rdhttp.h
+++ b/src/rdhttp.h
@@ -62,9 +62,22 @@ typedef struct rd_http_req_s {
                                                  *   write to. */
 } rd_http_req_t;
 
-static void rd_http_req_destroy(rd_http_req_t *hreq);
-rd_http_error_t *rd_http_req_init(rd_http_req_t *hreq, const char *url);
-rd_http_error_t *rd_http_req_perform_sync(rd_http_req_t *hreq);
+rd_http_error_t *rd_http_req_init (rd_http_req_t *hreq, const char *url);
+rd_http_error_t *rd_http_req_perform_sync (rd_http_req_t *hreq);
+rd_http_error_t *rd_http_parse_token_to_json (rd_http_req_t *hreq,
+                                             cJSON **jsonp);
+rd_http_error_t *rd_http_extract_jwt_from_json (cJSON **cjson,
+                                               char **jwt_token,
+                                               const char *key);
+rd_http_error_t
+*rd_http_post_json (const char *url,
+                    struct curl_slist **headers,
+                    const char *data_to_token,
+                    const size_t data_to_token_size,
+                    const long timeout,
+                    const size_t retry,
+                    cJSON **jsonp);
+
 #endif
 
 

--- a/src/rdhttp.h
+++ b/src/rdhttp.h
@@ -70,7 +70,7 @@ rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
                                           const struct curl_slist *headers,
                                           const char *data_to_token,
                                           size_t data_to_token_size,
-                                          rd_ts_t timeout,
+                                          int timeout,
                                           int retry,
                                           int retry_ms,
                                           cJSON **jsonp);

--- a/src/rdhttp.h
+++ b/src/rdhttp.h
@@ -70,7 +70,7 @@ rd_http_error_t *rd_http_post_expect_json(rd_kafka_t *rk,
                                           const struct curl_slist *headers,
                                           const char *data_to_token,
                                           size_t data_to_token_size,
-                                          int timeout,
+                                          int timeout_s,
                                           int retry,
                                           int retry_ms,
                                           cJSON **jsonp);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -54,6 +54,9 @@
 #include "rdkafka_interceptor.h"
 #include "rdkafka_idempotence.h"
 #include "rdkafka_sasl_oauthbearer.h"
+#if WITH_CURL
+#include "rdkafka_sasl_oauthbearer_oidc.h"
+#endif
 #if WITH_SSL
 #include "rdkafka_ssl.h"
 #endif
@@ -2238,11 +2241,20 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                 rd_kafka_conf_set_oauthbearer_token_refresh_cb(
                     &rk->rk_conf, rd_kafka_oauthbearer_unsecured_token);
 
-        if (rk->rk_conf.sasl.oauthbearer.token_refresh_cb)
+        if (rk->rk_conf.sasl.oauthbearer.token_refresh_cb &&
+            rk->rk_conf.sasl.oauthbearer.method !=
+                RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC)
                 rk->rk_conf.enabled_events |=
                     RD_KAFKA_EVENT_OAUTHBEARER_TOKEN_REFRESH;
 #endif
 
+#if WITH_CURL
+        if (rk->rk_conf.sasl.oauthbearer.method ==
+                RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC &&
+            !rk->rk_conf.sasl.oauthbearer.token_refresh_cb)
+                rd_kafka_conf_set_oauthbearer_token_refresh_cb(
+                    &rk->rk_conf, rd_kafka_oidc_token_refresh_cb);
+#endif
         rk->rk_controllerid = -1;
 
         /* Admin client defaults */
@@ -2330,6 +2342,24 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                 rk->rk_conf.security_protocol = RD_KAFKA_PROTO_PLAINTEXT;
         }
 
+        /* Create background thread and queue if background_event_cb()
+         * RD_KAFKA_EVENT_BACKGROUND has been enabled.
+         * Do this before creating the main thread since after
+         * the main thread is created it is no longer trivial to error
+         * out from rd_kafka_new(). */
+
+        if (rk->rk_conf.background_event_cb ||
+            (rk->rk_conf.enabled_events & RD_KAFKA_EVENT_BACKGROUND)) {
+                rd_kafka_resp_err_t err;
+                rd_kafka_wrlock(rk);
+                err =
+                    rd_kafka_background_thread_create(rk, errstr, errstr_size);
+                rd_kafka_wrunlock(rk);
+                if (err)
+                        goto fail;
+        }
+
+        mtx_lock(&rk->rk_init_lock);
 
         if (rk->rk_conf.security_protocol == RD_KAFKA_PROTO_SASL_SSL ||
             rk->rk_conf.security_protocol == RD_KAFKA_PROTO_SASL_PLAINTEXT) {
@@ -2396,24 +2426,6 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
         }
         pthread_sigmask(SIG_SETMASK, &newset, &oldset);
 #endif
-
-        /* Create background thread and queue if background_event_cb()
-         * RD_KAFKA_EVENT_BACKGROUND has been enabled.
-         * Do this before creating the main thread since after
-         * the main thread is created it is no longer trivial to error
-         * out from rd_kafka_new(). */
-        if (rk->rk_conf.background_event_cb ||
-            (rk->rk_conf.enabled_events & RD_KAFKA_EVENT_BACKGROUND)) {
-                rd_kafka_resp_err_t err;
-                rd_kafka_wrlock(rk);
-                err =
-                    rd_kafka_background_thread_create(rk, errstr, errstr_size);
-                rd_kafka_wrunlock(rk);
-                if (err)
-                        goto fail;
-        }
-
-        mtx_lock(&rk->rk_init_lock);
 
         /* Lock handle here to synchronise state, i.e., hold off
          * the thread until we've finalized the handle. */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -401,6 +401,8 @@ typedef enum {
         RD_KAFKA_RESP_ERR__NOOP = -141,
         /** No offset to automatically reset to */
         RD_KAFKA_RESP_ERR__AUTO_OFFSET_RESET = -140,
+        /** OAUTH/OIDC failure*/
+	RD_KAFKA_RESP_ERR__AUTH = -139,
 
         /** End internal error codes */
         RD_KAFKA_RESP_ERR__END = -100,

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -401,8 +401,6 @@ typedef enum {
         RD_KAFKA_RESP_ERR__NOOP = -141,
         /** No offset to automatically reset to */
         RD_KAFKA_RESP_ERR__AUTO_OFFSET_RESET = -140,
-        /** OAUTH/OIDC failure*/
-	RD_KAFKA_RESP_ERR__AUTH = -139,
 
         /** End internal error codes */
         RD_KAFKA_RESP_ERR__END = -100,

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -3690,30 +3690,30 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                         if (!conf->sasl.oauthbearer.client_id)
                                 return "`sasl.oauthbearer.client.id` is "
                                        "mandatory when "
-                                       "`sasl.oauthbearer.method` is set";
+                                       "`sasl.oauthbearer.method=oidc` is set";
 
                         if (!conf->sasl.oauthbearer.client_secret) {
                                 return "`sasl.oauthbearer.client.secret` is "
                                        "mandatory when "
-                                       "`sasl.oauthbearer.method` is set";
+                                       "`sasl.oauthbearer.method=oidc` is set";
                         }
 
                         if (!conf->sasl.oauthbearer.token_endpoint_url) {
                                 return "`sasl.oauthbearer.token.endpoint.url` "
                                        "is mandatory when "
-                                       "`sasl.oauthbearer.method` is set";
+                                       "`sasl.oauthbearer.method=oidc` is set";
                         }
 
                         if (!conf->sasl.oauthbearer.scope) {
                                 return "`sasl.oauthbearer.scope` "
                                        "is mandatory when "
-                                       "`sasl.oauthbearer.method` is set";
+                                       "`sasl.oauthbearer.method=oidc` is set";
                         }
 
                         if (!conf->sasl.oauthbearer.extensions_str) {
                                 return "`sasl.oauthbearer.extensions` "
                                        "is mandatory when "
-                                       "`sasl.oauthbearer.method` is set";
+                                       "`sasl.oauthbearer.method=oidc` is set";
                         }
                 }
 

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -3577,8 +3577,7 @@ static void rd_kafka_sw_str_sanitize_inplace(char *str) {
  *          on success. The array count is returned in \p cntp.
  *          The returned pointer must be freed with rd_free().
  */
-static RD_UNUSED char **
-rd_kafka_conf_kv_split(const char **input, size_t incnt, size_t *cntp) {
+char **rd_kafka_conf_kv_split(const char **input, size_t incnt, size_t *cntp) {
         size_t i;
         char **out, *p;
         size_t lens   = 0;
@@ -3686,12 +3685,46 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                "`sasl.oauthbearer.method=oidc` are "
                                "mutually exclusive";
 
+                if (conf->sasl.oauthbearer.method ==
+                    RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC) {
+                        if (!conf->sasl.oauthbearer.client_id)
+                                return "`sasl.oauthbearer.client.id` is "
+                                       "mandatory when "
+                                       "`sasl.oauthbearer.method` is set";
+
+                        if (!conf->sasl.oauthbearer.client_secret) {
+                                return "`sasl.oauthbearer.client.secret` is "
+                                       "mandatory when "
+                                       "`sasl.oauthbearer.method` is set";
+                        }
+
+                        if (!conf->sasl.oauthbearer.token_endpoint_url) {
+                                return "`sasl.oauthbearer.token.endpoint.url` "
+                                       "is mandatory when "
+                                       "`sasl.oauthbearer.method` is set";
+                        }
+
+                        if (!conf->sasl.oauthbearer.scope) {
+                                return "`sasl.oauthbearer.scope` "
+                                       "is mandatory when "
+                                       "`sasl.oauthbearer.method` is set";
+                        }
+
+                        if (!conf->sasl.oauthbearer.extensions_str) {
+                                return "`sasl.oauthbearer.extensions` "
+                                       "is mandatory when "
+                                       "`sasl.oauthbearer.method` is set";
+                        }
+                }
+
                 /* Enable background thread for the builtin OIDC handler,
                  * unless a refresh callback has been set. */
                 if (conf->sasl.oauthbearer.method ==
                         RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC &&
-                    !conf->sasl.oauthbearer.token_refresh_cb)
+                    !conf->sasl.oauthbearer.token_refresh_cb) {
                         conf->enabled_events |= RD_KAFKA_EVENT_BACKGROUND;
+                        conf->sasl.enable_callback_queue = 1;
+                }
         }
 
 #endif

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -599,6 +599,7 @@ struct rd_kafka_topic_conf_s {
 };
 
 
+char **rd_kafka_conf_kv_split(const char **input, size_t incnt, size_t *cntp);
 
 void rd_kafka_anyconf_destroy(int scope, void *conf);
 

--- a/src/rdkafka_sasl_oauthbearer.c
+++ b/src/rdkafka_sasl_oauthbearer.c
@@ -36,6 +36,9 @@
 #include <openssl/evp.h>
 #include "rdunittest.h"
 
+#if WITH_CURL
+#include "rdkafka_sasl_oauthbearer_oidc.h"
+#endif
 
 
 /**
@@ -1321,17 +1324,15 @@ static int rd_kafka_sasl_oauthbearer_init(rd_kafka_t *rk,
                 handle->callback_q = rd_kafka_q_keep(rk->rk_rep);
         }
 
+#if WITH_CURL
         if (rk->rk_conf.sasl.oauthbearer.method ==
                 RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC &&
-#if FIXME /************************ FIXME  when .._oidc.c is added ****/
             rk->rk_conf.sasl.oauthbearer.token_refresh_cb ==
-                rd_kafka_sasl_oauthbearer_oidc_token_refresh_cb
-#else
-            1
-#endif
-            ) /* move this paren up on the .._refresh_cb
-               * line when FIXME is fixed. */
+                rd_kafka_oidc_token_refresh_cb) {
                 handle->internal_refresh = rd_true;
+                rd_kafka_sasl_background_callbacks_enable(rk);
+        }
+#endif
 
         /* Otherwise enqueue a refresh callback for the application. */
         rd_kafka_oauthbearer_enqueue_token_refresh(handle);

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -1,0 +1,397 @@
+/*
+ * librdkafka - The Apache Kafka C/C++ library
+ *
+ * Copyright (c) 2021 Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * Builtin SASL OAUTHBEARER support
+ */
+#include "rdkafka_int.h"
+#include "rdkafka_transport_int.h"
+#include "rdkafka_sasl_int.h"
+#include <openssl/evp.h>
+#include "rdunittest.h"
+#include "cJSON.h"
+#include <curl/curl.h>
+#include "rdhttp.h"
+#include "rdkafka_sasl_oauthbearer_oidc.h"
+
+/**
+ * @brief Base64 encode binary input \p in
+ * @returns return rd_true if encode succeed, else return rd_false.
+ *          The base64-encoded string will be returned at \p out with it's
+ *          size.
+ */
+static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
+        size_t max_len;
+
+        /* OpenSSL takes an |int| argument so the input cannot exceed that. */
+        if (in->size > INT_MAX) {
+                return rd_false;
+        }
+
+        /* This does not overflow given the |INT_MAX| bound, above. */
+        max_len = (((in->size + 2) / 3) * 4) + 1;
+        out->ptr = rd_malloc(max_len);
+        if (out->ptr == NULL) {
+                return rd_false;
+        }
+
+        out->size = EVP_EncodeBlock((uint8_t*)out->ptr,
+                                  (uint8_t*)in->ptr,
+                                  (int)in->size);
+        assert(out->size < max_len);
+        out->ptr[out->size] = 0;
+        return rd_true;
+}
+
+
+/**
+ * @brief Generate Authorization field for HTTP header.
+ *        The field contains base64-encoded string which
+ *        is generated from client_id and client_secret.
+ *
+ * @returns a newly allocated string with partially base64-encoded string.
+ *
+ * @locality Any thread.
+ */
+static char *build_authorization_base64_header (const char *client_id,
+        const char *client_secret, char **error) {
+
+        static const char *authorization_header = "Authorization:Basic %s";
+        static const char *error_message = "Failed to generate base64-encoded "
+                                           "string\n";
+        size_t len;
+        size_t client_id_len;
+        size_t client_secret_len;
+        size_t authorization_base64_header_size;
+        rd_chariov_t client_authorization_in;
+        rd_chariov_t client_authorization_out;
+        char *authorization_base64_header;
+        rd_bool_t rd_base64_encode_status;
+
+        client_id_len = strlen(client_id);
+        client_secret_len = strlen(client_secret);
+        len = client_id_len + client_secret_len + 2;
+
+        client_authorization_in.ptr = rd_malloc(len);
+        memcpy(client_authorization_in.ptr, client_id, client_id_len);
+        memcpy(client_authorization_in.ptr + client_id_len, ":", 1);
+        memcpy(client_authorization_in.ptr + client_id_len + 1,
+               client_secret,
+               client_secret_len + 1);
+
+        client_authorization_in.size = len;
+
+        rd_base64_encode_status = rd_false;
+        rd_base64_encode_status = rd_base64_encode(&client_authorization_in, &client_authorization_out);
+
+        if (!rd_base64_encode_status) {
+                *error = rd_malloc(strlen(error_message) + 1);
+                strcpy(*error, error_message);
+                rd_free(client_authorization_in.ptr);
+                return NULL;
+        }
+
+        authorization_base64_header_size = strlen(authorization_header) - 1 +
+                                           client_authorization_out.size;
+        authorization_base64_header =
+                rd_malloc(authorization_base64_header_size);
+
+        rd_snprintf(authorization_base64_header,
+                    authorization_base64_header_size,
+                    authorization_header,
+                    client_authorization_out.ptr);
+
+        rd_free(client_authorization_in.ptr);
+        rd_free(client_authorization_out.ptr);
+        return authorization_base64_header;
+}
+
+
+/**
+ * @brief Build headers for HTTP(S) requests.
+ *
+ * @returns The result will be responsed in \p *headers.
+ *          If succeed, return rd_true with NULL in \p *error,
+ *          If failed, return rd_false with error message in \p *error.
+ *
+ * @locality Any thread.
+ */
+static rd_bool_t build_headers (rd_kafka_conf_t *conf,
+                                struct curl_slist **headers,
+                                char **error) {
+        static const char *miss_client_id_error_message = "client_id is "
+                "a required field";
+        static const char *miss_client_secret_error_message = "client_secret "
+                "is a required field";
+        static const char *accept_header = "Accept:application/json";
+        const char *client_id;
+        const char *client_secret;
+        char *authorization_base64_header;
+
+        client_id = conf->sasl.oauthbearer.client_id;
+
+        if (client_id == NULL) {
+                *error = rd_malloc(strlen(miss_client_id_error_message)
+                                   + 1);
+                strcpy(*error, miss_client_id_error_message);
+                return rd_false;
+        }
+
+        client_secret = conf->sasl.oauthbearer.client_secret;
+        if (client_secret == NULL) {
+                *error = rd_malloc(strlen(miss_client_secret_error_message)
+                                   + 1);
+                strcpy(*error, miss_client_secret_error_message);
+                return rd_false;
+        }
+
+        authorization_base64_header =
+                build_authorization_base64_header(client_id,
+                                                  client_secret,
+                                                  &*error);
+        if (authorization_base64_header == NULL)
+                return rd_false;
+
+        *headers = curl_slist_append(*headers, accept_header);
+        *headers = curl_slist_append(*headers, authorization_base64_header);
+        rd_free(authorization_base64_header);
+        return rd_true;
+}
+
+
+/**
+ * @brief Implementation of Oauth/OIDC token refresh call back function,
+ *        will receive the json response after HTTP call from token provider,
+ *        then extract the jwt from the json response, and forward it to
+ *        the broker.
+ */
+void rd_kafka_conf_set_oauthbearer_oidc_token_refresh_cb (rd_kafka_t *rk,
+        const char *oauthbearer_config, void *opaque) {
+        static const char *data = "grant_type=client_credentials,scope=%s";
+        static const char *token_key = "access_token";
+        static const long timeout = 20;
+        static const size_t retry = 3;
+
+        cJSON *json = NULL;
+        rd_http_error_t *herr;
+        char *jwt_token = NULL;
+        struct curl_slist *headers = NULL;
+        char *data_to_token;
+        size_t data_to_token_size;
+        const char *scope;
+        const char *token_url;
+        rd_bool_t build_headers_status;
+        char *error;
+
+        token_url = rk->rk_conf.sasl.oauthbearer.token_endpoint_url;
+        if (token_url == NULL) {
+                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
+                             "token_url is a required field");
+                return;
+        }
+
+        build_headers_status = rd_false;
+        build_headers_status = build_headers(&rk->rk_conf, &headers, &error);
+        if (!build_headers_status) {
+                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
+                             "Failed to build headers: %s",
+                             error);
+                rd_free(error);
+                return;
+        }
+
+        /* Build data field */
+        scope = rk->rk_conf.sasl.oauthbearer.scope;
+        if (scope == NULL) {
+                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
+                             "scope is a required field");
+                return;
+        }
+        data_to_token_size = strlen(data) + strlen(scope) - 1;
+        data_to_token = rd_malloc(data_to_token_size);
+        rd_snprintf(data_to_token, data_to_token_size, data, scope);
+        herr = rd_http_post_json(token_url,
+                                 &headers,
+                                 data_to_token,
+                                 data_to_token_size,
+                                 timeout,
+                                 retry,
+                                 &json);
+        if (unlikely(herr != NULL)) {
+                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
+                             "Failed to receive json result from HTTP(S), "
+                             "returned error code: %d, returned error string: "
+                             "%s", herr->code, herr->errstr);
+                rd_http_error_destroy(herr);
+                goto exit;
+        }
+        herr = rd_http_extract_jwt_from_json(&json, &jwt_token, token_key);
+        if (unlikely(herr != NULL)) {
+                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
+                             "Failed to extract jwt from json, "
+                             "returned error code: %d, returned error string: "
+                             "%s", herr->code, herr->errstr);
+                rd_http_error_destroy(herr);
+                goto exit;
+        }
+
+        /* TODO: Forward token to broker. */
+
+exit:
+        RD_IF_FREE(data_to_token, rd_free);
+        cJSON_Delete(json);
+        RD_IF_FREE(headers, curl_slist_free_all);
+        RD_IF_FREE(jwt_token, rd_free);
+        return;
+}
+
+
+/**
+ * @brief make sure the jwt is able to be extracted from HTTP(S) requests.
+ */
+int unittest_sasl_oauthbearer_oidc_should_succeed (void) {
+
+        static const char *token_key = "access_token";
+        static const char *expected_jwt_token =
+                "\"eyJhbGciOiJIUzI1NiIsInR5"
+                "cCI6IkpXVCIsImtpZCI6ImFiY2VkZmcifQ"
+                "."
+                "eyJpYXQiOjE2MzIzNzUzMjAsInN1YiI6InN"
+                "1YiIsImV4cCI6MTYzMjM3NTYyMH0"
+                "."
+                "bT5oY8K-rS2gQ7Awc40844bK3zhzBhZb7sputErqQHY\"";
+        const char *token_format = "{\"%s\":%s}";
+        char *expected_token_value;
+        size_t token_len = 0;
+        rd_http_req_t hreq;
+        rd_http_error_t *herr;
+        cJSON *json = NULL;
+        char *token = NULL;
+
+        RD_UT_BEGIN();
+
+        herr = rd_http_req_init(&hreq, "");
+        RD_UT_ASSERT(!herr,
+                     "Expected initializa succeed, "
+                     "but failed with error code: %d, error string: %s",
+                     herr->code, herr->errstr);
+
+        token_len = strlen(token_key) + strlen(expected_jwt_token) + 8;
+        expected_token_value = rd_malloc(token_len);
+        rd_snprintf(expected_token_value,
+                    token_len,
+                    token_format,
+                    token_key,
+                    expected_jwt_token);
+
+        hreq.hreq_buf = rd_buf_new(1, token_len + 1);
+        rd_buf_write(hreq.hreq_buf, expected_token_value, token_len);
+
+        herr = rd_http_parse_token_to_json(&hreq, &json);
+        RD_UT_ASSERT(!herr,
+                     "Expected parse token to json to succeed, "
+                     "but failed with error code: %d, error string: %s",
+                     herr->code, herr->errstr);
+
+        herr = rd_http_extract_jwt_from_json(&json, &token, token_key);
+        RD_UT_ASSERT(!herr,
+                     "Expected extract jwt from json to succeed, "
+                     "but failed with error code: %d, error string %s",
+                     herr->code, herr->errstr);
+
+        RD_UT_ASSERT(!strcmp(expected_jwt_token, token),
+                     "Incorrect token received: "
+                     "expected=%s; received=%s",
+                     expected_jwt_token, token);
+
+        rd_free(token);
+        rd_free(expected_token_value);
+        rd_http_error_destroy(herr);
+        cJSON_Delete(json);
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief make sure the return expected error if received empty json
+ *        from HTTP(S)
+ */
+int unittest_sasl_oauthbearer_oidc_with_empty_key (void) {
+        static const char *token_key = "access_token";
+        static const char *empty_token_format = "{}";
+        static const char *expected_error_string =
+                "Expected non-empty JSON response";
+        static const int expected_error_code = -1;
+        size_t token_len = 0;
+        rd_http_req_t hreq;
+        rd_http_error_t *herr = NULL;
+        cJSON *json = NULL;
+        char *token = NULL;
+
+        RD_UT_BEGIN();
+
+        herr = rd_http_req_init(&hreq, "");
+        RD_UT_ASSERT(!herr,
+                     "Expected initializa succeed, "
+                     "but failed with error code: %d, error string: %s",
+                     herr->code, herr->errstr);
+
+        token_len = strlen(empty_token_format);
+
+        hreq.hreq_buf = rd_buf_new(1, token_len + 1);
+        rd_buf_write(hreq.hreq_buf , empty_token_format, token_len);
+
+        herr = rd_http_parse_token_to_json(&hreq, &json);
+
+        herr = rd_http_extract_jwt_from_json(&json, &token, token_key);
+        RD_UT_ASSERT(herr,
+                     "Expecte extract jwt from json to fail, but not");
+        RD_UT_ASSERT(herr->code == expected_error_code,
+                     "%d is expected error code, but received %d",
+                     expected_error_code, herr->code);
+        RD_UT_ASSERT(!strcmp(herr->errstr, expected_error_string),
+                     "%s is expected error string, but received %s",
+                     expected_error_string, herr->errstr);
+
+        rd_http_error_destroy(herr);
+        cJSON_Delete(json);
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief make sure the jwt is able to be extracted from HTTP(S) requests.
+ */
+int unittest_sasl_oauthbearer_oidc (void) {
+
+        int fails = 0;
+        fails += unittest_sasl_oauthbearer_oidc_should_succeed();
+        fails += unittest_sasl_oauthbearer_oidc_with_empty_key();
+        return fails;
+}

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -202,6 +202,7 @@ void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
                              "token from \"%s\": %s (%d)",
                              token_url, herr->errstr, herr->code);
                 rd_kafka_oauthbearer_set_token_failure(rk, herr->errstr);
+                rd_http_error_destroy(herr);
                 goto done;
         }
 

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -174,7 +174,7 @@ void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
                 &headers);
         if (errstr != NULL) {
                 rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTH,
+				RD_KAFKA_RESP_ERR__AUTHENTICATION,
 				"Failed to build OAUTHBEARER OIDC headers: %s",
                                 errstr);
                 return;
@@ -199,7 +199,7 @@ void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
                                         &json);
         if (unlikely(herr != NULL)) {
 		rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTH,
+				RD_KAFKA_RESP_ERR__AUTHENTICATION,
 				"Failed to receive json result from HTTP(S), "
                                 "returned error code: %d, returned error "
                                 "string: %s", herr->code, herr->errstr);
@@ -209,7 +209,7 @@ void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
         parsed_token = cJSON_GetObjectItem(json, "access_token");
         if (unlikely(parsed_token == NULL)) {
                 rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTH,
+				RD_KAFKA_RESP_ERR__AUTHENTICATION,
 				"Expected non-empty JSON response");
                 rd_http_error_destroy(herr);
                 goto done;

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -45,19 +45,18 @@
  *          The base64-encoded string will be returned at \p out with it's
  *          size.
  */
-static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
+static rd_bool_t rd_base64_encode(const rd_chariov_t *in, rd_chariov_t *out) {
         size_t max_len;
 
-        max_len = (((in->size + 2) / 3) * 4) + 1;
+        max_len  = (((in->size + 2) / 3) * 4) + 1;
         out->ptr = rd_malloc(max_len);
         if (out->ptr == NULL)
                 return rd_false;
 
-        out->size = EVP_EncodeBlock((uint8_t*)out->ptr,
-                                  (uint8_t*)in->ptr,
-                                  (int)in->size);
+        out->size = EVP_EncodeBlock((uint8_t *)out->ptr, (uint8_t *)in->ptr,
+                                    (int)in->size);
 
-        if (out->size > INT_MAX) {
+        if (out->size > max_len) {
                 rd_free(out->ptr);
                 return rd_false;
         }
@@ -75,45 +74,39 @@ static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
  *        The authorization field will be returned in
  *        \p *authorization_base64_headerp.
  *
- * @returns return NULL if succeed, else return the error message.
  *
  * @locality Any thread.
  */
-static char *rd_kafka_oidc_build_auth_header (const char *client_id,
-        const char *client_secret, char **authorization_base64_headerp) {
+static void
+rd_kafka_oidc_build_auth_header(const char *client_id,
+                                const char *client_secret,
+                                char **authorization_base64_headerp) {
 
         rd_chariov_t client_authorization_in;
         rd_chariov_t client_authorization_out;
 
         size_t authorization_base64_header_size;
 
-        client_authorization_in.size = strlen(client_id) +
-                                       strlen(client_secret) + 2;
+        client_authorization_in.size =
+            strlen(client_id) + strlen(client_secret) + 2;
         client_authorization_in.ptr = rd_malloc(client_authorization_in.size);
-        rd_snprintf(client_authorization_in.ptr,
-                    client_authorization_in.size,
-                    "%s:%s",
-                    client_id,
-                    client_secret);
+        rd_snprintf(client_authorization_in.ptr, client_authorization_in.size,
+                    "%s:%s", client_id, client_secret);
 
-        if (!rd_base64_encode(&client_authorization_in,
-                &client_authorization_out)) {
-                rd_free(client_authorization_in.ptr);
-                return "Failed to generate base64-encoded string";
-        }
+        client_authorization_in.size = client_authorization_in.size - 1;
+        rd_assert(rd_base64_encode(&client_authorization_in,
+                                   &client_authorization_out));
 
-        authorization_base64_header_size = strlen("Authorization: Basic ") +
-                client_authorization_out.size + 1;
+        authorization_base64_header_size =
+            strlen("Authorization: Basic ") + client_authorization_out.size + 1;
         *authorization_base64_headerp =
-                rd_malloc(authorization_base64_header_size);
+            rd_malloc(authorization_base64_header_size);
         rd_snprintf(*authorization_base64_headerp,
-                    authorization_base64_header_size,
-                    "Authorization: Basic %s",
+                    authorization_base64_header_size, "Authorization: Basic %s",
                     client_authorization_out.ptr);
 
         rd_free(client_authorization_in.ptr);
         rd_free(client_authorization_out.ptr);
-        return NULL;
 }
 
 
@@ -125,22 +118,19 @@ static char *rd_kafka_oidc_build_auth_header (const char *client_id,
  *
  * @locality Any thread.
  */
-static char *rd_kafka_oidc_build_headers (const char *client_id,
-                                          const char *client_secret,
-                                          struct curl_slist **headersp) {
+static char *rd_kafka_oidc_build_headers(const char *client_id,
+                                         const char *client_secret,
+                                         struct curl_slist **headersp) {
         char *authorization_base64_header = NULL;
-        char *error;
 
-        error = rd_kafka_oidc_build_auth_header(client_id,
-                client_secret, &authorization_base64_header);
-        if (error != NULL)
-                return error;
+        rd_kafka_oidc_build_auth_header(client_id, client_secret,
+                                        &authorization_base64_header);
 
         *headersp = curl_slist_append(*headersp, "Accept: application/json");
         *headersp = curl_slist_append(*headersp, authorization_base64_header);
 
-        *headersp = curl_slist_append(*headersp,
-                "Content-Type: application/x-www-form-urlencoded");
+        *headersp = curl_slist_append(
+            *headersp, "Content-Type: application/x-www-form-urlencoded");
 
         rd_free(authorization_base64_header);
         return NULL;
@@ -148,16 +138,17 @@ static char *rd_kafka_oidc_build_headers (const char *client_id,
 
 
 /**
- * @brief Implementation of Oauth/OIDC token refresh call back function,
- *        will receive the json response after HTTP call from token provider,
- *        then extract the jwt from the json response, and forward it to
+ * @brief Implementation of Oauth/OIDC token refresh callback function,
+ *        will receive the JSON response after HTTP call to token provider,
+ *        then extract the jwt from the JSON response, and forward it to
  *        the broker.
  */
-void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
-        const char *oauthbearer_config, void *opaque) {
-        static const long timeout = 20;
-        static const int retry = 3;
-        static const int interval = 30000000;
+void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
+                                    const char *oauthbearer_config,
+                                    void *opaque) {
+        static const rd_ts_t timeout_s = 20;
+        static const int retry         = 3;
+        static const int retry_ms      = 30 * 1000;
 
         cJSON *json = NULL;
         cJSON *parsed_token;
@@ -167,56 +158,68 @@ void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
         char *post_fields;
         size_t post_fields_size;
         char *errstr;
+        const char *token_url;
+
+        char set_token_errstr[512];
+
+        const char *extension_str;
+        size_t extension_cnt;
+        char **extension;
+        char **extension_key_value;
+        size_t extension_key_value_cnt;
+
+        if (rd_kafka_terminating(rk))
+                return;
 
         errstr = rd_kafka_oidc_build_headers(
-                rk->rk_conf.sasl.oauthbearer.client_id,
-                rk->rk_conf.sasl.oauthbearer.client_secret,
-                &headers);
+            rk->rk_conf.sasl.oauthbearer.client_id,
+            rk->rk_conf.sasl.oauthbearer.client_secret, &headers);
         if (errstr != NULL) {
-                rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTHENTICATION,
-				"Failed to build OAUTHBEARER OIDC headers: %s",
-                                errstr);
+                rd_kafka_set_fatal_error(rk, RD_KAFKA_RESP_ERR__AUTHENTICATION,
+                                         "Failed to build OAUTHBEARER "
+                                         "OIDC headers: %s",
+                                         errstr);
                 return;
         }
 
         /* Build post fields */
-        post_fields_size =
-                strlen("grant_type=client_credentials,scope=")
-                + strlen(rk->rk_conf.sasl.oauthbearer.scope) + 1;
+        post_fields_size = strlen("grant_type=client_credentials&scope=") +
+                           strlen(rk->rk_conf.sasl.oauthbearer.scope) + 1;
         post_fields = rd_malloc(post_fields_size);
-        rd_snprintf(post_fields,
-                    post_fields_size,
-                    "grant_type=client_credentials,scope=%s",
+        rd_snprintf(post_fields, post_fields_size,
+                    "grant_type=client_credentials&scope=%s",
                     rk->rk_conf.sasl.oauthbearer.scope);
-        herr = rd_http_post_expect_json(rk,
-                                        headers,
-                                        post_fields,
-                                        post_fields_size,
-                                        timeout,
-                                        retry,
-                                        interval,
-                                        &json);
-        if (unlikely(herr != NULL)) {
-		rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTHENTICATION,
-				"Failed to receive json result from HTTP(S), "
-                                "returned error code: %d, returned error "
-                                "string: %s", herr->code, herr->errstr);
-                rd_http_error_destroy(herr);
-                goto done;
-        }
-        parsed_token = cJSON_GetObjectItem(json, "access_token");
-        if (unlikely(parsed_token == NULL)) {
-                rd_kafka_op_err(rk,
-				RD_KAFKA_RESP_ERR__AUTHENTICATION,
-				"Expected non-empty JSON response");
-                rd_http_error_destroy(herr);
-                goto done;
-        }
-        jwt_token = cJSON_Print(parsed_token);
 
-        /* TODO: Forward token to broker. */
+        token_url = rk->rk_conf.sasl.oauthbearer.token_endpoint_url;
+
+        herr = rd_http_post_expect_json(rk, token_url, headers, post_fields,
+                                        post_fields_size, timeout_s, retry,
+                                        retry_ms, &json);
+
+        if (unlikely(herr != NULL)) {
+                rd_kafka_log(rk, LOG_ERR, "OIDC",
+                             "Failed to retrieve OIDC "
+                             "token from \"%s\": %s (%d)",
+                             token_url, herr->errstr, herr->code);
+                rd_kafka_oauthbearer_set_token_failure(rk, herr->errstr);
+                goto done;
+        }
+
+        parsed_token = cJSON_GetObjectItem(json, "access_token");
+
+        jwt_token     = parsed_token->valuestring;
+        extension_str = rk->rk_conf.sasl.oauthbearer.extensions_str;
+        extension =
+            rd_string_split(extension_str, ',', rd_true, &extension_cnt);
+
+        extension_key_value = rd_kafka_conf_kv_split(
+            (const char **)extension, extension_cnt, &extension_key_value_cnt);
+
+        if (rd_kafka_oauthbearer_set_token(
+                rk, jwt_token, rd_uclock(), "",
+                (const char **)extension_key_value, extension_key_value_cnt,
+                set_token_errstr, sizeof(set_token_errstr)) == -1)
+                rd_kafka_oauthbearer_set_token_failure(rk, set_token_errstr);
 
 done:
         RD_IF_FREE(post_fields, rd_free);
@@ -226,24 +229,30 @@ done:
 
 
 /**
- * @brief make sure the jwt is able to be extracted from HTTP(S) requests.
+ * @brief Make sure the jwt is able to be extracted from HTTP(S) response.
+ *        The JSON response after HTTP(S) call to token provider will be in
+ *        rd_http_req_t.hreq_buf and jwt is the value of field "access_token",
+ *        the format is {"access_token":"*******"}.
+ *        This function mocks up the rd_http_req_t.hreq_buf using an dummy
+ *        jwt. The rd_http_parse_json will extract the jwt from rd_http_req_t
+ *        and make sure the extracted jwt is same with the dummy one.
+ *
  */
-static int ut_sasl_oauthbearer_oidc_should_succeed (void) {
-        static const char *token_key = "access_token";
+static int ut_sasl_oauthbearer_oidc_should_succeed(void) {
         static const char *expected_jwt_token =
-                "\"eyJhbGciOiJIUzI1NiIsInR5"
-                "cCI6IkpXVCIsImtpZCI6ImFiY2VkZmcifQ"
-                "."
-                "eyJpYXQiOjE2MzIzNzUzMjAsInN1YiI6InN"
-                "1YiIsImV4cCI6MTYzMjM3NTYyMH0"
-                "."
-                "bT5oY8K-rS2gQ7Awc40844bK3zhzBhZb7sputErqQHY\"";
+            "eyJhbGciOiJIUzI1NiIsInR5"
+            "cCI6IkpXVCIsImtpZCI6ImFiY2VkZmcifQ"
+            "."
+            "eyJpYXQiOjE2MzIzNzUzMjAsInN1YiI6InN"
+            "1YiIsImV4cCI6MTYzMjM3NTYyMH0"
+            "."
+            "bT5oY8K-rS2gQ7Awc40844bK3zhzBhZb7sputErqQHY";
         char *expected_token_value;
-        size_t token_len = 0;
+        size_t token_len;
         rd_http_req_t hreq;
         rd_http_error_t *herr;
         cJSON *json = NULL;
-        char *token = NULL;
+        char *token;
         cJSON *parsed_token;
 
         RD_UT_BEGIN();
@@ -255,37 +264,31 @@ static int ut_sasl_oauthbearer_oidc_should_succeed (void) {
                      "but failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
-        token_len = strlen(token_key) + strlen(expected_jwt_token) + 8;
+        token_len = strlen("access_token") + strlen(expected_jwt_token) + 12;
 
         expected_token_value = rd_malloc(token_len);
-        rd_snprintf(expected_token_value,
-                    token_len,
-                    "{\"%s\":%s}",
-                    "access_token",
-                    expected_jwt_token);
-
+        rd_snprintf(expected_token_value, token_len, "{\"%s\":\"%s\"}",
+                    "access_token", expected_jwt_token);
         rd_buf_write(hreq.hreq_buf, expected_token_value, token_len);
 
         herr = rd_http_parse_json(&hreq, &json);
         RD_UT_ASSERT(!herr,
-                     "Expected parse token to json to succeed, "
-                     "but failed with error code: %d, error string: %s",
+                     "Failed to parse JSON token with error code: %d, "
+                     "error string: %s",
                      herr->code, herr->errstr);
 
-        RD_UT_ASSERT(json, "Expected non-empty json, but not.");
+        RD_UT_ASSERT(json, "Expected non-empty json.");
 
         parsed_token = cJSON_GetObjectItem(json, "access_token");
 
-        RD_UT_ASSERT(parsed_token,
-                     "Expected non-empty JSON response, but not");
-        token = cJSON_Print(parsed_token);
+        RD_UT_ASSERT(parsed_token, "Expected non-empty JSON response.");
+        token = parsed_token->valuestring;
 
         RD_UT_ASSERT(!strcmp(expected_jwt_token, token),
                      "Incorrect token received: "
                      "expected=%s; received=%s",
                      expected_jwt_token, token);
 
-        rd_free(token);
         rd_free(expected_token_value);
         rd_http_error_destroy(herr);
         rd_http_req_destroy(&hreq);
@@ -296,14 +299,14 @@ static int ut_sasl_oauthbearer_oidc_should_succeed (void) {
 
 
 /**
- * @brief make sure if the json doesn't include the "access_token" key,
- *        it won't fail and return an empty token.
+ * @brief Make sure JSON doesn't include the "access_token" key,
+ *        it will fail and return an empty token.
  */
-static int ut_sasl_oauthbearer_oidc_with_empty_key (void) {
+static int ut_sasl_oauthbearer_oidc_with_empty_key(void) {
         static const char *empty_token_format = "{}";
-        size_t token_len = 0;
+        size_t token_len;
         rd_http_req_t hreq;
-        rd_http_error_t *herr = NULL;
+        rd_http_error_t *herr;
         cJSON *json = NULL;
         cJSON *parsed_token;
 
@@ -311,27 +314,26 @@ static int ut_sasl_oauthbearer_oidc_with_empty_key (void) {
 
         herr = rd_http_req_init(&hreq, "");
         RD_UT_ASSERT(!herr,
-                     "Expected initialization succeed, "
+                     "Expected initialization to succeed, "
                      "but it failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
         token_len = strlen(empty_token_format);
 
-        rd_buf_write(hreq.hreq_buf , empty_token_format, token_len);
+        rd_buf_write(hreq.hreq_buf, empty_token_format, token_len);
 
         herr = rd_http_parse_json(&hreq, &json);
 
         RD_UT_ASSERT(!herr,
-                     "Expected parse token to json to succeed, "
-                     "but failed with error code: %d, error string: %s",
+                     "Expected JSON token parsing to succeed, "
+                     "but it failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
-        RD_UT_ASSERT(json, "Expected non-empty json, but not.");
+        RD_UT_ASSERT(json, "Expected non-empty json.");
 
         parsed_token = cJSON_GetObjectItem(json, "access_token");
 
-        RD_UT_ASSERT(!parsed_token,
-                     "Expected empty JSON response, but not");
+        RD_UT_ASSERT(!parsed_token, "Expected empty JSON response");
 
         rd_http_req_destroy(&hreq);
         rd_http_error_destroy(herr);
@@ -345,7 +347,7 @@ static int ut_sasl_oauthbearer_oidc_with_empty_key (void) {
  * @brief make sure the jwt is able to be extracted from HTTP(S) requests
  *        or fail as expected.
  */
-int unittest_sasl_oauthbearer_oidc (void) {
+int unittest_sasl_oauthbearer_oidc(void) {
         int fails = 0;
         fails += ut_sasl_oauthbearer_oidc_should_succeed();
         fails += ut_sasl_oauthbearer_oidc_with_empty_key();

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -221,7 +221,8 @@ void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
         double exp;
 
         cJSON *json = NULL;
-        cJSON *parsed_token, *payloads, *jwt_exp, *jwt_sub;
+        cJSON *payloads = NULL;
+        cJSON *parsed_token, *jwt_exp, *jwt_sub;
 
         rd_http_error_t *herr;
 

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -28,12 +28,10 @@
 
 
 /**
- * Builtin SASL OAUTHBEARER support
+ * Builtin SASL OAUTHBEARER OIDC support
  */
 #include "rdkafka_int.h"
-#include "rdkafka_transport_int.h"
 #include "rdkafka_sasl_int.h"
-#include <openssl/evp.h>
 #include "rdunittest.h"
 #include "cJSON.h"
 #include <curl/curl.h>
@@ -41,7 +39,8 @@
 #include "rdkafka_sasl_oauthbearer_oidc.h"
 
 /**
- * @brief Base64 encode binary input \p in
+ * @brief Base64 encode binary input \p in, and write base64-encoded string
+ *        and it's size to \p out
  * @returns return rd_true if encode succeed, else return rd_false.
  *          The base64-encoded string will be returned at \p out with it's
  *          size.
@@ -49,22 +48,21 @@
 static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
         size_t max_len;
 
-        /* OpenSSL takes an |int| argument so the input cannot exceed that. */
-        if (in->size > INT_MAX) {
-                return rd_false;
-        }
-
-        /* This does not overflow given the |INT_MAX| bound, above. */
         max_len = (((in->size + 2) / 3) * 4) + 1;
         out->ptr = rd_malloc(max_len);
-        if (out->ptr == NULL) {
+        if (out->ptr == NULL)
                 return rd_false;
-        }
 
         out->size = EVP_EncodeBlock((uint8_t*)out->ptr,
                                   (uint8_t*)in->ptr,
                                   (int)in->size);
-        assert(out->size < max_len);
+
+        if (out->size > INT_MAX) {
+                rd_free(out->ptr);
+                return rd_false;
+        }
+
+        rd_assert(out->size < max_len);
         out->ptr[out->size] = 0;
         return rd_true;
 }
@@ -73,116 +71,79 @@ static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
 /**
  * @brief Generate Authorization field for HTTP header.
  *        The field contains base64-encoded string which
- *        is generated from client_id and client_secret.
+ *        is generated from \p client_id and \p client_secret.
+ *        The authorization field will be returned in
+ *        \p *authorization_base64_headerp.
  *
- * @returns a newly allocated string with partially base64-encoded string.
+ * @returns return NULL if succeed, else return the error message.
  *
  * @locality Any thread.
  */
-static char *build_authorization_base64_header (const char *client_id,
-        const char *client_secret, char **error) {
+static char *rd_kafka_oidc_build_auth_header (const char *client_id,
+        const char *client_secret, char **authorization_base64_headerp) {
 
-        static const char *authorization_header = "Authorization:Basic ";
-        static const char *error_message = "Failed to generate base64-encoded "
-                                           "string\n";
-        size_t len;
-        size_t client_id_len;
-        size_t client_secret_len;
-        size_t authorization_base64_header_size;
         rd_chariov_t client_authorization_in;
         rd_chariov_t client_authorization_out;
-        char *authorization_base64_header;
-        rd_bool_t rd_base64_encode_status;
 
-        client_id_len = strlen(client_id);
-        client_secret_len = strlen(client_secret);
-        len = client_id_len + client_secret_len + 2;
+        size_t authorization_base64_header_size;
 
-        client_authorization_in.ptr = rd_malloc(len);
-        memcpy(client_authorization_in.ptr, client_id, client_id_len);
-        memcpy(client_authorization_in.ptr + client_id_len, ":", 1);
-        memcpy(client_authorization_in.ptr + client_id_len + 1,
-               client_secret,
-               client_secret_len + 1);
+        client_authorization_in.size = strlen(client_id) +
+                                       strlen(client_secret) + 2;
+        client_authorization_in.ptr = rd_malloc(client_authorization_in.size);
+        rd_snprintf(client_authorization_in.ptr,
+                    client_authorization_in.size,
+                    "%s:%s",
+                    client_id,
+                    client_secret);
 
-        client_authorization_in.size = len;
-
-        rd_base64_encode_status = rd_false;
-        rd_base64_encode_status = rd_base64_encode(&client_authorization_in, &client_authorization_out);
-
-        if (!rd_base64_encode_status) {
-                *error = rd_malloc(strlen(error_message) + 1);
-                strcpy(*error, error_message);
+        if (!rd_base64_encode(&client_authorization_in,
+                &client_authorization_out)) {
                 rd_free(client_authorization_in.ptr);
-                return NULL;
+                return "Failed to generate base64-encoded string";
         }
 
-        authorization_base64_header_size = strlen(authorization_header) +
-                                           client_authorization_out.size + 1;
-        authorization_base64_header =
+        authorization_base64_header_size = strlen("Authorization: Basic ") +
+                client_authorization_out.size + 1;
+        *authorization_base64_headerp =
                 rd_malloc(authorization_base64_header_size);
-        memcpy(authorization_base64_header,
-               authorization_header,
-               strlen(authorization_header));
-        memcpy(authorization_base64_header + strlen(authorization_header),
-               client_authorization_out.ptr,
-               client_authorization_out.size + 1);
+        rd_snprintf(*authorization_base64_headerp,
+                    authorization_base64_header_size,
+                    "Authorization: Basic %s",
+                    client_authorization_out.ptr);
 
         rd_free(client_authorization_in.ptr);
         rd_free(client_authorization_out.ptr);
-        return authorization_base64_header;
+        return NULL;
 }
 
 
 /**
- * @brief Build headers for HTTP(S) requests.
+ * @brief Build headers for HTTP(S) requests based on \p client_id
+ *        and \p client_secret. The result will be returned in \p *headers.
  *
- * @returns The result will be responsed in \p *headers.
- *          If succeed, return rd_true with NULL in \p *error,
- *          If failed, return rd_false with error message in \p *error.
+ * @returns If succeed, return NULL, else return the error message.
  *
  * @locality Any thread.
  */
-static rd_bool_t build_headers (rd_kafka_conf_t *conf,
-                                struct curl_slist **headers,
-                                char **error) {
-        static const char *miss_client_id_error_message = "client_id is "
-                "a required field";
-        static const char *miss_client_secret_error_message = "client_secret "
-                "is a required field";
-        static const char *accept_header = "Accept:application/json";
-        const char *client_id;
-        const char *client_secret;
-        char *authorization_base64_header;
+static char *rd_kafka_oidc_build_headers (const char *client_id,
+                                          const char *client_secret,
+                                          struct curl_slist **headersp) {
+        char *authorization_base64_header = NULL;
+        char *error;
 
-        client_id = conf->sasl.oauthbearer.client_id;
+        error = rd_kafka_oidc_build_auth_header(client_id,
+                client_secret, &authorization_base64_header);
+        if (error != NULL)
+                return error;
 
-        if (client_id == NULL) {
-                *error = rd_malloc(strlen(miss_client_id_error_message)
-                                   + 1);
-                strcpy(*error, miss_client_id_error_message);
-                return rd_false;
-        }
+        *headersp = curl_slist_append(*headersp, "Accept: application/json");
+        *headersp = curl_slist_append(*headersp, authorization_base64_header);
 
-        client_secret = conf->sasl.oauthbearer.client_secret;
-        if (client_secret == NULL) {
-                *error = rd_malloc(strlen(miss_client_secret_error_message)
-                                   + 1);
-                strcpy(*error, miss_client_secret_error_message);
-                return rd_false;
-        }
+        *headersp = curl_slist_append(*headersp,
+                "Content-Type: application/x-www-form-urlencoded");
 
-        authorization_base64_header =
-                build_authorization_base64_header(client_id,
-                                                  client_secret,
-                                                  &*error);
-        if (authorization_base64_header == NULL)
-                return rd_false;
-
-        *headers = curl_slist_append(*headers, accept_header);
-        *headers = curl_slist_append(*headers, authorization_base64_header);
         rd_free(authorization_base64_header);
-        return rd_true;
+        return NULL;
 }
 
 
@@ -192,92 +153,82 @@ static rd_bool_t build_headers (rd_kafka_conf_t *conf,
  *        then extract the jwt from the json response, and forward it to
  *        the broker.
  */
-void rd_kafka_conf_set_oauthbearer_oidc_token_refresh_cb (rd_kafka_t *rk,
+void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
         const char *oauthbearer_config, void *opaque) {
-        static const char *data = "grant_type=client_credentials,scope=%s";
-        static const char *token_key = "access_token";
         static const long timeout = 20;
-        static const size_t retry = 3;
+        static const int retry = 3;
+        static const int interval = 30000000;
 
         cJSON *json = NULL;
+        cJSON *parsed_token;
         rd_http_error_t *herr;
-        char *jwt_token = NULL;
+        char *jwt_token;
         struct curl_slist *headers = NULL;
-        char *data_to_token;
-        size_t data_to_token_size;
-        const char *scope;
-        const char *token_url;
-        rd_bool_t build_headers_status;
-        char *error;
+        char *post_fields;
+        size_t post_fields_size;
+        char *errstr;
 
-        token_url = rk->rk_conf.sasl.oauthbearer.token_endpoint_url;
-        if (token_url == NULL) {
-                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
-                             "token_url is a required field");
+        errstr = rd_kafka_oidc_build_headers(
+                rk->rk_conf.sasl.oauthbearer.client_id,
+                rk->rk_conf.sasl.oauthbearer.client_secret,
+                &headers);
+        if (errstr != NULL) {
+                rd_kafka_op_err(rk,
+				RD_KAFKA_RESP_ERR__AUTH,
+				"Failed to build OAUTHBEARER OIDC headers: %s",
+                                errstr);
                 return;
         }
 
-        build_headers_status = rd_false;
-        build_headers_status = build_headers(&rk->rk_conf, &headers, &error);
-        if (!build_headers_status) {
-                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
-                             "Failed to build headers: %s",
-                             error);
-                rd_free(error);
-                return;
-        }
-
-        /* Build data field */
-        scope = rk->rk_conf.sasl.oauthbearer.scope;
-        if (scope == NULL) {
-                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
-                             "scope is a required field");
-                return;
-        }
-        data_to_token_size = strlen(data) + strlen(scope) - 1;
-        data_to_token = rd_malloc(data_to_token_size);
-        rd_snprintf(data_to_token, data_to_token_size, data, scope);
-        herr = rd_http_post_json(token_url,
-                                 &headers,
-                                 data_to_token,
-                                 data_to_token_size,
-                                 timeout,
-                                 retry,
-                                 &json);
+        /* Build post fields */
+        post_fields_size =
+                strlen("grant_type=client_credentials,scope=")
+                + strlen(rk->rk_conf.sasl.oauthbearer.scope) + 1;
+        post_fields = rd_malloc(post_fields_size);
+        rd_snprintf(post_fields,
+                    post_fields_size,
+                    "grant_type=client_credentials,scope=%s",
+                    rk->rk_conf.sasl.oauthbearer.scope);
+        herr = rd_http_post_expect_json(rk,
+                                        headers,
+                                        post_fields,
+                                        post_fields_size,
+                                        timeout,
+                                        retry,
+                                        interval,
+                                        &json);
         if (unlikely(herr != NULL)) {
-                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
-                             "Failed to receive json result from HTTP(S), "
-                             "returned error code: %d, returned error string: "
-                             "%s", herr->code, herr->errstr);
+		rd_kafka_op_err(rk,
+				RD_KAFKA_RESP_ERR__AUTH,
+				"Failed to receive json result from HTTP(S), "
+                                "returned error code: %d, returned error "
+                                "string: %s", herr->code, herr->errstr);
                 rd_http_error_destroy(herr);
-                goto exit;
+                goto done;
         }
-        herr = rd_http_extract_jwt_from_json(&json, &jwt_token, token_key);
-        if (unlikely(herr != NULL)) {
-                rd_kafka_log(rk, LOG_ERR, "OAUTH/OIDC",
-                             "Failed to extract jwt from json, "
-                             "returned error code: %d, returned error string: "
-                             "%s", herr->code, herr->errstr);
+        parsed_token = cJSON_GetObjectItem(json, "access_token");
+        if (unlikely(parsed_token == NULL)) {
+                rd_kafka_op_err(rk,
+				RD_KAFKA_RESP_ERR__AUTH,
+				"Expected non-empty JSON response");
                 rd_http_error_destroy(herr);
-                goto exit;
+                goto done;
         }
+        jwt_token = cJSON_Print(parsed_token);
 
         /* TODO: Forward token to broker. */
 
-exit:
-        RD_IF_FREE(data_to_token, rd_free);
-        cJSON_Delete(json);
+done:
+        RD_IF_FREE(post_fields, rd_free);
+        RD_IF_FREE(json, cJSON_Delete);
         RD_IF_FREE(headers, curl_slist_free_all);
-        RD_IF_FREE(jwt_token, rd_free);
-        return;
 }
 
 
 /**
  * @brief make sure the jwt is able to be extracted from HTTP(S) requests.
  */
-int unittest_sasl_oauthbearer_oidc_should_succeed (void) {
-
+static int ut_sasl_oauthbearer_oidc_should_succeed (void) {
         static const char *token_key = "access_token";
         static const char *expected_jwt_token =
                 "\"eyJhbGciOiJIUzI1NiIsInR5"
@@ -287,44 +238,47 @@ int unittest_sasl_oauthbearer_oidc_should_succeed (void) {
                 "1YiIsImV4cCI6MTYzMjM3NTYyMH0"
                 "."
                 "bT5oY8K-rS2gQ7Awc40844bK3zhzBhZb7sputErqQHY\"";
-        const char *token_format = "{\"%s\":%s}";
         char *expected_token_value;
         size_t token_len = 0;
         rd_http_req_t hreq;
         rd_http_error_t *herr;
         cJSON *json = NULL;
         char *token = NULL;
+        cJSON *parsed_token;
 
         RD_UT_BEGIN();
 
         herr = rd_http_req_init(&hreq, "");
+
         RD_UT_ASSERT(!herr,
-                     "Expected initializa succeed, "
+                     "Expected initialize succeed, "
                      "but failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
         token_len = strlen(token_key) + strlen(expected_jwt_token) + 8;
+
         expected_token_value = rd_malloc(token_len);
         rd_snprintf(expected_token_value,
                     token_len,
-                    token_format,
-                    token_key,
+                    "{\"%s\":%s}",
+                    "access_token",
                     expected_jwt_token);
 
-        hreq.hreq_buf = rd_buf_new(1, token_len + 1);
         rd_buf_write(hreq.hreq_buf, expected_token_value, token_len);
 
-        herr = rd_http_parse_token_to_json(&hreq, &json);
+        herr = rd_http_parse_json(&hreq, &json);
         RD_UT_ASSERT(!herr,
                      "Expected parse token to json to succeed, "
                      "but failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
-        herr = rd_http_extract_jwt_from_json(&json, &token, token_key);
-        RD_UT_ASSERT(!herr,
-                     "Expected extract jwt from json to succeed, "
-                     "but failed with error code: %d, error string %s",
-                     herr->code, herr->errstr);
+        RD_UT_ASSERT(json, "Expected non-empty json, but not.");
+
+        parsed_token = cJSON_GetObjectItem(json, "access_token");
+
+        RD_UT_ASSERT(parsed_token,
+                     "Expected non-empty JSON response, but not");
+        token = cJSON_Print(parsed_token);
 
         RD_UT_ASSERT(!strcmp(expected_jwt_token, token),
                      "Incorrect token received: "
@@ -334,65 +288,66 @@ int unittest_sasl_oauthbearer_oidc_should_succeed (void) {
         rd_free(token);
         rd_free(expected_token_value);
         rd_http_error_destroy(herr);
+        rd_http_req_destroy(&hreq);
         cJSON_Delete(json);
+
         RD_UT_PASS();
 }
 
 
 /**
- * @brief make sure the return expected error if received empty json
- *        from HTTP(S)
+ * @brief make sure if the json doesn't include the "access_token" key,
+ *        it won't fail and return an empty token.
  */
-int unittest_sasl_oauthbearer_oidc_with_empty_key (void) {
-        static const char *token_key = "access_token";
+static int ut_sasl_oauthbearer_oidc_with_empty_key (void) {
         static const char *empty_token_format = "{}";
-        static const char *expected_error_string =
-                "Expected non-empty JSON response";
-        static const int expected_error_code = -1;
         size_t token_len = 0;
         rd_http_req_t hreq;
         rd_http_error_t *herr = NULL;
         cJSON *json = NULL;
-        char *token = NULL;
+        cJSON *parsed_token;
 
         RD_UT_BEGIN();
 
         herr = rd_http_req_init(&hreq, "");
         RD_UT_ASSERT(!herr,
-                     "Expected initializa succeed, "
-                     "but failed with error code: %d, error string: %s",
+                     "Expected initialization succeed, "
+                     "but it failed with error code: %d, error string: %s",
                      herr->code, herr->errstr);
 
         token_len = strlen(empty_token_format);
 
-        hreq.hreq_buf = rd_buf_new(1, token_len + 1);
         rd_buf_write(hreq.hreq_buf , empty_token_format, token_len);
 
-        herr = rd_http_parse_token_to_json(&hreq, &json);
+        herr = rd_http_parse_json(&hreq, &json);
 
-        herr = rd_http_extract_jwt_from_json(&json, &token, token_key);
-        RD_UT_ASSERT(herr,
-                     "Expecte extract jwt from json to fail, but not");
-        RD_UT_ASSERT(herr->code == expected_error_code,
-                     "%d is expected error code, but received %d",
-                     expected_error_code, herr->code);
-        RD_UT_ASSERT(!strcmp(herr->errstr, expected_error_string),
-                     "%s is expected error string, but received %s",
-                     expected_error_string, herr->errstr);
+        RD_UT_ASSERT(!herr,
+                     "Expected parse token to json to succeed, "
+                     "but failed with error code: %d, error string: %s",
+                     herr->code, herr->errstr);
 
+        RD_UT_ASSERT(json, "Expected non-empty json, but not.");
+
+        parsed_token = cJSON_GetObjectItem(json, "access_token");
+
+        RD_UT_ASSERT(!parsed_token,
+                     "Expected empty JSON response, but not");
+
+        rd_http_req_destroy(&hreq);
         rd_http_error_destroy(herr);
         cJSON_Delete(json);
+        cJSON_Delete(parsed_token);
         RD_UT_PASS();
 }
 
 
 /**
- * @brief make sure the jwt is able to be extracted from HTTP(S) requests.
+ * @brief make sure the jwt is able to be extracted from HTTP(S) requests
+ *        or fail as expected.
  */
 int unittest_sasl_oauthbearer_oidc (void) {
-
         int fails = 0;
-        fails += unittest_sasl_oauthbearer_oidc_should_succeed();
-        fails += unittest_sasl_oauthbearer_oidc_with_empty_key();
+        fails += ut_sasl_oauthbearer_oidc_should_succeed();
+        fails += ut_sasl_oauthbearer_oidc_with_empty_key();
         return fails;
 }

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -82,7 +82,7 @@ static rd_bool_t rd_base64_encode (const rd_chariov_t *in, rd_chariov_t *out) {
 static char *build_authorization_base64_header (const char *client_id,
         const char *client_secret, char **error) {
 
-        static const char *authorization_header = "Authorization:Basic %s";
+        static const char *authorization_header = "Authorization:Basic ";
         static const char *error_message = "Failed to generate base64-encoded "
                                            "string\n";
         size_t len;
@@ -117,15 +117,16 @@ static char *build_authorization_base64_header (const char *client_id,
                 return NULL;
         }
 
-        authorization_base64_header_size = strlen(authorization_header) - 1 +
-                                           client_authorization_out.size;
+        authorization_base64_header_size = strlen(authorization_header) +
+                                           client_authorization_out.size + 1;
         authorization_base64_header =
                 rd_malloc(authorization_base64_header_size);
-
-        rd_snprintf(authorization_base64_header,
-                    authorization_base64_header_size,
-                    authorization_header,
-                    client_authorization_out.ptr);
+        memcpy(authorization_base64_header,
+               authorization_header,
+               strlen(authorization_header));
+        memcpy(authorization_base64_header + strlen(authorization_header),
+               client_authorization_out.ptr,
+               client_authorization_out.size + 1);
 
         rd_free(client_authorization_in.ptr);
         rd_free(client_authorization_out.ptr);

--- a/src/rdkafka_sasl_oauthbearer_oidc.h
+++ b/src/rdkafka_sasl_oauthbearer_oidc.h
@@ -28,9 +28,9 @@
 
 #ifndef _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
 #define _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
-void rd_kafka_conf_set_oauthbearer_oidc_token_refresh_cb (rd_kafka_t *rk,
-                                                          const char *oauthbearer_config,
-                                                          void *opaque);
+void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
+                                     const char *oauthbearer_config,
+                                     void *opaque);
 
 int unittest_sasl_oauthbearer_oidc(void);
 

--- a/src/rdkafka_sasl_oauthbearer_oidc.h
+++ b/src/rdkafka_sasl_oauthbearer_oidc.h
@@ -28,9 +28,9 @@
 
 #ifndef _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
 #define _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
-void rd_kafka_oidc_token_refresh_cb (rd_kafka_t *rk,
-                                     const char *oauthbearer_config,
-                                     void *opaque);
+void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
+                                    const char *oauthbearer_config,
+                                    void *opaque);
 
 int unittest_sasl_oauthbearer_oidc(void);
 

--- a/src/rdkafka_sasl_oauthbearer_oidc.h
+++ b/src/rdkafka_sasl_oauthbearer_oidc.h
@@ -1,0 +1,37 @@
+/*
+ * librdkafka - The Apache Kafka C/C++ library
+ *
+ * Copyright (c) 2021 Magnus Edenhill
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
+#define _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_
+void rd_kafka_conf_set_oauthbearer_oidc_token_refresh_cb (rd_kafka_t *rk,
+                                                          const char *oauthbearer_config,
+                                                          void *opaque);
+
+int unittest_sasl_oauthbearer_oidc(void);
+
+#endif /* _RDKAFKA_SASL_OAUTHBEARER_OIDC_H_ */

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -47,6 +47,7 @@
 
 #include "rdsysqueue.h"
 #include "rdkafka_sasl_oauthbearer.h"
+#include "rdkafka_sasl_oauthbearer_oidc.h"
 #include "rdkafka_msgset.h"
 #include "rdkafka_txnmgr.h"
 
@@ -418,7 +419,12 @@ extern int unittest_scram(void);
 extern int unittest_assignors(void);
 extern int unittest_map(void);
 #if WITH_CURL
+<<<<<<< HEAD
 extern int unittest_http(void);
+=======
+extern int unittest_http (void);
+extern int unittest_sasl_oauthbearer_oidc (void);
+>>>>>>> Retrieve jwt token from token provider
 #endif
 
 int rd_unittest(void) {
@@ -456,6 +462,7 @@ int rd_unittest(void) {
                 {"assignors", unittest_assignors},
 #if WITH_CURL
                 {"http", unittest_http},
+                { "sasl_oauthbearer_oidc", unittest_sasl_oauthbearer_oidc },
 #endif
                 {NULL}
         };

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -47,7 +47,9 @@
 
 #include "rdsysqueue.h"
 #include "rdkafka_sasl_oauthbearer.h"
+#if WITH_CURL
 #include "rdkafka_sasl_oauthbearer_oidc.h"
+#endif
 #include "rdkafka_msgset.h"
 #include "rdkafka_txnmgr.h"
 

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -421,12 +421,8 @@ extern int unittest_scram(void);
 extern int unittest_assignors(void);
 extern int unittest_map(void);
 #if WITH_CURL
-<<<<<<< HEAD
 extern int unittest_http(void);
-=======
-extern int unittest_http (void);
-extern int unittest_sasl_oauthbearer_oidc (void);
->>>>>>> Retrieve jwt token from token provider
+extern int unittest_sasl_oauthbearer_oidc(void);
 #endif
 
 int rd_unittest(void) {
@@ -464,7 +460,7 @@ int rd_unittest(void) {
                 {"assignors", unittest_assignors},
 #if WITH_CURL
                 {"http", unittest_http},
-                { "sasl_oauthbearer_oidc", unittest_sasl_oauthbearer_oidc },
+                {"sasl_oauthbearer_oidc", unittest_sasl_oauthbearer_oidc},
 #endif
                 {NULL}
         };

--- a/tests/0126-oauthbearer_oidc.c
+++ b/tests/0126-oauthbearer_oidc.c
@@ -65,7 +65,7 @@ static void do_test_produce_consumer_with_OIDC(rd_kafka_conf_t *conf) {
         test_consumer_subscribe(c1, topic);
 
         /* If token valid time is less than 3s, it will fresh the toke. */
-        rd_usleep(3 * 1000, NULL);
+        rd_usleep(3 * 1000 * 1000, NULL);
         test_consumer_poll("OIDC.C1", c1, testid, 1, -1, 1, NULL);
 
         test_consumer_close(c1);

--- a/tests/0126-oauthbearer_oidc.c
+++ b/tests/0126-oauthbearer_oidc.c
@@ -31,33 +31,26 @@
  * is built from within the librdkafka source tree and thus differs. */
 #include "rdkafka.h" /* for Kafka driver */
 
-
+static rd_bool_t expected_failure;
 /**
  * @brief After config OIDC, make sure the producer and consumer
  *        can work successfully.
  *
  */
 static void do_test_produce_consumer_with_OIDC(rd_kafka_conf_t *conf) {
-        if (test_needs_auth()) {
-                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
-                return;
-        }
-
         const char *topic;
         uint64_t testid;
         rd_kafka_t *p1;
         rd_kafka_t *c1;
-        int msgcounter;
-        rd_kafka_topic_t *rkt;
 
         SUB_TEST("Test producer and consumer with oidc configuration");
 
         test_conf_set(conf, "sasl.oauthbearer.token.endpoint.url",
-                      "https://dev-531534.okta.com/oauth2/default/v1/token");
+                      rd_getenv("VALID_OIDC_URL", NULL));
 
         testid = test_id_generate();
 
-        rd_kafka_conf_set_dr_msg_cb(rd_kafka_conf_dup(conf), test_dr_msg_cb);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         p1 = test_create_handle(RD_KAFKA_PRODUCER, rd_kafka_conf_dup(conf));
 
@@ -65,18 +58,14 @@ static void do_test_produce_consumer_with_OIDC(rd_kafka_conf_t *conf) {
         test_create_topic(p1, topic, 1, 3);
         TEST_SAY("Topic: %s is created\n", topic);
 
-        rkt = test_create_producer_topic(p1, topic);
-        TEST_SAY("Auto-creating topic %s\n", topic);
-        test_auto_create_topic_rkt(p1, rkt, tmout_multip(5000));
-
-        test_produce_msgs_nowait(p1, rkt, testid, 0, 0, 1, NULL, 0, 0,
-                                 &msgcounter);
-        TEST_SAY("Flushing..\n");
-        rd_kafka_flush(p1, 1000);
+        test_produce_msgs2(p1, topic, testid, 0, 0, 5, NULL, 0);
 
         test_conf_set(conf, "auto.offset.reset", "earliest");
         c1 = test_create_consumer(topic, NULL, rd_kafka_conf_dup(conf), NULL);
         test_consumer_subscribe(c1, topic);
+
+        /* If token valid time is less than 3s, it will fresh the toke. */
+        rd_usleep(3 * 1000, NULL);
         test_consumer_poll("OIDC.C1", c1, testid, 1, -1, 1, NULL);
 
         test_consumer_close(c1);
@@ -90,13 +79,46 @@ static void do_test_produce_consumer_with_OIDC(rd_kafka_conf_t *conf) {
 static void
 auth_error_cb(rd_kafka_t *rk, int err, const char *reason, void *opaque) {
         if (err == RD_KAFKA_RESP_ERR__AUTHENTICATION ||
-            err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN)
+            err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN) {
                 TEST_SAY("Expected error: %s: %s\n", rd_kafka_err2str(err),
                          reason);
-        else
+                expected_failure = rd_true;
+        } else
                 TEST_FAIL("Unexpected error: %s: %s", rd_kafka_err2str(err),
                           reason);
         rd_kafka_yield(rk);
+}
+
+
+/**
+ * @brief After config OIDC, if the token is expired, make sure
+ *        the authentication fail as expected.
+ *
+ */
+static void do_test_produce_consumer_with_OIDC_expired_token_should_fail(
+    rd_kafka_conf_t *conf) {
+        rd_kafka_t *c1;
+        uint64_t testid;
+
+        SUB_TEST("Test OAUTHBEARER/OIDC failing with expired JWT");
+
+        expected_failure = rd_false;
+        test_conf_set(conf, "sasl.oauthbearer.token.endpoint.url",
+                      rd_getenv("EXPIRED_TOKEN_OIDC_URL", NULL));
+
+        rd_kafka_conf_set_error_cb(conf, auth_error_cb);
+
+        testid = test_id_generate();
+
+        c1 = test_create_consumer("OIDC.fail.C1", NULL, rd_kafka_conf_dup(conf),
+                                  NULL);
+
+        rd_kafka_consumer_poll(c1, 10 * 1000);
+        TEST_ASSERT(expected_failure);
+
+        test_consumer_close(c1);
+        rd_kafka_destroy(c1);
+        SUB_TEST_PASS();
 }
 
 
@@ -107,18 +129,15 @@ auth_error_cb(rd_kafka_t *rk, int err, const char *reason, void *opaque) {
  */
 static void
 do_test_produce_consumer_with_OIDC_should_fail(rd_kafka_conf_t *conf) {
-        if (test_needs_auth()) {
-                TEST_SKIP("Mock cluster does not support SSL/SASL\n");
-                return;
-        }
-
         rd_kafka_t *c1;
         uint64_t testid;
 
         SUB_TEST("Test OAUTHBEARER/OIDC failing with invalid JWT");
 
+        expected_failure = rd_false;
+
         test_conf_set(conf, "sasl.oauthbearer.token.endpoint.url",
-                      "http://localhost:8080/retrieve/badformat");
+                      rd_getenv("INVALID_OIDC_URL", NULL));
 
         rd_kafka_conf_set_error_cb(conf, auth_error_cb);
 
@@ -129,6 +148,8 @@ do_test_produce_consumer_with_OIDC_should_fail(rd_kafka_conf_t *conf) {
 
         rd_kafka_consumer_poll(c1, 10 * 1000);
 
+        TEST_ASSERT(expected_failure);
+
         test_consumer_close(c1);
         rd_kafka_destroy(c1);
         SUB_TEST_PASS();
@@ -136,36 +157,21 @@ do_test_produce_consumer_with_OIDC_should_fail(rd_kafka_conf_t *conf) {
 
 
 int main_0126_oauthbearer_oidc(int argc, char **argv) {
-        rd_kafka_conf_res_t res;
         rd_kafka_conf_t *conf;
-        char errstr[512];
+        const char *sec;
 
         test_conf_init(&conf, NULL, 60);
 
-        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.method", "OIDC", errstr,
-                                sizeof(errstr));
-
-        if (res == RD_KAFKA_CONF_INVALID) {
-                rd_kafka_conf_destroy(conf);
-                TEST_SKIP("%s\n", errstr);
+        sec = test_conf_get(conf, "security.protocol");
+        if (strcmp(sec, "sasl_plaintext")) {
+                TEST_SKIP("Mock cluster does not config SSL/SASL\n");
                 return 0;
         }
 
-        if (res != RD_KAFKA_CONF_OK)
-                TEST_FAIL("%s", errstr);
-
-        test_conf_set(conf, "sasl.mechanisms", "OAUTHBEARER");
-        test_conf_set(conf, "security.protocol", "SASL_PLAINTEXT");
-        test_conf_set(conf, "sasl.oauthbearer.client.id", "clientid123");
-        test_conf_set(conf, "sasl.oauthbearer.client.secret",
-                      "clientsecret123");
-        test_conf_set(
-            conf, "sasl.oauthbearer.extensions",
-            "ExtensionworkloadIdentity=develC348S,Extensioncluster=lkc123");
-        test_conf_set(conf, "sasl.oauthbearer.scope", "test");
-
         do_test_produce_consumer_with_OIDC(rd_kafka_conf_dup(conf));
         do_test_produce_consumer_with_OIDC_should_fail(rd_kafka_conf_dup(conf));
+        do_test_produce_consumer_with_OIDC_expired_token_should_fail(
+            rd_kafka_conf_dup(conf));
 
         rd_kafka_conf_destroy(conf);
         return 0;

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -11,7 +11,6 @@ from trivup.trivup import Cluster
 from trivup.apps.ZookeeperApp import ZookeeperApp
 from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
-from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
 from trivup.apps.SslApp import SslApp
 
 from cluster_testing import read_scenario_conf
@@ -42,9 +41,6 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
     print('## Test version %s' % version)
 
     cluster = Cluster('LibrdkafkaTestCluster', root_path, debug=debug)
-
-    if args.conf.get('oidc_method') == 'OIDC':
-        oidcapp = OauthbearerOIDCApp(cluster)
 
     # Enable SSL if desired
     if 'SSL' in conf.get('security.protocol', ''):
@@ -122,10 +118,6 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 os.write(
                     fd, ('sasl.oauthbearer.scope=test\n'.encode(
                          'ascii')))
-                cmd_env['VALID_OIDC_URL'] = oidcapp.conf.get('valid_url')
-                cmd_env['INVALID_OIDC_URL'] = oidcapp.conf.get('badformat_url')
-                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = oidcapp.conf.get(
-                    'expired_url')
             else:
                 os.write(
                     fd, ('enable.sasl.oauthbearer.unsecure.jwt=true\n'.encode(

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -11,6 +11,7 @@ from trivup.trivup import Cluster
 from trivup.apps.ZookeeperApp import ZookeeperApp
 from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
+from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
 from trivup.apps.SslApp import SslApp
 
 from cluster_testing import read_scenario_conf
@@ -41,6 +42,9 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
     print('## Test version %s' % version)
 
     cluster = Cluster('LibrdkafkaTestCluster', root_path, debug=debug)
+
+    if args.conf.get('oidc_method') == 'OIDC':
+        oidcapp = OauthbearerOIDCApp(cluster)
 
     # Enable SSL if desired
     if 'SSL' in conf.get('security.protocol', ''):
@@ -118,11 +122,10 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 os.write(
                     fd, ('sasl.oauthbearer.scope=test\n'.encode(
                          'ascii')))
-                cmd_env['VALID_OIDC_URL'] = "http://localhost:8080/retrieve"
-                cmd_env['INVALID_OIDC_URL'] = \
-                    "http://localhost:8080/retrieve/badformat"
-                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = \
-                    "http://localhost:8080/retrieve/expire"
+                cmd_env['VALID_OIDC_URL'] = oidcapp.conf.get('valid_url')
+                cmd_env['INVALID_OIDC_URL'] = oidcapp.conf.get('badformat_url')
+                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = oidcapp.conf.get(
+                    'expired_url')
             else:
                 os.write(
                     fd, ('enable.sasl.oauthbearer.unsecure.jwt=true\n'.encode(

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -100,7 +100,7 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 break
         elif mech == 'OAUTHBEARER':
             security_protocol = 'SASL_PLAINTEXT'
-            if defconf.get('oidc_method') == 'OIDC':
+            if defconf.get('oauthbearer_method') == 'OIDC':
                 os.write(
                     fd, ('sasl.oauthbearer.method=OIDC\n'.encode(
                          'ascii')))
@@ -303,8 +303,8 @@ if __name__ == '__main__':
         default=None,
         help='SASL mechanism (PLAIN, SCRAM-SHA-nnn, GSSAPI, OAUTHBEARER)')
     parser.add_argument(
-        '--oidc-method',
-        dest='oidc_method',
+        '--oauthbearer-method',
+        dest='oauthbearer_method',
         type=str,
         default=None,
         help='OAUTHBEARER/OIDC method (DEFAULT, OIDC), \
@@ -330,15 +330,14 @@ if __name__ == '__main__':
             args.conf['sasl_users'] = 'testuser=testpass'
         args.conf['sasl_mechanisms'] = args.sasl
     retcode = 0
-    if args.oidc_method:
-        if args.oidc_method == "OIDC" and \
+    if args.oauthbearer_method:
+        if args.oauthbearer_method == "OIDC" and \
            args.conf['sasl_mechanisms'] != 'OAUTHBEARER':
-            print('If config `--oidc-method=OIDC`, '
+            print('If config `--oauthbearer-method=OIDC`, '
                   '`--sasl` must be set to `OAUTHBEARER`')
             retcode = 3
             sys.exit(retcode)
-
-        args.conf['oidc_method'] = args.oidc_method
+        args.conf['oauthbearer_method'] = args.oauthbearer_method
 
     args.conf.get('conf', list()).append("log.retention.bytes=1000000000")
 

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -100,12 +100,36 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 break
         elif mech == 'OAUTHBEARER':
             security_protocol = 'SASL_PLAINTEXT'
-            os.write(
-                fd, ('enable.sasl.oauthbearer.unsecure.jwt=true\n'.encode(
-                    'ascii')))
-            os.write(fd, ('sasl.oauthbearer.config=%s\n' %
-                          'scope=requiredScope principal=admin').encode(
-                              'ascii'))
+            if defconf.get('oidc_method') == 'OIDC':
+                os.write(
+                    fd, ('sasl.oauthbearer.method=OIDC\n'.encode(
+                         'ascii')))
+                os.write(
+                    fd, ('sasl.oauthbearer.client.id=123\n'.encode(
+                         'ascii')))
+                os.write(
+                    fd, ('sasl.oauthbearer.client.secret=abc\n'.encode(
+                         'ascii')))
+                os.write(
+                    fd, ('sasl.oauthbearer.extensions=\
+                         ExtensionworkloadIdentity=develC348S,\
+                         Extensioncluster=lkc123\n'.encode(
+                         'ascii')))
+                os.write(
+                    fd, ('sasl.oauthbearer.scope=test\n'.encode(
+                         'ascii')))
+                cmd_env['VALID_OIDC_URL'] = "http://localhost:8080/retrieve"
+                cmd_env['INVALID_OIDC_URL'] = \
+                    "http://localhost:8080/retrieve/badformat"
+                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = \
+                    "http://localhost:8080/retrieve/expire"
+            else:
+                os.write(
+                    fd, ('enable.sasl.oauthbearer.unsecure.jwt=true\n'.encode(
+                         'ascii')))
+                os.write(fd, ('sasl.oauthbearer.config=%s\n' %
+                         'scope=requiredScope principal=admin').encode(
+                         'ascii'))
         else:
             print(
                 '# FIXME: SASL %s client config not written to %s' %
@@ -283,6 +307,13 @@ if __name__ == '__main__':
         type=str,
         default=None,
         help='SASL mechanism (PLAIN, SCRAM-SHA-nnn, GSSAPI, OAUTHBEARER)')
+    parser.add_argument(
+        '--oidc-method',
+        dest='oidc_method',
+        type=str,
+        default=None,
+        help='OAUTHBEARER/OIDC method (DEFAULT, OIDC), \
+             must config SASL mechanism to OAUTHBEARER')
 
     args = parser.parse_args()
     if args.conf is not None:
@@ -303,10 +334,19 @@ if __name__ == '__main__':
                 != -1) and 'sasl_users' not in args.conf:
             args.conf['sasl_users'] = 'testuser=testpass'
         args.conf['sasl_mechanisms'] = args.sasl
+    retcode = 0
+    if args.oidc_method:
+        if args.oidc_method == "OIDC" and \
+           args.conf['sasl_mechanisms'] != 'OAUTHBEARER':
+            print('If config `--oidc-method=OIDC`, '
+                  '`--sasl` must be set to `OAUTHBEARER`')
+            retcode = 3
+            sys.exit(retcode)
+
+        args.conf['oidc_method'] = args.oidc_method
 
     args.conf.get('conf', list()).append("log.retention.bytes=1000000000")
 
-    retcode = 0
     for version in args.versions:
         r = test_version(version, cmd=args.cmd, deploy=args.deploy,
                          conf=args.conf, debug=args.debug,

--- a/tests/librdkafka.suppressions
+++ b/tests/librdkafka.suppressions
@@ -443,3 +443,41 @@
    fun:rd_atomic64_get
 }
 
+{
+   osx_dyld_img
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:strdup
+   fun:__si_module_static_ds_block_invoke
+   fun:_dispatch_client_callout
+   fun:_dispatch_once_callout
+   fun:si_module_static_ds
+   fun:si_module_with_name
+   fun:si_module_config_modules_for_category
+   fun:__si_module_static_search_block_invoke
+   fun:_dispatch_client_callout
+   fun:_dispatch_once_callout
+   fun:si_module_static_search
+   fun:si_module_with_name
+   fun:si_search
+   fun:getpwuid_r
+   fun:_CFRuntimeBridgeClasses
+   fun:__CFInitialize
+   fun:_ZN16ImageLoaderMachO11doImageInitERKN11ImageLoader11LinkContextE
+   fun:_ZN16ImageLoaderMachO16doInitializationERKN11ImageLoader11LinkContextE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader23recursiveInitializationERKNS_11LinkContextEjPKcRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader19processInitializersERKNS_11LinkContextEjRNS_21InitializerTimingListERNS_15UninitedUpwardsE
+   fun:_ZN11ImageLoader15runInitializersERKNS_11LinkContextERNS_21InitializerTimingListE
+   fun:_ZN4dyld24initializeMainExecutableEv
+   fun:_ZN4dyld5_mainEPK12macho_headermiPPKcS5_S5_Pm
+   fun:_ZN13dyldbootstrap5startEPKN5dyld311MachOLoadedEiPPKcS3_Pm
+   fun:_dyld_start
+}

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -127,6 +127,7 @@
     <ClInclude Include="..\src\rdkafka_request.h" />
     <ClInclude Include="..\src\rdkafka_sasl.h" />
     <ClInclude Include="..\src\rdkafka_sasl_int.h" />
+    <ClInclude Include="..\src\rdkafka_sasl_oauthbearer_oidc.h" />
     <ClInclude Include="..\src\rdkafka_transport_int.h" />
     <ClInclude Include="..\src\rdlist.h" />
     <ClInclude Include="..\src\rdposix.h" />
@@ -202,6 +203,7 @@
     <ClCompile Include="..\src\rdkafka_sasl_plain.c" />
     <ClCompile Include="..\src\rdkafka_sasl_scram.c" />
     <ClCompile Include="..\src\rdkafka_sasl_oauthbearer.c" />
+    <ClCompile Include="..\src\rdkafka_sasl_oauthbearer_oidc.c" />
     <ClCompile Include="..\src\rdkafka_subscription.c" />
     <ClCompile Include="..\src\rdkafka_assignment.c" />
     <ClCompile Include="..\src\rdkafka_timer.c" />
@@ -252,4 +254,4 @@
     <None Include="..\README.win32" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-</Project>
+</Project>


### PR DESCRIPTION
Retrieve jwt from token provider and forward it to the broker:  the example received from provider is listed as the json below, extract the token key with key work "access_token".
```
{
    “access_token”: “eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImFiY2VkZmcifQ.eyJleHAiOjE2MzI2ODYwNjAsImlhdCI6MTYzMjY4NTc2MCwic3ViIjoic3ViIn0.yY0F9NUD-MJydlF0NzfNXQtl7gYKO6A-yKM-6_6RTcg”
}
```

Test:
1. The extract jwt from json is tested with unit test.
2. The HTTP(S) request to http server part is tested with the following function which is not added to the unit test part:
```
int unittest_sasl_oauthbearer_oidc (void) {
        rd_kafka_conf_res_t res;

        rd_kafka_conf_t *conf = NULL;
        rd_kafka_t *rk;
        char errstr[512];

        RD_UT_BEGIN();

        conf = rd_kafka_conf_new();
        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.token.endpoint.url",
                                "http://localhost:8080/retrieve", NULL, 0);
        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.client.id",
                                "123", NULL, 0);
        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.client.secret",
                               "abc", NULL, 0);
        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.scope",
                                "test-scope", NULL, 0);
        res = rd_kafka_conf_set(conf, "sasl.oauthbearer.extensions",
                                "grant_type=client_credentials,"
                                "scope=test-scope",
                                NULL, 0);
        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
        rd_kafka_conf_set_oauthbearer_oidc_token_refresh_cb(rk, NULL, NULL);

        rd_kafka_destroy(rk);
        RD_UT_PASS();
}
```

3. Tested with OKTA as token provider and mock up broker.
```
[0126_oauthbearer_oidc       /  4.993s] [ do_test_produce_consumer_with_OIDC:48: Test producer and consumer with oidc configuration: PASS (4.99s) ]
[0126_oauthbearer_oidc       /  4.994s] [ do_test_produce_consumer_with_OIDC_should_fail:110: Test OAUTHBEARER/OIDC failing with invalid JWT ]
[0126_oauthbearer_oidc       /  4.995s] Created    kafka instance 0126_oauthbearer_oidc#consumer-3
[<MAIN>                      /  5.026s] 1 test(s) running: 0126_oauthbearer_oidc
[<MAIN>                      /  6.031s] 1 test(s) running: 0126_oauthbearer_oidc
%3|1635444868.772|FAIL|0126_oauthbearer_oidc#consumer-3| [thrd:sasl_plaintext://0.0.0.0:57804/bootstrap]: sasl_plaintext://0.0.0.0:57804/bootstrap: SASL authentication error: {"status":"invalid_token"} (after 313ms in state AUTH_REQ)
[0126_oauthbearer_oidc       /  6.314s] Expected error: Local: Authentication failure: sasl_plaintext://0.0.0.0:57804/bootstrap: SASL authentication error: {"status":"invalid_token"} (after 313ms in state AUTH_REQ)
[0126_oauthbearer_oidc       /  6.314s] Closing consumer 0126_oauthbearer_oidc#consumer-3
[0126_oauthbearer_oidc       /  6.314s] CONSUMER.CLOSE: duration 0.050ms
[0126_oauthbearer_oidc       /  6.315s] [ do_test_produce_consumer_with_OIDC_should_fail:110: Test OAUTHBEARER/OIDC failing with invalid JWT: PASS (1.32s) ]
[0126_oauthbearer_oidc       /  6.315s] 0126_oauthbearer_oidc: duration 6314.545ms
[0126_oauthbearer_oidc       /  6.315s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      /  7.036s] ALL-TESTS: duration 7035.850ms
TEST 20211028111429 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |   7.037s |
| 0126_oauthbearer_oidc                    |     PASSED |   6.315s |
#==================================================================#
[<MAIN>                      /  7.041s] 0 thread(s) in use by librdkafka
[<MAIN>                      /  7.041s] 
============== ALL TESTS PASSED ==============
###
###  ./test-runner in bare mode PASSED! ###
###
bash-3.2$ 
```

4. The build failure from Windows is not related to this PR:
```
[100%] Built target test-runner
Install the project...
-- Install configuration: ""
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/cmake/RdKafka/RdKafkaConfig.cmake
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/cmake/RdKafka/RdKafkaConfigVersion.cmake
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/cmake/RdKafka/FindLZ4.cmake
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/cmake/RdKafka/RdKafkaTargets.cmake
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/cmake/RdKafka/RdKafkaTargets-noconfig.cmake
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/share/licenses/librdkafka/LICENSES.txt
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/pkgconfig/rdkafka-static.pc
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/librdkafka.a
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/include/librdkafka/rdkafka.h
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/include/librdkafka/rdkafka_mock.h
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/pkgconfig/rdkafka++-static.pc
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/lib/librdkafka++.a
-- Installing: C:/Users/travis/build/edenhill/librdkafka/dest/include/librdkafka/rdkafkacpp.h
~/build/edenhill/librdkafka/mergescratch ~/build/edenhill/librdkafka
~/build/edenhill/librdkafka
```
5. Tested with mock up token provider.
```
[0126_oauthbearer_oidc       /  7.192s] 0126_oauthbearer_oidc: duration 7191.931ms
[0126_oauthbearer_oidc       /  7.192s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      /  8.018s] ALL-TESTS: duration 8018.276ms
TEST 20211115233334 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |   8.019s |
| 0126_oauthbearer_oidc                    |     PASSED |   7.192s |
#==================================================================#
[<MAIN>                      /  8.021s] 0 thread(s) in use by librdkafka
[<MAIN>                      /  8.021s] 
============== ALL TESTS PASSED ==============
###
###  ./test-runner in bare mode PASSED! ###
###
```

6. valgrind: TESTS=0126 ./run-test.sh valgrind --exit-on-first-error=no
Saw two leaks, but I don't think they are related to my change.
(1) related to rd_http_req_destroy(&hreq)
```==116526== HEAP SUMMARY:
==116526==     in use at exit: 80 bytes in 1 blocks
==116526==   total heap usage: 6,618 allocs, 6,617 frees, 433,555 bytes allocated
==116526== 
==116526== 80 bytes in 1 blocks are definitely lost in loss record 1 of 1
==116526==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==116526==    by 0x4A051CC: rd_malloc (rd.h:131)
==116526==    by 0x4A05F26: rd_buf_new (rdbuf.c:380)
==116526==    by 0x4A622C9: rd_http_req_init (rdhttp.c:139)
==116526==    by 0x4A65468: ut_sasl_oauthbearer_oidc_should_succeed (rdkafka_sasl_oauthbearer_oidc.c:410)
==116526==    by 0x4A6598B: unittest_sasl_oauthbearer_oidc (rdkafka_sasl_oauthbearer_oidc.c:504)
==116526==    by 0x4A116FF: rd_unittest (rdunittest.c:497)
==116526==    by 0x48DEFCC: rd_kafka_unittest (rdkafka.c:4860)
==116526==    by 0x1A5A3B: main_0000_unittests (0000-unittests.c:68)
==116526==    by 0x2884B7: run_test0 (test.c:1103)
==116526==    by 0x288ADD: run_test_from_thread (test.c:1167)
==116526==    by 0x4B686D9: start_thread (pthread_create.c:474)
==116526== 
==116526== 
```
Saw the same error for rdhttp.c.
```
==110197== 80 bytes in 1 blocks are definitely lost in loss record 1 of 2
==110197==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==110197==    by 0x4A051CC: rd_malloc (rd.h:131)
==110197==    by 0x4A05F26: rd_buf_new (rdbuf.c:380)
==110197==    by 0x4A622EF: rd_http_req_init (rdhttp.c:139)
==110197==    by 0x4A62B9E: rd_http_get_json (rdhttp.c:388)
==110197==    by 0x4A63009: unittest_http (rdhttp.c:475)
==110197==    by 0x4A11725: rd_unittest (rdunittest.c:497)
==110197==    by 0x48DEFCC: rd_kafka_unittest (rdkafka.c:4860)
==110197==    by 0x1A5A3B: main_0000_unittests (0000-unittests.c:68)
==110197==    by 0x2884B7: run_test0 (test.c:1103)
==110197==    by 0x288ADD: run_test_from_thread (test.c:1167)
==110197==    by 0x4B686D9: start_thread (pthread_create.c:474)
```
(2) Related to test_create_topic()
```
HEAP SUMMARY:
==121240==     in use at exit: 5,032 bytes in 70 blocks
==121240==   total heap usage: 6,830 allocs, 6,760 frees, 1,155,127 bytes allocated
==121240== 
==121240== 8 bytes in 1 blocks are indirectly lost in loss record 1 of 13
==121240==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==121240==    by 0x4999A2B: rd_calloc (rd.h:125)
==121240==    by 0x4999E88: rd_list_prealloc_elems (rdlist.c:108)
==121240==    by 0x4999D88: rd_list_init_copy (rdlist.c:69)
==121240==    by 0x49D3DB6: rd_kafka_NewTopic_copy (rdkafka_admin.c:1479)
==121240==    by 0x49D68D1: rd_kafka_CreateTopics (rdkafka_admin.c:1739)
==121240==    by 0x299822: test_admin_create_topic (test.c:4585)
==121240==    by 0x299C99: test_create_topic (test.c:4653)
==121240==    by 0x1B0B60: do_test_produce_consumer_with_OIDC (0126-oauthbearer_oidc.c:66)
==121240==    by 0x1B1876: main_0126_oauthbearer_oidc (0126-oauthbearer_oidc.c:206)
==121240==    by 0x2884C3: run_test0 (test.c:1103)
==121240==    by 0x288AE9: run_test_from_thread (test.c:1167)
==121240== 
==121240== 
==121240== Exit program on first error (--exit-on-first-error=yes)

```
Saw the same error for 0090-idempotence.c
```
HEAP SUMMARY:
==120515==     in use at exit: 340 bytes in 8 blocks
==120515==   total heap usage: 6,359 allocs, 6,351 frees, 2,160,748 bytes allocated
==120515== 
==120515== 8 bytes in 1 blocks are indirectly lost in loss record 1 of 7
==120515==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==120515==    by 0x4999A2B: rd_calloc (rd.h:125)
==120515==    by 0x4999E88: rd_list_prealloc_elems (rdlist.c:108)
==120515==    by 0x4999D88: rd_list_init_copy (rdlist.c:69)
==120515==    by 0x49D3DB6: rd_kafka_NewTopic_copy (rdkafka_admin.c:1479)
==120515==    by 0x49D68D1: rd_kafka_CreateTopics (rdkafka_admin.c:1739)
==120515==    by 0x299822: test_admin_create_topic (test.c:4585)
==120515==    by 0x299C99: test_create_topic (test.c:4653)
==120515==    by 0x176AB0: do_test_implicit_ack (0090-idempotence.c:133)
==120515==    by 0x177078: main_0090_idempotence (0090-idempotence.c:165)
==120515==    by 0x2884C3: run_test0 (test.c:1103)
==120515==    by 0x288AE9: run_test_from_thread (test.c:1167)
==120515== 
==120515== 

```
Since the above errors are not related to this PR, I will dig more and send a new PR to fix.

7. Tested with manually set the token urls:
```
VALID_OIDC_URL=http://localhost:8080/retrieve INVALID_OIDC_URL=http://localhost:8080/retrieve/badformat EXPIRED_TOKEN_OIDC_URL=http://localhost:8080/retrieve/expire TESTS=0126 make

[0126_oauthbearer_oidc       / 29.667s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      / 30.100s] ALL-TESTS: duration 30099.377ms
TEST 20211121131641 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |  30.100s |
| 0126_oauthbearer_oidc                    |     PASSED |  29.667s |
#==================================================================#
[<MAIN>                      / 30.101s] 0 thread(s) in use by librdkafka
[<MAIN>                      / 30.101s] 
============== ALL TESTS PASSED ==============
###
###  ./test-runner in bare mode PASSED! ###
###

```