### PR TITLE
Improve linger/timeout validation error message with aliases

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4429,8 +4429,13 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 conf->buffering_max_ms_dbl) {
                                 if (rd_kafka_conf_is_modified(conf,
                                                               "linger.ms"))
-                                        return "`message.timeout.ms` must be "
-                                               "greater than `linger.ms`";
+                                        return "`delivery.timeout.ms` "
+                                               "(alias "
+                                               "`message.timeout.ms`) "
+                                               "must be greater than "
+                                               "`linger.ms` "
+                                               "(alias "
+                                               "`queue.buffering.max.ms`)";
                                 else /* Auto adjust linger.ms to be lower
                                       * than message.timeout.ms */
                                         conf->buffering_max_ms_dbl =
@@ -4506,7 +4511,9 @@ const char *rd_kafka_topic_conf_finalize(rd_kafka_type_t cltype,
         if (tconf->message_timeout_ms != 0 &&
             (double)tconf->message_timeout_ms <= conf->buffering_max_ms_dbl &&
             rd_kafka_conf_is_modified(conf, "linger.ms"))
-                return "`message.timeout.ms` must be greater than `linger.ms`";
+                return "`delivery.timeout.ms` "
+                       "(alias `message.timeout.ms`) must be greater than "
+                       "`linger.ms` (alias `queue.buffering.max.ms`)";
 
         return NULL;
 }


### PR DESCRIPTION
Improves the producer config validation error message to explicitly mention alias mappings.

  Previously, the error said:

  - message.timeout.ms must be greater than linger.ms

  This could be confusing when users configure equivalent keys using different names (delivery.timeout.ms, queue.buffering.max.ms).

  This change updates the message to:

  - delivery.timeout.ms (alias message.timeout.ms) must be greater than linger.ms (alias queue.buffering.max.ms)

  Result:

  - clearer diagnostics
  - faster troubleshooting when mixed alias names are used
  - no behavior change, message-only improvement