### PR TITLE
Fix: fix callback missing when metadata request failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ librdkafka v1.9.0 is a feature release:
    to connect to (#3705).
  * Millisecond timeouts (`timeout_ms`) in various APIs, such as `rd_kafka_poll()`,
    was limited to roughly 36 hours before wrapping. (#3034)
+ * If a metadata request triggered by `rd_kafka_metadata()` or consumer group rebalancing
+   encountered a non-retriable error it would not be propagated to the caller and thus
+   cause a stall or timeout, this has now been fixed. (@aiquestion, #3625)
 
 
 ### Consumer fixes

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1841,7 +1841,7 @@ err:
                            rd_kafka_err2str(err),
                            (int)(request->rkbuf_ts_sent / 1000),
                            rd_kafka_actions2str(actions));
-                // enq callback event with metadata err and not retry
+                /* Respond back to caller on non-retriable errors */
                 if (rko && rko->rko_replyq.q) {
                         rko->rko_err           = err;
                         rko->rko_u.metadata.md = NULL;

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -1841,6 +1841,13 @@ err:
                            rd_kafka_err2str(err),
                            (int)(request->rkbuf_ts_sent / 1000),
                            rd_kafka_actions2str(actions));
+                // enq callback event with metadata err and not retry
+                if (rko && rko->rko_replyq.q) {
+                        rko->rko_err           = err;
+                        rko->rko_u.metadata.md = NULL;
+                        rd_kafka_replyq_enq(&rko->rko_replyq, rko, 0);
+                        rko = NULL;
+                }
         }
 
 


### PR DESCRIPTION
We experience this issue when main thread cgrp start to do a rebalance
and failed when parsing metadata, the cgrp callback will be lost 
and result in consumer unassigned.

If rd_kafka_handle_Metadata failed and will not retry, need to enque 
the callback with err.