### PR TITLE
Fix JSON schema

### DIFF
--- a/src/statistics_schema.json
+++ b/src/statistics_schema.json
@@ -7,50 +7,47 @@
           "title": "Rolling window statistics",
           "description": "The values are in microseconds unless otherwise stated.",
           "properties": {
-              "type": "object",
-              "properties": {
-                  "min": {
-                      "type": "integer"
-                  },
-                  "max": {
-                      "type": "integer"
-                  },
-                  "avg": {
-                      "type": "integer"
-                  },
-                  "sum": {
-                      "type": "integer"
-                  },
-                  "stddev": {
-                      "type": "integer"
-                  },
-                  "p50": {
-                      "type": "integer"
-                  },
-                  "p75": {
-                      "type": "integer"
-                  },
-                  "p90": {
-                      "type": "integer"
-                  },
-                  "p95": {
-                      "type": "integer"
-                  },
-                  "p99": {
-                      "type": "integer"
-                  },
-                  "p99_99": {
-                      "type": "integer"
-                  },
-                  "outofrange": {
-                      "type": "integer"
-                  },
-                  "hdrsize": {
-                      "type": "integer"
-                  },
-                  "cnt": {
-                      "type": "integer"
-                  }
+              "min": {
+                  "type": "integer"
+              },
+              "max": {
+                  "type": "integer"
+              },
+              "avg": {
+                  "type": "integer"
+              },
+              "sum": {
+                  "type": "integer"
+              },
+              "stddev": {
+                  "type": "integer"
+              },
+              "p50": {
+                  "type": "integer"
+              },
+              "p75": {
+                  "type": "integer"
+              },
+              "p90": {
+                  "type": "integer"
+              },
+              "p95": {
+                  "type": "integer"
+              },
+              "p99": {
+                  "type": "integer"
+              },
+              "p99_99": {
+                  "type": "integer"
+              },
+              "outofrange": {
+                  "type": "integer"
+              },
+              "hdrsize": {
+                  "type": "integer"
+              },
+              "cnt": {
+                  "type": "integer"
               }
           }
       }


### PR DESCRIPTION
While plaining around with code generation for the JSON statistics I think I've found some miss-configuration in the JSON schema. Applying the suggested changes I was able to successfully generate parser code using the JSON schema as source.

Parser code generator was:  https://app.quicktype.io
