### PR TITLE
Copy public headers to include/librdkafka/*.h

### DIFF
--- a/src-cpp/CMakeLists.txt
+++ b/src-cpp/CMakeLists.txt
@@ -30,8 +30,18 @@ endif()
 
 target_link_libraries(rdkafka++ PUBLIC rdkafka)
 
-# Support '#include <rdkafcpp.h>'
-target_include_directories(rdkafka++ PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>")
+# Copy public API headers to include/librdkafka/
+configure_file("rdkafkacpp.h" "include/librdkafka/rdkafkacpp.h" COPYONLY)
+
+# Support '#include <rdkafcpp.h>' and '#include <librdkafka/rdkafkacpp.h>'
+target_include_directories(rdkafka++
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 if(NOT RDKAFKA_BUILD_STATIC)
     target_compile_definitions(rdkafka++ PRIVATE LIBRDKAFKACPP_EXPORTS)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,8 +184,19 @@ if(MINGW)
   list(APPEND rdkafka_compile_definitions WINVER=0x0603 _WIN32_WINNT=0x0603 UNICODE)
 endif(MINGW)
 
-# Support '#include <rdkafka.h>'
-target_include_directories(rdkafka PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+# Copy public API headers to include/librdkafka/
+configure_file("rdkafka.h" "include/librdkafka/rdkafka.h" COPYONLY)
+configure_file("rdkafka_mock.h" "include/librdkafka/rdkafka_mock.h" COPYONLY)
+
+# Support '#include <rdkafka.h>' and '#include <librdkafka/rdkafka.h>'
+target_include_directories(rdkafka
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 target_compile_definitions(rdkafka PUBLIC ${rdkafka_compile_definitions})
 if(RDKAFKA_BUILD_STATIC)
   target_compile_definitions(rdkafka PUBLIC LIBRDKAFKA_STATICLIB)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,6 +196,12 @@ set(dummy "${GENERATED_DIR}/dummy")
 file(MAKE_DIRECTORY "${dummy}")
 target_include_directories(rdkafka PUBLIC "$<BUILD_INTERFACE:${dummy}>")
 
+if(WITH_CURL)
+  find_package(CURL REQUIRED)
+  target_include_directories(rdkafka PUBLIC ${CURL_INCLUDE_DIRS})
+  target_link_libraries(rdkafka PUBLIC ${CURL_LIBRARIES})
+endif()
+
 if(WITH_HDRHISTOGRAM)
   target_link_libraries(rdkafka PUBLIC m)
 endif()


### PR DESCRIPTION
As an alternative to https://github.com/edenhill/librdkafka/pull/4004.

This approach copies the public headers at build time when using CMake.
This behavior is not implemented for Make as I am not familiar with mklove.
When using `add_subdirectory` in CMake, the new include directory is added along the old one automatically, so linking to the `rdkafka` or `rdkafka++` target should work.

Currently, no deprecation warning is emitted.
It could be implemented by applying `configure_file` on each header and setting a flag when deploying it to `include/librdkafka/`.