### PR TITLE
Fix compilation with boringssl

### DIFF
--- a/src/rdkafka_conf.h
+++ b/src/rdkafka_conf.h
@@ -32,7 +32,8 @@
 #include "rdlist.h"
 #include "rdkafka_cert.h"
 
-#if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10100000
+#if WITH_SSL && OPENSSL_VERSION_NUMBER >= 0x10100000 &&                        \
+    !defined(OPENSSL_IS_BORINGSSL)
 #define WITH_SSL_ENGINE 1
 /* Deprecated in OpenSSL 3 */
 #include <openssl/engine.h>

--- a/src/rdkafka_ssl.c
+++ b/src/rdkafka_ssl.c
@@ -466,7 +466,7 @@ static int rd_kafka_transport_ssl_set_endpoint_id(rd_kafka_transport_t *rktrans,
             RD_KAFKA_SSL_ENDPOINT_ID_NONE)
                 return 0;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(OPENSSL_IS_BORINGSSL)
         if (!SSL_set1_host(rktrans->rktrans_ssl, name))
                 goto fail;
 #elif OPENSSL_VERSION_NUMBER >= 0x1000200fL /* 1.0.2 */


### PR DESCRIPTION
Sincle 1.7.0 compilation with boringssl  was not working out of the box (see a93482b7ef36d06e9483770e040ff31dbeb9ff74)   

It seems like after 3709caa91391cb115848ef9946ad228aa56ea476 only some tiny switches are needed to make it work again.

See https://boringssl.googlesource.com/boringssl/+/HEAD/PORTING.md
