### PR TITLE
Fix memory leaks (mostly in tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ configuration property.
  * Windows: couldn't read a PKCS#12 keystore correctly because binary mode wasn't explicitly set and Windows defaults to text mode.
  * Fixed memory leak when loading SSL certificates (@Mekk, #3930)
  * Load all CA certificates from `ssl.ca.pem`, not just the first one.
+ * Each HTTP request made when using OAUTHBEARER OIDC would leak a small
+   amount of memory.
 
 ### Transactional producer fixes
 

--- a/src/rdhttp.c
+++ b/src/rdhttp.c
@@ -107,7 +107,7 @@ static rd_http_error_t *rd_http_error_new_from_buf(int code,
 
 void rd_http_req_destroy(rd_http_req_t *hreq) {
         RD_IF_FREE(hreq->hreq_curl, curl_easy_cleanup);
-        RD_IF_FREE(hreq->hreq_buf, rd_buf_destroy);
+        RD_IF_FREE(hreq->hreq_buf, rd_buf_destroy_free);
 }
 
 

--- a/src/rdkafka_sasl_oauthbearer_oidc.c
+++ b/src/rdkafka_sasl_oauthbearer_oidc.c
@@ -552,6 +552,8 @@ static int ut_sasl_oauthbearer_oidc_post_fields(void) {
                      " received post_fields is %s",
                      expected_post_fields, post_fields);
 
+        rd_free(post_fields);
+
         RD_UT_PASS();
 }
 
@@ -581,6 +583,8 @@ static int ut_sasl_oauthbearer_oidc_post_fields_with_empty_scope(void) {
                      "Expected expected_post_fields is %s"
                      " received post_fields is %s",
                      expected_post_fields, post_fields);
+
+        rd_free(post_fields);
 
         RD_UT_PASS();
 }

--- a/tests/0004-conf.c
+++ b/tests/0004-conf.c
@@ -716,6 +716,7 @@ int main_0004_conf(int argc, char **argv) {
                             "Expected rd_kafka_new() to fail with "
                             "invalid ssl.ca.location");
                 TEST_SAY("rd_kafka_new() failed as expected: %s\n", errstr);
+                rd_kafka_conf_destroy(conf);
         }
 
 #ifdef _WIN32

--- a/tests/0026-consume_pause.c
+++ b/tests/0026-consume_pause.c
@@ -485,6 +485,8 @@ static void consume_seek_pause_resume(void) {
         TEST_SAY("Assigning partition\n");
         TEST_CALL_ERR__(rd_kafka_assign(rk, parts));
 
+        rd_kafka_topic_partition_list_destroy(parts);
+
 
         TEST_SAY("Consuming messages 0..100\n");
         test_msgver_init(&mv, testid);

--- a/tests/0101-fetch-from-follower.cpp
+++ b/tests/0101-fetch-from-follower.cpp
@@ -235,6 +235,7 @@ static int get_broker_rack_count(std::vector<int> &replica_ids) {
     test_assert(!err, cerrstr);
 
     rd_kafka_DescribeConfigs(p->c_ptr(), &config, 1, options, mainq);
+    rd_kafka_ConfigResource_destroy(config);
     rd_kafka_AdminOptions_destroy(options);
     rd_kafka_event_t *rkev = test_wait_admin_result(
         mainq, RD_KAFKA_EVENT_DESCRIBECONFIGS_RESULT, 5000);
@@ -275,6 +276,7 @@ static int get_broker_rack_count(std::vector<int> &replica_ids) {
     rd_kafka_event_destroy(rkev);
   }
 
+  rd_kafka_queue_destroy(mainq);
   delete p;
 
   return (int)racks.size();

--- a/tests/0101-fetch-from-follower.cpp
+++ b/tests/0101-fetch-from-follower.cpp
@@ -61,11 +61,11 @@
  */
 
 
-static void test_assert(bool cond, std::string msg) {
-  if (!cond)
-    Test::Say(msg);
-  assert(cond);
-}
+#define test_assert(cond, msg)                                                 \
+  do {                                                                         \
+    if (!(cond))                                                               \
+      Test::Say(msg);                                                          \
+  } while (0)
 
 
 class TestEvent2Cb : public RdKafka::EventCb {

--- a/tests/0102-static_group_rebalance.c
+++ b/tests/0102-static_group_rebalance.c
@@ -493,6 +493,7 @@ static void do_test_fenced_member(void) {
                     rd_kafka_err2str(rkm->err), rd_kafka_message_errstr(rkm));
         TEST_SAY("Fenced consumer returned expected: %s: %s\n",
                  rd_kafka_err2name(rkm->err), rd_kafka_message_errstr(rkm));
+        rd_kafka_message_destroy(rkm);
 
 
         /* Read the actual error */

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -2835,7 +2835,8 @@ static void do_test_disconnected_group_coord(rd_bool_t switch_coord) {
         state.mcluster     = mcluster;
         state.grpid        = grpid;
         state.broker_id    = switch_coord ? 3 : 2;
-        thrd_create(&thrd, delayed_up_cb, &state);
+        if (thrd_create(&thrd, delayed_up_cb, &state) != thrd_success)
+                TEST_FAIL("Failed to create thread");
 
         TEST_SAY("Calling send_offsets_to_transaction()\n");
         offsets = rd_kafka_topic_partition_list_new(1);

--- a/tests/0110-batch_size.cpp
+++ b/tests/0110-batch_size.cpp
@@ -133,6 +133,8 @@ static void do_test_batch_size() {
   if (!p)
     Test::Fail("Failed to create Producer: " + errstr);
 
+  delete conf;
+
   /* Produce messages */
   char val[msgsize];
   memset(val, 'a', msgsize);

--- a/tests/0117-mock_errors.c
+++ b/tests/0117-mock_errors.c
@@ -287,9 +287,7 @@ static void do_test_joingroup_coordinator_load_in_progress() {
             mcluster, RD_KAFKAP_FindCoordinator, 1,
             RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS);
 
-        consumer = test_create_consumer("mygroup", NULL,
-                                        rd_kafka_conf_dup(conf), NULL);
-
+        consumer = test_create_consumer("mygroup", NULL, conf, NULL);
 
         test_consumer_subscribe(consumer, topic);
 


### PR DESCRIPTION
Seems ASAN stopped reporting leaks properly, these are from valgrind runs.