### PR TITLE
Fix LNK2019 with curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,13 @@ endif()
 # }
 
 # CURL {
-option(WITH_CURL "With CURL" OFF)
-if(WITH_CURL)
-  list(APPEND BUILT_WITH "CURL")
-  find_package(CURL CONFIG REQUIRED)
+find_package(CURL QUIET)
+if(CURL_FOUND)
+  set(with_curl_default ON)
+else()
+  set(with_curl_default OFF)
 endif()
+option(WITH_CURL "With CURL" ${with_curl_default})
 # }
 
 # ZSTD {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ else()
   set(with_curl_default OFF)
 endif()
 option(WITH_CURL "With CURL" ${with_curl_default})
+if(WITH_CURL)
+  list(APPEND BUILT_WITH "CURL")
+endif()
 # }
 
 # ZSTD {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,15 +54,10 @@ endif()
 # }
 
 # CURL {
-find_package(CURL QUIET)
-if(CURL_FOUND)
-  set(with_curl_default ON)
-else()
-  set(with_curl_default OFF)
-endif()
-option(WITH_CURL "With CURL" ${with_curl_default})
+option(WITH_CURL "With CURL" OFF)
 if(WITH_CURL)
   list(APPEND BUILT_WITH "CURL")
+  find_package(CURL CONFIG REQUIRED)
 endif()
 # }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,6 +206,10 @@ if(WITH_ZLIB)
   target_link_libraries(rdkafka PUBLIC ZLIB::ZLIB)
 endif()
 
+if(WITH_CURL)
+  target_link_libraries(rdkafka PUBLIC CURL::libcurl)
+endif()
+
 if(WITH_ZSTD)
   target_link_libraries(rdkafka PRIVATE ${ZSTD_LIBRARY})
   target_include_directories(rdkafka PRIVATE ${ZSTD_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,7 @@ if(WITH_ZLIB)
 endif()
 
 if(WITH_CURL)
+  find_package(CURL CONFIG REQUIRED)
   target_link_libraries(rdkafka PUBLIC CURL::libcurl)
 endif()
 


### PR DESCRIPTION
Since not add `target_link_libraries` when `WITH_CURL` is ON, there are LNK2019 error as below:
```
cmd.exe /C "cd . && D:\downloads\tools\cmake-3.22.2-windows\cmake-3.22.2-windows-i386\bin\cmake.exe -E vs_link_dll --intdir=src\CMakeFiles\rdkafka.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\x86\link.exe  src\CMakeFiles\rdkafka.dir\crc32c.c.obj src\CMakeFiles\rdkafka.dir\rdaddr.c.obj src\CMakeFiles\rdkafka.dir\rdavl.c.obj src\CMakeFiles\rdkafka.dir\rdbuf.c.obj src\CMakeFiles\rdkafka.dir\rdcrc32.c.obj src\CMakeFiles\rdkafka.dir\rdfnv1a.c.obj src\CMakeFiles\rdkafka.dir\rdkafka.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_broker.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_buf.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_cgrp.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_conf.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_event.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_feature.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_lz4.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_metadata.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_metadata_cache.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msg.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msgset_reader.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msgset_writer.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_offset.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_op.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_partition.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_pattern.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_queue.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_range_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_request.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_roundrobin_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl_plain.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sticky_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_subscription.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_assignment.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_timer.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_topic.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_transport.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_interceptor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_header.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_admin.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_aux.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_background.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_idempotence.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_txnmgr.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_cert.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_coord.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock_handlers.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock_cgrp.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_error.c.obj src\CMakeFiles\rdkafka.dir\rdlist.c.obj src\CMakeFiles\rdkafka.dir\rdlog.c.obj src\CMakeFiles\rdkafka.dir\rdmurmur2.c.obj src\CMakeFiles\rdkafka.dir\rdports.c.obj src\CMakeFiles\rdkafka.dir\rdrand.c.obj src\CMakeFiles\rdkafka.dir\rdregex.c.obj src\CMakeFiles\rdkafka.dir\rdstring.c.obj src\CMakeFiles\rdkafka.dir\rdunittest.c.obj src\CMakeFiles\rdkafka.dir\rdvarint.c.obj src\CMakeFiles\rdkafka.dir\rdmap.c.obj src\CMakeFiles\rdkafka.dir\snappy.c.obj src\CMakeFiles\rdkafka.dir\tinycthread.c.obj src\CMakeFiles\rdkafka.dir\tinycthread_extra.c.obj src\CMakeFiles\rdkafka.dir\rdxxhash.c.obj src\CMakeFiles\rdkafka.dir\cJSON.c.obj src\CMakeFiles\rdkafka.dir\rdhttp.c.obj src\CMakeFiles\rdkafka.dir\rddl.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_plugin.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl_win32.c.obj src\CMakeFiles\rdkafka.dir\regexp.c.obj  /out:src\rdkafka.dll /implib:src\rdkafka.lib /pdb:src\rdkafka.pdb /dll /version:0.0 /machine:X86 /nologo    /debug /INCREMENTAL  D:\installed\x86-windows\debug\lib\lz4d.lib  ws2_32.lib  secur32.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib  && cd ."
LINK Pass 1: command "C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1432~1.313\bin\Hostx64\x86\link.exe src\CMakeFiles\rdkafka.dir\crc32c.c.obj src\CMakeFiles\rdkafka.dir\rdaddr.c.obj src\CMakeFiles\rdkafka.dir\rdavl.c.obj src\CMakeFiles\rdkafka.dir\rdbuf.c.obj src\CMakeFiles\rdkafka.dir\rdcrc32.c.obj src\CMakeFiles\rdkafka.dir\rdfnv1a.c.obj src\CMakeFiles\rdkafka.dir\rdkafka.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_broker.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_buf.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_cgrp.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_conf.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_event.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_feature.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_lz4.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_metadata.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_metadata_cache.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msg.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msgset_reader.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_msgset_writer.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_offset.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_op.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_partition.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_pattern.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_queue.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_range_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_request.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_roundrobin_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl_plain.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sticky_assignor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_subscription.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_assignment.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_timer.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_topic.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_transport.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_interceptor.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_header.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_admin.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_aux.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_background.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_idempotence.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_txnmgr.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_cert.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_coord.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock_handlers.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_mock_cgrp.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_error.c.obj src\CMakeFiles\rdkafka.dir\rdlist.c.obj src\CMakeFiles\rdkafka.dir\rdlog.c.obj src\CMakeFiles\rdkafka.dir\rdmurmur2.c.obj src\CMakeFiles\rdkafka.dir\rdports.c.obj src\CMakeFiles\rdkafka.dir\rdrand.c.obj src\CMakeFiles\rdkafka.dir\rdregex.c.obj src\CMakeFiles\rdkafka.dir\rdstring.c.obj src\CMakeFiles\rdkafka.dir\rdunittest.c.obj src\CMakeFiles\rdkafka.dir\rdvarint.c.obj src\CMakeFiles\rdkafka.dir\rdmap.c.obj src\CMakeFiles\rdkafka.dir\snappy.c.obj src\CMakeFiles\rdkafka.dir\tinycthread.c.obj src\CMakeFiles\rdkafka.dir\tinycthread_extra.c.obj src\CMakeFiles\rdkafka.dir\rdxxhash.c.obj src\CMakeFiles\rdkafka.dir\cJSON.c.obj src\CMakeFiles\rdkafka.dir\rdhttp.c.obj src\CMakeFiles\rdkafka.dir\rddl.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_plugin.c.obj src\CMakeFiles\rdkafka.dir\rdkafka_sasl_win32.c.obj src\CMakeFiles\rdkafka.dir\regexp.c.obj /out:src\rdkafka.dll /implib:src\rdkafka.lib /pdb:src\rdkafka.pdb /dll /version:0.0 /machine:X86 /nologo /debug /INCREMENTAL D:\installed\x86-windows\debug\lib\lz4d.lib ws2_32.lib secur32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:src\CMakeFiles\rdkafka.dir/intermediate.manifest src\CMakeFiles\rdkafka.dir/manifest.res" failed (exit code 1120) with the following output:
   Creating library src\rdkafka.lib and object src\rdkafka.exp
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_global_init referenced in function _rd_http_global_init
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_easy_init referenced in function _rd_http_req_init
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_easy_setopt referenced in function _rd_http_req_init
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_easy_perform referenced in function _rd_http_req_perform_sync
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_easy_cleanup referenced in function _rd_http_req_destroy
rdhttp.c.obj : error LNK2019: unresolved external symbol __imp__curl_easy_getinfo referenced in function _rd_http_req_perform_sync
src\rdkafka.dll : fatal error LNK1120: 6 unresolved externals
```