### PR TITLE
Allow any form of unassign*() during consumer close

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -6,6 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          sudo apt update
           sudo apt install -y python3 python3-pip python3-setuptools libcurl4-openssl-dev libssl-dev libsasl2-dev
           python3 -m pip install -r tests/requirements.txt
       - run: |
@@ -24,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          sudo apt update
           sudo apt install -y python3 python3-pip python3-setuptools clang-format
           python3 -m pip install -r packaging/tools/requirements.txt
       - name: Style checker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ librdkafka v1.9.0 is a feature release:
    If there is more than one eligible strategy, preference is determined by the
    configured order of strategies. The partitions are assigned to group members according
    to the strategy order preference now. (#3818)
+ * Any form of unassign*() (absolute or incremental) is now allowed during
+   consumer close rebalancing and they're all treated as absolute unassigns.
+   (@kevinconaway)
 
 
 ### Producer fixes

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -4703,29 +4703,8 @@ static void rd_kafka_cgrp_handle_assign_op(rd_kafka_cgrp_t *rkcg,
                                            rd_kafka_op_t *rko) {
         rd_kafka_error_t *error = NULL;
 
-        if (rd_kafka_cgrp_rebalance_protocol(rkcg) ==
-                RD_KAFKA_REBALANCE_PROTOCOL_COOPERATIVE &&
-            !(rko->rko_u.assign.method == RD_KAFKA_ASSIGN_METHOD_INCR_ASSIGN ||
-              rko->rko_u.assign.method == RD_KAFKA_ASSIGN_METHOD_INCR_UNASSIGN))
-                error = rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                           "Changes to the current assignment "
-                                           "must be made using "
-                                           "incremental_assign() or "
-                                           "incremental_unassign() "
-                                           "when rebalance protocol type is "
-                                           "COOPERATIVE");
-
-        else if (rd_kafka_cgrp_rebalance_protocol(rkcg) ==
-                     RD_KAFKA_REBALANCE_PROTOCOL_EAGER &&
-                 !(rko->rko_u.assign.method == RD_KAFKA_ASSIGN_METHOD_ASSIGN))
-                error = rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                           "Changes to the current assignment "
-                                           "must be made using "
-                                           "assign() when rebalance "
-                                           "protocol type is EAGER");
-
-        else if (rd_kafka_fatal_error_code(rkcg->rkcg_rk) ||
-                 rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
+        if (rd_kafka_fatal_error_code(rkcg->rkcg_rk) ||
+            rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
                 /* Treat all assignments as unassign when a fatal error is
                  * raised or the cgrp is terminating. */
 
@@ -4744,7 +4723,29 @@ static void rd_kafka_cgrp_handle_assign_op(rd_kafka_cgrp_t *rkcg,
                         rko->rko_u.assign.partitions = NULL;
                 }
                 rko->rko_u.assign.method = RD_KAFKA_ASSIGN_METHOD_ASSIGN;
-        }
+
+        } else if (rd_kafka_cgrp_rebalance_protocol(rkcg) ==
+                       RD_KAFKA_REBALANCE_PROTOCOL_COOPERATIVE &&
+                   !(rko->rko_u.assign.method ==
+                         RD_KAFKA_ASSIGN_METHOD_INCR_ASSIGN ||
+                     rko->rko_u.assign.method ==
+                         RD_KAFKA_ASSIGN_METHOD_INCR_UNASSIGN))
+                error = rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                           "Changes to the current assignment "
+                                           "must be made using "
+                                           "incremental_assign() or "
+                                           "incremental_unassign() "
+                                           "when rebalance protocol type is "
+                                           "COOPERATIVE");
+
+        else if (rd_kafka_cgrp_rebalance_protocol(rkcg) ==
+                     RD_KAFKA_REBALANCE_PROTOCOL_EAGER &&
+                 !(rko->rko_u.assign.method == RD_KAFKA_ASSIGN_METHOD_ASSIGN))
+                error = rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                           "Changes to the current assignment "
+                                           "must be made using "
+                                           "assign() when rebalance "
+                                           "protocol type is EAGER");
 
         if (!error) {
                 switch (rko->rko_u.assign.method) {


### PR DESCRIPTION

https://github.com/confluentinc/confluent-kafka-go/issues/767#issuecomment-1107465737