### PR TITLE
Fix for fenced producer after disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 librdkafka v1.9.3 is a maintenance release:
 
- * Self-contained static libraries can now be built on Linux arm64 too
+ * Self-contained static libraries can now be built on Linux arm64.
  * Fixes to the transactional and idempotent producer (#3971).
 
 
@@ -10,8 +10,8 @@ librdkafka v1.9.3 is a maintenance release:
 
 ### Transactional producer fixes
 
- * When requesting an abort with drain and bump after message timeouts, the bump was executed first, causing a series of retries on InitProducerIdRequest until a transaction timeout happen and the producer was fenced. This commit changes the order of the operations, starting the drain bump after the complete transaction ack (#3971).
- * While a commit operation was in queue, a timeout happens that can cause an abort. The state changes from COMMITTING_TRANSACTION to ABORTABLE_ERROR to ABORTING_TRANSACTION. When the broker comes up the error is permanent or fatal because the state has changed from the initial one (#3971).
+ * In certain circumstances, an InitProducerId request would be issued to bump the producer epoch before the open transaction was aborted, causing the producer to enter a failed state. The producer will now wait until the transaction is aborted before requesting an epoch bump. (#3971).
+ * While a commit operation was in queue, a timeout happens that can cause an abort. The state changes from COMMITTING_TRANSACTION to ABORTABLE_ERROR to ABORTING_TRANSACTION. When the broker comes up the error, that before was retriable, now is permanent or fatal because the state has changed from the initial one (#3971).
  * When doing a drain and bump txn_curr_coord is not null in state WAIT_TRANSPORT, but if txn_coord has to be requested or broker is down it's retried. During this retry the txn_curr_coord can be set to null after a COORDINATOR_NOT_AVAILABLE error so when it comes back to the WAIT_TRANSPORT case a fatal error happens in the assert. It has to query for a transaction coordinator and retry (#3971).
  * When aborting a transaction, if a local TIMED_OUT, TIMED_OUT_QUEUE or OUTDATED error happens, the error was not retriable (nor fenced or abortable) so rd_kafka_txn_op_abort_transaction_ack is never called, caller code doesn't know what to do so starts a new transaction but begin transaction fails because transactional state is not READY. These errors are now retriable (#3971).
  * When calling TxnOffsetCommit, if retries were needed they were made at full speed, causing too much logging and network calls. A one second timeout has been added between retries (#3971).

--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -490,6 +490,7 @@ void rd_kafka_idemp_pid_update(rd_kafka_broker_t *rkb,
         /* The idempotence state change will trigger the transaction manager,
          * see rd_kafka_txn_idemp_state_change(). */
         rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_ASSIGNED);
+        rd_kafka_txns_complete_waiting(rk);
 
         rd_kafka_wrunlock(rk);
 
@@ -540,6 +541,7 @@ static void rd_kafka_idemp_drain_done(rd_kafka_t *rk) {
                                      rd_kafka_pid2str(rk->rk_eos.pid));
                         rd_kafka_idemp_set_state(rk,
                                                  RD_KAFKA_IDEMP_STATE_ASSIGNED);
+                        rd_kafka_txns_complete_waiting(rk);
                         wakeup_brokers = rd_true;
                 }
         }
@@ -599,6 +601,32 @@ void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason) {
  *
  * The PID is not bumped until the queues are fully drained.
  *
+ * @param fmt is a human-readable reason for the bump.
+ *
+ * @locality any
+ * @locks none
+ */
+void rd_kafka_idemp_drain_epoch_bump_start(rd_kafka_t *rk, const char *reason) {
+        rd_kafka_wrlock(rk);
+        rd_kafka_dbg(rk, EOS, "DRAIN",
+                     "Beginning partition drain for %s epoch bump "
+                     "for %d partition(s) with in-flight requests: %s",
+                     rd_kafka_pid2str(rk->rk_eos.pid),
+                     rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), reason);
+        rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_BUMP);
+        rd_kafka_wrunlock(rk);
+        /* Check right away if the drain could be done. */
+        rd_kafka_idemp_check_drain_done(rk);
+}
+
+/**
+ * @brief Schedule an epoch bump when the local ProduceRequest queues
+ *        have been fully drained, or abort the current transaction,
+ *        if the producer is transactional, and
+ *        rd_kafka_idemp_drain_epoch_bump_start will be called after that.
+ *
+ * The PID is not bumped until the queues are fully drained.
+ *
  * @param fmt is a human-readable reason for the bump
  *
  *
@@ -616,22 +644,13 @@ void rd_kafka_idemp_drain_epoch_bump(rd_kafka_t *rk,
         rd_vsnprintf(buf, sizeof(buf), fmt, ap);
         va_end(ap);
 
-        rd_kafka_wrlock(rk);
-        rd_kafka_dbg(rk, EOS, "DRAIN",
-                     "Beginning partition drain for %s epoch bump "
-                     "for %d partition(s) with in-flight requests: %s",
-                     rd_kafka_pid2str(rk->rk_eos.pid),
-                     rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), buf);
-        rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_BUMP);
-        rd_kafka_wrunlock(rk);
-
-        /* Transactions: bumping the epoch requires the current transaction
-         *               to be aborted. */
-        if (rd_kafka_is_transactional(rk))
+        if (rd_kafka_is_transactional(rk)) {
+                /* Transactions: requires aborting the current transaction
+                 * before bumping the epoch . */
                 rd_kafka_txn_set_abortable_error_with_bump(rk, err, "%s", buf);
-
-        /* Check right away if the drain could be done. */
-        rd_kafka_idemp_check_drain_done(rk);
+        } else {
+                rd_kafka_idemp_drain_epoch_bump_start(rk, buf);
+        }
 }
 
 /**

--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -596,7 +596,7 @@ void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason) {
         rd_kafka_wrlock(rk);
         rd_kafka_dbg(rk, EOS, "DRAIN",
                      "Beginning partition drain for %s reset "
-                     "for %d partition(s) with in-flight requests: %s",
+                     "for %" PRId32 " partition(s) with in-flight requests: %s",
                      rd_kafka_pid2str(rk->rk_eos.pid),
                      rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), reason);
         rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_RESET);
@@ -622,7 +622,7 @@ void rd_kafka_idemp_drain_epoch_bump_start(rd_kafka_t *rk, const char *reason) {
         rd_kafka_wrlock(rk);
         rd_kafka_dbg(rk, EOS, "DRAIN",
                      "Beginning partition drain for %s epoch bump "
-                     "for %d partition(s) with in-flight requests: %s",
+                     "for %" PRId32 " partition(s) with in-flight requests: %s",
                      rd_kafka_pid2str(rk->rk_eos.pid),
                      rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), reason);
         rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_BUMP);

--- a/src/rdkafka_idempotence.h
+++ b/src/rdkafka_idempotence.h
@@ -73,6 +73,7 @@ void rd_kafka_idemp_pid_update(rd_kafka_broker_t *rkb,
                                const rd_kafka_pid_t pid);
 void rd_kafka_idemp_pid_fsm(rd_kafka_t *rk);
 void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason);
+void rd_kafka_idemp_drain_epoch_bump_start(rd_kafka_t *rk, const char *reason);
 void rd_kafka_idemp_drain_epoch_bump(rd_kafka_t *rk,
                                      rd_kafka_resp_err_t err,
                                      const char *fmt,

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -496,6 +496,10 @@ struct rd_kafka_s {
 
                 /**< Transaction coordinator query timer */
                 rd_kafka_timer_t txn_coord_tmr;
+
+                /**< Queue of the completed transaction waiting response after
+                 * epoch bump */
+                rd_kafka_q_t *completed_txn_waiting_bump;
         } rk_eos;
 
         rd_atomic32_t rk_flushing; /**< Application is calling flush(). */

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -2027,10 +2027,13 @@ rd_kafka_error_t *rd_kafka_send_offsets_to_transaction(
  *
  * Current state must be either COMMIT_NOT_ACKED or ABORT_NOT_ACKED.
  *
+ * @returns true if the transaction was completed, false if an epoch bump
+ *          if needed before completing.
+ *
  * @locality rdkafka main thread
  * @locks rd_kafka_wrlock(rk) MUST be held
  */
-static void rd_kafka_txn_complete(rd_kafka_t *rk, rd_bool_t is_commit) {
+static rd_bool_t rd_kafka_txn_complete(rd_kafka_t *rk, rd_bool_t is_commit) {
         rd_kafka_dbg(rk, EOS, "TXNCOMPLETE", "Transaction successfully %s",
                      is_commit ? "committed" : "aborted");
 
@@ -2038,10 +2041,23 @@ static void rd_kafka_txn_complete(rd_kafka_t *rk, rd_bool_t is_commit) {
         rd_kafka_txn_clear_pending_partitions(rk);
         rd_kafka_txn_clear_partitions(rk);
 
+        rd_bool_t drain_bump =
+            rk->rk_eos.txn_requires_epoch_bump ||
+            rk->rk_eos.idemp_state != RD_KAFKA_IDEMP_STATE_ASSIGNED;
+
         rk->rk_eos.txn_requires_epoch_bump = rd_false;
         rk->rk_eos.txn_req_cnt             = 0;
 
-        rd_kafka_txn_set_state(rk, RD_KAFKA_TXN_STATE_READY);
+        if (drain_bump) {
+                rd_kafka_wrunlock(rk);
+                rd_kafka_idemp_drain_epoch_bump_start(
+                    rk, "txn_requires_epoch_bump");
+                rd_kafka_wrlock(rk);
+                return rd_false;
+        } else {
+                rd_kafka_txn_set_state(rk, RD_KAFKA_TXN_STATE_READY);
+                return rd_true;
+        }
 }
 
 
@@ -2390,6 +2406,8 @@ rd_kafka_txn_op_commit_transaction_ack(rd_kafka_t *rk,
                                        rd_kafka_q_t *rkq,
                                        rd_kafka_op_t *rko) {
         rd_kafka_error_t *error;
+        rd_bool_t complete    = rd_true;
+        rd_kafka_q_t *reply_q = rd_kafka_q_keep(rko->rko_replyq.q);
 
         if (rko->rko_err == RD_KAFKA_RESP_ERR__DESTROY)
                 return RD_KAFKA_OP_RES_HANDLED;
@@ -2402,14 +2420,21 @@ rd_kafka_txn_op_commit_transaction_ack(rd_kafka_t *rk,
 
         rd_kafka_dbg(rk, EOS, "TXNCOMMIT",
                      "Committed transaction now acked by application");
-        rd_kafka_txn_complete(rk, rd_true /*is commit*/);
-
+        complete = rd_kafka_txn_complete(rk, rd_true /*is commit*/);
+        if (!complete) {
+                /* Set this queue as waiting for completion.
+                 * rd_kafka_txn_curr_api_reply_error will be called
+                 * by rd_kafka_txns_complete_waiting
+                 */
+                rk->rk_eos.completed_txn_waiting_bump = reply_q;
+        }
         /* FALLTHRU */
 done:
         rd_kafka_wrunlock(rk);
 
-        rd_kafka_txn_curr_api_reply_error(rd_kafka_q_keep(rko->rko_replyq.q),
-                                          error);
+        if (complete) {
+                rd_kafka_txn_curr_api_reply_error(reply_q, error);
+        }
 
         return RD_KAFKA_OP_RES_HANDLED;
 }
@@ -2588,49 +2613,6 @@ static rd_kafka_op_res_t rd_kafka_txn_op_abort_transaction(rd_kafka_t *rk,
                 goto done;
         }
 
-        if (rk->rk_eos.txn_requires_epoch_bump ||
-            rk->rk_eos.idemp_state != RD_KAFKA_IDEMP_STATE_ASSIGNED) {
-                /* If the underlying idempotent producer's state indicates it
-                 * is re-acquiring its PID we need to wait for that to finish
-                 * before allowing a new begin_transaction(), and since that is
-                 * not a blocking call we need to perform that wait in this
-                 * state instead.
-                 * This may happen on epoch bump and fatal idempotent producer
-                 * error which causes the current transaction to enter the
-                 * abortable state.
-                 * To recover we need to request an epoch bump from the
-                 * transaction coordinator. This is handled automatically
-                 * by the idempotent producer, so we just need to wait for
-                 * the new pid to be assigned.
-                 */
-
-                if (rk->rk_eos.idemp_state == RD_KAFKA_IDEMP_STATE_ASSIGNED) {
-                        rd_kafka_dbg(rk, EOS, "TXNABORT", "PID already bumped");
-                        rd_kafka_txn_set_state(
-                            rk, RD_KAFKA_TXN_STATE_ABORT_NOT_ACKED);
-                        goto done;
-                }
-
-                rd_kafka_dbg(rk, EOS, "TXNABORT",
-                             "Waiting for transaction coordinator "
-                             "PID bump to complete before aborting "
-                             "transaction (idempotent producer state %s)",
-                             rd_kafka_idemp_state2str(rk->rk_eos.idemp_state));
-
-                /* Replace the current init replyq, if any, which is
-                 * from a previous timed out abort_transaction() call. */
-                RD_IF_FREE(rk->rk_eos.txn_init_rkq, rd_kafka_q_destroy);
-
-                /* Grab a separate reference to use in state_change(),
-                 * outside the curr_api to allow the curr_api to
-                 * to timeout while the PID bump continues in the
-                 * the background. */
-                rk->rk_eos.txn_init_rkq = rd_kafka_q_keep(rko->rko_replyq.q);
-
-                rd_kafka_wrunlock(rk);
-                return RD_KAFKA_OP_RES_HANDLED;
-        }
-
         if (!rk->rk_eos.txn_req_cnt) {
                 rd_kafka_dbg(rk, EOS, "TXNABORT",
                              "No partitions registered: not sending EndTxn");
@@ -2685,6 +2667,8 @@ rd_kafka_txn_op_abort_transaction_ack(rd_kafka_t *rk,
                                       rd_kafka_q_t *rkq,
                                       rd_kafka_op_t *rko) {
         rd_kafka_error_t *error;
+        rd_bool_t complete    = rd_true;
+        rd_kafka_q_t *reply_q = rd_kafka_q_keep(rko->rko_replyq.q);
 
         if (rko->rko_err == RD_KAFKA_RESP_ERR__DESTROY)
                 return RD_KAFKA_OP_RES_HANDLED;
@@ -2694,17 +2678,32 @@ rd_kafka_txn_op_abort_transaction_ack(rd_kafka_t *rk,
         if ((error = rd_kafka_txn_require_state(
                  rk, RD_KAFKA_TXN_STATE_ABORT_NOT_ACKED)))
                 goto done;
+        if (rk->rk_eos.completed_txn_waiting_bump != NULL) {
+                /* If a queue is already waiting for completion,
+                 * return handled without calling
+                 * rd_kafka_txn_complete again.
+                 */
+                complete = rd_false;
+                goto done;
+        }
 
         rd_kafka_dbg(rk, EOS, "TXNABORT",
                      "Aborted transaction now acked by application");
-        rd_kafka_txn_complete(rk, rd_false /*is abort*/);
-
+        complete = rd_kafka_txn_complete(rk, rd_false /*is abort*/);
+        if (!complete) {
+                /* Set this queue as waiting for completion.
+                 * rd_kafka_txn_curr_api_reply_error will be called
+                 * by rd_kafka_txns_complete_waiting
+                 */
+                rk->rk_eos.completed_txn_waiting_bump = reply_q;
+        }
         /* FALLTHRU */
 done:
         rd_kafka_wrunlock(rk);
 
-        rd_kafka_txn_curr_api_reply_error(rd_kafka_q_keep(rko->rko_replyq.q),
-                                          error);
+        if (complete) {
+                rd_kafka_txn_curr_api_reply_error(reply_q, error);
+        }
 
         return RD_KAFKA_OP_RES_HANDLED;
 }
@@ -3174,4 +3173,21 @@ void rd_kafka_txns_init(rd_kafka_t *rk) {
             rk->rk_eos.txn_coord, &rk->rk_eos.txn_coord->rkb_persistconn.coord);
 
         rd_atomic64_init(&rk->rk_eos.txn_dr_fails, 0);
+}
+
+/**
+ * @brief Complete a pending commit or abort.
+ */
+void rd_kafka_txns_complete_waiting(rd_kafka_t *rk) {
+        rd_kafka_error_t *error;
+        if ((error = rd_kafka_txn_require_state(
+                 rk, RD_KAFKA_TXN_STATE_ABORT_NOT_ACKED,
+                 RD_KAFKA_TXN_STATE_COMMIT_NOT_ACKED))) {
+                return;
+        }
+
+        rd_kafka_txn_set_state(rk, RD_KAFKA_TXN_STATE_READY);
+        rd_kafka_txn_curr_api_reply_error(rk->rk_eos.completed_txn_waiting_bump,
+                                          NULL);
+        rk->rk_eos.completed_txn_waiting_bump = NULL;
 }

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -1458,6 +1458,63 @@ rd_kafka_txn_send_TxnOffsetCommitRequest(rd_kafka_broker_t *rkb,
                                          rd_kafka_resp_cb_t *resp_cb,
                                          void *reply_opaque);
 
+
+static void rd_kafka_txn_handle_TxnOffsetCommit(rd_kafka_t *rk,
+                                                rd_kafka_broker_t *rkb,
+                                                rd_kafka_resp_err_t err,
+                                                rd_kafka_buf_t *rkbuf,
+                                                rd_kafka_buf_t *request,
+                                                void *opaque);
+
+/**
+ * @brief Retries TxnOffsetCommit
+ * replies \c RD_KAFKA_RESP_ERR__TIMED_OUT
+ * if transaction absolute timeout expired.
+ *
+ * @locality rdkafka main thread
+ * @locks none
+ */
+static void rd_kafka_txn_handle_TxnOffsetCommit_retry(rd_kafka_op_t *rko) {
+        rd_kafka_t *rk = rko->rko_rk;
+        int remains_ms = rd_timeout_remains(rko->rko_u.txn.abs_timeout);
+        if (!rd_timeout_expired(remains_ms)) {
+                rd_kafka_coord_req(
+                    rk, RD_KAFKA_COORD_GROUP,
+                    rko->rko_u.txn.cgmetadata->group_id,
+                    rd_kafka_txn_send_TxnOffsetCommitRequest, rko,
+                    rd_timeout_remains_limit0(remains_ms,
+                                              rk->rk_conf.socket_timeout_ms),
+                    RD_KAFKA_REPLYQ(rk->rk_ops, 0),
+                    rd_kafka_txn_handle_TxnOffsetCommit, rko);
+        } else {
+                rd_kafka_resp_err_t err = RD_KAFKA_RESP_ERR__TIMED_OUT;
+                char errstr[512];
+                rd_snprintf(errstr, sizeof(errstr),
+                            "Transactional API operation (%s) timed out",
+                            rk->rk_eos.txn_curr_api.name);
+                int actions = RD_KAFKA_ERR_ACTION_PERMANENT;
+
+                rd_kafka_txn_set_abortable_error(rk, err, "%s", errstr);
+                rd_kafka_txn_curr_api_reply(
+                    rd_kafka_q_keep(rko->rko_replyq.q), actions,
+                    RD_KAFKA_RESP_ERR__TIMED_OUT, "%s", errstr);
+                rd_kafka_op_destroy(rko);
+        }
+}
+
+/**
+ * @brief Retry TxnOffsetCommit callback
+ *
+ * @locality rdkafka main thread
+ * @locks none
+ */
+static void
+rd_kafka_txn_handle_TxnOffsetCommit_retry_cb(rd_kafka_timers_t *rkts,
+                                             void *arg) {
+        rd_kafka_op_t *rko = arg;
+        rd_kafka_txn_handle_TxnOffsetCommit_retry(rko);
+}
+
 /**
  * @brief Handle TxnOffsetCommitResponse
  *
@@ -1475,6 +1532,8 @@ static void rd_kafka_txn_handle_TxnOffsetCommit(rd_kafka_t *rk,
         int actions                                 = 0;
         rd_kafka_topic_partition_list_t *partitions = NULL;
         char errstr[512];
+        static rd_interval_t last_retry   = RD_ZERO_INIT;
+        static rd_kafka_timer_t retry_tmr = RD_ZERO_INIT;
 
         *errstr = '\0';
 
@@ -1538,6 +1597,7 @@ done:
                 /* Set a non-actionable actions flag so that curr_api_reply()
                  * is called below, without other side-effects. */
                 actions = RD_KAFKA_ERR_ACTION_SPECIAL;
+                rd_interval_init(&last_retry);
                 return;
 
         case RD_KAFKA_RESP_ERR_NOT_COORDINATOR:
@@ -1593,19 +1653,31 @@ done:
                 int remains_ms = rd_timeout_remains(rko->rko_u.txn.abs_timeout);
 
                 if (!rd_timeout_expired(remains_ms)) {
-                        rd_kafka_coord_req(
-                            rk, RD_KAFKA_COORD_GROUP,
-                            rko->rko_u.txn.cgmetadata->group_id,
-                            rd_kafka_txn_send_TxnOffsetCommitRequest, rko,
-                            rd_timeout_remains_limit0(
-                                remains_ms, rk->rk_conf.socket_timeout_ms),
-                            RD_KAFKA_REPLYQ(rk->rk_ops, 0),
-                            rd_kafka_txn_handle_TxnOffsetCommit, rko);
+                        rd_ts_t diff =
+                            rd_interval(&last_retry, 1000 * 1000 /* 1s */, 0);
+                        if (diff < 0) {
+                                rd_kafka_dbg(
+                                    rk, EOS, "TXNOFFSETCOMMIT",
+                                    "Waiting %ld µs before next retry. rkb:%s "
+                                    "err:%s actions:(%s)",
+                                    -diff,
+                                    rkb ? rd_kafka_broker_name(rkb) : "(none)",
+                                    rd_kafka_err2name(err),
+                                    rd_kafka_actions2str(actions));
+                                rd_kafka_timer_start_oneshot(
+                                    &rk->rk_timers, &retry_tmr, rd_true, -diff,
+                                    rd_kafka_txn_handle_TxnOffsetCommit_retry_cb,
+                                    rko);
+                        } else {
+                                rd_kafka_txn_handle_TxnOffsetCommit_retry(rko);
+                        }
                         return;
                 } else if (!err)
                         err = RD_KAFKA_RESP_ERR__TIMED_OUT;
                 actions |= RD_KAFKA_ERR_ACTION_PERMANENT;
         }
+
+        rd_interval_init(&last_retry);
 
         if (actions & RD_KAFKA_ERR_ACTION_PERMANENT)
                 rd_kafka_txn_set_abortable_error(rk, err, "%s", errstr);

--- a/src/rdkafka_txnmgr.h
+++ b/src/rdkafka_txnmgr.h
@@ -167,5 +167,5 @@ rd_bool_t rd_kafka_txn_coord_set(rd_kafka_t *rk,
 
 void rd_kafka_txns_term(rd_kafka_t *rk);
 void rd_kafka_txns_init(rd_kafka_t *rk);
-
+void rd_kafka_txns_complete_waiting(rd_kafka_t *rk);
 #endif /* _RDKAFKA_TXNMGR_H_ */

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -539,6 +539,10 @@ static void do_test_txn_fenced_reinit(rd_kafka_resp_err_t error_code) {
         rd_kafka_mock_broker_push_request_error_rtts(
             mcluster, txn_coord, RD_KAFKAP_InitProducerId, 1, error_code, 0);
 
+        /* Fail the Abort Transaction */
+        rd_kafka_mock_broker_push_request_error_rtts(
+            mcluster, txn_coord, RD_KAFKAP_EndTxn, 1, error_code, 0);
+
         /* Produce a message, let it fail with a fatal idempo error. */
         rd_kafka_mock_push_request_errors(
             mcluster, RD_KAFKAP_Produce, 1,


### PR DESCRIPTION
This is a collection of fixes developed while running different long running chaos tests with single and multiple brokers and several configurations. 

* When requesting an abort with drain and bump after message timeouts, the bump was executed first, causing a series of retries on InitProducerIdRequest until a transaction timeout happen and the producer was fenced. This commit changes the order of the operations, starting the drain bump after the complete transaction ack.
 * While a commit operation was in queue, a timeout happens that can cause an abort. The state changes from COMMITTING_TRANSACTION to ABORTABLE_ERROR to ABORTING_TRANSACTION. When the broker comes up the error is permanent or fatal because the state has changed from the initial one.
 * When doing a drain and bump txn_curr_coord is not null in state WAIT_TRANSPORT, but if txn_coord has to be requested or broker is down it's retried. During this retry the txn_curr_coord can be set to null after a COORDINATOR_NOT_AVAILABLE error so when it comes back to the WAIT_TRANSPORT case a fatal error happens in the assert. It has to query for a transaction coordinator and retry.
 * When aborting a transaction, if a local TIMED_OUT, TIMED_OUT_QUEUE or OUTDATED error happens, the error was not retriable (nor fenced or abortable) so rd_kafka_txn_op_abort_transaction_ack is never called, caller code doesn't know what to do so starts a new transaction but begin transaction fails because transactional state is not READY. These errors are now retriable.
 * When calling TxnOffsetCommit, if retries were needed they were made at full speed, causing too much logging and network calls. A one second timeout has been added between retries.