### PR TITLE
do not cap buffer size on zstd decompress

### DIFF
--- a/src/rdkafka_zstd.c
+++ b/src/rdkafka_zstd.c
@@ -60,10 +60,7 @@ rd_kafka_resp_err_t rd_kafka_zstd_decompress(rd_kafka_broker_t *rkb,
                 break;
         }
 
-        /* Increase output buffer until it can fit the entire result,
-         * capped by message.max.bytes */
-        while (out_bufsize <=
-               (unsigned long long)rkb->rkb_rk->rk_conf.recv_max_msg_size) {
+        while (1) { /* will only loop if decompressed does not fit buffer */
                 size_t ret;
                 char *decompressed;
 
@@ -106,13 +103,7 @@ rd_kafka_resp_err_t rd_kafka_zstd_decompress(rd_kafka_broker_t *rkb,
                 }
         }
 
-        rd_rkb_dbg(rkb, MSG, "ZSTD",
-                   "Unable to decompress ZSTD "
-                   "(input buffer %" PRIusz
-                   ", output buffer %llu): "
-                   "output would exceed message.max.bytes (%d)",
-                   inlen, out_bufsize, rkb->rkb_rk->rk_conf.max_msg_size);
-
+        /* should never return here */
         return RD_KAFKA_RESP_ERR__BAD_COMPRESSION;
 }
 

--- a/tests/zstd_manual_test.sh
+++ b/tests/zstd_manual_test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+
+#
+# Manual test (verification) of ZSTD decompression
+#
+
+set -e
+# Debug what commands are being executed:
+#set -x
+
+TOPIC=zstd
+
+# Create topic
+${KAFKA_PATH}/bin/kafka-topics.sh --bootstrap-server $BROKERS --create \
+	     --topic $TOPIC --partitions 1 --replication-factor 1
+
+# Produce with Kafka
+tmpfile=$(mktemp)
+# Fill the file with repeated 'a' char (499kb) easy to compress
+(printf 'a%.0s' {1..510976} ; printf '\n') > $tmpfile
+
+echo "### Producing 6000 messages with Kafka: from ${tmpfile}"
+(for i in {1..6000}; do cat $tmpfile ; done) | ${KAFKA_PATH}/bin/kafka-console-producer.sh \
+			     --broker-list $BROKERS \
+			     --topic $TOPIC \
+           --max-memory-bytes 20971520 \
+           --batch-size 10485760 \
+           --compression-codec zstd \
+           --producer-property max.request.size=512000 \
+           --producer-property linger.ms=60000
+
+# Consume with rdkafka
+echo ""
+echo "### Consuming with librdkafka: expect no decompression errors"
+../examples/rdkafka_performance -C -b $BROKERS -t $TOPIC -p 0 -o beginning -e \
+          -X message.max.bytes=10240000 \
+			    $RDK_ARGS
+
+
+echo ""
+echo "### $TEST_KAFKA_VERSION: Did you see error message containing \"Consume error for topic \"zstd\" [0]\" ?"


### PR DESCRIPTION
Hello,

I recently had some issues with librdkafka based consumer (from go) and zstd compressed messages.

When a java producer sends batch of messages it only estimates the compressed size and adjust the observed ratio after sending each batch.
It can happen that the producer is sending highly compressible messages and at this point it seems that it can send more data than allowed by the maximum set in its config.

On consumer side, rdkafka is strictly capping on message.max.bytes and in this case the consumer will fail forever reading from a topic when encountering a batch larger than this limit. 

I provided an example (as manual test) showing how this can be easily reproduced. A 500kb message made of same char is produced for 6000 times. The consumer will try to consume the batch but at a certain point it's unable to go forward since the fetch request it's doing is overflowing the available buffer.

I don't know if I mess with some configuration setting but actually, out of curiosity, the error is coming with 3.2.0 broker but NOT with 2.4.0

In order to reproduce the issue, on test folder I ran 

`./interactive_broker_version.py 3.2.0 -c ./zstd_manual_test.sh`

The proposed fix is just removing the hard limit that is imposed on zstd decompression. This uncapped behavious is also used on lz4 already.

Thanks in advance for your review

Andrea