### PR TITLE
Integration test for OIDC

### DIFF
--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -351,13 +351,13 @@ void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
         }
 
         if (rk->rk_conf.sasl.oauthbearer.extensions_str) {
-                extensions = rd_string_split(
-                        rk->rk_conf.sasl.oauthbearer.extensions_str, ',',
-                        rd_true, &extension_cnt);
+                extensions =
+                    rd_string_split(rk->rk_conf.sasl.oauthbearer.extensions_str,
+                                    ',', rd_true, &extension_cnt);
 
                 extension_key_value = rd_kafka_conf_kv_split(
-                        (const char **)extensions, extension_cnt,
-                        &extension_key_value_cnt);
+                    (const char **)extensions, extension_cnt,
+                    &extension_key_value_cnt);
         }
 
         if (rd_kafka_oauthbearer_set_token(

--- a/tests/LibrdkafkaTestApp.py
+++ b/tests/LibrdkafkaTestApp.py
@@ -68,20 +68,22 @@ class LibrdkafkaTestApp(App):
             elif mech == 'OAUTHBEARER':
                 self.security_protocol = 'SASL_PLAINTEXT'
                 oidc = cluster.find_app(OauthbearerOIDCApp)
-                if oidc:
+                if oidc is not None:
                     conf_blob.append('sasl.oauthbearer.method=%s\n' %
-                                     self.conf.get('sasl.oauthbearer.method'))
+                                     oidc.conf.get('sasl_oauthbearer_method'))
                     conf_blob.append('sasl.oauthbearer.client.id=%s\n' %
-                                     self.conf.get(
-                                         'sasl.oauthbearer.client.id'))
+                                     oidc.conf.get(
+                                         'sasl_oauthbearer_client_id'))
                     conf_blob.append('sasl.oauthbearer.client.secret=%s\n' %
-                                     self.conf.get(
-                                         'sasl.oauthbearer.client.secret'))
+                                     oidc.conf.get(
+                                         'sasl_oauthbearer_client_secret'))
                     conf_blob.append('sasl.oauthbearer.extensions=%s\n' %
-                                     self.conf.get(
-                                         'sasl.oauthbearer.extensions'))
+                                     oidc.conf.get(
+                                         'sasl_oauthbearer_extensions'))
                     conf_blob.append('sasl.oauthbearer.scope=%s\n' %
-                                     self.conf.get('sasl.oauthbearer.scope'))
+                                     oidc.conf.get('sasl_oauthbearer_scope'))
+                    conf_blob.append('sasl.oauthbearer.token.endpoint.url=%s\n'
+                                     % oidc.conf.get('valid_url'))
                     self.env_add('VALID_OIDC_URL', oidc.conf.get('valid_url'))
                     self.env_add(
                         'INVALID_OIDC_URL',

--- a/tests/LibrdkafkaTestApp.py
+++ b/tests/LibrdkafkaTestApp.py
@@ -10,6 +10,7 @@ from trivup.trivup import App, UuidAllocator
 from trivup.apps.ZookeeperApp import ZookeeperApp
 from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
+from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
 
 import json
 
@@ -66,10 +67,34 @@ class LibrdkafkaTestApp(App):
 
             elif mech == 'OAUTHBEARER':
                 self.security_protocol = 'SASL_PLAINTEXT'
-                conf_blob.append('enable.sasl.oauthbearer.unsecure.jwt=true\n')
-                conf_blob.append(
-                    'sasl.oauthbearer.config=%s\n' %
-                    self.conf.get('sasl_oauthbearer_config'))
+                oidc = cluster.find_app(OauthbearerOIDCApp)
+                if oidc:
+                    conf_blob.append('sasl.oauthbearer.method=%s\n' %
+                                     self.conf.get('sasl.oauthbearer.method'))
+                    conf_blob.append('sasl.oauthbearer.client.id=%s\n' %
+                                     self.conf.get(
+                                         'sasl.oauthbearer.client.id'))
+                    conf_blob.append('sasl.oauthbearer.client.secret=%s\n' %
+                                     self.conf.get(
+                                         'sasl.oauthbearer.client.secret'))
+                    conf_blob.append('sasl.oauthbearer.extensions=%s\n' %
+                                     self.conf.get(
+                                         'sasl.oauthbearer.extensions'))
+                    conf_blob.append('sasl.oauthbearer.scope=%s\n' %
+                                     self.conf.get('sasl.oauthbearer.scope'))
+                    self.env_add('VALID_OIDC_URL', oidc.conf.get('valid_url'))
+                    self.env_add(
+                        'INVALID_OIDC_URL',
+                        oidc.conf.get('badformat_url'))
+                    self.env_add(
+                        'EXPIRED_TOKEN_OIDC_URL',
+                        oidc.conf.get('expired_url'))
+                else:
+                    conf_blob.append(
+                        'enable.sasl.oauthbearer.unsecure.jwt=true\n')
+                    conf_blob.append(
+                        'sasl.oauthbearer.config=%s\n' %
+                        self.conf.get('sasl_oauthbearer_config'))
 
             elif mech == 'GSSAPI':
                 self.security_protocol = 'SASL_PLAINTEXT'

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -12,6 +12,7 @@ from trivup.apps.ZookeeperApp import ZookeeperApp
 from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
 from trivup.apps.SslApp import SslApp
+from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
 
 import os
 import sys
@@ -69,6 +70,10 @@ class LibrdkafkaTestCluster(Cluster):
             # Kerberos needs to be started prior to Kafka so that principals
             # and keytabs are available at the time of Kafka config generation.
             kdc.start()
+
+        if 'OAUTHBEARER' in defconf.get('sasl_mechanisms', []) and \
+                'OIDC' in defconf.get('sasl.oauthbearer.method', []):
+            self.oidc = OauthbearerOIDCApp(self)
 
         # Brokers
         defconf.update({'replication_factor': min(num_brokers, 3),

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -72,9 +72,9 @@ class LibrdkafkaTestCluster(Cluster):
             kdc.start()
 
         if 'OAUTHBEARER'.casefold() == \
-            defconf.get('sasl_mechanisms', None).casefold() and \
+            defconf.get('sasl_mechanisms', "").casefold() and \
                 'OIDC'.casefold() == \
-                defconf.get('sasl_oauthbearer_method').casefold():
+                defconf.get('sasl_oauthbearer_method', "").casefold():
             self.oidc = OauthbearerOIDCApp(self)
 
         # Brokers

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -71,8 +71,10 @@ class LibrdkafkaTestCluster(Cluster):
             # and keytabs are available at the time of Kafka config generation.
             kdc.start()
 
-        if 'OAUTHBEARER' in defconf.get('sasl_mechanisms', []) and \
-                'OIDC' in defconf.get('sasl.oauthbearer.method', []):
+        if 'OAUTHBEARER'.casefold() == \
+            defconf.get('sasl_mechanisms', None).casefold() and \
+                'OIDC'.casefold() == \
+                defconf.get('sasl_oauthbearer_method').casefold():
             self.oidc = OauthbearerOIDCApp(self)
 
         # Brokers

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -12,6 +12,7 @@ from trivup.apps.ZookeeperApp import ZookeeperApp
 from trivup.apps.KafkaBrokerApp import KafkaBrokerApp
 from trivup.apps.KerberosKdcApp import KerberosKdcApp
 from trivup.apps.SslApp import SslApp
+from trivup.apps.OauthbearerOIDCApp import OauthbearerOIDCApp
 
 from cluster_testing import read_scenario_conf
 
@@ -41,6 +42,9 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
     print('## Test version %s' % version)
 
     cluster = Cluster('LibrdkafkaTestCluster', root_path, debug=debug)
+
+    if args.conf.get('oauthbearer_method') == 'OIDC':
+        oidcapp = OauthbearerOIDCApp(cluster)
 
     # Enable SSL if desired
     if 'SSL' in conf.get('security.protocol', ''):
@@ -118,6 +122,11 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 os.write(
                     fd, ('sasl.oauthbearer.scope=test\n'.encode(
                          'ascii')))
+                cmd_env['VALID_OIDC_URL'] = oidcapp.conf.get('valid_url')
+                cmd_env['INVALID_OIDC_URL'] = oidcapp.conf.get('badformat_url')
+                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = oidcapp.conf.get(
+                    'expired_url')
+
             else:
                 os.write(
                     fd, ('enable.sasl.oauthbearer.unsecure.jwt=true\n'.encode(

--- a/tests/interactive_broker_version.py
+++ b/tests/interactive_broker_version.py
@@ -43,8 +43,8 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
 
     cluster = Cluster('LibrdkafkaTestCluster', root_path, debug=debug)
 
-    if args.conf.get('oauthbearer_method') == 'OIDC':
-        oidcapp = OauthbearerOIDCApp(cluster)
+    if conf.get('sasl_oauthbearer_method') == 'OIDC':
+        oidc = OauthbearerOIDCApp(cluster)
 
     # Enable SSL if desired
     if 'SSL' in conf.get('security.protocol', ''):
@@ -104,7 +104,7 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 break
         elif mech == 'OAUTHBEARER':
             security_protocol = 'SASL_PLAINTEXT'
-            if defconf.get('oauthbearer_method') == 'OIDC':
+            if defconf.get('sasl_oauthbearer_method') == 'OIDC':
                 os.write(
                     fd, ('sasl.oauthbearer.method=OIDC\n'.encode(
                          'ascii')))
@@ -122,9 +122,9 @@ def test_version(version, cmd=None, deploy=True, conf={}, debug=False,
                 os.write(
                     fd, ('sasl.oauthbearer.scope=test\n'.encode(
                          'ascii')))
-                cmd_env['VALID_OIDC_URL'] = oidcapp.conf.get('valid_url')
-                cmd_env['INVALID_OIDC_URL'] = oidcapp.conf.get('badformat_url')
-                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = oidcapp.conf.get(
+                cmd_env['VALID_OIDC_URL'] = oidc.conf.get('valid_url')
+                cmd_env['INVALID_OIDC_URL'] = oidc.conf.get('badformat_url')
+                cmd_env['EXPIRED_TOKEN_OIDC_URL'] = oidc.conf.get(
                     'expired_url')
 
             else:
@@ -313,7 +313,7 @@ if __name__ == '__main__':
         help='SASL mechanism (PLAIN, SCRAM-SHA-nnn, GSSAPI, OAUTHBEARER)')
     parser.add_argument(
         '--oauthbearer-method',
-        dest='oauthbearer_method',
+        dest='sasl_oauthbearer_method',
         type=str,
         default=None,
         help='OAUTHBEARER/OIDC method (DEFAULT, OIDC), \
@@ -339,14 +339,15 @@ if __name__ == '__main__':
             args.conf['sasl_users'] = 'testuser=testpass'
         args.conf['sasl_mechanisms'] = args.sasl
     retcode = 0
-    if args.oauthbearer_method:
-        if args.oauthbearer_method == "OIDC" and \
+    if args.sasl_oauthbearer_method:
+        if args.sasl_oauthbearer_method == "OIDC" and \
            args.conf['sasl_mechanisms'] != 'OAUTHBEARER':
             print('If config `--oauthbearer-method=OIDC`, '
                   '`--sasl` must be set to `OAUTHBEARER`')
             retcode = 3
             sys.exit(retcode)
-        args.conf['oauthbearer_method'] = args.oauthbearer_method
+        args.conf['sasl_oauthbearer_method'] = \
+            args.sasl_oauthbearer_method
 
     args.conf.get('conf', list()).append("log.retention.bytes=1000000000")
 

--- a/tests/sasl_test.py
+++ b/tests/sasl_test.py
@@ -121,6 +121,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-sasl', action='store_false', dest='sasl',
                         default=True,
                         help='Don\'t run SASL tests')
+    parser.add_argument('--no-oidc', action='store_false', dest='oidc',
+                        default=True,
+                        help='Don\'t run OAuth/OIDC tests')
     parser.add_argument('--no-plaintext', action='store_false',
                         dest='plaintext', default=True,
                         help='Don\'t run PLAINTEXT tests')
@@ -172,6 +175,13 @@ if __name__ == '__main__':
     sasl_oauthbearer_conf = {'sasl_mechanisms': 'OAUTHBEARER',
                              'sasl_oauthbearer_config':
                              'scope=requiredScope principal=admin'}
+    sasl_oauth_oidc_conf = {'sasl_mechanisms': 'OAUTHBEARER',
+                            'sasl.oauthbearer.method': 'OIDC',
+                            'sasl.oauthbearer.client.id': 'abc123',
+                            'sasl.oauthbearer.client.secret': 'S3cr3t!',
+                            'sasl.oauthbearer.scope': 'test',
+                            'sasl.oauthbearer.extensions': 'ExtensionworkloadIdentity=develC348S,\
+                                Extensioncluster=lkc123'}
     sasl_kerberos_conf = {'sasl_mechanisms': 'GSSAPI',
                           'sasl_servicename': 'kafka'}
     suites = [{'name': 'SASL PLAIN',
@@ -211,6 +221,11 @@ if __name__ == '__main__':
                'rdkconf': {'sasl_oauthbearer_config': 'scope=wrongScope'},
                'tests': ['0001'],
                'expect_fail': ['all']},
+              {'name': 'OAuth/OIDC',
+               'run': args.oidc,
+               'tests': ['0126'],
+               'conf': sasl_oauth_oidc_conf,
+               'expect_fail': ['2.1.0', '0.10.2.0', '0.9.0.1', '0.8.2.2']},
               {'name': 'SASL Kerberos',
                'run': args.sasl,
                'conf': sasl_kerberos_conf,

--- a/tests/sasl_test.py
+++ b/tests/sasl_test.py
@@ -176,12 +176,8 @@ if __name__ == '__main__':
                              'sasl_oauthbearer_config':
                              'scope=requiredScope principal=admin'}
     sasl_oauth_oidc_conf = {'sasl_mechanisms': 'OAUTHBEARER',
-                            'sasl.oauthbearer.method': 'OIDC',
-                            'sasl.oauthbearer.client.id': 'abc123',
-                            'sasl.oauthbearer.client.secret': 'S3cr3t!',
-                            'sasl.oauthbearer.scope': 'test',
-                            'sasl.oauthbearer.extensions': 'ExtensionworkloadIdentity=develC348S,\
-                                Extensioncluster=lkc123'}
+                            'sasl_oauthbearer_method': 'OIDC',
+                            }
     sasl_kerberos_conf = {'sasl_mechanisms': 'GSSAPI',
                           'sasl_servicename': 'kafka'}
     suites = [{'name': 'SASL PLAIN',
@@ -223,9 +219,10 @@ if __name__ == '__main__':
                'expect_fail': ['all']},
               {'name': 'OAuth/OIDC',
                'run': args.oidc,
-               'tests': ['0126'],
+               'tests': ['0001', '0126'],
                'conf': sasl_oauth_oidc_conf,
-               'expect_fail': ['2.1.0', '0.10.2.0', '0.9.0.1', '0.8.2.2']},
+               'expect_fail': ['2.8.1', '2.1.0', '0.10.2.0',
+                               '0.9.0.1', '0.8.2.2']},
               {'name': 'SASL Kerberos',
                'run': args.sasl,
                'conf': sasl_kerberos_conf,

--- a/tests/sasl_test.py
+++ b/tests/sasl_test.py
@@ -176,8 +176,7 @@ if __name__ == '__main__':
                              'sasl_oauthbearer_config':
                              'scope=requiredScope principal=admin'}
     sasl_oauth_oidc_conf = {'sasl_mechanisms': 'OAUTHBEARER',
-                            'sasl_oauthbearer_method': 'OIDC',
-                            }
+                            'sasl_oauthbearer_method': 'OIDC'}
     sasl_kerberos_conf = {'sasl_mechanisms': 'GSSAPI',
                           'sasl_servicename': 'kafka'}
     suites = [{'name': 'SASL PLAIN',


### PR DESCRIPTION
Integration test for OAuth/OIDC with AK 3.1.0.

This one has dependency on https://github.com/edenhill/trivup/pull/13, since the OauthbearerOIDCApp is not merged yet, so the build failure is expected.

Local test:
1) 
```
./sasl_test.py 3.1.0
#### Version 3.1.0, suite OAuth/OIDC: STARTING
[2022-02-01 17:31:01.344881] KafkaBrokerApp-3: Failed to set RLIMIT_NOFILE(9223372036854775807,9223372036854775807): current limit exceeds maximum limit
[2022-02-01 17:31:01.351036] KafkaBrokerApp-4: Failed to set RLIMIT_NOFILE(9223372036854775807,9223372036854775807): current limit exceeds maximum limit
[2022-02-01 17:31:01.358083] KafkaBrokerApp-5: Failed to set RLIMIT_NOFILE(9223372036854775807,9223372036854775807): current limit exceeds maximum limit
# Connect to cluster with bootstrap.servers PLAINTEXT://localhost:52993,PLAINTEXT://localhost:52997,PLAINTEXT://localhost:53001
# librdkafka regression tests started, logs in /Users/jliu/Documents/Code/jliunyu/librdkafka/tests/tmp/LibrdkafkaTestCluster/43765461/LibrdkafkaTestApp/8ecae6be
#### Version 3.1.0, suite OAuth/OIDC: PASSED: All 1/1 tests passed as expected
#### Test output: /Users/jliu/Documents/Code/jliunyu/librdkafka/tests/tmp/LibrdkafkaTestCluster/43765461/LibrdkafkaTestApp/8ecae6be/stderr.log
#### Full test suite report (1 suite(s))
PASSED  OAuth/OIDC @ 3.1.0                                : All 1/1 tests passed as expected
#### 1 suites PASSED, 0 suites FAILED
```
2) 
./sasl_test.py
#### Version 3.1.0, suite SASL_SSL PLAIN: FAILED: 72/75 tests passed: expected all to pass
The 3 failed tests are not related, same failure without my change:
FAILED   --> 0052_msg_timestamps 
FAILED   --> 0077_compaction 
FAILED   --> 0113_cooperative_rebalance


AppVeyor build failure is download error which is not related.
