### PR TITLE
rdvarint: Fix Undefined Behaviour: left-shift of negative value (#2403)

### DIFF
--- a/src/rdvarint.h
+++ b/src/rdvarint.h
@@ -68,7 +68,8 @@ static RD_INLINE RD_UNUSED size_t rd_uvarint_enc_u64(char *dst,
 static RD_INLINE RD_UNUSED size_t rd_uvarint_enc_i64(char *dst,
                                                      size_t dstsize,
                                                      int64_t num) {
-        return rd_uvarint_enc_u64(dst, dstsize, (num << 1) ^ (num >> 63));
+        return rd_uvarint_enc_u64(dst, dstsize,
+                                  ((uint64_t)num << 1) ^ ((uint64_t)num >> 63));
 }
 
 


### PR DESCRIPTION
Diagnostic:
librdkafka/src/rdvarint.h:71:54: runtime error: left shift of negative value -1

Cause:
In src/rdkafka_msgset_writer.c:701, `rd_uvarint_enc_i32` is called with `num` -1 when `rkm->rkm_key`. This results in doing (-1 << 1) in librdkafka/src/rdvarint.h:71, which is undefined behaviour.

Fix:
Use unsigned values to do bit shifting. This requires that signed values are 2's complement to work, but I believe this is already a requirement for varint, plus it will be required in C23.