### PR TITLE
cmake: Use CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ configure_file("packaging/cmake/config.h.in" "${GENERATED_DIR}/config.h")
 
 include(GNUInstallDirs)
 
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 


### PR DESCRIPTION
this ensures that it is portable across platforms e.g. ppc64/linux
uses lib64 not lib

Signed-off-by: Khem Raj <raj.khem@gmail.com>