### PR TITLE
create new topic-partition list comparison method based on hashing

### DIFF
--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -814,6 +814,12 @@ int rd_kafka_topic_partition_list_cmp(const void *_a,
                                       const void *_b,
                                       int (*cmp)(const void *, const void *));
 
+int rd_kafka_topic_partition_list_cmp_with_hash(
+    const void *_a,
+    const void *_b,
+    int (*cmp)(const void *, const void *),
+    unsigned int (*hash)(const void *));
+
 /**
  * Creates a new empty topic partition private.
  *

--- a/src/rdkafka_sticky_assignor.c
+++ b/src/rdkafka_sticky_assignor.c
@@ -1564,8 +1564,9 @@ static rd_bool_t areSubscriptionsIdentical(
         }
 
         RD_MAP_FOREACH(ignore, pcurr, consumer2AllPotentialPartitions) {
-                if (pprev && rd_kafka_topic_partition_list_cmp(
-                                 pcurr, pprev, rd_kafka_topic_partition_cmp))
+                if (pprev && rd_kafka_topic_partition_list_cmp_with_hash(
+                                 pcurr, pprev, rd_kafka_topic_partition_cmp,
+                                 rd_kafka_topic_partition_hash))
                         return rd_false;
                 pprev = pcurr;
         }
@@ -1921,7 +1922,6 @@ rd_kafka_sticky_assignor_assign_cb(rd_kafka_t *rk,
         sortedPartitions = sortPartitions(
             rk, &currentAssignment, &prevAssignment, isFreshAssignment,
             &partition2AllPotentialConsumers, &consumer2AllPotentialPartitions);
-
 
         /* All partitions that need to be assigned (initially set to all
          * partitions but adjusted in the following loop) */


### PR DESCRIPTION
the new method is much faster than the old, O(Na + Nb) compared to the older one, which is O(Na * Nb)

Background:
The old one was causing problems with partition counts ~3600 in the cooperative-sticky partition assignment.
The group leader ended up being kicked out of the group because he spent too much time calculating the partition assignment, and didn't sent any heartbeat inbetween.

reducing the complexity of this pushes the runtime down. Concrete example with 3600 partitions and 1800 consumers before: ~240s
after: ~3s

fixes problem in https://github.com/confluentinc/librdkafka/issues/4629


I have tried to stick to the styles, but ran into problems with getting the right version of clang-format (10 doesn't seem to be available via homebrew)

I have have also run the unit tests, they pass.

I am currently running 0113-cooperative-rebalance.cpp test case.

I'm not sure if I should be completely replacing the old comparison function, but happy to do so based on comments