### PR TITLE
Make dynamic MinGW build copy DLLs instead of trying to manipulate PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ matrix:
     - ./configure --install-deps --source-deps-only --disable-lz4-ext --prefix="$PWD/dest" --enable-static --enable-strip
 
  - name: "Windows MinGW-w64 Dynamic"
-   if: tag IS PRESENT
    os: windows
    env:
     - LINKAGE=std

--- a/packaging/mingw-w64/configure-build-msys2-mingw.sh
+++ b/packaging/mingw-w64/configure-build-msys2-mingw.sh
@@ -19,6 +19,7 @@ cmake \
 $mingw64 mingw32-make
 $mingw64 mingw32-make install
 
-export PATH="$PWD/dest/bin:/mingw64/bin/:${PATH}"
 cd tests
+cp ../dest/bin/librdkafka.dll ./
+cp ../dest/bin/librdkafka++.dll ./
 ./test-runner.exe -l -Q -p1 0000


### PR DESCRIPTION
My stab at fixing the issues highlighted in the #3607 chat recently. When running locally, the two librdkafka DLLs were the only issue. Copying the DLLs to the same folder as the EXE is a much more common practice on Windows than adding the folder the DLLs live in to PATH, so I'm giving this a shot.