### PR TITLE
Save one superfluous message timeout toppar scan

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4008,6 +4008,7 @@ static void rd_kafka_broker_producer_serve(rd_kafka_broker_t *rkb,
                (abs_timeout > (now = rd_clock()))) {
                 rd_bool_t do_timeout_scan;
                 rd_ts_t next_wakeup = abs_timeout;
+                int overshoot;
 
                 rd_kafka_broker_unlock(rkb);
 
@@ -4015,9 +4016,8 @@ static void rd_kafka_broker_producer_serve(rd_kafka_broker_t *rkb,
                  * on each state change, to make sure messages in
                  * partition rktp_xmit_msgq are timed out before
                  * being attempted to re-transmit. */
-                do_timeout_scan =
-                    cnt++ == 0 ||
-                    rd_interval(&timeout_scan, 1000 * 1000, now) >= 0;
+                overshoot = rd_interval(&timeout_scan, 1000 * 1000, now);
+                do_timeout_scan = cnt++ == 0 || overshoot >= 0;
 
                 rd_kafka_broker_produce_toppars(rkb, now, &next_wakeup,
                                                 do_timeout_scan);


### PR DESCRIPTION
C short-circuit evaluation seems to cobble the message timeout scanning condition in `rd_kafka_broker_producer_serve` such that instead of first iteration only (as intended according to adjacent code comment) you get a timeout in the first and second, so typically two scans instead of one

The side effect appears to have been introduced in 8af1b39 and getting rid of it is a minor optimisation, but consideration worthy for high-partition count topics