### PR TITLE
Incorrect complete transaction and pid bump order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@ librdkafka v1.9.3 is a maintenance release:
 
  * Self-contained static libraries can now be built on Linux arm64 (#4005).
  * Fix for using PKCS#12 keystores on Windows.
+ * Fixes to the transactional and idempotent producer.
 
 
 ## Fixes
 
 ### General fixes
 
- * Windows: couldn't read a PKCS#12 keystore correctly because binary mode wasn't explicitly set and Windows defaults to text mode.
+ * Windows: couldn't read a PKCS#12 keystore correctly because binary
+   mode wasn't explicitly set and Windows defaults to text mode (#3999).
+
+
+### Transactional producer fixes
+
+ * Changed the order of the abort and PID bump operations,
+   starting the drain and bump after completing the transaction (#4011).
 
 
 

--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -582,7 +582,7 @@ void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason) {
         rd_kafka_wrlock(rk);
         rd_kafka_dbg(rk, EOS, "DRAIN",
                      "Beginning partition drain for %s reset "
-                     "for %d partition(s) with in-flight requests: %s",
+                     "for %" PRId32 " partition(s) with in-flight requests: %s",
                      rd_kafka_pid2str(rk->rk_eos.pid),
                      rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), reason);
         rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_RESET);
@@ -596,6 +596,33 @@ void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason) {
 /**
  * @brief Schedule an epoch bump when the local ProduceRequest queues
  *        have been fully drained.
+ *
+ * The PID is not bumped until the queues are fully drained.
+ *
+ * @param fmt is a human-readable reason for the bump.
+ *
+ * @locality any
+ * @locks none
+ */
+void rd_kafka_idemp_drain_epoch_bump_start(rd_kafka_t *rk, const char *reason) {
+        rd_kafka_wrlock(rk);
+        rd_kafka_dbg(rk, EOS, "DRAIN",
+                     "Beginning partition drain for %s epoch bump "
+                     "for %" PRId32 " partition(s) with in-flight requests: %s",
+                     rd_kafka_pid2str(rk->rk_eos.pid),
+                     rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), reason);
+        rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_BUMP);
+        rd_kafka_wrunlock(rk);
+
+        /* Check right away if the drain could be done. */
+        rd_kafka_idemp_check_drain_done(rk);
+}
+
+/**
+ * @brief Schedule an epoch bump when the local ProduceRequest queues
+ *        have been fully drained, or abort the current transaction,
+ *        if the producer is transactional, and
+ *        rd_kafka_idemp_drain_epoch_bump_start will be called after that.
  *
  * The PID is not bumped until the queues are fully drained.
  *
@@ -616,22 +643,13 @@ void rd_kafka_idemp_drain_epoch_bump(rd_kafka_t *rk,
         rd_vsnprintf(buf, sizeof(buf), fmt, ap);
         va_end(ap);
 
-        rd_kafka_wrlock(rk);
-        rd_kafka_dbg(rk, EOS, "DRAIN",
-                     "Beginning partition drain for %s epoch bump "
-                     "for %d partition(s) with in-flight requests: %s",
-                     rd_kafka_pid2str(rk->rk_eos.pid),
-                     rd_atomic32_get(&rk->rk_eos.inflight_toppar_cnt), buf);
-        rd_kafka_idemp_set_state(rk, RD_KAFKA_IDEMP_STATE_DRAIN_BUMP);
-        rd_kafka_wrunlock(rk);
-
-        /* Transactions: bumping the epoch requires the current transaction
-         *               to be aborted. */
-        if (rd_kafka_is_transactional(rk))
+        if (rd_kafka_is_transactional(rk)) {
+                /* Transactions: requires aborting the current transaction
+                 * before bumping the epoch . */
                 rd_kafka_txn_set_abortable_error_with_bump(rk, err, "%s", buf);
-
-        /* Check right away if the drain could be done. */
-        rd_kafka_idemp_check_drain_done(rk);
+        } else {
+                rd_kafka_idemp_drain_epoch_bump_start(rk, buf);
+        }
 }
 
 /**

--- a/src/rdkafka_idempotence.h
+++ b/src/rdkafka_idempotence.h
@@ -73,6 +73,7 @@ void rd_kafka_idemp_pid_update(rd_kafka_broker_t *rkb,
                                const rd_kafka_pid_t pid);
 void rd_kafka_idemp_pid_fsm(rd_kafka_t *rk);
 void rd_kafka_idemp_drain_reset(rd_kafka_t *rk, const char *reason);
+void rd_kafka_idemp_drain_epoch_bump_start(rd_kafka_t *rk, const char *reason);
 void rd_kafka_idemp_drain_epoch_bump(rd_kafka_t *rk,
                                      rd_kafka_resp_err_t err,
                                      const char *fmt,

--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -1876,6 +1876,33 @@ rd_kafka_mock_broker_push_request_error_rtts(rd_kafka_mock_cluster_t *mcluster,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+rd_kafka_resp_err_t
+rd_kafka_mock_broker_error_stack_cnt(rd_kafka_mock_cluster_t *mcluster,
+                                     int32_t broker_id,
+                                     int16_t ApiKey,
+                                     size_t *cnt) {
+        rd_kafka_mock_broker_t *mrkb;
+        rd_kafka_mock_error_stack_t *errstack;
+
+        if (!mcluster || !cnt)
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+
+        mtx_lock(&mcluster->lock);
+
+        if (!(mrkb = rd_kafka_mock_broker_find(mcluster, broker_id))) {
+                mtx_unlock(&mcluster->lock);
+                return RD_KAFKA_RESP_ERR__UNKNOWN_BROKER;
+        }
+
+        errstack = rd_kafka_mock_error_stack_get(&mrkb->errstacks, ApiKey);
+
+        *cnt = errstack->cnt;
+
+        mtx_unlock(&mcluster->lock);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
 
 void rd_kafka_mock_topic_set_error(rd_kafka_mock_cluster_t *mcluster,
                                    const char *topic,

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -191,6 +191,26 @@ rd_kafka_mock_broker_push_request_error_rtts(rd_kafka_mock_cluster_t *mcluster,
 
 
 /**
+ * @brief Get the count of errors in
+ *        the broker's error stack for the given \p ApiKey.
+
+ * \p mcluster the mock cluster.
+ * \p broker_id id of the broker in the cluster.
+ * \p ApiKey is the Kafka protocol request type, e.g., ProduceRequest (0).
+ * \p cnt pointer for receiving the count.
+ *
+ * @returns \c RD_KAFKA_RESP_ERR_NO_ERROR if the count was retrieved,
+ * \c RD_KAFKA_RESP_ERR__UNKNOWN_BROKER if there was not broker with this id,
+ * \c RD_KAFKA_RESP_ERR__INVALID_ARG if some of the parameters are not valid.
+ */
+rd_kafka_resp_err_t
+rd_kafka_mock_broker_error_stack_cnt(rd_kafka_mock_cluster_t *mcluster,
+                                     int32_t broker_id,
+                                     int16_t ApiKey,
+                                     size_t *cnt);
+
+
+/**
  * @brief Set the topic error to return in protocol requests.
  *
  * Currently only used for TopicMetadataRequest and AddPartitionsToTxnRequest.

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -2058,7 +2058,7 @@ static rd_bool_t rd_kafka_txn_complete(rd_kafka_t *rk, rd_bool_t is_commit) {
         if (drain_bump) {
                 rd_kafka_wrunlock(rk);
                 rd_kafka_idemp_drain_epoch_bump_start(
-                    rk, "txn_requires_epoch_bump");
+                    rk, "Transaction requires epoch bump");
                 rd_kafka_wrlock(rk);
                 return rd_false;
         } else {

--- a/src/rdkafka_txnmgr.h
+++ b/src/rdkafka_txnmgr.h
@@ -167,5 +167,4 @@ rd_bool_t rd_kafka_txn_coord_set(rd_kafka_t *rk,
 
 void rd_kafka_txns_term(rd_kafka_t *rk);
 void rd_kafka_txns_init(rd_kafka_t *rk);
-
 #endif /* _RDKAFKA_TXNMGR_H_ */

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -544,6 +544,10 @@ static void do_test_txn_fenced_reinit(rd_kafka_resp_err_t error_code) {
         rd_kafka_mock_broker_push_request_error_rtts(
             mcluster, txn_coord, RD_KAFKAP_InitProducerId, 1, error_code, 0);
 
+        /* Fail the Abort Transaction */
+        rd_kafka_mock_broker_push_request_error_rtts(
+            mcluster, txn_coord, RD_KAFKAP_EndTxn, 1, error_code, 0);
+
         /* Produce a message, let it fail with a fatal idempo error. */
         rd_kafka_mock_push_request_errors(
             mcluster, RD_KAFKAP_Produce, 1,


### PR DESCRIPTION
Changed the order of the abort and PID bump operations,  starting the drain and bump after completing the transaction.