### PR TITLE
fix undefined behaviour in config parsing

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -2863,7 +2863,7 @@ static size_t rd_kafka_conf_flags2str(char *dest,
 
         /* Phase 1: scan for set flags, accumulate needed size.
          * Phase 2: write to dest */
-        for (j = 0; prop->s2i[j].str; j++) {
+        for (j = 0; j < (int)RD_ARRAYSIZE(prop->s2i) && prop->s2i[j].str; j++) {
                 if (prop->type == _RK_C_S2F && ival != -1 &&
                     (ival & prop->s2i[j].val) != prop->s2i[j].val)
                         continue;


### PR DESCRIPTION
Undefined behaviour error:
```
rdkafka_conf.c:2866:21: runtime error: index 20 out of bounds for type 'struct (anonymous struct at rdkafka_conf.c:87:9) const[20]'
```