### PR TITLE
Fix librdkafka-static.a generation

### DIFF
--- a/configure.self
+++ b/configure.self
@@ -146,6 +146,10 @@ void foo (void) {
         # SASL OAUTHBEARER's default unsecured JWS implementation
         # requires base64 encoding from OpenSSL
         mkl_allvar_set WITH_SASL_OAUTHBEARER WITH_SASL_OAUTHBEARER y
+
+        if [[ $WITH_CURL == y ]]; then
+            mkl_allvar_set WITH_OAUTHBEARER_OIDC WITH_OAUTHBEARER_OIDC y
+        fi
     fi
 
     # CRC32C: check for crc32 instruction support.

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -108,16 +108,16 @@ $(LIBNAME_LDS):
 $(LIBFILENAME): $(OBJS) $(LIBNAME_LDS)
 	@printf "$(MKL_YELLOW)Creating shared library $@$(MKL_CLR_RESET)\n"
 	$(CC_LD) $(LDFLAGS) $(LIB_LDFLAGS) $(OBJS) -o $@ $(LIBS)
-ifeq ($(WITH_STRIP),y)
 	cp $@ $(LIBFILENAMEDBG)
+ifeq ($(WITH_STRIP),y)
 	$(STRIP) -S $@
 endif
 
 $(LIBNAME).a:	$(OBJS)
 	@printf "$(MKL_YELLOW)Creating static library $@$(MKL_CLR_RESET)\n"
 	$(AR) rcs$(ARFLAGS) $@ $(OBJS)
-ifeq ($(WITH_STRIP),y)
 	cp $@ $(LIBNAME)-dbg.a
+ifeq ($(WITH_STRIP),y)
 	$(STRIP) -S $@
 	$(RANLIB) $@
 endif

--- a/mklove/Makefile.base
+++ b/mklove/Makefile.base
@@ -162,8 +162,14 @@ endif # MKL_DYNAMIC_LIBS
 
 else # MKL_STATIC_LIBS is empty
 _STATIC_FILENAME=$(LIBNAME).a
-$(LIBNAME)-static.a:
-	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: Not creating self-contained static library $@: no static libraries available/enabled$(MKL_CLR_RESET)\n"
+$(LIBNAME)-static.a: $(LIBNAME).a
+	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: No static libraries available/enabled for inclusion in self-contained static library $@: this library will be identical to $(LIBNAME).a$(MKL_CLR_RESET)\n"
+ifneq ($(MKL_DYNAMIC_LIBS),)
+	@printf "$(MKL_RED)WARNING:$(MKL_YELLOW) $@: The following libraries were not available as static libraries and need to be linked dynamically: $(MKL_DYNAMIC_LIBS)$(MKL_CLR_RESET)\n"
+	cp $(LIBNAME).a $@
+	cp $(LIBNAME)-dbg.a $(LIBNAME)-static-dbg.a
+	cp $@ $(LIBNAME)-static-dbg.a
+endif # MKL_DYNAMIC_LIBS
 endif # MKL_STATIC_LIBS
 
 endif # MKL_NO_SELFCONTAINED_STATIC_LIB

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,7 @@ if(WITH_SASL_OAUTHBEARER)
   list(APPEND sources rdkafka_sasl_oauthbearer.c)
 endif()
 
-if(WITH_CURL)
+if(WITH_OAUTHBEARER_OIDC)
   list(APPEND sources rdkafka_sasl_oauthbearer_oidc.c)
 endif()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ SRCS_$(WITH_ZSTD) += rdkafka_zstd.c
 SRCS_$(WITH_HDRHISTOGRAM) += rdhdrhistogram.c
 SRCS_$(WITH_SSL) += rdkafka_ssl.c
 SRCS_$(WITH_CURL) += rdhttp.c
-SRCS_$(WITH_CURL) += rdkafka_sasl_oauthbearer_oidc.c
+SRCS_$(WITH_OAUTHBEARER_OIDC) += rdkafka_sasl_oauthbearer_oidc.c
 
 SRCS_LZ4 = rdxxhash.c
 ifneq ($(WITH_LZ4_EXT), y)

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -54,7 +54,7 @@
 #include "rdkafka_interceptor.h"
 #include "rdkafka_idempotence.h"
 #include "rdkafka_sasl_oauthbearer.h"
-#if WITH_CURL
+#if WITH_OAUTHBEARER_OIDC
 #include "rdkafka_sasl_oauthbearer_oidc.h"
 #endif
 #if WITH_SSL
@@ -2248,13 +2248,14 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                     RD_KAFKA_EVENT_OAUTHBEARER_TOKEN_REFRESH;
 #endif
 
-#if WITH_CURL
+#if WITH_OAUTHBEARER_OIDC
         if (rk->rk_conf.sasl.oauthbearer.method ==
                 RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC &&
             !rk->rk_conf.sasl.oauthbearer.token_refresh_cb)
                 rd_kafka_conf_set_oauthbearer_token_refresh_cb(
                     &rk->rk_conf, rd_kafka_oidc_token_refresh_cb);
 #endif
+
         rk->rk_controllerid = -1;
 
         /* Admin client defaults */

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -170,13 +170,17 @@ struct rd_kafka_property {
 
 #if WITH_CURL
 #define _UNSUPPORTED_HTTP .unsupported = NULL
-#define _UNSUPPORTED_OIDC .unsupported = NULL
 #else
 #define _UNSUPPORTED_HTTP .unsupported = "libcurl not available at build time"
+#endif
+
+#if WITH_OAUTHBEARER_OIDC
+#define _UNSUPPORTED_OIDC .unsupported = NULL
+#else
 #define _UNSUPPORTED_OIDC                                                      \
         .unsupported =                                                         \
-            "OAuth/OIDC depends on libcurl which was not available "           \
-            "at build time"
+            "OAuth/OIDC depends on libcurl and OpenSSL which were not "        \
+            "available at build time"
 #endif
 
 #ifdef _WIN32

--- a/src/rdkafka_sasl_oauthbearer.c
+++ b/src/rdkafka_sasl_oauthbearer.c
@@ -36,7 +36,7 @@
 #include <openssl/evp.h>
 #include "rdunittest.h"
 
-#if WITH_CURL
+#if WITH_OAUTHBEARER_OIDC
 #include "rdkafka_sasl_oauthbearer_oidc.h"
 #endif
 
@@ -1325,7 +1325,7 @@ static int rd_kafka_sasl_oauthbearer_init(rd_kafka_t *rk,
                 handle->callback_q = rd_kafka_q_keep(rk->rk_rep);
         }
 
-#if WITH_CURL
+#if WITH_OAUTHBEARER_OIDC
         if (rk->rk_conf.sasl.oauthbearer.method ==
                 RD_KAFKA_SASL_OAUTHBEARER_METHOD_OIDC &&
             rk->rk_conf.sasl.oauthbearer.token_refresh_cb ==

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -47,7 +47,7 @@
 
 #include "rdsysqueue.h"
 #include "rdkafka_sasl_oauthbearer.h"
-#if WITH_CURL
+#if WITH_OAUTHBEARER_OIDC
 #include "rdkafka_sasl_oauthbearer_oidc.h"
 #endif
 #include "rdkafka_msgset.h"
@@ -422,6 +422,8 @@ extern int unittest_assignors(void);
 extern int unittest_map(void);
 #if WITH_CURL
 extern int unittest_http(void);
+#endif
+#if WITH_OAUTHBEARER_OIDC
 extern int unittest_sasl_oauthbearer_oidc(void);
 #endif
 
@@ -460,6 +462,8 @@ int rd_unittest(void) {
                 {"assignors", unittest_assignors},
 #if WITH_CURL
                 {"http", unittest_http},
+#endif
+#if WITH_OAUTHBEARER_OIDC
                 {"sasl_oauthbearer_oidc", unittest_sasl_oauthbearer_oidc},
 #endif
                 {NULL}

--- a/src/win32_config.h
+++ b/src/win32_config.h
@@ -33,11 +33,12 @@
 #define _RD_WIN32_CONFIG_H_
 
 #ifndef WITHOUT_WIN32_CONFIG
-#define WITH_SSL    1
-#define WITH_ZLIB   1
-#define WITH_SNAPPY 1
-#define WITH_ZSTD   1
-#define WITH_CURL   1
+#define WITH_SSL              1
+#define WITH_ZLIB             1
+#define WITH_SNAPPY           1
+#define WITH_ZSTD             1
+#define WITH_CURL             1
+#define WITH_OAUTHBEARER_OIDC 1
 /* zstd is linked dynamically on Windows, but the dynamic library provides
  * the experimental/advanced API, just as the static builds on *nix */
 #define WITH_ZSTD_STATIC      1


### PR DESCRIPTION
Building RPM packages on CP centos8 builders caused librdkafka-static.a not to be generated because all dependencies were provided by RPMs. But librdkafka-static.a is included in the librdkafka.spec RPM file, so RPM packaging failed.

This PR makes sure librdkafka-static.a is always generated; if there are no dependencies to link statically it will just be identical to librdkafka.a.

.. and some other minor build fixes.