### PR TITLE
Try to avoid master references when possible

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1260,7 +1260,7 @@ CHM_FILE               =
 HHC_LOCATION           =
 
 # The GENERATE_CHI flag controls if a separate .chi index file is generated
-# (YES) or that it should be included in the master .chm file (NO).
+# (YES) or that it should be included in the primary .chm file (NO).
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 


### PR DESCRIPTION
References to some words such as master/slave, blacklist, whitelist, etc. shoud be avoided. 

References to master branch or blacklist in librdkafka also exist, but removing them would imply higher impact, such as backward uncompatibility when changing topic.blacklist, for example

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>