### PR TITLE
fix: acl binding enum checks

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7651,7 +7651,7 @@ RD_EXPORT void rd_kafka_AclBinding_destroy(rd_kafka_AclBinding_t *acl_binding);
  */
 RD_EXPORT void
 rd_kafka_AclBinding_destroy_array(rd_kafka_AclBinding_t **acl_bindings,
-                                   size_t acl_bindings_cnt);
+                                  size_t acl_bindings_cnt);
 
 /**
  * @brief Get an array of acl results from a CreateAcls result.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7643,6 +7643,16 @@ rd_kafka_AclBinding_error(const rd_kafka_AclBinding_t *acl);
  */
 RD_EXPORT void rd_kafka_AclBinding_destroy(rd_kafka_AclBinding_t *acl_binding);
 
+
+/**
+ * @brief Helper function to destroy all AclBinding objects in
+ *        the \p acl_bindings array (of \p acl_bindings_cnt elements).
+ *        The array itself is not freed.
+ */
+RD_EXPORT void
+rd_kafka_AclBinding_destroy_array(rd_kafka_AclBinding_t **acl_bindings,
+                                   size_t acl_bindings_cnt);
+
 /**
  * @brief Get an array of acl results from a CreateAcls result.
  *

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -4229,6 +4229,14 @@ static void rd_kafka_AclBinding_free(void *ptr) {
         rd_kafka_AclBinding_destroy(ptr);
 }
 
+
+void rd_kafka_AclBinding_destroy_array(rd_kafka_AclBinding_t **acl_bindings,
+                                       size_t acl_bindings_cnt) {
+        size_t i;
+        for (i = 0; i < acl_bindings_cnt; i++)
+                rd_kafka_AclBinding_destroy(acl_bindings[i]);
+}
+
 /**
  * @brief Parse CreateAclsResponse and create ADMIN_RESULT op.
  */

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -4366,7 +4366,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                                     char *errstr,
                                     size_t errstr_size) {
         const int log_decode_errors = LOG_ERR;
-        rd_kafka_broker_t *rkb      = rko_req->rko_rk->rk_internal_rkb;
+        rd_kafka_broker_t *rkb      = reply->rkbuf_rkb;
         rd_kafka_resp_err_t err     = RD_KAFKA_RESP_ERR_NO_ERROR;
         rd_kafka_op_t *rko_result   = NULL;
         int32_t res_cnt;
@@ -4414,7 +4414,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
 
                 if (res_type <= RD_KAFKA_RESOURCE_UNKNOWN ||
                     res_type >= RD_KAFKA_RESOURCE__CNT) {
-                        rd_rkb_log(rkb, LOG_WARNING, "DESCRIBEACLRESPONSE",
+                        rd_rkb_log(rkb, LOG_WARNING, "DESCRIBEACLSRESPONSE",
                                    "DescribeAclsResponse returned unknown "
                                    "resource type %d",
                                    res_type);
@@ -4424,7 +4424,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         RD_KAFKA_RESOURCE_PATTERN_UNKNOWN ||
                     resource_pattern_type >=
                         RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT) {
-                        rd_rkb_log(rkb, LOG_WARNING, "DESCRIBEACLRESPONSE",
+                        rd_rkb_log(rkb, LOG_WARNING, "DESCRIBEACLSRESPONSE",
                                    "DescribeAclsResponse returned unknown "
                                    "resource pattern type %d",
                                    resource_pattern_type);
@@ -4438,8 +4438,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                 for (j = 0; j < (int)acl_cnt; j++) {
                         rd_kafkap_str_t kprincipal;
                         rd_kafkap_str_t khost;
-                        int8_t operation =
-                            RD_KAFKA_ACL_OPERATION_UNKNOWN;
+                        int8_t operation = RD_KAFKA_ACL_OPERATION_UNKNOWN;
                         int8_t permission_type =
                             RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
                         char *principal;
@@ -4455,7 +4454,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         if (operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
                             operation >= RD_KAFKA_ACL_OPERATION__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DESCRIBEACLRESPONSE",
+                                           "DESCRIBEACLSRESPONSE",
                                            "DescribeAclsResponse returned "
                                            "unknown acl operation %d",
                                            operation);
@@ -4466,7 +4465,7 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                             permission_type >=
                                 RD_KAFKA_ACL_PERMISSION_TYPE__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DESCRIBEACLRESPONSE",
+                                           "DESCRIBEACLSRESPONSE",
                                            "DescribeAclsResponse returned "
                                            "unknown acl permission type %d",
                                            permission_type);
@@ -4617,7 +4616,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                                   char *errstr,
                                   size_t errstr_size) {
         const int log_decode_errors = LOG_ERR;
-        rd_kafka_broker_t *rkb      = rko_req->rko_rk->rk_internal_rkb;
+        rd_kafka_broker_t *rkb      = reply->rkbuf_rkb;
         rd_kafka_op_t *rko_result   = NULL;
         rd_kafka_resp_err_t err     = RD_KAFKA_RESP_ERR_NO_ERROR;
         int32_t res_cnt;
@@ -4659,8 +4658,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                 rd_kafka_buf_read_arraycnt(reply, &matching_acls_cnt, 100000);
                 for (j = 0; j < (int)matching_acls_cnt; j++) {
                         int16_t acl_error_code;
-                        int8_t res_type =
-                            RD_KAFKA_RESOURCE_UNKNOWN;
+                        int8_t res_type = RD_KAFKA_RESOURCE_UNKNOWN;
                         rd_kafkap_str_t acl_error_msg =
                             RD_KAFKAP_STR_INITIALIZER;
                         rd_kafkap_str_t kres_name;
@@ -4668,8 +4666,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafkap_str_t kprincipal;
                         int8_t resource_pattern_type =
                             RD_KAFKA_RESOURCE_PATTERN_LITERAL;
-                        int8_t operation =
-                            RD_KAFKA_ACL_OPERATION_UNKNOWN;
+                        int8_t operation = RD_KAFKA_ACL_OPERATION_UNKNOWN;
                         int8_t permission_type =
                             RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
                         rd_kafka_AclBinding_t *matching_acl;
@@ -4709,7 +4706,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                         if (res_type <= RD_KAFKA_RESOURCE_UNKNOWN ||
                             res_type >= RD_KAFKA_RESOURCE__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DELETEACLRESPONSE",
+                                           "DELETEACLSRESPONSE",
                                            "DeleteAclsResponse returned "
                                            "unknown resource type %d",
                                            res_type);
@@ -4720,7 +4717,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                             resource_pattern_type >=
                                 RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DELETEACLRESPONSE",
+                                           "DELETEACLSRESPONSE",
                                            "DeleteAclsResponse returned "
                                            "unknown resource pattern type %d",
                                            resource_pattern_type);
@@ -4730,7 +4727,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                         if (operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
                             operation >= RD_KAFKA_ACL_OPERATION__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DELETEACLRESPONSE",
+                                           "DELETEACLSRESPONSE",
                                            "DeleteAclsResponse returned "
                                            "unknown acl operation %d",
                                            operation);
@@ -4741,7 +4738,7 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                             permission_type >=
                                 RD_KAFKA_ACL_PERMISSION_TYPE__CNT) {
                                 rd_rkb_log(rkb, LOG_WARNING,
-                                           "DELETEACLRESPONSE",
+                                           "DELETEACLSRESPONSE",
                                            "DeleteAclsResponse returned "
                                            "unknown acl permission type %d",
                                            permission_type);

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -4397,10 +4397,10 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                      rd_kafka_AclBinding_free);
 
         for (i = 0; i < (int)res_cnt; i++) {
-                rd_kafka_ResourceType_t res_type = RD_KAFKA_RESOURCE_UNKNOWN;
+                int8_t res_type = RD_KAFKA_RESOURCE_UNKNOWN;
                 rd_kafkap_str_t kres_name;
                 char *res_name;
-                rd_kafka_ResourcePatternType_t resource_pattern_type =
+                int8_t resource_pattern_type =
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL;
                 int32_t acl_cnt;
 
@@ -4438,9 +4438,9 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                 for (j = 0; j < (int)acl_cnt; j++) {
                         rd_kafkap_str_t kprincipal;
                         rd_kafkap_str_t khost;
-                        rd_kafka_AclOperation_t operation =
+                        int8_t operation =
                             RD_KAFKA_ACL_OPERATION_UNKNOWN;
-                        rd_kafka_AclPermissionType_t permission_type =
+                        int8_t permission_type =
                             RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
                         char *principal;
                         char *host;
@@ -4658,19 +4658,19 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                 /* #maching_acls */
                 rd_kafka_buf_read_arraycnt(reply, &matching_acls_cnt, 100000);
                 for (j = 0; j < (int)matching_acls_cnt; j++) {
-                        rd_kafka_resp_err_t acl_error_code;
-                        rd_kafka_ResourceType_t res_type =
+                        int16_t acl_error_code;
+                        int8_t res_type =
                             RD_KAFKA_RESOURCE_UNKNOWN;
                         rd_kafkap_str_t acl_error_msg =
                             RD_KAFKAP_STR_INITIALIZER;
                         rd_kafkap_str_t kres_name;
                         rd_kafkap_str_t khost;
                         rd_kafkap_str_t kprincipal;
-                        rd_kafka_ResourcePatternType_t resource_pattern_type =
+                        int8_t resource_pattern_type =
                             RD_KAFKA_RESOURCE_PATTERN_LITERAL;
-                        rd_kafka_AclOperation_t operation =
+                        int8_t operation =
                             RD_KAFKA_ACL_OPERATION_UNKNOWN;
-                        rd_kafka_AclPermissionType_t permission_type =
+                        int8_t permission_type =
                             RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
                         rd_kafka_AclBinding_t *matching_acl;
                         char *acl_errstr = NULL;

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -4071,6 +4071,36 @@ rd_kafka_AclBinding_new(rd_kafka_ResourceType_t restype,
                 return NULL;
         }
 
+        if (restype == RD_KAFKA_RESOURCE_ANY ||
+            restype <= RD_KAFKA_RESOURCE_UNKNOWN ||
+            restype >= RD_KAFKA_RESOURCE__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid resource type");
+                return NULL;
+        }
+
+        if (resource_pattern_type == RD_KAFKA_RESOURCE_PATTERN_ANY ||
+            resource_pattern_type == RD_KAFKA_RESOURCE_PATTERN_MATCH ||
+            resource_pattern_type <= RD_KAFKA_RESOURCE_PATTERN_UNKNOWN ||
+            resource_pattern_type >= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT) {
+                rd_snprintf(errstr, errstr_size,
+                            "Invalid resource pattern type");
+                return NULL;
+        }
+
+        if (operation == RD_KAFKA_ACL_OPERATION_ANY ||
+            operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
+            operation >= RD_KAFKA_ACL_OPERATION__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid operation");
+                return NULL;
+        }
+
+        if (permission_type == RD_KAFKA_ACL_PERMISSION_TYPE_ANY ||
+            permission_type <= RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN ||
+            permission_type >= RD_KAFKA_ACL_PERMISSION_TYPE__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid permission type");
+                return NULL;
+        }
+
         return rd_kafka_AclBinding_new0(
             restype, name, resource_pattern_type, principal, host, operation,
             permission_type, RD_KAFKA_RESP_ERR_NO_ERROR, NULL);
@@ -4086,6 +4116,33 @@ rd_kafka_AclBindingFilter_t *rd_kafka_AclBindingFilter_new(
     rd_kafka_AclPermissionType_t permission_type,
     char *errstr,
     size_t errstr_size) {
+
+
+        if (restype <= RD_KAFKA_RESOURCE_UNKNOWN ||
+            restype >= RD_KAFKA_RESOURCE__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid resource type");
+                return NULL;
+        }
+
+        if (resource_pattern_type <= RD_KAFKA_RESOURCE_PATTERN_UNKNOWN ||
+            resource_pattern_type >= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT) {
+                rd_snprintf(errstr, errstr_size,
+                            "Invalid resource pattern type");
+                return NULL;
+        }
+
+        if (operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
+            operation >= RD_KAFKA_ACL_OPERATION__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid operation");
+                return NULL;
+        }
+
+        if (permission_type <= RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN ||
+            permission_type >= RD_KAFKA_ACL_PERMISSION_TYPE__CNT) {
+                rd_snprintf(errstr, errstr_size, "Invalid permission type");
+                return NULL;
+        }
+
         return rd_kafka_AclBinding_new0(
             restype, name, resource_pattern_type, principal, host, operation,
             permission_type, RD_KAFKA_RESP_ERR_NO_ERROR, NULL);
@@ -4346,6 +4403,16 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_i8(reply, &resource_pattern_type);
                 }
 
+                if (res_type <= RD_KAFKA_RESOURCE_UNKNOWN ||
+                    res_type >= RD_KAFKA_RESOURCE__CNT)
+                        res_type = RD_KAFKA_RESOURCE_UNKNOWN;
+                if (resource_pattern_type <=
+                        RD_KAFKA_RESOURCE_PATTERN_UNKNOWN ||
+                    resource_pattern_type >=
+                        RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT)
+                        resource_pattern_type =
+                            RD_KAFKA_RESOURCE_PATTERN_UNKNOWN;
+
                 /* #resources */
                 rd_kafka_buf_read_arraycnt(reply, &acl_cnt, 100000);
 
@@ -4365,6 +4432,16 @@ rd_kafka_DescribeAclsResponse_parse(rd_kafka_op_t *rko_req,
                         rd_kafka_buf_read_i8(reply, &permission_type);
                         RD_KAFKAP_STR_DUPA(&principal, &kprincipal);
                         RD_KAFKAP_STR_DUPA(&host, &khost);
+
+                        if (operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
+                            operation >= RD_KAFKA_ACL_OPERATION__CNT)
+                                operation = RD_KAFKA_ACL_OPERATION_UNKNOWN;
+                        if (permission_type <=
+                                RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN ||
+                            permission_type >=
+                                RD_KAFKA_ACL_PERMISSION_TYPE__CNT)
+                                permission_type =
+                                    RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
 
                         acl = rd_kafka_AclBinding_new(
                             res_type, res_name, resource_pattern_type,
@@ -4595,6 +4672,25 @@ rd_kafka_DeleteAclsResponse_parse(rd_kafka_op_t *rko_req,
                         RD_KAFKAP_STR_DUPA(&res_name, &kres_name);
                         RD_KAFKAP_STR_DUPA(&principal, &kprincipal);
                         RD_KAFKAP_STR_DUPA(&host, &khost);
+
+                        if (res_type <= RD_KAFKA_RESOURCE_UNKNOWN ||
+                            res_type >= RD_KAFKA_RESOURCE__CNT)
+                                res_type = RD_KAFKA_RESOURCE_UNKNOWN;
+                        if (resource_pattern_type <=
+                                RD_KAFKA_RESOURCE_PATTERN_UNKNOWN ||
+                            resource_pattern_type >=
+                                RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT)
+                                resource_pattern_type =
+                                    RD_KAFKA_RESOURCE_PATTERN_UNKNOWN;
+                        if (operation <= RD_KAFKA_ACL_OPERATION_UNKNOWN ||
+                            operation >= RD_KAFKA_ACL_OPERATION__CNT)
+                                operation = RD_KAFKA_ACL_OPERATION_UNKNOWN;
+                        if (permission_type <=
+                                RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN ||
+                            permission_type >=
+                                RD_KAFKA_ACL_PERMISSION_TYPE__CNT)
+                                permission_type =
+                                    RD_KAFKA_ACL_PERMISSION_TYPE_UNKNOWN;
 
                         matching_acl = rd_kafka_AclBinding_new0(
                             res_type, res_name, resource_pattern_type,

--- a/tests/0080-admin_ut.c
+++ b/tests/0080-admin_ut.c
@@ -718,43 +718,49 @@ static void do_test_AclBinding() {
         const char *principal = "User:test";
         const char *host      = "*";
 
-        SUB_TEST_QUICK("AclBinding");
+        SUB_TEST_QUICK();
 
         // Valid acl binding
+        *errstr = '\0';
         new_acl = rd_kafka_AclBinding_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(new_acl, "expected AclBinding");
         rd_kafka_AclBinding_destroy(new_acl);
 
+        *errstr = '\0';
         new_acl = rd_kafka_AclBinding_new(
             RD_KAFKA_RESOURCE_TOPIC, NULL, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid resource name"),
                     "expected error string \"Invalid resource name\", not %s",
                     errstr);
+
+        *errstr = '\0';
         new_acl = rd_kafka_AclBinding_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             NULL, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid principal"),
                     "expected error string \"Invalid principal\", not %s",
                     errstr);
+
+        *errstr = '\0';
         new_acl = rd_kafka_AclBinding_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, NULL, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid host"),
                     "expected error string \"Invalid host\", not %s", errstr);
 
         for (i = -1; i <= RD_KAFKA_RESOURCE__CNT; i++) {
-                errstr[0] = 0;
-                new_acl   = rd_kafka_AclBinding_new(
+                *errstr = '\0';
+                new_acl = rd_kafka_AclBinding_new(
                     i, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal,
                     host, RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_resource_types[i]) {
                         TEST_ASSERT(new_acl, "expected AclBinding");
                         rd_kafka_AclBinding_destroy(new_acl);
@@ -767,11 +773,11 @@ static void do_test_AclBinding() {
                             errstr);
         }
         for (i = -1; i <= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT; i++) {
-                errstr[0] = 0;
-                new_acl   = rd_kafka_AclBinding_new(
+                *errstr = '\0';
+                new_acl = rd_kafka_AclBinding_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic, i, principal, host,
                     RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_resource_pattern_types[i]) {
                         TEST_ASSERT(new_acl, "expected AclBinding");
                         rd_kafka_AclBinding_destroy(new_acl);
@@ -785,11 +791,11 @@ static void do_test_AclBinding() {
                             errstr);
         }
         for (i = -1; i <= RD_KAFKA_ACL_OPERATION__CNT; i++) {
-                errstr[0] = 0;
-                new_acl   = rd_kafka_AclBinding_new(
+                *errstr = '\0';
+                new_acl = rd_kafka_AclBinding_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host, i,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_acl_operation[i]) {
                         TEST_ASSERT(new_acl, "expected AclBinding");
                         rd_kafka_AclBinding_destroy(new_acl);
@@ -801,11 +807,11 @@ static void do_test_AclBinding() {
                                     errstr);
         }
         for (i = -1; i <= RD_KAFKA_ACL_PERMISSION_TYPE__CNT; i++) {
-                errstr[0] = 0;
-                new_acl   = rd_kafka_AclBinding_new(
+                *errstr = '\0';
+                new_acl = rd_kafka_AclBinding_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
-                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, 512);
+                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, sizeof(errstr));
                 if (i >= 0 && valid_acl_permission_type[i]) {
                         TEST_ASSERT(new_acl, "expected AclBinding");
                         rd_kafka_AclBinding_destroy(new_acl);
@@ -844,43 +850,47 @@ static void do_test_AclBindingFilter() {
         const char *principal = "User:test";
         const char *host      = "*";
 
-        SUB_TEST_QUICK("AclBindingFilter");
+        SUB_TEST_QUICK();
 
         // Valid acl binding
+        *errstr        = '\0';
         new_acl_filter = rd_kafka_AclBindingFilter_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
         rd_kafka_AclBinding_destroy(new_acl_filter);
 
+        *errstr        = '\0';
         new_acl_filter = rd_kafka_AclBindingFilter_new(
             RD_KAFKA_RESOURCE_TOPIC, NULL, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
         rd_kafka_AclBinding_destroy(new_acl_filter);
 
+        *errstr        = '\0';
         new_acl_filter = rd_kafka_AclBindingFilter_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             NULL, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
         rd_kafka_AclBinding_destroy(new_acl_filter);
 
+        *errstr        = '\0';
         new_acl_filter = rd_kafka_AclBindingFilter_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
             principal, NULL, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
         rd_kafka_AclBinding_destroy(new_acl_filter);
 
         for (i = -1; i <= RD_KAFKA_RESOURCE__CNT; i++) {
-                errstr[0]      = 0;
+                *errstr        = '\0';
                 new_acl_filter = rd_kafka_AclBindingFilter_new(
                     i, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal,
                     host, RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_resource_types[i]) {
                         TEST_ASSERT(new_acl_filter,
                                     "expected AclBindingFilter");
@@ -894,11 +904,11 @@ static void do_test_AclBindingFilter() {
                             errstr);
         }
         for (i = -1; i <= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT; i++) {
-                errstr[0]      = 0;
+                *errstr        = '\0';
                 new_acl_filter = rd_kafka_AclBindingFilter_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic, i, principal, host,
                     RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_resource_pattern_types[i]) {
                         TEST_ASSERT(new_acl_filter,
                                     "expected AclBindingFilter");
@@ -913,11 +923,11 @@ static void do_test_AclBindingFilter() {
                             errstr);
         }
         for (i = -1; i <= RD_KAFKA_ACL_OPERATION__CNT; i++) {
-                errstr[0]      = 0;
+                *errstr        = '\0';
                 new_acl_filter = rd_kafka_AclBindingFilter_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host, i,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
                 if (i >= 0 && valid_acl_operation[i]) {
                         TEST_ASSERT(new_acl_filter,
                                     "expected AclBindingFilter");
@@ -930,11 +940,11 @@ static void do_test_AclBindingFilter() {
                                     errstr);
         }
         for (i = -1; i <= RD_KAFKA_ACL_PERMISSION_TYPE__CNT; i++) {
-                errstr[0]      = 0;
+                *errstr        = '\0';
                 new_acl_filter = rd_kafka_AclBindingFilter_new(
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
-                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, 512);
+                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, sizeof(errstr));
                 if (i >= 0 && valid_acl_permission_type[i]) {
                         TEST_ASSERT(new_acl_filter,
                                     "expected AclBindingFilter");
@@ -994,7 +1004,7 @@ static void do_test_CreateAcls(const char *what,
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
                     RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         }
 
         if (with_options) {
@@ -1107,7 +1117,7 @@ static void do_test_DescribeAcls(const char *what,
         describe_acls     = rd_kafka_AclBindingFilter_new(
             RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_PREFIXED,
             principal, host, RD_KAFKA_ACL_OPERATION_ALL,
-            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
 
         if (with_options) {
                 options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ANY);
@@ -1222,7 +1232,7 @@ static void do_test_DeleteAcls(const char *what,
                     RD_KAFKA_RESOURCE_TOPIC, topic,
                     RD_KAFKA_RESOURCE_PATTERN_PREFIXED, principal, host,
                     RD_KAFKA_ACL_OPERATION_ALL,
-                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, sizeof(errstr));
         }
 
         if (with_options) {

--- a/tests/0080-admin_ut.c
+++ b/tests/0080-admin_ut.c
@@ -694,6 +694,610 @@ static void do_test_DeleteConsumerGroupOffsets(const char *what,
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief AclBinding tests
+ *
+ *
+ *
+ */
+static void do_test_AclBinding() {
+        int i;
+        char errstr[512];
+        rd_kafka_AclBinding_t *new_acl;
+
+        rd_bool_t valid_resource_types[]         = {rd_false, rd_false, rd_true,
+                                            rd_true,  rd_true,  rd_false};
+        rd_bool_t valid_resource_pattern_types[] = {
+            rd_false, rd_false, rd_false, rd_true, rd_true, rd_false};
+        rd_bool_t valid_acl_operation[] = {
+            rd_false, rd_false, rd_true, rd_true, rd_true, rd_true, rd_true,
+            rd_true,  rd_true,  rd_true, rd_true, rd_true, rd_true, rd_false};
+        rd_bool_t valid_acl_permission_type[] = {rd_false, rd_false, rd_true,
+                                                 rd_true, rd_false};
+        const char *topic     = test_mk_topic_name(__FUNCTION__, 1);
+        const char *principal = "User:test";
+        const char *host      = "*";
+
+        SUB_TEST_QUICK("AclBinding");
+
+        // Valid acl binding
+        new_acl = rd_kafka_AclBinding_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(new_acl, "expected AclBinding");
+        rd_kafka_AclBinding_destroy(new_acl);
+
+        new_acl = rd_kafka_AclBinding_new(
+            RD_KAFKA_RESOURCE_TOPIC, NULL, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid resource name"),
+                    "expected error string \"Invalid resource name\", not %s",
+                    errstr);
+        new_acl = rd_kafka_AclBinding_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            NULL, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid principal"),
+                    "expected error string \"Invalid principal\", not %s",
+                    errstr);
+        new_acl = rd_kafka_AclBinding_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, NULL, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(!new_acl && !strcmp(errstr, "Invalid host"),
+                    "expected error string \"Invalid host\", not %s", errstr);
+
+        for (i = -1; i <= RD_KAFKA_RESOURCE__CNT; i++) {
+                errstr[0] = 0;
+                new_acl   = rd_kafka_AclBinding_new(
+                    i, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal,
+                    host, RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_resource_types[i]) {
+                        TEST_ASSERT(new_acl, "expected AclBinding");
+                        rd_kafka_AclBinding_destroy(new_acl);
+                } else
+                        TEST_ASSERT(
+                            !new_acl &&
+                                !strcmp(errstr, "Invalid resource type"),
+                            "expected error string \"Invalid resource type\", "
+                            "not %s",
+                            errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT; i++) {
+                errstr[0] = 0;
+                new_acl   = rd_kafka_AclBinding_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic, i, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_resource_pattern_types[i]) {
+                        TEST_ASSERT(new_acl, "expected AclBinding");
+                        rd_kafka_AclBinding_destroy(new_acl);
+                } else
+                        TEST_ASSERT(
+                            !new_acl &&
+                                !strcmp(errstr,
+                                        "Invalid resource pattern type"),
+                            "expected error string \"Invalid resource pattern "
+                            "type\", not %s",
+                            errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_ACL_OPERATION__CNT; i++) {
+                errstr[0] = 0;
+                new_acl   = rd_kafka_AclBinding_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host, i,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_acl_operation[i]) {
+                        TEST_ASSERT(new_acl, "expected AclBinding");
+                        rd_kafka_AclBinding_destroy(new_acl);
+                } else
+                        TEST_ASSERT(!new_acl &&
+                                        !strcmp(errstr, "Invalid operation"),
+                                    "expected error string \"Invalid "
+                                    "operation\", not %s",
+                                    errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_ACL_PERMISSION_TYPE__CNT; i++) {
+                errstr[0] = 0;
+                new_acl   = rd_kafka_AclBinding_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, 512);
+                if (i >= 0 && valid_acl_permission_type[i]) {
+                        TEST_ASSERT(new_acl, "expected AclBinding");
+                        rd_kafka_AclBinding_destroy(new_acl);
+                } else
+                        TEST_ASSERT(
+                            !new_acl &&
+                                !strcmp(errstr, "Invalid permission type"),
+                            "expected error string \"permission type\", not %s",
+                            errstr);
+        }
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief AclBindingFilter tests
+ *
+ *
+ *
+ */
+static void do_test_AclBindingFilter() {
+        int i;
+        char errstr[512];
+        rd_kafka_AclBindingFilter_t *new_acl_filter;
+
+        rd_bool_t valid_resource_types[]         = {rd_false, rd_true, rd_true,
+                                            rd_true,  rd_true, rd_false};
+        rd_bool_t valid_resource_pattern_types[] = {
+            rd_false, rd_true, rd_true, rd_true, rd_true, rd_false};
+        rd_bool_t valid_acl_operation[] = {
+            rd_false, rd_true, rd_true, rd_true, rd_true, rd_true, rd_true,
+            rd_true,  rd_true, rd_true, rd_true, rd_true, rd_true, rd_false};
+        rd_bool_t valid_acl_permission_type[] = {rd_false, rd_true, rd_true,
+                                                 rd_true, rd_false};
+        const char *topic     = test_mk_topic_name(__FUNCTION__, 1);
+        const char *principal = "User:test";
+        const char *host      = "*";
+
+        SUB_TEST_QUICK("AclBindingFilter");
+
+        // Valid acl binding
+        new_acl_filter = rd_kafka_AclBindingFilter_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
+        rd_kafka_AclBinding_destroy(new_acl_filter);
+
+        new_acl_filter = rd_kafka_AclBindingFilter_new(
+            RD_KAFKA_RESOURCE_TOPIC, NULL, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
+        rd_kafka_AclBinding_destroy(new_acl_filter);
+
+        new_acl_filter = rd_kafka_AclBindingFilter_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            NULL, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
+        rd_kafka_AclBinding_destroy(new_acl_filter);
+
+        new_acl_filter = rd_kafka_AclBindingFilter_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL,
+            principal, NULL, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        TEST_ASSERT(new_acl_filter, "expected AclBindingFilter");
+        rd_kafka_AclBinding_destroy(new_acl_filter);
+
+        for (i = -1; i <= RD_KAFKA_RESOURCE__CNT; i++) {
+                errstr[0]      = 0;
+                new_acl_filter = rd_kafka_AclBindingFilter_new(
+                    i, topic, RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal,
+                    host, RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_resource_types[i]) {
+                        TEST_ASSERT(new_acl_filter,
+                                    "expected AclBindingFilter");
+                        rd_kafka_AclBinding_destroy(new_acl_filter);
+                } else
+                        TEST_ASSERT(
+                            !new_acl_filter &&
+                                !strcmp(errstr, "Invalid resource type"),
+                            "expected error string \"Invalid resource type\", "
+                            "not %s",
+                            errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_RESOURCE_PATTERN_TYPE__CNT; i++) {
+                errstr[0]      = 0;
+                new_acl_filter = rd_kafka_AclBindingFilter_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic, i, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_resource_pattern_types[i]) {
+                        TEST_ASSERT(new_acl_filter,
+                                    "expected AclBindingFilter");
+                        rd_kafka_AclBinding_destroy(new_acl_filter);
+                } else
+                        TEST_ASSERT(
+                            !new_acl_filter &&
+                                !strcmp(errstr,
+                                        "Invalid resource pattern type"),
+                            "expected error string \"Invalid resource pattern "
+                            "type\", not %s",
+                            errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_ACL_OPERATION__CNT; i++) {
+                errstr[0]      = 0;
+                new_acl_filter = rd_kafka_AclBindingFilter_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host, i,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+                if (i >= 0 && valid_acl_operation[i]) {
+                        TEST_ASSERT(new_acl_filter,
+                                    "expected AclBindingFilter");
+                        rd_kafka_AclBinding_destroy(new_acl_filter);
+                } else
+                        TEST_ASSERT(!new_acl_filter &&
+                                        !strcmp(errstr, "Invalid operation"),
+                                    "expected error string \"Invalid "
+                                    "operation\", not %s",
+                                    errstr);
+        }
+        for (i = -1; i <= RD_KAFKA_ACL_PERMISSION_TYPE__CNT; i++) {
+                errstr[0]      = 0;
+                new_acl_filter = rd_kafka_AclBindingFilter_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL, i, errstr, 512);
+                if (i >= 0 && valid_acl_permission_type[i]) {
+                        TEST_ASSERT(new_acl_filter,
+                                    "expected AclBindingFilter");
+                        rd_kafka_AclBinding_destroy(new_acl_filter);
+                } else
+                        TEST_ASSERT(
+                            !new_acl_filter &&
+                                !strcmp(errstr, "Invalid permission type"),
+                            "expected error string \"permission type\", not %s",
+                            errstr);
+        }
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief CreateAcls tests
+ *
+ *
+ *
+ */
+static void do_test_CreateAcls(const char *what,
+                               rd_kafka_t *rk,
+                               rd_kafka_queue_t *useq,
+                               rd_bool_t with_background_event_cb,
+                               rd_bool_t with_options) {
+        rd_kafka_queue_t *q;
+#define MY_NEW_ACLS_CNT 2
+        rd_kafka_AclBinding_t *new_acls[MY_NEW_ACLS_CNT];
+        rd_kafka_AdminOptions_t *options = NULL;
+        int exp_timeout                  = MY_SOCKET_TIMEOUT_MS;
+        int i;
+        char errstr[512];
+        const char *errstr2;
+        rd_kafka_resp_err_t err;
+        test_timing_t timing;
+        rd_kafka_event_t *rkev;
+        const rd_kafka_CreateAcls_result_t *res;
+        const rd_kafka_acl_result_t **resacls;
+        size_t resacls_cnt;
+        void *my_opaque       = NULL, *opaque;
+        const char *principal = "User:test";
+        const char *host      = "*";
+
+        SUB_TEST_QUICK("%s CreaetAcls with %s, timeout %dms", rd_kafka_name(rk),
+                       what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        /**
+         * Construct AclBinding array
+         */
+        for (i = 0; i < MY_NEW_ACLS_CNT; i++) {
+                const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+                new_acls[i]       = rd_kafka_AclBinding_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_LITERAL, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        }
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ANY);
+
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+                err         = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+                my_opaque = (void *)123;
+                rd_kafka_AdminOptions_set_opaque(options, my_opaque);
+        }
+
+        TIMING_START(&timing, "CreateAcls");
+        TEST_SAY("Call CreateAcls, timeout is %dms\n", exp_timeout);
+        rd_kafka_CreateAcls(rk, new_acls, MY_NEW_ACLS_CNT, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        if (with_background_event_cb) {
+                /* Result event will be triggered by callback from
+                 * librdkafka background queue thread. */
+                TIMING_START(&timing, "CreateAcls.wait_background_event_cb");
+                rkev = wait_background_event_cb();
+        } else {
+                /* Poll result queue */
+                TIMING_START(&timing, "CreateAcls.queue_poll");
+                rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        }
+
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("CreateAcls: got %s in %.3fs\n", rd_kafka_event_name(rkev),
+                 TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Convert event to proper result */
+        res = rd_kafka_event_CreateAcls_result(rkev);
+        TEST_ASSERT(res, "expected CreateAcls_result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        opaque = rd_kafka_event_opaque(rkev);
+        TEST_ASSERT(opaque == my_opaque, "expected opaque to be %p, not %p",
+                    my_opaque, opaque);
+
+        /* Expecting error */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected CreateAcls to return error %s, not %s (%s)",
+                    rd_kafka_err2str(RD_KAFKA_RESP_ERR__TIMED_OUT),
+                    rd_kafka_err2str(err), err ? errstr2 : "n/a");
+
+        /* Attempt to extract acls results anyway, should return NULL. */
+        resacls = rd_kafka_CreateAcls_result_acls(res, &resacls_cnt);
+        TEST_ASSERT(!resacls && resacls_cnt == 0,
+                    "expected no acl result, got %p cnt %" PRIusz, resacls,
+                    resacls_cnt);
+
+        rd_kafka_event_destroy(rkev);
+
+        rd_kafka_AclBinding_destroy_array(new_acls, MY_NEW_ACLS_CNT);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+#undef MY_NEW_ACLS_CNT
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief DescribeAcls tests
+ *
+ *
+ *
+ */
+static void do_test_DescribeAcls(const char *what,
+                                 rd_kafka_t *rk,
+                                 rd_kafka_queue_t *useq,
+                                 rd_bool_t with_background_event_cb,
+                                 rd_bool_t with_options) {
+        rd_kafka_queue_t *q;
+        rd_kafka_AclBindingFilter_t *describe_acls;
+        rd_kafka_AdminOptions_t *options = NULL;
+        int exp_timeout                  = MY_SOCKET_TIMEOUT_MS;
+        char errstr[512];
+        const char *errstr2;
+        rd_kafka_resp_err_t err;
+        test_timing_t timing;
+        rd_kafka_event_t *rkev;
+        const rd_kafka_DescribeAcls_result_t *res;
+        const rd_kafka_AclBinding_t **res_acls;
+        size_t res_acls_cnt;
+        void *my_opaque       = NULL, *opaque;
+        const char *principal = "User:test";
+        const char *host      = "*";
+
+        SUB_TEST_QUICK("%s DescribeAcls with %s, timeout %dms",
+                       rd_kafka_name(rk), what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        /**
+         * Construct AclBindingFilter
+         */
+        const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+        describe_acls     = rd_kafka_AclBindingFilter_new(
+            RD_KAFKA_RESOURCE_TOPIC, topic, RD_KAFKA_RESOURCE_PATTERN_PREFIXED,
+            principal, host, RD_KAFKA_ACL_OPERATION_ALL,
+            RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ANY);
+
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+                err         = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+                my_opaque = (void *)123;
+                rd_kafka_AdminOptions_set_opaque(options, my_opaque);
+        }
+
+        TIMING_START(&timing, "DescribeAcls");
+        TEST_SAY("Call DescribeAcls, timeout is %dms\n", exp_timeout);
+        rd_kafka_DescribeAcls(rk, describe_acls, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        if (with_background_event_cb) {
+                /* Result event will be triggered by callback from
+                 * librdkafka background queue thread. */
+                TIMING_START(&timing, "DescribeAcls.wait_background_event_cb");
+                rkev = wait_background_event_cb();
+        } else {
+                /* Poll result queue */
+                TIMING_START(&timing, "DescribeAcls.queue_poll");
+                rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        }
+
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("DescribeAcls: got %s in %.3fs\n", rd_kafka_event_name(rkev),
+                 TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Convert event to proper result */
+        res = rd_kafka_event_DescribeAcls_result(rkev);
+        TEST_ASSERT(res, "expected DescribeAcls_result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        opaque = rd_kafka_event_opaque(rkev);
+        TEST_ASSERT(opaque == my_opaque, "expected opaque to be %p, not %p",
+                    my_opaque, opaque);
+
+        /* Expecting error */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected DescribeAcls to return error %s, not %s (%s)",
+                    rd_kafka_err2str(RD_KAFKA_RESP_ERR__TIMED_OUT),
+                    rd_kafka_err2str(err), err ? errstr2 : "n/a");
+
+        /* Attempt to extract result acls anyway, should return NULL. */
+        res_acls = rd_kafka_DescribeAcls_result_acls(res, &res_acls_cnt);
+        TEST_ASSERT(!res_acls && res_acls_cnt == 0,
+                    "expected no result acls, got %p cnt %" PRIusz, res_acls,
+                    res_acls_cnt);
+
+        rd_kafka_event_destroy(rkev);
+
+        rd_kafka_AclBinding_destroy(describe_acls);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief DeleteAcls tests
+ *
+ *
+ *
+ */
+static void do_test_DeleteAcls(const char *what,
+                               rd_kafka_t *rk,
+                               rd_kafka_queue_t *useq,
+                               rd_bool_t with_background_event_cb,
+                               rd_bool_t with_options) {
+#define DELETE_ACLS_FILTERS_CNT 2
+        rd_kafka_queue_t *q;
+        rd_kafka_AclBindingFilter_t *delete_acls[DELETE_ACLS_FILTERS_CNT];
+        rd_kafka_AdminOptions_t *options = NULL;
+        int exp_timeout                  = MY_SOCKET_TIMEOUT_MS;
+        int i;
+        char errstr[512];
+        const char *errstr2;
+        rd_kafka_resp_err_t err;
+        test_timing_t timing;
+        rd_kafka_event_t *rkev;
+        const rd_kafka_DeleteAcls_result_t *res;
+        const rd_kafka_DeleteAcls_result_response_t **res_response;
+        size_t res_response_cnt;
+        void *my_opaque       = NULL, *opaque;
+        const char *principal = "User:test";
+        const char *host      = "*";
+
+        SUB_TEST_QUICK("%s DeleteAcls with %s, timeout %dms", rd_kafka_name(rk),
+                       what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        /**
+         * Construct AclBindingFilter array
+         */
+        for (i = 0; i < DELETE_ACLS_FILTERS_CNT; i++) {
+                const char *topic = test_mk_topic_name(__FUNCTION__, 1);
+                delete_acls[i]    = rd_kafka_AclBindingFilter_new(
+                    RD_KAFKA_RESOURCE_TOPIC, topic,
+                    RD_KAFKA_RESOURCE_PATTERN_PREFIXED, principal, host,
+                    RD_KAFKA_ACL_OPERATION_ALL,
+                    RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW, errstr, 512);
+        }
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ANY);
+
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+                err         = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+                my_opaque = (void *)123;
+                rd_kafka_AdminOptions_set_opaque(options, my_opaque);
+        }
+
+        TIMING_START(&timing, "DeleteAcls");
+        TEST_SAY("Call DeleteAcls, timeout is %dms\n", exp_timeout);
+        rd_kafka_DeleteAcls(rk, delete_acls, DELETE_ACLS_FILTERS_CNT, options,
+                            q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        if (with_background_event_cb) {
+                /* Result event will be triggered by callback from
+                 * librdkafka background queue thread. */
+                TIMING_START(&timing, "DeleteAcls.wait_background_event_cb");
+                rkev = wait_background_event_cb();
+        } else {
+                /* Poll result queue */
+                TIMING_START(&timing, "DeleteAcls.queue_poll");
+                rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        }
+
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("DeleteAcls: got %s in %.3fs\n", rd_kafka_event_name(rkev),
+                 TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Convert event to proper result */
+        res = rd_kafka_event_DeleteAcls_result(rkev);
+        TEST_ASSERT(res, "expected DeleteAcls_result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        opaque = rd_kafka_event_opaque(rkev);
+        TEST_ASSERT(opaque == my_opaque, "expected opaque to be %p, not %p",
+                    my_opaque, opaque);
+
+        /* Expecting error */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected DeleteAcls to return error %s, not %s (%s)",
+                    rd_kafka_err2str(RD_KAFKA_RESP_ERR__TIMED_OUT),
+                    rd_kafka_err2str(err), err ? errstr2 : "n/a");
+
+        /* Attempt to extract result responses anyway, should return NULL. */
+        res_response =
+            rd_kafka_DeleteAcls_result_responses(res, &res_response_cnt);
+        TEST_ASSERT(!res_response && res_response_cnt == 0,
+                    "expected no result response, got %p cnt %" PRIusz,
+                    res_response, res_response_cnt);
+
+        rd_kafka_event_destroy(rkev);
+
+        rd_kafka_AclBinding_destroy_array(delete_acls, DELETE_ACLS_FILTERS_CNT);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+#undef DELETE_ACLS_FILTERS_CNT
+
+        SUB_TEST_PASS();
+}
+
 
 
 /**
@@ -946,11 +1550,14 @@ static void do_test_options(rd_kafka_t *rk) {
                     RD_KAFKA_ADMIN_OP_DELETEGROUPS,                            \
                     RD_KAFKA_ADMIN_OP_DELETERECORDS,                           \
                     RD_KAFKA_ADMIN_OP_DELETECONSUMERGROUPOFFSETS,              \
+                    RD_KAFKA_ADMIN_OP_CREATEACLS,                              \
+                    RD_KAFKA_ADMIN_OP_DESCRIBEACLS,                            \
+                    RD_KAFKA_ADMIN_OP_DELETEACLS,                              \
                     RD_KAFKA_ADMIN_OP_ANY /* Must be last */                   \
         }
         struct {
                 const char *setter;
-                const rd_kafka_admin_op_t valid_apis[9];
+                const rd_kafka_admin_op_t valid_apis[12];
         } matrix[] = {
             {"request_timeout", _all_apis},
             {"operation_timeout",
@@ -1120,6 +1727,26 @@ static void do_test_apis(rd_kafka_type_t cltype) {
                                            0);
         do_test_DeleteConsumerGroupOffsets("temp queue, options", rk, NULL, 1);
         do_test_DeleteConsumerGroupOffsets("main queue, options", rk, mainq, 1);
+
+        do_test_AclBinding();
+        do_test_AclBindingFilter();
+
+        do_test_CreateAcls("temp queue, no options", rk, NULL, rd_false,
+                           rd_false);
+        do_test_CreateAcls("temp queue, options", rk, NULL, rd_false, rd_true);
+        do_test_CreateAcls("main queue, options", rk, mainq, rd_false, rd_true);
+
+        do_test_DescribeAcls("temp queue, no options", rk, NULL, rd_false,
+                             rd_false);
+        do_test_DescribeAcls("temp queue, options", rk, NULL, rd_false,
+                             rd_true);
+        do_test_DescribeAcls("main queue, options", rk, mainq, rd_false,
+                             rd_true);
+
+        do_test_DeleteAcls("temp queue, no options", rk, NULL, rd_false,
+                           rd_false);
+        do_test_DeleteAcls("temp queue, options", rk, NULL, rd_false, rd_true);
+        do_test_DeleteAcls("main queue, options", rk, mainq, rd_false, rd_true);
 
         do_test_mix(rk, mainq);
 

--- a/tests/0081-admin.c
+++ b/tests/0081-admin.c
@@ -1201,9 +1201,7 @@ do_test_CreateAcls(rd_kafka_t *rk, rd_kafka_queue_t *useq, int version) {
 
         rd_kafka_AdminOptions_destroy(admin_options);
         rd_kafka_event_destroy(rkev_acl_create);
-        rd_kafka_AclBinding_destroy(acl_bindings[0]);
-        rd_kafka_AclBinding_destroy(acl_bindings[1]);
-
+        rd_kafka_AclBinding_destroy_array(acl_bindings, 2);
         if (!useq)
                 rd_kafka_queue_destroy(q);
 
@@ -1534,8 +1532,7 @@ do_test_DescribeAcls(rd_kafka_t *rk, rd_kafka_queue_t *useq, int version) {
         rd_kafka_AclBinding_destroy(acl_bindings_describe);
         rd_kafka_event_destroy(rkev_acl_describe);
         rd_kafka_AdminOptions_destroy(admin_options);
-        rd_kafka_AclBinding_destroy(acl_bindings_create[0]);
-        rd_kafka_AclBinding_destroy(acl_bindings_create[1]);
+        rd_kafka_AclBinding_destroy_array(acl_bindings_create, 2);
 
         if (!useq)
                 rd_kafka_queue_destroy(q);
@@ -1892,9 +1889,7 @@ do_test_DeleteAcls(rd_kafka_t *rk, rd_kafka_queue_t *useq, int version) {
         rd_kafka_event_destroy(rkev_acl_delete);
         rd_kafka_AdminOptions_destroy(admin_options_delete);
 
-        rd_kafka_AclBinding_destroy(acl_bindings_create[0]);
-        rd_kafka_AclBinding_destroy(acl_bindings_create[1]);
-        rd_kafka_AclBinding_destroy(acl_bindings_create[2]);
+        rd_kafka_AclBinding_destroy_array(acl_bindings_create, 3);
 
         if (!useq)
                 rd_kafka_queue_destroy(q);


### PR DESCRIPTION
If some kinds of enums like ANY or MATCH are passed when creating an AclBinding, an error should be given before calling the CreateAcls operation on the Kafka broker, in order to return a better explaination, because in these cases it returns an "unknown error". Also when a different value is returned from a future version of Kafka that value is mapped to UNKNOWN.

The ACL binding destroy array function is added too