### PR TITLE
Conditionally include sys/random.h based on HAVE_GETENTROPY

### DIFF
--- a/src/rdrand.c
+++ b/src/rdrand.c
@@ -31,7 +31,7 @@
 #include "rdtime.h"
 #include "tinycthread.h"
 #include "rdmurmur2.h"
-#ifndef _WIN32
+#if HAVE_GETENTROPY
 /* getentropy() can be present in one of these two */
 #include <unistd.h>
 #include <sys/random.h>


### PR DESCRIPTION
This fixes Conda build errors on Linux aarch64 and ppc64. See, for example, https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1429288&view=logs&j=60238c3a-ba84-5ca5-39dc-717fbb421dbc&t=9cf66154-4ecc-5714-a3ee-b77d4233a250