### PR TITLE
Fix for invalid state transition when commit times out and abort is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ librdkafka v1.9.3 is a maintenance release:
  * Fix for using PKCS#12 keystores on Windows.
  * OpenSSL 3.0.x support - the maximum bundled OpenSSL version is now 3.0.5 (previously 1.1.1q).
  * Updated to zlib 1.2.13 and zstd 1.5.2 in self-contained librdkafka bundles.
+ * Fixes to the transactional and idempotent producer.
 
 
 ## Upgrade considerations
@@ -47,6 +48,15 @@ configuration property.
 ## Enhancements
 
  * Bundled zlib upgraded to version 1.2.13.
+
+### Transactional producer fixes
+
+ * When a commit operation is in queue, a timeout can happen,
+ causing an abortable error. The subsequent abort can cause
+ the an assert to fail for an invalid state transition.
+ This fix allows to recover from that acknowledging the
+ previously succeeded commit operation. (#4016).
+
 
 
 # librdkafka v1.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ configuration property.
 
  * When a commit operation is in queue, a timeout can happen,
  causing an abortable error. The subsequent abort can cause
- the an assert to fail for an invalid state transition.
+ an assert to fail for an invalid state transition.
  This fix allows to recover from that acknowledging the
  previously succeeded commit operation. (#4016).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,9 @@ configuration property.
  * When a commit operation is in queue, a timeout can happen,
  causing an abortable error. The subsequent abort can cause
  an assert to fail for an invalid state transition.
- This fix allows to recover from that acknowledging the
- previously succeeded commit operation. (#4016).
+ This fix allows to recover from that, retrying the
+ commit or abort operation until a response by the broker
+ is received (#4016).
 
 
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -8124,6 +8124,9 @@ rd_kafka_resp_err_t rd_kafka_oauthbearer_set_token_failure(rd_kafka_t *rk,
  *
  * @remark The returned error object (if not NULL) must be destroyed with
  *         rd_kafka_error_destroy().
+ *
+ * @remark Not allowed to be called concurrently
+ *         to other transactional calls.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_init_transactions(rd_kafka_t *rk, int timeout_ms);
@@ -8173,6 +8176,9 @@ rd_kafka_error_t *rd_kafka_init_transactions(rd_kafka_t *rk, int timeout_ms);
  *
  * @remark The returned error object (if not NULL) must be destroyed with
  *         rd_kafka_error_destroy().
+ *
+ * @remark Not allowed to be called concurrently
+ *         to other transactional calls.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_begin_transaction(rd_kafka_t *rk);
@@ -8221,7 +8227,8 @@ rd_kafka_error_t *rd_kafka_begin_transaction(rd_kafka_t *rk);
  *          rd_kafka_error_txn_requires_abort() or rd_kafka_error_is_fatal()
  *          respectively.
  *          Error codes:
- *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction,
+ *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction
+ *          or a concurrent transactional call is already in progress,
  *          RD_KAFKA_RESP_ERR_INVALID_PRODUCER_EPOCH if the current producer
  *          transaction has been fenced by a newer producer instance,
  *          RD_KAFKA_RESP_ERR_TRANSACTIONAL_ID_AUTHORIZATION_FAILED if the
@@ -8241,6 +8248,9 @@ rd_kafka_error_t *rd_kafka_begin_transaction(rd_kafka_t *rk);
  *
  * @remark The returned error object (if not NULL) must be destroyed with
  *         rd_kafka_error_destroy().
+ *
+ * @remark Not allowed to be called concurrently
+ *         to other transactional calls.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_send_offsets_to_transaction(
@@ -8295,7 +8305,8 @@ rd_kafka_error_t *rd_kafka_send_offsets_to_transaction(
  *          rd_kafka_error_txn_requires_abort() or rd_kafka_error_is_fatal()
  *          respectively.
  *          Error codes:
- *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction,
+ *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction
+ *          or a concurrent transactional call is already in progress,
  *          RD_KAFKA_RESP_ERR__TIMED_OUT if the transaction could not be
  *          complete commmitted within \p timeout_ms, this is a retriable
  *          error as the commit continues in the background,
@@ -8312,6 +8323,9 @@ rd_kafka_error_t *rd_kafka_send_offsets_to_transaction(
  *
  * @remark The returned error object (if not NULL) must be destroyed with
  *         rd_kafka_error_destroy().
+ *
+ * @remark Not allowed to be called concurrently
+ *         to other transactional calls.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_commit_transaction(rd_kafka_t *rk, int timeout_ms);
@@ -8354,7 +8368,8 @@ rd_kafka_error_t *rd_kafka_commit_transaction(rd_kafka_t *rk, int timeout_ms);
  *          by calling rd_kafka_error_is_retriable(), or whether a fatal error
  *          has been raised by calling rd_kafka_error_is_fatal().
  *          Error codes:
- *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction,
+ *          RD_KAFKA_RESP_ERR__STATE if not currently in a transaction
+ *          or a concurrent transactional call is already in progress,
  *          RD_KAFKA_RESP_ERR__TIMED_OUT if the transaction could not be
  *          complete commmitted within \p timeout_ms, this is a retriable
  *          error as the commit continues in the background,
@@ -8371,6 +8386,8 @@ rd_kafka_error_t *rd_kafka_commit_transaction(rd_kafka_t *rk, int timeout_ms);
  *
  * @remark The returned error object (if not NULL) must be destroyed with
  *         rd_kafka_error_destroy().
+ * @remark Not allowed to be called concurrently
+ *         to other transactional calls.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_abort_transaction(rd_kafka_t *rk, int timeout_ms);

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -447,6 +447,16 @@ struct rd_kafka_s {
                  */
                 rd_kafka_q_t *txn_init_rkq;
 
+                /**< Last called transaction API. Useful for telling when it's
+                 * necessary to reset txn_init_rkq.
+                 *
+                 *   @locks rk_lock
+                 */
+                struct {
+                        char name[64]; /**< API name, e.g.,
+                                        *   SendOffsetsToTransaction */
+                } txn_last_api;
+
                 int txn_req_cnt; /**< Number of transaction
                                   *   requests sent.
                                   *   This is incremented when a

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -447,16 +447,6 @@ struct rd_kafka_s {
                  */
                 rd_kafka_q_t *txn_init_rkq;
 
-                /**< Last called transaction API. Useful for telling when it's
-                 * necessary to reset txn_init_rkq.
-                 *
-                 *   @locks rk_lock
-                 */
-                struct {
-                        char name[64]; /**< API name, e.g.,
-                                        *   SendOffsetsToTransaction */
-                } txn_last_api;
-
                 int txn_req_cnt; /**< Number of transaction
                                   *   requests sent.
                                   *   This is incremented when a

--- a/src/rdkafka_txnmgr.c
+++ b/src/rdkafka_txnmgr.c
@@ -1192,16 +1192,15 @@ static rd_kafka_error_t *rd_kafka_txn_curr_api_req(rd_kafka_t *rk,
 
         rd_assert(for_reuse == reuse);
 
-        rd_snprintf(rk->rk_eos.txn_curr_api.name,
-                    sizeof(rk->rk_eos.txn_curr_api.name), "%s", name);
         /* When API changes, destroy previous pending queue. */
         if (rk->rk_eos.txn_init_rkq &&
-            strcmp(rk->rk_eos.txn_last_api.name, name)) {
+            strcmp(rk->rk_eos.txn_curr_api.name, name)) {
                 rd_kafka_q_destroy_owner(rk->rk_eos.txn_init_rkq);
-                rk->rk_eos.txn_init_rkq       = NULL;
-                *rk->rk_eos.txn_last_api.name = '\0';
+                rk->rk_eos.txn_init_rkq = NULL;
         }
 
+        rd_snprintf(rk->rk_eos.txn_curr_api.name,
+                    sizeof(rk->rk_eos.txn_curr_api.name), "%s", name);
         rk->rk_eos.txn_curr_api.flags |= flags;
 
         /* Then update for_reuse to the passed flags so that
@@ -1275,8 +1274,6 @@ static rd_kafka_error_t *rd_kafka_txn_curr_api_req(rd_kafka_t *rk,
                 if (!rk->rk_eos.txn_init_rkq) {
                         rk->rk_eos.txn_init_rkq = current_q;
                 }
-                rd_snprintf(rk->rk_eos.txn_last_api.name,
-                            sizeof(rk->rk_eos.txn_last_api.name), "%s", name);
         }
         if (reply)
                 rd_kafka_op_destroy(reply);

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3189,8 +3189,8 @@ do_test_txn_concurrent_operations(rd_bool_t is_commit,
 
         TEST_SAY("Concurrent operation while retrying\n");
         concurrent_operation = do_test_txn_concurrent_operations_abort;
-        if (!is_commit && different_concurrent_operation ||
-            is_commit && !different_concurrent_operation) {
+        if ((!is_commit && different_concurrent_operation) ||
+            (is_commit && !different_concurrent_operation)) {
                 concurrent_operation = do_test_txn_concurrent_operations_commit;
         }
         if (thrd_create(&thr, concurrent_operation, (void *)rk) !=

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -2870,7 +2870,7 @@ static void do_test_disconnected_group_coord(rd_bool_t switch_coord) {
  * @brief Test that transaction state different from the initial one,
  * because of a local timed out, doesn't cause an illegal state transition.
  */
-static void do_test_txn_state_different_from_the_initial_one() {
+static void do_test_txn_state_different_from_the_initial_one(void) {
         rd_kafka_t *rk;
         rd_kafka_mock_cluster_t *mcluster;
         int32_t coord_id = 1;

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3006,52 +3006,13 @@ static void do_test_txn_retriable_on_local_timeout(rd_bool_t is_commit,
 }
 
 
-static int do_test_txn_operations_not_expected_commit(void *arg) {
-        rd_kafka_t *rk          = arg;
-        rd_kafka_error_t *error = rd_kafka_commit_transaction(rk, 100);
-        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
-                    "Expected _STATE, not %s", rd_kafka_error_name(error));
-        TEST_ASSERT(!rd_kafka_error_is_fatal(error) &&
-                        !rd_kafka_error_is_retriable(error) &&
-                        !rd_kafka_error_txn_requires_abort(error),
-                    "Expected an error without flags, found is_fatal: %s,"
-                    " is_retriable: %s, txn_requires_abort: %s",
-                    RD_STR_ToF(rd_kafka_error_is_fatal(error)),
-                    RD_STR_ToF(rd_kafka_error_is_retriable(error)),
-                    RD_STR_ToF(rd_kafka_error_txn_requires_abort(error)));
-        rd_kafka_error_destroy(error);
-        return 0;
-}
-
-static int do_test_txn_operations_not_expected_abort(void *arg) {
-        rd_usleep(500 * 1000, NULL);
-        rd_kafka_t *rk          = arg;
-        rd_kafka_error_t *error = rd_kafka_abort_transaction(rk, 100);
-        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
-                    "Expected _STATE, not %s", rd_kafka_error_name(error));
-        TEST_ASSERT(!rd_kafka_error_is_fatal(error) &&
-                        !rd_kafka_error_is_retriable(error) &&
-                        !rd_kafka_error_txn_requires_abort(error),
-                    "Expected an error without flags, found is_fatal: %s,"
-                    " is_retriable: %s, txn_requires_abort: %s",
-                    RD_STR_ToF(rd_kafka_error_is_fatal(error)),
-                    RD_STR_ToF(rd_kafka_error_is_retriable(error)),
-                    RD_STR_ToF(rd_kafka_error_txn_requires_abort(error)));
-        rd_kafka_error_destroy(error);
-        return 0;
-}
-
 /**
  * @brief Test cases where the caller is not sending the requested
- * operation, or sending a concurrent one from a different thread.
+ * operation.
  *
  * @param is_commit is it a commit or abort test.
- * @param different_concurrent_operation send a concurrent operation
- * of a different type or of the same type.
  */
-static void
-do_test_txn_unexpected_operations(rd_bool_t is_commit,
-                                  rd_bool_t different_concurrent_operation) {
+static void do_test_txn_unexpected_operations(rd_bool_t is_commit) {
         rd_kafka_t *rk;
         rd_kafka_mock_cluster_t *mcluster;
         int32_t coord_id = 1;
@@ -3061,12 +3022,8 @@ do_test_txn_unexpected_operations(rd_bool_t is_commit,
         int msgcnt                   = 1000;
         int remains                  = 0;
         rd_kafka_error_t *error;
-        thrd_t thr;
-        thrd_start_t concurrent_operation;
 
-        SUB_TEST_QUICK("is_commit=%s different_concurrent_operation=%s",
-                       RD_STR_ToF(is_commit),
-                       RD_STR_ToF(different_concurrent_operation));
+        SUB_TEST_QUICK("is_commit=%s", RD_STR_ToF(is_commit));
 
         rk = create_txn_producer(&mcluster, transactional_id, 3,
                                  "transaction.timeout.ms", "100000", NULL);
@@ -3132,12 +3089,109 @@ do_test_txn_unexpected_operations(rd_bool_t is_commit,
                     "Expected _STATE, not %s", rd_kafka_error_name(error));
         rd_kafka_error_destroy(error);
 
+        rd_kafka_destroy(rk);
+        memset(allowed_errors, 0, 5 * sizeof(int));
+        test_curr->is_fatal_cb = NULL;
+        SUB_TEST_PASS();
+}
+
+
+static int do_test_txn_concurrent_operations_commit(void *arg) {
+        /* Ensures this is the second call */
+        rd_usleep(500 * 1000, NULL);
+        rd_kafka_t *rk          = arg;
+        rd_kafka_error_t *error = rd_kafka_commit_transaction(rk, 100);
+        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _CONFLICT, not %s", rd_kafka_error_name(error));
+        TEST_ASSERT(!rd_kafka_error_is_fatal(error) &&
+                        !rd_kafka_error_is_retriable(error) &&
+                        !rd_kafka_error_txn_requires_abort(error),
+                    "Expected an error without flags, found is_fatal: %s,"
+                    " is_retriable: %s, txn_requires_abort: %s",
+                    RD_STR_ToF(rd_kafka_error_is_fatal(error)),
+                    RD_STR_ToF(rd_kafka_error_is_retriable(error)),
+                    RD_STR_ToF(rd_kafka_error_txn_requires_abort(error)));
+        rd_kafka_error_destroy(error);
+        return 0;
+}
+
+static int do_test_txn_concurrent_operations_abort(void *arg) {
+        rd_usleep(500 * 1000, NULL);
+        rd_kafka_t *rk          = arg;
+        rd_kafka_error_t *error = rd_kafka_abort_transaction(rk, 100);
+        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _CONFLICT, not %s", rd_kafka_error_name(error));
+        TEST_ASSERT(!rd_kafka_error_is_fatal(error) &&
+                        !rd_kafka_error_is_retriable(error) &&
+                        !rd_kafka_error_txn_requires_abort(error),
+                    "Expected an error without flags, found is_fatal: %s,"
+                    " is_retriable: %s, txn_requires_abort: %s",
+                    RD_STR_ToF(rd_kafka_error_is_fatal(error)),
+                    RD_STR_ToF(rd_kafka_error_is_retriable(error)),
+                    RD_STR_ToF(rd_kafka_error_txn_requires_abort(error)));
+        rd_kafka_error_destroy(error);
+        return 0;
+}
+
+
+/**
+ * @brief Test cases where the caller is sending a concurrent
+ * operation from a different thread.
+ *
+ * @param is_commit is it a commit or abort test.
+ * @param different_operation send a concurrent operation
+ * of a different type or of the same type.
+ */
+static void
+do_test_txn_concurrent_operations(rd_bool_t is_commit,
+                                  rd_bool_t different_concurrent_operation) {
+        rd_kafka_t *rk;
+        rd_kafka_mock_cluster_t *mcluster;
+        int32_t coord_id = 1;
+        rd_kafka_resp_err_t err;
+        const char *topic            = "test";
+        const char *transactional_id = "txnid";
+        int msgcnt                   = 1000;
+        int remains                  = 0;
+        rd_kafka_error_t *error;
+        thrd_t thr;
+        thrd_start_t concurrent_operation;
+
+        SUB_TEST_QUICK("is_commit=%s different_concurrent_operation=%s",
+                       RD_STR_ToF(is_commit),
+                       RD_STR_ToF(different_concurrent_operation));
+
+        rk = create_txn_producer(&mcluster, transactional_id, 3,
+                                 "transaction.timeout.ms", "100000", NULL);
+
+        allowed_errors[0]      = RD_KAFKA_RESP_ERR__TRANSPORT;
+        allowed_errors[1]      = RD_KAFKA_RESP_ERR__TIMED_OUT;
+        test_curr->is_fatal_cb = error_is_fatal_cb;
+
+        err = rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+        TEST_ASSERT(!err, "Failed to create topic: %s", rd_kafka_err2str(err));
+
+        rd_kafka_mock_coordinator_set(mcluster, "transaction", transactional_id,
+                                      coord_id);
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, coord_id);
+
+        TEST_SAY("Starting transaction\n");
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, -1));
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(rk));
+
+        test_produce_msgs2_nowait(rk, topic, 0, RD_KAFKA_PARTITION_UA, 0,
+                                  msgcnt, NULL, 0, &remains);
+
+        /* Make sure messages are sent. */
+        err = rd_kafka_flush(rk, -1);
+        TEST_ASSERT(!err, "Expected no error while flushing, got: %s",
+                    rd_kafka_err2str(err));
+
         TEST_SAY("Concurrent operation while retrying\n");
-        concurrent_operation = do_test_txn_operations_not_expected_abort;
+        concurrent_operation = do_test_txn_concurrent_operations_abort;
         if (!is_commit && different_concurrent_operation ||
             is_commit && !different_concurrent_operation) {
-                concurrent_operation =
-                    do_test_txn_operations_not_expected_commit;
+                concurrent_operation = do_test_txn_concurrent_operations_commit;
         }
         if (thrd_create(&thr, concurrent_operation, (void *)rk) !=
             thrd_success) {
@@ -3252,16 +3306,19 @@ int main_0105_transactions_mock(int argc, char **argv) {
         do_test_txn_retriable_on_local_timeout(rd_false, /* is_commit */
                                                rd_true /* timeout_queue */);
 
-        do_test_txn_unexpected_operations(
+        do_test_txn_unexpected_operations(rd_true /* is_commit */);
+        do_test_txn_unexpected_operations(rd_false /* is_commit */);
+
+        do_test_txn_concurrent_operations(
             rd_true, /* is_commit */
             rd_true /* different_concurrent_operation */);
-        do_test_txn_unexpected_operations(
+        do_test_txn_concurrent_operations(
             rd_true, /* is_commit */
             rd_false /* different_concurrent_operation */);
-        do_test_txn_unexpected_operations(
+        do_test_txn_concurrent_operations(
             rd_false, /* is_commit */
             rd_true /* different_concurrent_operation */);
-        do_test_txn_unexpected_operations(
+        do_test_txn_concurrent_operations(
             rd_false, /* is_commit */
             rd_false /* different_concurrent_operation */);
 

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -65,6 +65,8 @@ error_is_fatal_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, const char *reason) {
                             * that we'll also see ALL_BROKERS_DOWN. */
                            (allowed_errors[i] == RD_KAFKA_RESP_ERR__TRANSPORT &&
                             err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN));
+                if (allowed)
+                        break;
         }
         if (allowed) {
                 TEST_SAY("Ignoring allowed error: %s: %s\n",


### PR DESCRIPTION
While a commit operation was in queue, a timeout happens that can cause an abort. The state changes from COMMITTING_TRANSACTION to ABORTABLE_ERROR to ABORTING_TRANSACTION. When the broker comes up the error, that before was retriable, now is permanent or fatal because the state has changed from the initial one