### PR TITLE
cgrp: Fix NULL dereference in LeaveGroup when coordinator unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ librdkafka v2.14.2 is a maintenance release:
   Fix data race in timers. The callback and its argument could have been modified after the lock is released.
   Happening since 1.x (#5089).
 
+### Consumer fixes
+
+* Fix crash (SIGSEGV) in `rd_kafka_cgrp_handle_LeaveGroup()` when coordinator
+  is unavailable during consumer close. The error logging path dereferenced
+  a potentially NULL broker pointer. Happening since 1.x.
 
 ### Admin client fixes
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -981,12 +981,12 @@ static void rd_kafka_cgrp_handle_LeaveGroup(rd_kafka_t *rk,
 
 err:
         if (ErrorCode)
-                rd_kafka_dbg(rkb->rkb_rk, CGRP, "LEAVEGROUP",
+                rd_kafka_dbg(rk, CGRP, "LEAVEGROUP",
                              "LeaveGroup response error in state %s: %s",
                              rd_kafka_cgrp_state_names[rkcg->rkcg_state],
                              rd_kafka_err2str(ErrorCode));
         else
-                rd_kafka_dbg(rkb->rkb_rk, CGRP, "LEAVEGROUP",
+                rd_kafka_dbg(rk, CGRP, "LEAVEGROUP",
                              "LeaveGroup response received in state %s",
                              rd_kafka_cgrp_state_names[rkcg->rkcg_state]);
 

--- a/tests/0018-cgrp_term.c
+++ b/tests/0018-cgrp_term.c
@@ -330,9 +330,115 @@ static void do_test(rd_bool_t with_queue) {
 }
 
 
+/**
+ * @name Test LeaveGroup handling when coordinator becomes unavailable
+ *
+ * Verifies that rd_kafka_cgrp_handle_LeaveGroup() correctly handles the case
+ * where the coordinator broker (rkb) is NULL when the consumer group initiates
+ * LeaveGroup during shutdown.
+ *
+ * Previously, rd_kafka_dbg() calls in the error path would dereference
+ * rkb->rkb_rk when rkb was NULL, causing a SIGSEGV crash.
+ *
+ * The fix uses the always-valid `rk` parameter instead of `rkb->rkb_rk`.
+ */
+
+static int leavegroup_allowed_error;
+
+static int leavegroup_error_is_fatal_cb(rd_kafka_t *rk,
+                                        rd_kafka_resp_err_t err,
+                                        const char *reason) {
+        if (err == leavegroup_allowed_error ||
+            err == RD_KAFKA_RESP_ERR__TRANSPORT ||
+            err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN ||
+            err == RD_KAFKA_RESP_ERR_GROUP_COORDINATOR_NOT_AVAILABLE ||
+            err == RD_KAFKA_RESP_ERR_NOT_COORDINATOR_FOR_GROUP) {
+                TEST_SAY("Ignoring allowed error: %s: %s\n",
+                         rd_kafka_err2name(err), reason);
+                return 0;
+        }
+        return 1;
+}
+
+/**
+ * @brief Test that consumer close/destroy handles missing coordinator
+ *        gracefully and does not crash.
+ *
+ * Scenario:
+ * 1. Create a consumer and subscribe to a topic
+ * 2. Wait for consumer to join group and establish coordinator connection
+ * 3. Make coordinator unavailable (broker goes down)
+ * 4. Close/destroy the consumer, which triggers LeaveGroup
+ * 5. Verify no crash occurs (the bug would cause SIGSEGV here)
+ */
+static void do_test_leavegroup_no_coordinator(void) {
+        rd_kafka_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        rd_kafka_topic_partition_list_t *subscription;
+        rd_kafka_message_t *rkm;
+
+        SUB_TEST();
+
+        TEST_SKIP_MOCK_CLUSTER();
+
+        test_curr->is_fatal_cb   = leavegroup_error_is_fatal_cb;
+        leavegroup_allowed_error = RD_KAFKA_RESP_ERR__TRANSPORT;
+
+        mcluster = test_mock_cluster_new(2, &bootstraps);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 2);
+        rd_kafka_mock_group_initial_rebalance_delay_ms(mcluster, 0);
+        rd_kafka_mock_partition_set_leader(mcluster, topic, 0, 1);
+        rd_kafka_mock_coordinator_set(mcluster, "group", topic, 1);
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", topic);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_set(conf, "session.timeout.ms", "6000");
+        test_conf_set(conf, "heartbeat.interval.ms", "1000");
+
+        consumer = test_create_consumer(topic, NULL, conf, NULL);
+
+        subscription = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subscription, topic,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_subscribe(consumer, subscription));
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        TEST_SAY("Waiting for consumer to join group and get assignment\n");
+        rkm = rd_kafka_consumer_poll(consumer, 10000);
+        if (rkm)
+                rd_kafka_message_destroy(rkm);
+
+        TEST_SAY(
+            "Simulating coordinator failure by making broker unavailable\n");
+        rd_kafka_mock_broker_set_down(mcluster, 1);
+
+        rd_sleep(1);
+
+        TEST_SAY(
+            "Destroying consumer - this triggers LeaveGroup "
+            "with coordinator unavailable\n");
+        rd_kafka_destroy(consumer);
+
+        TEST_SAY("Consumer destroyed successfully (no crash)\n");
+
+        test_mock_cluster_destroy(mcluster);
+
+        test_curr->is_fatal_cb   = NULL;
+        leavegroup_allowed_error = RD_KAFKA_RESP_ERR_NO_ERROR;
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0018_cgrp_term(int argc, char **argv) {
         do_test(rd_false /* rd_kafka_consumer_close() */);
         do_test(rd_true /*  rd_kafka_consumer_close_queue() */);
+        do_test_leavegroup_no_coordinator();
 
         return 0;
 }


### PR DESCRIPTION
## Summary

Issue: https://github.com/confluentinc/librdkafka/issues/5347

Fix SIGSEGV crash in `rd_kafka_cgrp_handle_LeaveGroup()` when the coordinator broker becomes unavailable during consumer close.

## Problem

When a consumer is destroyed (`rd_kafka_destroy()`) and the group coordinator is unavailable, `rd_kafka_cgrp_leave()` calls `rd_kafka_cgrp_handle_LeaveGroup()` with a NULL broker pointer (`rkb = rkcg->rkcg_coord`). The error path then dereferences this NULL pointer:

    `rd_kafka_dbg(rkb->rkb_rk, CGRP, "LEAVEGROUP", ...);  // CRASH: rkb is NULL`

This crash requires the coordinator to become unavailable at the exact moment the consumer is shutting down. Typical triggers:
- Rolling broker upgrades where the coordinator broker restarts
- Coordinator failover during consumer shutdown
- Network partition isolating the coordinator

## Solution 

Replace `rkb->rkb_rk` with `rk` in the `rd_kafka_dbg()` calls. The `rk` parameter is always valid (passed directly to the function), and is semantically equivalent to `rkb->rkb_rk` when `rkb` is non-NULL.

**Without the fix (crashes):**
- Consumer process dies with SIGSEGV
- Local resources may not be cleaned up (memory, file handles, etc.)
- Broker doesn't get LeaveGroup
- Broker waits for session timeout → rebalance

**With the fix (graceful exit):**
- Consumer process exits cleanly
- Local resources are properly cleaned up
- Broker doesn't get LeaveGroup
- Broker waits for session timeout → rebalance

The broker-side outcome is identical. In both cases, the broker doesn't receive LeaveGroup and must wait for session timeout. We can't avoid this because the coordinator is unavailable. But this way there is no core dump and crash.


### Backtrace
```
    #0  rd_kafka_cgrp_handle_LeaveGroup (rk=0x..., rkb=0x0, err=RD_KAFKA_RESP_ERR__WAIT_COORD, ...)
        at rdkafka_cgrp.c:984
    #1  rd_kafka_cgrp_leave (rkcg=0x...) at rdkafka_cgrp.c:1158
    #2  rd_kafka_cgrp_terminate (rkcg=0x...) at rdkafka_cgrp.c:...
    #3  rd_kafka_destroy_internal (rk=0x...) at rdkafka.c:...
```

* We observed intermittent SIGSEGV crashes in production during consumer shutdown
* We captured the core dump and analyzed with gdb
* The above backtrace shows `rkb=0x0` (NULL) in `rd_kafka_cgrp_handle_LeaveGroup()`
* We traced the call site in `rd_kafka_cgrp_leave()` (line 1158):
  ```c
  } else
      rd_kafka_cgrp_handle_LeaveGroup(rkcg->rkcg_rk, rkcg->rkcg_coord,  // <-- rkcg_coord is NULL here
                                       RD_KAFKA_RESP_ERR__WAIT_COORD,
                                       NULL, NULL, rkcg);
  ```
- This `else` branch is taken when no coordinator is available (`rkcg->rkcg_coord == NULL`)
- The function then attempts to log using `rkb->rkb_rk` at line 984, causing NULL dereference
- Confirmed that `rk` parameter is always valid and equivalent to `rkb->rkb_rk` when `rkb` is non-NULL


