### PR TITLE
Transaction offset commit shouldn't retry without waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ librdkafka v2.0.0 is a feature release:
 
  * Fixes to the transactional and idempotent producer.
  * OpenSSL 3.0.x support - the maximum bundled OpenSSL version is now 3.0.7 (previously 1.1.1q).
+ * Updated to zlib 1.2.13 and zstd 1.5.2 in self-contained librdkafka bundles.
+ * Fixes to the transactional and idempotent producer.
 
 
 ## Upgrade considerations
@@ -71,10 +73,14 @@ configuration property.
  * Timeouts for EndTxn requests (transaction commits and aborts) are now
    automatically retried and the error raised to the application is also
    a retriable error.
+ * When calling transaction offset commit, if the coordinator was found but
+   not available, retries were made without waits, causing too much logging
+   and network calls. An interval has been added between retries (#4031).
 
 ### Consumer fixes
 
  * Back-off and retry JoinGroup request if coordinator load is in progress.
+
 
 
 # librdkafka v1.9.2

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -424,11 +424,23 @@ struct rd_kafka_s {
                                                   *   result (possibly
                                                   *   intermediate) has been set.
                                                   */
-                        cnd_t cnd;               /**< Application thread will
-                                                  *   block on this cnd waiting
-                                                  *   for a result to be set. */
-                        mtx_t lock;              /**< Protects all fields of
-                                                  *   txn_curr_api. */
+                        rd_kafka_timer_t retry_tmr; /**< Retry timer, used
+                                                     * for calls that cannot
+                                                     * be retried directly
+                                                     * by re-enqueuing and
+                                                     * cannot be retried
+                                                     * immediately. */
+
+                        rd_interval_t last_retry; /**< Keep track
+                                                   * of last retry
+                                                   * to avoid retrying
+                                                   * too fast or waiting
+                                                   * when it's not needed. */
+                        cnd_t cnd;                /**< Application thread will
+                                                   *   block on this cnd waiting
+                                                   *   for a result to be set. */
+                        mtx_t lock;               /**< Protects all fields of
+                                                   *   txn_curr_api. */
                 } txn_curr_api;
 
 

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -2960,7 +2960,7 @@ do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_bool_t times_out) {
         rd_kafka_resp_err_t err;
         rd_kafka_topic_partition_list_t *offsets;
         rd_kafka_consumer_group_metadata_t *cgmetadata;
-        const rd_kafka_error_t *error;
+        rd_kafka_error_t *error;
         int timeout;
 
         SUB_TEST_QUICK("times_out=%s", RD_STR_ToF(times_out));
@@ -2999,6 +2999,8 @@ do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_bool_t times_out) {
         timeout = times_out ? 500 : 1500;
         error   = rd_kafka_send_offsets_to_transaction(rk, offsets, cgmetadata,
                                                      timeout);
+        rd_kafka_consumer_group_metadata_destroy(cgmetadata);
+        rd_kafka_topic_partition_list_destroy(offsets);
 
         if (times_out) {
                 TEST_ASSERT(rd_kafka_error_code(error) ==
@@ -3011,9 +3013,7 @@ do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_bool_t times_out) {
                             "expected \"Success\", found: %s",
                             rd_kafka_err2str(rd_kafka_error_code(error)));
         }
-
-        rd_kafka_consumer_group_metadata_destroy(cgmetadata);
-        rd_kafka_topic_partition_list_destroy(offsets);
+        rd_kafka_error_destroy(error);
 
         /* All done */
         rd_kafka_destroy(rk);
@@ -3684,7 +3684,7 @@ int main_0105_transactions_mock(int argc, char **argv) {
         do_test_txn_fenced_abort(RD_KAFKA_RESP_ERR_PRODUCER_FENCED);
 
         do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_true);
-        
+
         do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_false);
 
         return 0;


### PR DESCRIPTION
 When calling transaction offset commit, if the coordinator was found but
 not available, retries were made without waits, causing too much logging
 and network calls. An interval has been added between retries.