### PR TITLE
Fix the batch.size condition on the produce path

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3803,11 +3803,8 @@ static int rd_kafka_toppar_producer_serve(rd_kafka_broker_t *rkb,
                     now, flushing ? 1 : rkb->rkb_rk->rk_conf.buffering_max_us,
                     /* Batch message count threshold */
                     rkb->rkb_rk->rk_conf.batch_num_messages,
-                    /* Batch size threshold.
-                     * When compression is enabled the
-                     * threshold is increased by x8. */
-                    (rktp->rktp_rkt->rkt_conf.compression_codec ? 1 : 8) *
-                        (int64_t)rkb->rkb_rk->rk_conf.batch_size);
+                    /* Batch total size threshold */
+                    rkb->rkb_rk->rk_conf.batch_size);
         }
 
         rd_kafka_toppar_unlock(rktp);
@@ -3967,11 +3964,8 @@ static int rd_kafka_toppar_producer_serve(rd_kafka_broker_t *rkb,
                     flushing ? 1 : rkb->rkb_rk->rk_conf.buffering_max_us,
                     /* Batch message count threshold */
                     rkb->rkb_rk->rk_conf.batch_num_messages,
-                    /* Batch size threshold.
-                     * When compression is enabled the
-                     * threshold is increased by x8. */
-                    (rktp->rktp_rkt->rkt_conf.compression_codec ? 1 : 8) *
-                        (int64_t)rkb->rkb_rk->rk_conf.batch_size);
+                    /* Batch total size threshold */
+                    rkb->rkb_rk->rk_conf.batch_size);
                 rd_kafka_toppar_unlock(rktp);
         }
 


### PR DESCRIPTION
When the batch.size is exceeded, we will close and send the current batch. In case compression is enabled, we "inflate" the batch size by 8x for the purposes of this check.

At least, that's the intent. Currently the condition is reversed: the 8x inflation happens if compression is disabled, not the other way around. The effect is that messages linger for longer than expected in the queue, as if the batch size was 8x larger. They are still sent respecting the batch size however, since this occurs at a different location.

This change reverses the sense of the condition so that the 8x multiplier is applied iff compression is enabled.