### PR TITLE
Revert 8e20e1ee (#4117) to fix hang in destruction of groupconsumer

### DIFF
--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -201,8 +201,6 @@ void rd_kafka_toppar_op_version_bump(rd_kafka_toppar_t *rktp, int32_t version) {
         rktp->rktp_op_version = version;
         rko                   = rd_kafka_op_new(RD_KAFKA_OP_BARRIER);
         rko->rko_version      = version;
-        rko->rko_prio         = RD_KAFKA_PRIO_FLASH;
-        rko->rko_rktp         = rd_kafka_toppar_keep(rktp);
         rd_kafka_q_enq(rktp->rktp_fetchq, rko);
 }
 


### PR DESCRIPTION
We observed that destroying a groupconsumer would often hang waiting for the broker thread to exit. We tediously bisected the problem to the specific commit 8e20e1ee (the last commit before the v2.0.0rc1 tag). Only then did we find that a lot of people on GitHub were already complaining about that commit as introducing a resource leak: the commit adds a call to `rd_kafka_toppar_keep` that bumps the refcount of the toppar, and I don't immediately see a corresponding `rd_kafka_toppar_destroy` anywhere.

Reverting 8e20e1ee (as in this commit) does fix the hang in groupconsumer destruction which we were observing, so we've applied this patch to our downstream library.

Fixes #4486.