### PR TITLE
Combine message timeout drain bumps

### DIFF
--- a/tests/0094-idempotence_msg_timeout.c
+++ b/tests/0094-idempotence_msg_timeout.c
@@ -185,6 +185,9 @@ static void do_test_produce_timeout(const char *topic, const int msgrate) {
 
         test_flush(rk, 3 * 5000);
 
+        TEST_ASSERT(counters.dr_fail, "no delivery reports with error: "
+                    "timeout not detected?");
+
         TEST_SAY("%d/%d messages produced, %d delivered, %d failed\n",
                  msgcounter, msgcnt, counters.dr_ok, counters.dr_fail);
 


### PR DESCRIPTION
Amend #2163

Issue an idempotent producer drain-bump only once per entire scanning cycle rather than for each toppar

Passes test number 94 (idempotence msg timeout) extended to spot absence of detected timeouts