### PR TITLE
Support librdkafka on Alpine arm64

### DIFF
--- a/packaging/nuget/nugetpackage.py
+++ b/packaging/nuget/nugetpackage.py
@@ -91,6 +91,7 @@ class NugetPackage (Package):
                 'librdkafka.tgz',
                 './usr/local/lib/librdkafka.so.1',
                 'runtimes/linux-arm64/native/librdkafka.so'),
+
         # Linux musl alpine x64 without GSSAPI (no external deps)
         Mapping({'arch': 'x64',
                  'plat': 'linux',


### PR DESCRIPTION
Currently in Confluent's .NET client, when running on Alpine platforms with musl, the .NET library looks for the native `alpine-librdkafka.so` in `./linux-x64/native/alpine-librdkafka.so`, but the ARM64 equivalent does not exist. This PR hopes to address that.

See:
https://github.com/confluentinc/confluent-kafka-dotnet/issues/2341
https://github.com/confluentinc/librdkafka/issues/4897