### PR TITLE
cgrp: expose rebalancing true/false from API.

### DIFF
--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -148,7 +148,10 @@ RdKafka::KafkaConsumerImpl::assignment_lost () {
   return rd_kafka_assignment_lost(rk_) ? true : false;
 }
 
-
+bool
+RdKafka::KafkaConsumerImpl::is_rebalancing () {
+  return rd_kafka_consumer_is_rebalancing(rk_) ? true : false;
+}
 
 RdKafka::ErrorCode
 RdKafka::KafkaConsumerImpl::subscription (std::vector<std::string> &topics) {

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2790,6 +2790,12 @@ public:
    */
   virtual bool assignment_lost () = 0;
 
+  /** @brief Check whether the consumer is currently rebalancing
+   *
+   * @returns Returns true if currently consumer is rebalancing, false otherwise.
+   */
+  virtual bool is_rebalancing () = 0;
+
   /**
    * @brief The rebalance protocol currently in use. This will be
    *        "NONE" if the consumer has not (yet) joined a group, else it will

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -1138,6 +1138,7 @@ public:
 
   ErrorCode assignment (std::vector<TopicPartition*> &partitions);
   bool assignment_lost ();
+  bool is_rebalancing ();
   std::string rebalance_protocol () {
     const char *str = rd_kafka_rebalance_protocol(rk_);
     return std::string(str ? str : "");

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3871,6 +3871,15 @@ rd_kafka_message_t *rd_kafka_consumer_poll (rd_kafka_t *rk, int timeout_ms);
 RD_EXPORT
 rd_kafka_resp_err_t rd_kafka_consumer_close (rd_kafka_t *rk);
 
+/**
+ * @brief Check whether consumer is rebalancing
+ *
+ * @returns Returns 1 if the consumer is rebalancing, 0 otherwise.
+ *
+ */
+RD_EXPORT
+int rd_kafka_consumer_is_rebalancing (rd_kafka_t *rk);
+
 
 /**
  * @brief Incrementally add \p partitions to the current assignment.

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -181,6 +181,15 @@ rd_kafka_assignment_lost (rd_kafka_t *rk) {
         return rd_kafka_cgrp_assignment_is_lost(rkcg) == rd_true;
 }
 
+int
+rd_kafka_consumer_is_rebalancing (rd_kafka_t *rk) {
+    rd_kafka_cgrp_t *rkcg;
+
+    if (!(rkcg = rd_kafka_cgrp_get(rk)))
+        return 0;
+
+    return rkcg->rkcg_join_state != RD_KAFKA_CGRP_JOIN_STATE_STEADY;
+}
 
 const char *
 rd_kafka_rebalance_protocol (rd_kafka_t *rk) {


### PR DESCRIPTION
Attempt to expose rebalancing information through public APIs.

Goal is to be able to suspend user level background committing as it's needed during incremental cooperative rebalancing. @mhowlett made the same comment at the end of this PR:
https://github.com/edenhill/librdkafka/pull/3326

I'd update changelog and test cases etc once someone has confirmed that this general approach is fine.