### PR TITLE
fix include for pthread_set_name_np on freebsd

### DIFF
--- a/src/tinycthread_extra.h
+++ b/src/tinycthread_extra.h
@@ -40,6 +40,9 @@
 #include <pthread.h> /* needed for rwlock_t */
 #endif
 
+#ifdef __FreeBSD__
+#include <pthread_np.h> /* for pthread_set_name_np */
+#endif
 
 /**
  * @brief Set thread system name if platform supports it (pthreads)


### PR DESCRIPTION
```
Feb 27 21:33:43 FAILED: contrib/librdkafka-cmake/CMakeFiles/_rdkafka.dir/__/librdkafka/src/tinycthread_extra.c.o 
Feb 27 21:33:43 /usr/bin/sccache /usr/bin/clang-19 --target=x86_64-pc-freebsd11 --sysroot=/build/cmake/freebsd/../../contrib/sysroot/freebsd-x86_64 -DCJSON_HIDE_SYMBOLS -DLZ4_FAST_DEC_LOOP=1 -DSTD_EXCEPTION_HAS_STACK_TRACE=1 -DUNALIGNED_OK -DWITH_GZFILEOP -DX86_64 -DZLIB_COMPAT -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -D_LIBUNWIND_IS_NATIVE_ONLY -D_WITH_DPRINTF -Dcall_once=rd_kafka_call_once -Dcnd_broadcast=rd_kafka_cnd_broadcast -Dcnd_destroy=rd_kafka_cnd_destroy -Dcnd_init=rd_kafka_cnd_init -Dcnd_signal=rd_kafka_cnd_signal -Dcnd_timedwait=rd_kafka_cnd_timedwait -Dcnd_wait=rd_kafka_cnd_wait -Dmtx_destroy=rd_kafka_mtx_destroy -Dmtx_init=rd_kafka_mtx_init -Dmtx_lock=rd_kafka_mtx_lock -Dmtx_timedlock=rd_kafka_mtx_timedlock -Dmtx_trylock=rd_kafka_mtx_trylock -Dmtx_unlock=rd_kafka_mtx_unlock -Dthrd_create=rd_kafka_thrd_create -Dthrd_current=rd_kafka_thrd_current -Dthrd_detach=rd_kafka_thrd_detach -Dthrd_equal=rd_kafka_thrd_equal -Dthrd_exit=rd_kafka_thrd_exit -Dthrd_join=rd_kafka_thrd_join -Dthrd_sleep=rd_kafka_thrd_sleep -Dthrd_yield=rd_kafka_thrd_yield -Dtss_create=rd_kafka_tss_create -Dtss_delete=rd_kafka_tss_delete -Dtss_get=rd_kafka_tss_get -Dtss_set=rd_kafka_tss_set -I/build/build_docker/contrib/llvm-project/libcxx/include/c++/v1 -I/build/contrib/lz4/lib -I/build/contrib/zstd/lib -isystem /build/contrib/librdkafka-cmake/include -isystem /build/contrib/librdkafka/src -isystem /build/build_docker/contrib/librdkafka-cmake/auxdir -isystem /build/contrib/llvm-project/libcxxabi/include -isystem /build/contrib/libunwind/include -isystem /build/contrib/zlib-ng -isystem /build/build_docker/contrib/zlib-ng-cmake -isystem /build/contrib/openssl-cmake/linux_x86_64/include -isystem /build/contrib/openssl/include -fdiagnostics-color=always -Xclang -fuse-ctor-homing  -gdwarf-aranges -pipe -mssse3 -msse4.1 -msse4.2 -mpclmul -mpopcnt -fasynchronous-unwind-tables -ffile-prefix-map=/build=. -ftime-trace -falign-functions=32 -mbranches-within-32B-boundaries -ffp-contract=off  -fdiagnostics-absolute-paths -fPIC -w -ffunction-sections -fdata-sections -O2 -g -DNDEBUG -O3 -g  -std=gnu11   -D OS_FREEBSD -fno-sanitize=undefined -Werror -Wno-deprecated-declarations -Wno-poison-system-directories -MD -MT contrib/librdkafka-cmake/CMakeFiles/_rdkafka.dir/__/librdkafka/src/tinycthread_extra.c.o -MF contrib/librdkafka-cmake/CMakeFiles/_rdkafka.dir/__/librdkafka/src/tinycthread_extra.c.o.d -o contrib/librdkafka-cmake/CMakeFiles/_rdkafka.dir/__/librdkafka/src/tinycthread_extra.c.o -c /build/contrib/librdkafka/src/tinycthread_extra.c
Feb 27 21:33:43 /build/contrib/librdkafka/src/tinycthread_extra.c:47:9: error: call to undeclared function 'pthread_set_name_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
Feb 27 21:33:43    47 |         pthread_set_name_np(pthread_self(), name);
Feb 27 21:33:43       |         ^
Feb 27 21:33:43 1 error generated.
```

https://s3.amazonaws.com/clickhouse-test-reports/PRs/76621/5447120c7e3c50f338c7a8963a844b0c838e2a2f//build_amd_freebsd/build_log.log