### PR TITLE
Added async:able consumer_close_queue() and consumer_closed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ librdkafka v1.9.0 is a feature release:
    can now be triggered automatically on the librdkafka background thread.
  * `rd_kafka_queue_get_background()` now creates the background thread
    if not already created.
+ * Added `rd_kafka_consumer_close_queue()` and `rd_kafka_consumer_closed()`.
+   This allow applications and language bindings to implement asynchronous
+   consumer close where an application thread is polling for rebalance events
+   while the main thread is calling `consumer_close_queue()`.
  * Bundled zlib upgraded to version 1.2.12.
  * Bundled OpenSSL upgraded to 1.1.1n.
  * Added `test.mock.broker.rtt` to simulate RTT/latency for mock brokers.

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -280,6 +280,17 @@ RdKafka::ErrorCode RdKafka::KafkaConsumerImpl::close() {
 }
 
 
+RdKafka::Error *RdKafka::KafkaConsumerImpl::close(Queue *queue) {
+  QueueImpl *queueimpl = dynamic_cast<QueueImpl *>(queue);
+  rd_kafka_error_t *c_error;
+
+  c_error = rd_kafka_consumer_close_queue(rk_, queueimpl->queue_);
+  if (c_error)
+    return new ErrorImpl(c_error);
+
+  return NULL;
+}
+
 
 RdKafka::ConsumerGroupMetadata::~ConsumerGroupMetadata() {
 }

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2790,13 +2790,13 @@ class RD_EXPORT KafkaConsumer : public virtual Handle {
 
 
   /**
-   * @brief Close and shut down the proper.
+   * @brief Close and shut down the consumer.
    *
    * This call will block until the following operations are finished:
-   *  - Trigger a local rebalance to void the current assignment
-   *  - Stop consumption for current assignment
-   *  - Commit offsets
-   *  - Leave group
+   *  - Trigger a local rebalance to void the current assignment (if any).
+   *  - Stop consumption for current assignment (if any).
+   *  - Commit offsets (if any).
+   *  - Leave group (if applicable).
    *
    * The maximum blocking time is roughly limited to session.timeout.ms.
    *
@@ -2931,6 +2931,31 @@ class RD_EXPORT KafkaConsumer : public virtual Handle {
    */
   virtual Error *incremental_unassign(
       const std::vector<TopicPartition *> &partitions) = 0;
+
+  /**
+   * @brief Close and shut down the consumer.
+   *
+   * Same behaviour as RdKafka::KafkaConsumer::close() but with the following
+   * changes:
+   *
+   * Rebalance events/callbacks (etc) will be forwarded to the
+   * application-provided \p queue. The application must poll this queue (in
+   * another thread) until this close function returns or
+   * RdKafka::KafkaConsumer::closed() returns true.
+   *
+   * @remark Depending on consumer group join state there may or may not be
+   *         rebalance events emitted on \p rkqu.
+   *
+   * @returns an error object if the consumer close failed, else NULL.
+   *
+   * @sa RdKafka::KafkaConsumer::closed()
+   */
+  virtual Error *close(Queue *queue) = 0;
+
+
+  /** @returns true if the consumer has been closed with
+   *           RdKafka::KafkaConsumer::close(), else false. */
+  virtual bool closed() = 0;
 };
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -1367,6 +1367,12 @@ class KafkaConsumerImpl : virtual public KafkaConsumer,
 
   ErrorCode close();
 
+  Error *close(Queue *queue);
+
+  bool closed() {
+    return rd_kafka_consumer_closed(rk_) ? true : false;
+  };
+
   ErrorCode seek(const TopicPartition &partition, int timeout_ms);
 
   ErrorCode offsets_store(std::vector<TopicPartition *> &offsets) {

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3995,12 +3995,12 @@ RD_EXPORT
 rd_kafka_message_t *rd_kafka_consumer_poll(rd_kafka_t *rk, int timeout_ms);
 
 /**
- * @brief Close down the KafkaConsumer.
+ * @brief Close the consumer.
  *
- * @remark This call will block until the consumer has revoked its assignment,
- *         calling the \c rebalance_cb if it is configured, committed offsets
- *         to broker, and left the consumer group.
- *         The maximum blocking time is roughly limited to session.timeout.ms.
+ * This call will block until the consumer has revoked its assignment,
+ * calling the \c rebalance_cb if it is configured, committed offsets
+ * to broker, and left the consumer group (if applicable).
+ * The maximum blocking time is roughly limited to session.timeout.ms.
  *
  * @returns An error code indicating if the consumer close was succesful
  *          or not.
@@ -4014,6 +4014,40 @@ rd_kafka_message_t *rd_kafka_consumer_poll(rd_kafka_t *rk, int timeout_ms);
 RD_EXPORT
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk);
 
+
+/**
+ * @brief Close the consumer.
+ *
+ * Same behaviour as rd_kafka_consumer_close() but with the following changes:
+ *
+ * Rebalance events/callbacks (etc) will be forwarded to the
+ * application-provided \p rkqu. The application must poll this queue (in
+ * another thread) until this close function returns or
+ * rd_kafka_consumer_closed() returns true.
+ *
+ * @remark Depending on consumer group join state there may or may not be
+ *         rebalance events emitted on \p rkqu.
+ *
+ * @returns an error object if the consumer close failed, else NULL.
+ *
+ * @sa rd_kafka_consumer_closed()
+ */
+RD_EXPORT
+rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
+                                                rd_kafka_queue_t *rkqu);
+
+
+/**
+ * @returns 1 if the consumer is closed (rd_kafka_consumer_close() has been
+ *          called), else 0.
+ *
+ * Should be used in conjunction with rd_kafka_consumer_close_queue() for the
+ * polling thread to know when the consumer has been closed.
+ *
+ * @sa rd_kafka_consumer_close_queue()
+ */
+RD_EXPORT
+int rd_kafka_consumer_closed(rd_kafka_t *rk);
 
 /**
  * @brief Incrementally add \p partitions to the current assignment.

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -429,6 +429,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rd_interval_init(&rkcg->rkcg_join_intvl);
         rd_interval_init(&rkcg->rkcg_timeout_scan_intvl);
         rd_atomic32_init(&rkcg->rkcg_assignment_lost, rd_false);
+        rd_atomic32_init(&rkcg->rkcg_terminated, rd_false);
 
         rkcg->rkcg_errored_topics = rd_kafka_topic_partition_list_new(0);
 
@@ -2573,7 +2574,7 @@ static void rd_kafka_cgrp_heartbeat(rd_kafka_cgrp_t *rkcg) {
  * Cgrp is now terminated: decommission it and signal back to application.
  */
 static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
-        if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATED)
+        if (rd_atomic32_get(&rkcg->rkcg_terminated))
                 return; /* terminated() may be called multiple times,
                          * make sure to only terminate once. */
 
@@ -2605,14 +2606,14 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
                 rkcg->rkcg_coord = NULL;
         }
 
+        rd_atomic32_set(&rkcg->rkcg_terminated, rd_true);
+
         if (rkcg->rkcg_reply_rko) {
                 /* Signal back to application. */
                 rd_kafka_replyq_enq(&rkcg->rkcg_reply_rko->rko_replyq,
                                     rkcg->rkcg_reply_rko, 0);
                 rkcg->rkcg_reply_rko = NULL;
         }
-
-        rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_TERMINATED;
 }
 
 

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -125,8 +125,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_q_t *rkcg_ops;          /* Manager ops queue */
         rd_kafka_q_t *rkcg_wait_coord_q; /* Ops awaiting coord */
         int rkcg_flags;
-#define RD_KAFKA_CGRP_F_TERMINATE  0x1 /* Terminate cgrp (async) */
-#define RD_KAFKA_CGRP_F_TERMINATED 0x2 /* Cgrp terminated */
+#define RD_KAFKA_CGRP_F_TERMINATE 0x1 /* Terminate cgrp (async) */
 #define RD_KAFKA_CGRP_F_LEAVE_ON_UNASSIGN_DONE                                 \
         0x8 /* Send LeaveGroup when                                            \
              * unassign is done */
@@ -278,6 +277,8 @@ typedef struct rd_kafka_cgrp_s {
         rd_ts_t rkcg_ts_terminate; /* Timestamp of when
                                     * cgrp termination was
                                     * initiated. */
+
+        rd_atomic32_t rkcg_terminated; /**< Consumer has been closed */
 
         /* Protected by rd_kafka_*lock() */
         struct {

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -930,6 +930,8 @@ int rd_kafka_set_fatal_error0(rd_kafka_t *rk,
 #define rd_kafka_set_fatal_error(rk, err, fmt, ...)                            \
         rd_kafka_set_fatal_error0(rk, RD_DO_LOCK, err, fmt, __VA_ARGS__)
 
+rd_kafka_error_t *rd_kafka_get_fatal_error(rd_kafka_t *rk);
+
 static RD_INLINE RD_UNUSED rd_kafka_resp_err_t
 rd_kafka_fatal_error_code(rd_kafka_t *rk) {
         /* This is an optimization to avoid an atomic read which are costly

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -130,6 +130,7 @@ void rd_kafka_q_fwd_set0(rd_kafka_q_t *srcq,
                          rd_kafka_q_t *destq,
                          int do_lock,
                          int fwd_app) {
+        rd_assert(srcq != destq);
 
         if (do_lock)
                 mtx_lock(&srcq->rkq_lock);


### PR DESCRIPTION
This is mainly for the Go client, but can be used by applications as well.

This is blocking the v1.9.0 Go release.