### PR TITLE
correct preprocessor directive for Windows lean definition

### DIFF
--- a/src/rdaddr.h
+++ b/src/rdaddr.h
@@ -34,7 +34,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #else
-#define WIN32_MEAN_AND_LEAN
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #endif

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -58,8 +58,8 @@ extern "C" {
 
 #ifdef _WIN32
 #include <basetsd.h>
-#ifndef WIN32_MEAN_AND_LEAN
-#define WIN32_MEAN_AND_LEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h> /* for sockaddr, .. */
 #ifndef _SSIZE_T_DEFINED

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -50,8 +50,8 @@
 #include <netinet/tcp.h>
 #else
 
-#ifndef WIN32_MEAN_AND_LEAN
-#define WIN32_MEAN_AND_LEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
 #endif

--- a/src/rdwin32.h
+++ b/src/rdwin32.h
@@ -38,7 +38,7 @@
 #include <time.h>
 #include <assert.h>
 
-#define WIN32_MEAN_AND_LEAN
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h> /* for sockets + struct timeval */
 #include <io.h>
 #include <fcntl.h>

--- a/tests/0136-resolve_cb.c
+++ b/tests/0136-resolve_cb.c
@@ -33,7 +33,7 @@
 #ifndef _WIN32
 #include <netdb.h>
 #else
-#define WIN32_MEAN_AND_LEAN
+#define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #include <ws2ipdef.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
use WIN32_LEAN_AND_MEAN, not WIN32_MEAN_AND_LEAN

ref: https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#faster-builds-with-smaller-header-files