### PR TITLE
fix race for stat counters

### DIFF
--- a/src/rdkafka_buf.c
+++ b/src/rdkafka_buf.c
@@ -238,8 +238,8 @@ void rd_kafka_bufq_deq(rd_kafka_bufq_t *rkbufq, rd_kafka_buf_t *rkbuf) {
 
 void rd_kafka_bufq_init(rd_kafka_bufq_t *rkbufq) {
         TAILQ_INIT(&rkbufq->rkbq_bufs);
-        rd_atomic32_init(&rkbufq->rkbq_cnt, 0);
-        rd_atomic32_init(&rkbufq->rkbq_msg_cnt, 0);
+        rd_atomic32_set(&rkbufq->rkbq_cnt, 0);
+        rd_atomic32_set(&rkbufq->rkbq_msg_cnt, 0);
 }
 
 /**


### PR DESCRIPTION
Addresses https://github.com/confluentinc/librdkafka/issues/4522

rd_atomic32_set instead of rd_atomic32_init in rd_kafka_bufq_init