### PR TITLE
CLIENTS-2514: Fixed broken links

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -241,7 +241,7 @@ on the producer:
 
 See [STATISTICS.md](STATISTICS.md) for the full definition of metrics.
 A JSON schema for the statistics is available in
-[statistics-schema.json](src/statistics-schema.json).
+[statistics_schema.json](https://github.com/edenhill/librdkafka/blob/master/src/statistics_schema.json).
 
 
 ### Compression
@@ -776,7 +776,7 @@ automatically.
 librdkafka supports Exactly One Semantics (EOS) as defined in [KIP-98](https://cwiki.apache.org/confluence/display/KAFKA/KIP-98+-+Exactly+Once+Delivery+and+Transactional+Messaging).
 For more on the use of transactions, see [Transactions in Apache Kafka](https://www.confluent.io/blog/transactions-apache-kafka/).
 
-See [examples/transactions.c](examples/transactions.c) for an example
+See [examples/transactions.c](https://github.com/edenhill/librdkafka/blob/master/examples/transactions.c) for an example
 transactional EOS application.
 
 **Warning**
@@ -791,7 +791,7 @@ See KIP-447 for more information.
 
 ### Documentation
 
-The librdkafka API is documented in the [`rdkafka.h`](src/rdkafka.h)
+The librdkafka API is documented in the rdkafka.h
 header file, the configuration properties are documented in
 [`CONFIGURATION.md`](CONFIGURATION.md)
 
@@ -1090,7 +1090,7 @@ by setting `enable.ssl.certificate.verification=false`, but this is not
 recommended since it allows for rogue brokers and man-in-the-middle attacks,
 and should only be used for testing and troubleshooting purposes.
 
-CA location probe paths (see [rdkafka_ssl.c](src/rdkafka_ssl.c) for full list)
+CA location probe paths (see [rdkafka_ssl.c](https://github.com/edenhill/librdkafka/blob/master/src/rdkafka_ssl.c) for full list)
 used when OpenSSL is statically linked:
 
     "/etc/pki/tls/certs/ca-bundle.crt",


### PR DESCRIPTION
Fixing 4 broken links in the documentation.

1. Statistics Schema JSON
2. transaction.c example file
3. rdkafka.h src file
4. rdkafka_ssl.c src file