### PR TITLE
Mark II: Added asynchronous rd_kafka_consumer_close_queue() and .._consumer_closed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ librdkafka v1.9.0 is a feature release:
    can now be triggered automatically on the librdkafka background thread.
  * `rd_kafka_queue_get_background()` now creates the background thread
    if not already created.
+ * Added `rd_kafka_consumer_close_queue()` and `rd_kafka_consumer_closed()`.
+   This allow applications and language bindings to implement asynchronous
+   consumer close.
  * Bundled zlib upgraded to version 1.2.12.
  * Bundled OpenSSL upgraded to 1.1.1n.
  * Added `test.mock.broker.rtt` to simulate RTT/latency for mock brokers.

--- a/src-cpp/KafkaConsumerImpl.cpp
+++ b/src-cpp/KafkaConsumerImpl.cpp
@@ -280,6 +280,17 @@ RdKafka::ErrorCode RdKafka::KafkaConsumerImpl::close() {
 }
 
 
+RdKafka::Error *RdKafka::KafkaConsumerImpl::close(Queue *queue) {
+  QueueImpl *queueimpl = dynamic_cast<QueueImpl *>(queue);
+  rd_kafka_error_t *c_error;
+
+  c_error = rd_kafka_consumer_close_queue(rk_, queueimpl->queue_);
+  if (c_error)
+    return new ErrorImpl(c_error);
+
+  return NULL;
+}
+
 
 RdKafka::ConsumerGroupMetadata::~ConsumerGroupMetadata() {
 }

--- a/src-cpp/rdkafkacpp.h
+++ b/src-cpp/rdkafkacpp.h
@@ -2790,13 +2790,13 @@ class RD_EXPORT KafkaConsumer : public virtual Handle {
 
 
   /**
-   * @brief Close and shut down the proper.
+   * @brief Close and shut down the consumer.
    *
    * This call will block until the following operations are finished:
-   *  - Trigger a local rebalance to void the current assignment
-   *  - Stop consumption for current assignment
-   *  - Commit offsets
-   *  - Leave group
+   *  - Trigger a local rebalance to void the current assignment (if any).
+   *  - Stop consumption for current assignment (if any).
+   *  - Commit offsets (if any).
+   *  - Leave group (if applicable).
    *
    * The maximum blocking time is roughly limited to session.timeout.ms.
    *
@@ -2931,6 +2931,32 @@ class RD_EXPORT KafkaConsumer : public virtual Handle {
    */
   virtual Error *incremental_unassign(
       const std::vector<TopicPartition *> &partitions) = 0;
+
+  /**
+   * @brief Close and shut down the consumer.
+   *
+   * Performs the same actions as RdKafka::KafkaConsumer::close() but in a
+   * background thread.
+   *
+   * Rebalance events/callbacks (etc) will be forwarded to the
+   * application-provided \p queue. The application must poll this queue until
+   * RdKafka::KafkaConsumer::closed() returns true.
+   *
+   * @remark Depending on consumer group join state there may or may not be
+   *         rebalance events emitted on \p rkqu.
+   *
+   * @returns an error object if the consumer close failed, else NULL.
+   *
+   * @sa RdKafka::KafkaConsumer::closed()
+   */
+  virtual Error *close(Queue *queue) = 0;
+
+
+  /** @returns true if the consumer is closed, else 0.
+   *
+   * @sa RdKafka::KafkaConsumer::close()
+   */
+  virtual bool closed() = 0;
 };
 
 

--- a/src-cpp/rdkafkacpp_int.h
+++ b/src-cpp/rdkafkacpp_int.h
@@ -1367,6 +1367,12 @@ class KafkaConsumerImpl : virtual public KafkaConsumer,
 
   ErrorCode close();
 
+  Error *close(Queue *queue);
+
+  bool closed() {
+    return rd_kafka_consumer_closed(rk_) ? true : false;
+  };
+
   ErrorCode seek(const TopicPartition &partition, int timeout_ms);
 
   ErrorCode offsets_store(std::vector<TopicPartition *> &offsets) {

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3995,12 +3995,12 @@ RD_EXPORT
 rd_kafka_message_t *rd_kafka_consumer_poll(rd_kafka_t *rk, int timeout_ms);
 
 /**
- * @brief Close down the KafkaConsumer.
+ * @brief Close the consumer.
  *
- * @remark This call will block until the consumer has revoked its assignment,
- *         calling the \c rebalance_cb if it is configured, committed offsets
- *         to broker, and left the consumer group.
- *         The maximum blocking time is roughly limited to session.timeout.ms.
+ * This call will block until the consumer has revoked its assignment,
+ * calling the \c rebalance_cb if it is configured, committed offsets
+ * to broker, and left the consumer group (if applicable).
+ * The maximum blocking time is roughly limited to session.timeout.ms.
  *
  * @returns An error code indicating if the consumer close was succesful
  *          or not.
@@ -4013,6 +4013,40 @@ rd_kafka_message_t *rd_kafka_consumer_poll(rd_kafka_t *rk, int timeout_ms);
  */
 RD_EXPORT
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk);
+
+
+/**
+ * @brief Asynchronously close the consumer.
+ *
+ * Performs the same actions as rd_kafka_consumer_close() but in a
+ * background thread.
+ *
+ * Rebalance events/callbacks (etc) will be forwarded to the
+ * application-provided \p rkqu. The application must poll/serve this queue
+ * until rd_kafka_consumer_closed() returns true.
+ *
+ * @remark Depending on consumer group join state there may or may not be
+ *         rebalance events emitted on \p rkqu.
+ *
+ * @returns an error object if the consumer close failed, else NULL.
+ *
+ * @sa rd_kafka_consumer_closed()
+ */
+RD_EXPORT
+rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
+                                                rd_kafka_queue_t *rkqu);
+
+
+/**
+ * @returns 1 if the consumer is closed, else 0.
+ *
+ * Should be used in conjunction with rd_kafka_consumer_close_queue() to know
+ * when the consumer has been closed.
+ *
+ * @sa rd_kafka_consumer_close_queue()
+ */
+RD_EXPORT
+int rd_kafka_consumer_closed(rd_kafka_t *rk);
 
 
 /**

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -125,8 +125,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_q_t *rkcg_ops;          /* Manager ops queue */
         rd_kafka_q_t *rkcg_wait_coord_q; /* Ops awaiting coord */
         int rkcg_flags;
-#define RD_KAFKA_CGRP_F_TERMINATE  0x1 /* Terminate cgrp (async) */
-#define RD_KAFKA_CGRP_F_TERMINATED 0x2 /* Cgrp terminated */
+#define RD_KAFKA_CGRP_F_TERMINATE 0x1 /* Terminate cgrp (async) */
 #define RD_KAFKA_CGRP_F_LEAVE_ON_UNASSIGN_DONE                                 \
         0x8 /* Send LeaveGroup when                                            \
              * unassign is done */
@@ -278,6 +277,8 @@ typedef struct rd_kafka_cgrp_s {
         rd_ts_t rkcg_ts_terminate; /* Timestamp of when
                                     * cgrp termination was
                                     * initiated. */
+
+        rd_atomic32_t rkcg_terminated; /**< Consumer has been closed */
 
         /* Protected by rd_kafka_*lock() */
         struct {

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -930,6 +930,8 @@ int rd_kafka_set_fatal_error0(rd_kafka_t *rk,
 #define rd_kafka_set_fatal_error(rk, err, fmt, ...)                            \
         rd_kafka_set_fatal_error0(rk, RD_DO_LOCK, err, fmt, __VA_ARGS__)
 
+rd_kafka_error_t *rd_kafka_get_fatal_error(rd_kafka_t *rk);
+
 static RD_INLINE RD_UNUSED rd_kafka_resp_err_t
 rd_kafka_fatal_error_code(rd_kafka_t *rk) {
         /* This is an optimization to avoid an atomic read which are costly

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -130,6 +130,8 @@ void rd_kafka_q_fwd_set0(rd_kafka_q_t *srcq,
                          rd_kafka_q_t *destq,
                          int do_lock,
                          int fwd_app) {
+        if (unlikely(srcq == destq))
+                return;
 
         if (do_lock)
                 mtx_lock(&srcq->rkq_lock);


### PR DESCRIPTION
This is mainly for the Go client, but can be used by applications as well.


This is **Mark II**, which compared to #3863 makes the close truly asynchronous.

Most things are identical to #3863, main change is that consumer_close_queue() will now return as soon as the close is triggered, and it is up to the application to wait for consumer_closed() to return true in its poll loop.