### PR TITLE
rand: Ensure rd_jitter functions properly for new threads (#3929)

### DIFF
--- a/src/rdposix.h
+++ b/src/rdposix.h
@@ -247,4 +247,7 @@ static RD_UNUSED int rd_pipe_nonblocking(rd_socket_t *fds) {
 #define rd_open(path, flags, mode) open(path, flags, mode)
 #define rd_close(fd)               close(fd)
 
+/* PRNG */
+#define rd_rand_r(seed) rand_r(seed)
+
 #endif /* _RDPOSIX_H_ */

--- a/src/rdrand.c
+++ b/src/rdrand.c
@@ -33,21 +33,15 @@
 
 int rd_jitter(int low, int high) {
         int rand_num;
-#if HAVE_RAND_R
+        struct timeval tv;
         static RD_TLS unsigned int seed = 0;
 
-        /* Initial seed with time+thread id */
-        if (unlikely(seed == 0)) {
-                struct timeval tv;
-                rd_gettimeofday(&tv, NULL);
-                seed = (unsigned int)(tv.tv_usec / 1000);
-                seed ^= (unsigned int)(intptr_t)thrd_current();
-        }
+        rd_gettimeofday(&tv, NULL);
+        seed = (unsigned int)(tv.tv_usec / 1000);
+        seed ^= (unsigned int)(intptr_t)thrd_current();
 
-        rand_num = rand_r(&seed);
-#else
-        rand_num = rand();
-#endif
+        rand_num = rd_rand_r(&seed);
+
         return (low + (rand_num % ((high - low) + 1)));
 }
 

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -377,6 +377,31 @@ err:
 #define rd_open(path, flags, mode) _open(path, flags, mode)
 #define rd_close(fd)               _close(fd)
 
+/**
+ * PRNG
+ */
+
+/**
+ * @brief rand_r() for Windows systems to ensure thread agnostic rand() results
+ * @returns a pseudo-random integer in the range 0 to RAND_MAX inclusive [0,
+ * RAND_MAX].
+ */
+int rd_rand_r(unsigned int *seed) {
+        /* Source: https://git.musl-libc.org/cgit/musl/tree/src/prng/rand_r.c */
+
+        unsigned int x;
+
+        *seed = *seed * 1103515245 + 12345;
+
+        x = *seed;
+        x ^= x >> 11;
+        x ^= x << 7 & 0x9D2C5680;
+        x ^= x << 15 & 0xEFC60000;
+        x ^= x >> 18;
+
+        return x / 2;
+}
+
 #endif /* !__cplusplus*/
 
 #endif /* _RDWIN32_H_ */


### PR DESCRIPTION
In cases where a Windows producer spins up a new thread to produce a single message, the value emitted by rd_jitter is exactly the same for every new thread.

On Windows, calls to srand() modify thread-local state, with subsequent calls to rand() reading that same thread-local state.

The previous fix to call srand() once during rd_kafka_new (#2795) does not fully fix this situation, as a brand new thread can take the object without ever calling rd_kafka_new() or rd_kafka_global_srand().

This patch rectifies this problem by using a version of rand_r() from the musl c library for Win32 platforms. On POSIX platforms, rd_rand_r() is a #define that points to the system's existing rand_r().