### PR TITLE
src/rdkafka_conf.c: fix curl/curl.h include when WITH_CURL=OFF

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -56,7 +56,7 @@
 #include <windows.h>
 #endif
 
-#ifdef WITH_OAUTHBEARER_OIDC
+#if WITH_OAUTHBEARER_OIDC
 #include <curl/curl.h>
 #endif
 


### PR DESCRIPTION
Change #ifdef to #if for WITH_OAUTHBEARER_OIDC preprocessor check. When using CMake's cmakedefine01, the macro is always defined (as 0 or 1), so #ifdef always evaluates to true. Using #if correctly checks the value.

Fixes: https://github.com/confluentinc/librdkafka/issues/5204