### PR TITLE
OpenSSL Engine Certificate Rotation

### DIFF
--- a/src-cpp/HandleImpl.cpp
+++ b/src-cpp/HandleImpl.cpp
@@ -294,6 +294,12 @@ void RdKafka::HandleImpl::set_common_config(const RdKafka::ConfImpl *confimpl) {
     ssl_cert_verify_cb_ = confimpl->ssl_cert_verify_cb_;
   }
 
+  if (confimpl->ssl_cert_refresh_engine_data_cb_) {
+    rd_kafka_conf_set_ssl_cert_refresh_engine_data_cb(
+        confimpl->rk_conf_, RdKafka::ssl_cert_refresh_engine_data_cb_trampoline);
+    ssl_cert_refresh_engine_data_cb_ = confimpl->ssl_cert_refresh_engine_data_cb_;
+  }
+
   if (confimpl->open_cb_) {
 #ifndef _WIN32
     rd_kafka_conf_set_open_cb(confimpl->rk_conf_, RdKafka::open_cb_trampoline);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -2302,6 +2302,21 @@ rd_kafka_conf_res_t rd_kafka_conf_set_ssl_cert_verify_cb(
 
 
 /**
+ * @enum rd_kafka_cert_refresh_engine_data_cb_res_t
+ *
+ * @brief return values from rd_kafka_conf_set_ssl_cert_refresh_engine_data_cb
+ * callback
+ *
+ * @sa rd_kafka_conf_set_ssl_cert_refresh_engine_data_cb
+ */
+typedef enum rd_kafka_cert_refresh_engine_data_cb_res_t {
+  RD_KAFKA_CERT_REFRESH_OK,  /**< Certificate & key written to buffers */
+  RD_KAFKA_CERT_REFRESH_ERR, /**< Error loading certificate/key */
+  RD_KAFKA_CERT_REFRESH_MORE_BUFFER /**< Must be called again with larger buffer */
+} rd_kafka_cert_refresh_engine_data_cb_res_t;
+
+
+/**
  * @enum rd_kafka_cert_type_t
  *
  * @brief SSL certificate type

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -853,6 +853,9 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
     {_RK_GLOBAL, "ssl.certificate.verify_cb", _RK_C_PTR,
      _RK(ssl.cert_verify_cb),
      "Callback to verify the broker certificate chain.", _UNSUPPORTED_SSL},
+    {_RK_GLOBAL, "ssl.certificate.refresh_engine_data_cb", _RK_C_PTR,
+     _RK(ssl.cert_refresh_engine_data_cb),
+     "Callback to fetch a client certificate.", _UNSUPPORTED_OPENSSL_1_1_0},
 
     /* Point user in the right direction if they try to apply
      * Java client SSL / JAAS properties. */
@@ -2782,6 +2785,24 @@ rd_kafka_conf_res_t rd_kafka_conf_set_ssl_cert_verify_cb(
 #else
         rd_kafka_anyconf_set_internal(
             _RK_GLOBAL, conf, "ssl.certificate.verify_cb", ssl_cert_verify_cb);
+        return RD_KAFKA_CONF_OK;
+#endif
+}
+
+rd_kafka_conf_res_t rd_kafka_conf_set_ssl_cert_refresh_engine_data_cb(
+    rd_kafka_conf_t *conf,
+    int (*ssl_cert_refresh_engine_data_cb)(char *buf,
+                                           size_t *buf_size,
+                                           char *errstr,
+                                           size_t errstr_size,
+                                           void *opaque)) {
+
+#if !WITH_SSL
+        return RD_KAFKA_CONF_INVALID;
+#else
+        rd_kafka_anyconf_set_internal(_RK_GLOBAL, conf,
+                                      "ssl.certificate.refresh_engine_data_cb",
+                                      ssl_cert_refresh_engine_data_cb);
         return RD_KAFKA_CONF_OK;
 #endif
 }

--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -157,7 +157,7 @@ typedef enum {
 
 /* Increase in steps of 64 as needed.
  * This must be larger than sizeof(rd_kafka_[topic_]conf_t) */
-#define RD_KAFKA_CONF_PROPS_IDX_MAX (64 * 30)
+#define RD_KAFKA_CONF_PROPS_IDX_MAX (64 * 31)
 
 /**
  * @struct rd_kafka_anyconf_t
@@ -262,6 +262,11 @@ struct rd_kafka_conf_s {
                                       char *errstr,
                                       size_t errstr_size,
                                       void *opaque);
+                int (*cert_refresh_engine_data_cb)(char *buf,
+                                                   size_t *buf_size,
+                                                   char *errstr,
+                                                   size_t errstr_size,
+                                                   void *opaque);
         } ssl;
 
         struct {


### PR DESCRIPTION
Currently, certificate are only read on the creation of a client. That means that if the cert changes during the lifetime of the client connection, the client will now have incorrect certificate information. This change reads the cert for every broker reconnection using openssl engine. This means that when certs get rotated, the librdkafka client will always have the most recent one