### PR TITLE
Fix building without curl

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -56,7 +56,7 @@
 #include <windows.h>
 #endif
 
-#ifdef WITH_OAUTHBEARER_OIDC
+#if WITH_OAUTHBEARER_OIDC
 #include <curl/curl.h>
 #endif
 


### PR DESCRIPTION
`WITH_OAUTHBEARER_OIDC` is always defined, but it set to 0 if disabled, and 1 if enabled.
This is because `packaging/cmake/config.h.in` has: `#cmakedefine01 WITH_OAUTHBEARER_OIDC`

Therefore, `#ifdef WITH_OAUTHBEARER_OIDC`  always runs.