### PR TITLE
Enable OauthBearer support when librdkafka is built with Curl and SSL using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,19 @@ if(WITH_ZLIB)
 endif()
 # }
 
+# CURL {
+find_package(CURL QUIET)
+if(CURL_FOUND)
+  set(with_curl_default ON)
+else()
+  set(with_curl_default OFF)
+endif()
+option(WITH_CURL "With CURL" ${with_curl_default})
+if(WITH_CURL)
+  list(APPEND BUILT_WITH "CURL")
+endif()
+# }
+
 # ZSTD {
 find_package(ZSTD QUIET)
 if(ZSTD_FOUND)
@@ -147,6 +160,10 @@ if(WITH_SASL)
   endif()
 endif()
 # }
+
+if(WITH_SSL AND WITH_CURL)
+    set(WITH_OAUTHBEARER_OIDC ON)
+endif()
 
 # LZ4 {
 option(ENABLE_LZ4_EXT "Enable external LZ4 library support" ON)

--- a/packaging/cmake/Config.cmake.in
+++ b/packaging/cmake/Config.cmake.in
@@ -6,6 +6,10 @@ if(@WITH_ZLIB@)
   find_dependency(ZLIB)
 endif()
 
+if(@WITH_CURL@)
+  find_dependency(CURL)
+endif()
+
 if(@WITH_ZSTD@)
   find_library(ZSTD zstd)
   if(NOT ZSTD)

--- a/packaging/cmake/config.h.in
+++ b/packaging/cmake/config.h.in
@@ -27,6 +27,8 @@
 #cmakedefine01 WITH_PKGCONFIG
 #cmakedefine01 WITH_HDRHISTOGRAM
 #cmakedefine01 WITH_ZLIB
+#cmakedefine01 WITH_CURL
+#cmakedefine01 WITH_OAUTHBEARER_OIDC
 #cmakedefine01 WITH_ZSTD
 #cmakedefine01 WITH_LIBDL
 #cmakedefine01 WITH_PLUGINS


### PR DESCRIPTION
Resolves #3852