### PR TITLE
fix the scope for oauthbearer OIDC

### DIFF
--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -228,8 +228,7 @@ static void rd_kafka_oidc_build_post_fields(const char *scope,
                     strlen("grant_type=client_credentials&scope=") + scope_size;
                 *post_fields = rd_malloc(*post_fields_size + 1);
                 rd_snprintf(*post_fields, *post_fields_size + 1,
-                            "grant_type=client_credentials&scope=%s",
-                            scope);
+                            "grant_type=client_credentials&scope=%s", scope);
         }
 }
 
@@ -284,8 +283,7 @@ void rd_kafka_oidc_token_refresh_cb(rd_kafka_t *rk,
 
         /* Build post fields */
         rd_kafka_oidc_build_post_fields(rk->rk_conf.sasl.oauthbearer.scope,
-                                        &post_fields,
-                                        &post_fields_size);
+                                        &post_fields, &post_fields_size);
 
         token_url = rk->rk_conf.sasl.oauthbearer.token_endpoint_url;
 
@@ -533,10 +531,9 @@ static int ut_sasl_oauthbearer_oidc_with_empty_key(void) {
 static int ut_sasl_oauthbearer_oidc_post_fields(void) {
         static const char *scope = "test-scope";
         static const char *expected_post_fields =
-                "grant_type=client_credentials&scope=test-scope";
+            "grant_type=client_credentials&scope=test-scope";
 
-        size_t expected_post_fields_size =
-                strlen(expected_post_fields);
+        size_t expected_post_fields_size = strlen(expected_post_fields);
 
         size_t post_fields_size;
 
@@ -544,9 +541,7 @@ static int ut_sasl_oauthbearer_oidc_post_fields(void) {
 
         RD_UT_BEGIN();
 
-        rd_kafka_oidc_build_post_fields(scope,
-                                        &post_fields,
-                                        &post_fields_size);
+        rd_kafka_oidc_build_post_fields(scope, &post_fields, &post_fields_size);
 
         RD_UT_ASSERT(expected_post_fields_size == post_fields_size,
                      "Expected expected_post_fields_size is %zu"
@@ -566,10 +561,9 @@ static int ut_sasl_oauthbearer_oidc_post_fields(void) {
 static int ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope(void) {
         static const char *scope = NULL;
         static const char *expected_post_fields =
-                "grant_type=client_credentials";
+            "grant_type=client_credentials";
 
-        size_t expected_post_fields_size =
-                strlen(expected_post_fields);
+        size_t expected_post_fields_size = strlen(expected_post_fields);
 
         size_t post_fields_size;
 
@@ -577,9 +571,7 @@ static int ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope(void) {
 
         RD_UT_BEGIN();
 
-        rd_kafka_oidc_build_post_fields(scope,
-                                        &post_fields,
-                                        &post_fields_size);
+        rd_kafka_oidc_build_post_fields(scope, &post_fields, &post_fields_size);
 
         RD_UT_ASSERT(expected_post_fields_size == post_fields_size,
                      "Expected expected_post_fields_size is %zu"


### PR DESCRIPTION
There is a regression for oauthbearer oidc related to `scope`.

when malloc `post_fields`, the size is `post_fields_size + 1`, but when copy the string, the +1 missed. which is different than before. If the scope is “kirk-scope”, token provider will receive  “kirk-scop”, the last character will be missed.

```
Local test with AP 3.1
ailing with expired JWT: PASS (10.09s) ]
[0126_oauthbearer_oidc       / 30.075s] 0126_oauthbearer_oidc: duration 30074.752ms
[0126_oauthbearer_oidc       / 30.075s] ================= Test 0126_oauthbearer_oidc PASSED =================
[<MAIN>                      / 30.099s] ALL-TESTS: duration 30098.795ms
TEST 20220714092549 (bare, scenario default) SUMMARY
#==================================================================#
| <MAIN>                                   |     PASSED |  30.099s |
| 0126_oauthbearer_oidc                    |     PASSED |  30.075s |
#==================================================================#
```

Unit test:
```
RDUT: INFO: rdkafka_sasl_oauthbearer_oidc.c:442: ut_sasl_oauthbearer_oidc_should_succeed: BEGIN: 
RDUT: PASS: rdkafka_sasl_oauthbearer_oidc.c:481: ut_sasl_oauthbearer_oidc_should_succeed
RDUT: INFO: rdkafka_sasl_oauthbearer_oidc.c:497: ut_sasl_oauthbearer_oidc_with_empty_key: BEGIN: 
RDUT: PASS: rdkafka_sasl_oauthbearer_oidc.c:527: ut_sasl_oauthbearer_oidc_with_empty_key
RDUT: INFO: rdkafka_sasl_oauthbearer_oidc.c:545: ut_sasl_oauthbearer_oidc_post_fields: BEGIN: 
RDUT: PASS: rdkafka_sasl_oauthbearer_oidc.c:560: ut_sasl_oauthbearer_oidc_post_fields
RDUT: INFO: rdkafka_sasl_oauthbearer_oidc.c:578: ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope: BEGIN: 
RDUT: PASS: rdkafka_sasl_oauthbearer_oidc.c:593: ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope
RDUT: INFO: rdunittest.c:502: rd_unittest: unittest: sasl_oauthbearer_oidc: PASS
[0000_unittests              /  3.443s] 0000_unittests: duration 3442.826ms
[0000_unittests              /  3.443s] ================= Test 0000_unittests PASSED =================
[<MAIN>                      /  4.016s] ALL-TESTS: duration 4015.695ms
TEST 20220714092931 (bare, scenario default) SUMMARY
```