### PR TITLE
OpenSSL libraries path for M1 MacOS

### DIFF
--- a/mklove/modules/configure.libssl
+++ b/mklove/modules/configure.libssl
@@ -30,6 +30,8 @@ function manual_checks {
         # Add brew's OpenSSL pkg-config path on OSX
         # to avoid picking up the outdated system-provided openssl/libcrypto.
         mkl_env_append PKG_CONFIG_PATH "/usr/local/opt/openssl/lib/pkgconfig" ":"
+	# and similar path for M1 brew location
+        mkl_env_append PKG_CONFIG_PATH "/opt/homebrew/opt/openssl/lib/pkgconfig" ":"
     fi
 
     # OpenSSL provides both libcrypto and libssl


### PR DESCRIPTION
As mentioned in the issue #3867 
On m1 MacOS homebrew is located in a different place, so configure script is not able to locate libssl and libcrypto.
This change makes it possible to use those libraries during build on M1.