### PR TITLE
fix: Incorrect stored offset will be use after rebalanced

### DIFF
--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -824,7 +824,12 @@ rd_kafka_handle_OffsetFetch (rd_kafka_t *rk,
 				/* Update toppar's committed offset */
 				rd_kafka_toppar_lock(rktp);
 				rktp->rktp_committed_offset = rktpar->offset;
-                                /** Update toppar's stored offset to INVALID, issue #3745 */
+
+                                /* Update toppar's stored offset to INVALID.
+                                 * Reset the stored offset in rebalanced,
+                                 * so that it will not commit previous stored offset to broker, (issue #3745, #3710).
+                                 * And the codes in rdkafka_assignment.c -> rd_kafka_assignment_serve_removals() -> rd_kafka_offset_store0(rktp, RD_KAFKA_OFFSET_INVALID,RD_DONT_LOCK);
+                                 * can not fix the incorrect offset completely. */
                                 rktp->rktp_stored_offset = RD_KAFKA_OFFSET_INVALID;
 				rd_kafka_toppar_unlock(rktp);
 			}

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -824,6 +824,8 @@ rd_kafka_handle_OffsetFetch (rd_kafka_t *rk,
 				/* Update toppar's committed offset */
 				rd_kafka_toppar_lock(rktp);
 				rktp->rktp_committed_offset = rktpar->offset;
+                                /** Update toppar's stored offset to INVALID, issue #3745 */
+                                rktp->rktp_stored_offset = RD_KAFKA_OFFSET_INVALID;
 				rd_kafka_toppar_unlock(rktp);
 			}
 


### PR DESCRIPTION
Reset the stored offset in rebalanced, so that it will not commit previous stored offset to broker, (issue #3745, #3710).
And the codes in `rdkafka_assignment.c` -> `rd_kafka_assignment_serve_removals()` -> `rd_kafka_offset_store0(rktp, RD_KAFKA_OFFSET_INVALID,RD_DONT_LOCK);` can not fix the incorrect offset completely.