### PR TITLE
Update to fedora:35 to fix the CentOS 8 build

### DIFF
--- a/packaging/rpm/mock-on-docker.sh
+++ b/packaging/rpm/mock-on-docker.sh
@@ -10,8 +10,8 @@
 
 set -ex
 
-_DOCKER_IMAGE=fedora:33
-_MOCK_CONFIGS="epel-7-x86_64 epel-8-x86_64"
+_DOCKER_IMAGE=fedora:35
+_MOCK_CONFIGS="centos+epel-7-x86_64 centos-stream+epel-8-x86_64"
 
 if [[ $1 == "--build" ]]; then
     on_builder=1


### PR DESCRIPTION
mock epel-8-x86_64 is now broken in fedora:33:
https://bugzilla.redhat.com/show_bug.cgi?id=2049024

Update to fedora:35 with mock configs:
centos+epel-7-x86_64
centos-stream+epel-8-x86_64