### PR TITLE
bugfix: correctly set minVersion for compression version check

### DIFF
--- a/src/rdkafka_msgset_writer.c
+++ b/src/rdkafka_msgset_writer.c
@@ -146,8 +146,8 @@ rd_kafka_msgset_writer_select_MsgVersion(rd_kafka_msgset_writer_t *msetw) {
          */
         if (msetw->msetw_compression &&
             (rd_kafka_broker_ApiVersion_supported(
-                 rkb, RD_KAFKAP_Produce, 0,
-                 compr_req[msetw->msetw_compression].ApiVersion, NULL) == -1 ||
+                 rkb, RD_KAFKAP_Produce, compr_req[msetw->msetw_compression].ApiVersion,
+                 999, NULL) == -1 ||
              (compr_req[msetw->msetw_compression].feature &&
               !(msetw->msetw_rkb->rkb_features &
                 compr_req[msetw->msetw_compression].feature)))) {


### PR DESCRIPTION
currently the check is basically:

```
minVersion: 0
maxVersion: 0
```

Scenario:
Assume a Kafka Broker drops support for really old API version of Produce and implements version 3 to 12.


What will happen:
This check will return false and compression will be disabled.

What is expected:
Compression should indeed be supported.


Fix:
The modification fixes the check so that its now:

```
minVersion: 0
maxVersion: 999
```

It correctly set the `ApiVersion` field of struct as `min` param instead of `max`