### PR TITLE
use s1-prod-macos-arm64 semaphore build agent

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: M1 Pipeline
 agent:
   machine:
-    type: s1-prod-mac-m1
+    type: s1-prod-macos-arm64
 blocks:
   - name: 'Build, Test, Package'
     task:


### PR DESCRIPTION
This updates the Semaphore pipeline to use the `s1-prod-macos-arm64` build agent. This new agent was created in a more scalable and maintainable way than the old one.