### PR TITLE
cmake build fix: link against libcurl explicilty

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -238,6 +238,10 @@ endif()
 find_package(Threads REQUIRED)
 target_link_libraries(rdkafka PUBLIC Threads::Threads)
 
+if(WITH_CURL)
+    target_link_libraries(rdkafka PUBLIC curl)
+endif()
+
 if(WITH_SASL_CYRUS)
   target_include_directories(rdkafka PRIVATE ${SASL_INCLUDE_DIRS})
   target_link_libraries(rdkafka PUBLIC ${SASL_LIBRARIES})


### PR DESCRIPTION
Encountered build errors on linux related to the linker not finding libcurl for some reason. It's fixed now.

Fix: Add explicit linking against libcurl in src/CMakeLists.txt
Error:
`
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:163: undefined reference to curl_easy_perform' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:167: undefined reference tocurl_easy_getinfo'
/usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in function rd_http_req_get_content_type': /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:184: undefined reference tocurl_easy_getinfo'
/usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in function rd_http_post_expect_json': /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:316: undefined reference tocurl_easy_setopt'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:317: undefined reference to curl_easy_setopt' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:319: undefined reference tocurl_easy_setopt'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:321: undefined reference to curl_easy_setopt' /usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in functionrd_http_global_init':
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:443: undefined reference to curl_global_init' /usr/bin/ld: ../src/librdkafka.a(rdkafka_sasl_oauthbearer_oidc.c.o): in functionrd_kafka_oidc_build_headers':
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:116: undefined reference to curl_slist_append' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:117: undefined reference tocurl_slist_append'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:119: undefined reference to curl_slist_append' /usr/bin/ld: ../src/librdkafka.a(rdkafka_sasl_oauthbearer_oidc.c.o): in functionrd_kafka_oidc_token_refresh_cb':
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:382: undefined reference to curl_slist_free_all' collect2: error: ld returned 1 exit status make[4]: *** [_deps/librdkafka-build/examples/CMakeFiles/producer.dir/build.make:103: _deps/librdkafka-build/examples/producer] Error 1 make[3]: *** [CMakeFiles/Makefile2:928: _deps/librdkafka-build/examples/CMakeFiles/producer.dir/all] Error 2/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:163: undefined reference tocurl_easy_perform'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:167: undefined reference to curl_easy_getinfo' /usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in functionrd_http_req_get_content_type':
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:184: undefined reference to curl_easy_getinfo' /usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in functionrd_http_post_expect_json':
/home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:316: undefined reference to curl_easy_setopt' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:317: undefined reference tocurl_easy_setopt'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:319: undefined reference to curl_easy_setopt' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:321: undefined reference tocurl_easy_setopt'
/usr/bin/ld: ../src/librdkafka.a(rdhttp.c.o): in function rd_http_global_init': /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdhttp.c:443: undefined reference tocurl_global_init'
/usr/bin/ld: ../src/librdkafka.a(rdkafka_sasl_oauthbearer_oidc.c.o): in function rd_kafka_oidc_build_headers': /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:116: undefined reference tocurl_slist_append'
/usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:117: undefined reference to curl_slist_append' /usr/bin/ld: /home/adrian/repos/spoofy/build/_deps/librdkafka-src/src/rdkafka_sasl_oauthbearer_oidc.c:119: undefined reference tocurl_slist_append'
/usr/bin/ld: ../src/librd`