### PR TITLE
Update curl to 7.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ To restore the previous behaviour, set `ssl.endpoint.identification.algorithm` t
 ## Enhancements
 
  * Self-contained static libraries can now be built on Linux arm64 (#4005).
- * Updated to zlib 1.2.13 and zstd 1.5.2 in self-contained librdkafka bundles.
+ * Updated to zlib 1.2.13, zstd 1.5.2, and curl 7.86.0 in self-contained
+   librdkafka bundles.
  * Added `on_broker_state_change()` interceptor
  * The C++ API no longer returns strings by const value, which enables better move optimization in callers.
  * Added `rd_kafka_sasl_set_credentials()` API to update SASL credentials.

--- a/mklove/modules/configure.libcurl
+++ b/mklove/modules/configure.libcurl
@@ -45,8 +45,8 @@ void foo (void) {
 function install_source {
     local name=$1
     local destdir=$2
-    local ver=7.84.0
-    local checksum="3c6893d38d054d4e378267166858698899e9d87258e8ff1419d020c395384535"
+    local ver=7.86.0
+    local checksum="3dfdd39ba95e18847965cd3051ea6d22586609d9011d91df7bc5521288987a82"
 
     echo "### Installing $name $ver from source to $destdir"
     if [[ ! -f Makefile ]]; then

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,8 +16,8 @@
         },
         {
             "name": "curl",
-            "version>=": "7.84.0"
+            "version>=": "7.86.0"
         }
     ],
-    "builtin-baseline": "09adfdc8cdad76345b7cc7f3305899e1cbd66297"
+    "builtin-baseline": "56765209ec0e92c58a5fd91aa09c46a16d660026"
 }


### PR DESCRIPTION
Fixes CVE-2022-35252, CVE-2022-42915, CVE-2022-42916