### PR TITLE
Handle absent log.queue gracefully in rd_kafka_set_log_queue

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3404,7 +3404,8 @@ void rd_kafka_queue_forward(rd_kafka_queue_t *src, rd_kafka_queue_t *dst);
  *
  * @remark librdkafka maintains its own reference to the provided queue.
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or an error code on error.
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or an error code on error,
+ * eg RD_KAFKA_RESP_ERR__NOT_CONFIGURED when log.queue is not set to true.
  */
 RD_EXPORT
 rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -769,6 +769,10 @@ rd_kafka_queue_t *rd_kafka_queue_get_background(rd_kafka_t *rk) {
 rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
                                            rd_kafka_queue_t *rkqu) {
         rd_kafka_q_t *rkq;
+
+        if (!rk->rk_logq)
+                return RD_KAFKA_RESP_ERR__NOT_CONFIGURED;
+
         if (!rkqu)
                 rkq = rk->rk_rep;
         else

--- a/tests/0039-event.c
+++ b/tests/0039-event.c
@@ -190,7 +190,7 @@ int main_0039_event_log(int argc, char **argv) {
         /* Create kafka instance */
         rk     = test_create_handle(RD_KAFKA_PRODUCER, conf);
         eventq = rd_kafka_queue_get_main(rk);
-        rd_kafka_set_log_queue(rk, eventq);
+        TEST_CALL_ERR__(rd_kafka_set_log_queue(rk, eventq));
 
         while (waitevent) {
                 /* reset ctx */


### PR DESCRIPTION
To address issue #3664