### PR TITLE
Add a random key mode

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -825,12 +825,21 @@ static void do_sleep(int sleep_us) {
         }
 }
 
+static void make_random_key(char *buf, int buflen) {
+        for (int i = 0; i < buflen; i++) {
+                buf[i] = rand() >> 7; // throw away low bits which are worse
+        }
+}
+
 
 int main(int argc, char **argv) {
         char *brokers   = NULL;
         char mode       = 'C';
         char *topic     = NULL;
-        const char *key = NULL;
+        // if non-null, use this same key for every message
+        const char *fixedkey = NULL;
+        // if non-zero, use a different random key of the given length for every message
+        int randkey     = 0;
         int *partitions = NULL;
         int opt;
         int sendflags     = 0;
@@ -882,7 +891,7 @@ int main(int argc, char **argv) {
         topics = rd_kafka_topic_partition_list_new(1);
 
         while ((opt = getopt(argc, argv,
-                             "PCG:S:t:p:b:s:k:c:fi:MDd:m:F:x:"
+                             "PCG:S:t:p:b:s:k:K:c:fi:MDd:m:F:x:"
                              "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNH:")) != -1) {
                 switch (opt) {
                 case 'S':
@@ -916,7 +925,10 @@ int main(int argc, char **argv) {
                         msgsize = atoi(optarg);
                         break;
                 case 'k':
-                        key = optarg;
+                        fixedkey = optarg;
+                        break;
+                case 'K':
+                        randkey = atoi(optarg);
                         break;
                 case 'c':
                         msgcnt = atoi(optarg);
@@ -1222,6 +1234,11 @@ int main(int argc, char **argv) {
         signal(SIGUSR1, sig_usr1);
 #endif
 
+        if (fixedkey && randkey) {
+                fprintf(stderr, "%% -k and -K options are mutually exclusive\n");
+                exit(1);
+        }
+
 
         if (debug && rd_kafka_conf_set(conf, "debug", debug, errstr,
                                        sizeof(errstr)) != RD_KAFKA_CONF_OK) {
@@ -1375,7 +1392,17 @@ int main(int argc, char **argv) {
                 char *sbuf;
                 char *pbuf;
                 int outq;
-                int keylen  = key ? (int)strlen(key) : 0;
+
+                int keylen = 0;
+                const char *key = NULL;
+                if (randkey) {
+                        key = malloc(randkey);
+                        keylen = randkey;
+                } else if (fixedkey) {
+                        key = fixedkey;
+                        keylen = (int)strlen(fixedkey);
+                }
+
                 off_t rof   = 0;
                 size_t plen = strlen(msgpattern);
                 int partition =
@@ -1468,6 +1495,10 @@ int main(int argc, char **argv) {
 
                         if (msgsize == 0)
                                 pbuf = NULL;
+
+                        if (randkey) {
+                                make_random_key((char *)key, keylen);
+                        }
 
                         cnt.tx++;
                         while (run && (err = do_produce(


### PR DESCRIPTION
Currently rdkafka_performance offers a mode where you use a fixed key (-kfoobar) or no key at all, in which case the partitioner logic will choose the partition based on its own logic.

It is also useful to have a random key mode: this tends to spread messages evently across partitions (and hence brokers) which can have quite differnt characteristics as compared to the no-key partitioner behavior.

This change adds the -KN mode which uses a random key of length N, with a new key for each message.