### PR TITLE
Updated zlib download url (#4024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ librdkafka v1.9.3 is a maintenance release:
 ## Enhancements
 
  * Bundled zlib upgraded to version 1.2.13.
+ * Updated zlib download url (#4024).
 
 
 # librdkafka v1.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ librdkafka v1.9.3 is a maintenance release:
 ## Enhancements
 
  * Bundled zlib upgraded to version 1.2.13.
- * Updated zlib download url (#4024).
 
 
 # librdkafka v1.9.2

--- a/mklove/modules/configure.zlib
+++ b/mklove/modules/configure.zlib
@@ -48,7 +48,7 @@ function install_source {
     echo "### Installing $name $ver from source to $destdir"
     if [[ ! -f Makefile ]]; then
         mkl_download_archive \
-            "https://zlib.net/zlib-${ver}.tar.gz" \
+            "https://zlib.net/fossils/zlib-${ver}.tar.gz" \
             "256" \
             "$checksum" || return 1
     fi


### PR DESCRIPTION
Updated zlib download url from https://zlib.net/ to https://zlib.net/fossils/ as the former doesn't work for all the versions anymore