### PR TITLE
Fix cURL linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -197,6 +197,12 @@ set(dummy "${GENERATED_DIR}/dummy")
 file(MAKE_DIRECTORY "${dummy}")
 target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${dummy}>")
 
+if(WITH_CURL)
+  find_package(CURL REQUIRED)
+  target_include_directories(rdkafka PUBLIC ${CURL_INCLUDE_DIRS})
+  target_link_libraries(rdkafka PUBLIC ${CURL_LIBRARIES})
+endif()
+
 if(WITH_HDRHISTOGRAM)
   target_link_libraries(rdkafka PUBLIC m)
 endif()


### PR DESCRIPTION
Similar to https://github.com/edenhill/librdkafka/pull/3909, but somewhat more consistent with the surrounding CMake code linking to zlib or zstd.