### PR TITLE
Don't include headers for getentropy when we know it will fail

### DIFF
--- a/src/rdrand.c
+++ b/src/rdrand.c
@@ -31,7 +31,7 @@
 #include "rdtime.h"
 #include "tinycthread.h"
 #include "rdmurmur2.h"
-#ifndef _WIN32
+#if HAVE_GETENTROPY
 /* getentropy() can be present in one of these two */
 #include <unistd.h>
 #include <sys/random.h>


### PR DESCRIPTION
Fixes #5283.

https://github.com/confluentinc/librdkafka/pull/5265 introduced the use of the `getentropy` function, which requires glibc 2.25 ([source](https://man7.org/linux/man-pages/man3/getentropy.3.html)).

The way it was written, the headers where this function is declared are included unconditionally on non-Windows. This breaks the build when targeting older systems that don't support this function and do not have `<sys/random.h>`:

```
rdrand.c:37:10: fatal error: sys/random.h: No such file or directory
   37 | #include <sys/random.h>
```

This is despite the configure script already determining that `getentropy` is not available:
```
#8 18.26 checking for getentropy... no
```

The use of this function is gated by `HAVE_GETENTROPY`, here:
https://github.com/confluentinc/librdkafka/blob/f383af93b3b2ca975a85119da8258c44a7dbc0bf/src/rdrand.c#L114-L117. Therefore, it looks reasonable to use that same variable to determine whether the headers are needed. After all if the check for `getentropy` failed, there doesn't seem to be any purpose to including those headers.

The proposed fix avoids dropping compatibility for no cost, and seems to make logical sense.