### PR TITLE
Fix rkbuf_rkb assert on malformed JoinGroupResponse.metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ librdkafka v1.9.0 is a feature release:
    the parsed fetch response is truncated (which is a valid case).
    This should speed up the message fetch rate in case of maximum sized
    fetch responses.
+ * Fix consumer crash (`assert: rkbuf->rkbuf_rkb`) when parsing
+   malformed JoinGroupResponse consumer group metadata state.
 
 
 # librdkafka v1.8.2

--- a/src/rdkafka_buf.c
+++ b/src/rdkafka_buf.c
@@ -184,6 +184,9 @@ rd_kafka_buf_t *rd_kafka_buf_new_request0(rd_kafka_broker_t *rkb,
  * @remark \p free_cb (possibly NULL) will be used to free \p ptr when
  *         buffer refcount reaches 0.
  * @remark the buffer may only be read from, not written to.
+ *
+ * @warning If the caller has log_decode_errors > 0 then it must set up
+ *          \c rkbuf->rkbuf_rkb to a refcnt-increased broker object.
  */
 rd_kafka_buf_t *
 rd_kafka_buf_new_shadow(const void *ptr, size_t size, void (*free_cb)(void *)) {

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -286,7 +286,10 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
         void (*rkbuf_free_make_opaque_cb)(void *); /**< Free function for
                                                     *   rkbuf_make_opaque. */
 
-        struct rd_kafka_broker_s *rkbuf_rkb;
+        struct rd_kafka_broker_s *rkbuf_rkb; /**< Optional broker object
+                                              *   with refcnt increased used
+                                              *   for logging decode errors
+                                              *   if log_decode_errors is > 0 */
 
         rd_refcnt_t rkbuf_refcnt;
         void *rkbuf_opaque;
@@ -409,8 +412,7 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
 
 #define rd_kafka_buf_parse_fail(rkbuf, ...)                                    \
         do {                                                                   \
-                if (log_decode_errors > 0) {                                   \
-                        rd_kafka_assert(NULL, rkbuf->rkbuf_rkb);               \
+                if (log_decode_errors > 0 && rkbuf->rkbuf_rkb) {               \
                         rd_rkb_log(                                            \
                             rkbuf->rkbuf_rkb, log_decode_errors, "PROTOERR",   \
                             "Protocol parse failure for %s v%hd%s "            \
@@ -437,8 +439,7 @@ struct rd_kafka_buf_s { /* rd_kafka_buf_t */
  */
 #define rd_kafka_buf_underflow_fail(rkbuf, wantedlen, ...)                     \
         do {                                                                   \
-                if (log_decode_errors > 0) {                                   \
-                        rd_kafka_assert(NULL, rkbuf->rkbuf_rkb);               \
+                if (log_decode_errors > 0 && rkbuf->rkbuf_rkb) {               \
                         char __tmpstr[256];                                    \
                         rd_snprintf(__tmpstr, sizeof(__tmpstr),                \
                                     ": " __VA_ARGS__);                         \

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -1773,6 +1773,10 @@ static int rd_kafka_group_MemberMetadata_consumer_read(
         rkbuf = rd_kafka_buf_new_shadow(
             MemberMetadata->data, RD_KAFKAP_BYTES_LEN(MemberMetadata), NULL);
 
+        /* Protocol parser needs a broker handle to log errors on. */
+        rkbuf->rkbuf_rkb = rkb;
+        rd_kafka_broker_keep(rkb);
+
         rd_kafka_buf_read_i16(rkbuf, &Version);
         rd_kafka_buf_read_i32(rkbuf, &subscription_cnt);
 

--- a/tests/0129-fetch_aborted_msgs.c
+++ b/tests/0129-fetch_aborted_msgs.c
@@ -44,8 +44,8 @@
 int main_0129_fetch_aborted_msgs(int argc, char **argv) {
         rd_kafka_t *rk;
         rd_kafka_conf_t *conf;
-        const char *topic = test_mk_topic_name("0129_fetch_aborted_msgs", 1);
-        const int msgcnt  = 1000;
+        const char *topic    = test_mk_topic_name("0129_fetch_aborted_msgs", 1);
+        const int msgcnt     = 1000;
         const size_t msgsize = 1000;
 
         test_conf_init(&conf, NULL, 30);
@@ -57,10 +57,9 @@ int main_0129_fetch_aborted_msgs(int argc, char **argv) {
         rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
 
         test_admin_create_topic(rk, topic, 1, 1,
-                                (const char *[]){
-                                        "max.message.bytes", "10000",
-                                                "segment.bytes", "20000",
-                                                NULL });
+                                (const char *[]) {"max.message.bytes", "10000",
+                                                  "segment.bytes", "20000",
+                                                  NULL});
 
         TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, -1));
         TEST_CALL_ERROR__(rd_kafka_begin_transaction(rk));


### PR DESCRIPTION
https://github.com/confluentinc/confluent-kafka-go/issues/650