### PR TITLE
fix compilation error (minor)

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -4394,7 +4394,7 @@ const char *rd_kafka_version_str(void) {
         if (*LIBRDKAFKA_GIT_VERSION) {
                 of = rd_snprintf(ret, sizeof(ret), "%s",
                                  *LIBRDKAFKA_GIT_VERSION == 'v'
-                                     ? LIBRDKAFKA_GIT_VERSION + 1
+                                     ? &LIBRDKAFKA_GIT_VERSION[1]
                                      : LIBRDKAFKA_GIT_VERSION);
                 if (of > sizeof(ret))
                         of = sizeof(ret);


### PR DESCRIPTION
`rdkafka.c:4381:63: error: adding 'int' to a string does not append to`