### PR TITLE
[KIP-113] Add rd_kafka_DescribeLogDirs() admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 librdkafka v2.14.0 is a feature release:
 
 * [KIP-768](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=186877575#KIP768:ExtendSASL/OAUTHBEARERwithSupportforOIDC-ClientConfiguration) Extend SASL/OAUTHBEARER to support OIDC claim mapping beyond the default `sub` claim (#5336).
+* [KIP-113](https://cwiki.apache.org/confluence/display/KAFKA/KIP-113%3A+Support+replicas+movement+between+log+directories) Add support for AdminAPI `DescribeLogDirs()` (#5333, @piochelepiotr).
 
 # librdkafka v2.13.2
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5610,6 +5610,8 @@ typedef int rd_kafka_event_type_t;
 #define RD_KAFKA_EVENT_LISTOFFSETS_RESULT 0x400000
 /** ElectLeaders_result_t */
 #define RD_KAFKA_EVENT_ELECTLEADERS_RESULT 0x800000
+/** DescribeLogDirs_result_t */
+#define RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT 0x1000000
 
 /**
  * @returns the event type for the given event.
@@ -5894,6 +5896,8 @@ typedef rd_kafka_event_t rd_kafka_AlterUserScramCredentials_result_t;
 typedef rd_kafka_event_t rd_kafka_ListOffsets_result_t;
 /*! ElectLeaders result type */
 typedef rd_kafka_event_t rd_kafka_ElectLeaders_result_t;
+/*! DescribeLogDirs result type */
+typedef rd_kafka_event_t rd_kafka_DescribeLogDirs_result_t;
 
 /**
  * @brief Get CreateTopics result.
@@ -7118,6 +7122,7 @@ typedef enum rd_kafka_admin_op_t {
         RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER, /**< DescribeCluster */
         RD_KAFKA_ADMIN_OP_LISTOFFSETS,     /**< ListOffsets */
         RD_KAFKA_ADMIN_OP_ELECTLEADERS,    /**< ElectLeaders */
+        RD_KAFKA_ADMIN_OP_DESCRIBELOGDIRS, /**< DescribeLogDirs */
         RD_KAFKA_ADMIN_OP__CNT             /**< Number of ops defined */
 } rd_kafka_admin_op_t;
 
@@ -10137,6 +10142,190 @@ RD_EXPORT const rd_kafka_topic_partition_result_t **
 rd_kafka_ElectLeaders_result_partitions(
     const rd_kafka_ElectLeaders_result_t *result,
     size_t *cntp);
+
+/**@}*/
+
+/**
+ * @name Admin API - DescribeLogDirs
+ * @{
+ */
+
+/**
+ * @brief Opaque type for a log directory description.
+ */
+typedef struct rd_kafka_LogDirDescription_s rd_kafka_LogDirDescription_t;
+
+/**
+ * @brief Opaque type for a log directory topic description.
+ */
+typedef struct rd_kafka_LogDirTopicDescription_s
+    rd_kafka_LogDirTopicDescription_t;
+
+/**
+ * @brief Opaque type for a log directory partition description.
+ */
+typedef struct rd_kafka_LogDirPartitionDescription_s
+    rd_kafka_LogDirPartitionDescription_t;
+
+/**
+ * @brief Describe log directories on a broker.
+ *
+ * @param rk Client instance.
+ * @param topics Topic-partition list to filter results, or NULL
+ *        to describe all topics on the target broker.
+ * @param options Optional admin options, or NULL for defaults.
+ *                Valid options:
+ *                 - rd_kafka_AdminOptions_set_broker()
+ * @param rkqu Queue to emit result on.
+ *
+ * @remark The result event type emitted on the supplied queue is of type
+ *         \c RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT
+ */
+RD_EXPORT void
+rd_kafka_DescribeLogDirs(rd_kafka_t *rk,
+                         const rd_kafka_topic_partition_list_t *topics,
+                         const rd_kafka_AdminOptions_t *options,
+                         rd_kafka_queue_t *rkqu);
+
+/**
+ * @brief Get an array of log dir descriptions from a
+ *        DescribeLogDirs result.
+ *
+ * @param result Result to get log dir descriptions from.
+ * @param cntp is updated to the number of elements in the array.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p result object.
+ */
+RD_EXPORT const rd_kafka_LogDirDescription_t **
+rd_kafka_DescribeLogDirs_result_descriptions(
+    const rd_kafka_DescribeLogDirs_result_t *result,
+    size_t *cntp);
+
+/**
+ * @brief Get DescribeLogDirs result.
+ *
+ * @returns the result of a DescribeLogDirs request, or NULL if
+ * event is of different type.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p rkev object.
+ *
+ * Event types:
+ *   RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT
+ */
+RD_EXPORT const rd_kafka_DescribeLogDirs_result_t *
+rd_kafka_event_DescribeLogDirs_result(rd_kafka_event_t *rkev);
+
+/**
+ * @brief Get the error for a log dir description.
+ *
+ * @param logdir The log dir description.
+ *
+ * @returns the error associated with the log dir, or NULL
+ *          on success.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p logdir object.
+ */
+RD_EXPORT const rd_kafka_error_t *
+rd_kafka_LogDirDescription_error(const rd_kafka_LogDirDescription_t *logdir);
+
+/**
+ * @brief Get the log directory path from a log dir description.
+ *
+ * @param logdir The log dir description.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p logdir object.
+ */
+RD_EXPORT const char *
+rd_kafka_LogDirDescription_log_dir(const rd_kafka_LogDirDescription_t *logdir);
+
+/**
+ * @brief Get the array of topic descriptions from a log dir
+ *        description.
+ *
+ * @param logdir The log dir description.
+ * @param cntp is updated to the number of topics.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p logdir object.
+ */
+RD_EXPORT const rd_kafka_LogDirTopicDescription_t **
+rd_kafka_LogDirDescription_topics(const rd_kafka_LogDirDescription_t *logdir,
+                                  size_t *cntp);
+
+/**
+ * @brief Get the topic name from a log dir topic description.
+ *
+ * @param topic_desc The topic description.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p topic_desc object.
+ */
+RD_EXPORT const char *rd_kafka_LogDirTopicDescription_topic(
+    const rd_kafka_LogDirTopicDescription_t *topic_desc);
+
+/**
+ * @brief Get the array of partition descriptions from a log dir
+ *        topic description.
+ *
+ * @param topic_desc The topic description.
+ * @param cntp is updated to the number of partitions.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p topic_desc object.
+ */
+RD_EXPORT const rd_kafka_LogDirPartitionDescription_t **
+rd_kafka_LogDirTopicDescription_partitions(
+    const rd_kafka_LogDirTopicDescription_t *topic_desc,
+    size_t *cntp);
+
+/**
+ * @brief Get the partition index from a log dir partition
+ *        description.
+ *
+ * @param partition_desc The partition description.
+ *
+ * @returns the partition index.
+ */
+RD_EXPORT int32_t rd_kafka_LogDirPartitionDescription_partition(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc);
+
+/**
+ * @brief Get the partition size in bytes from a log dir partition
+ *        description.
+ *
+ * @param partition_desc The partition description.
+ *
+ * @returns the size in bytes on disk.
+ */
+RD_EXPORT int64_t rd_kafka_LogDirPartitionDescription_size(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc);
+
+/**
+ * @brief Get the offset lag from a log dir partition description.
+ *
+ * @param partition_desc The partition description.
+ *
+ * @returns the offset lag.
+ */
+RD_EXPORT int64_t rd_kafka_LogDirPartitionDescription_offset_lag(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc);
+
+/**
+ * @brief Get the is_future flag from a log dir partition
+ *        description.
+ *
+ * @param partition_desc The partition description.
+ *
+ * @returns 1 if this is a future log directory (i.e., the
+ *          partition is being moved to this log dir),
+ *          0 otherwise.
+ */
+RD_EXPORT int rd_kafka_LogDirPartitionDescription_is_future(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc);
 
 /**@}*/
 

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -9809,3 +9809,297 @@ void rd_kafka_ElectLeaders(rd_kafka_t *rk,
 }
 
 /**@}*/
+
+/**
+ * @name DescribeLogDirs
+ * @{
+ */
+
+static rd_kafka_LogDirPartitionDescription_t *
+rd_kafka_LogDirPartitionDescription_new(int32_t partition,
+                                        int64_t size,
+                                        int64_t offset_lag,
+                                        rd_bool_t is_future) {
+        rd_kafka_LogDirPartitionDescription_t *part;
+        part             = rd_calloc(1, sizeof(*part));
+        part->partition  = partition;
+        part->size       = size;
+        part->offset_lag = offset_lag;
+        part->is_future  = is_future;
+        return part;
+}
+
+static void rd_kafka_LogDirPartitionDescription_destroy(
+    rd_kafka_LogDirPartitionDescription_t *part) {
+        rd_free(part);
+}
+
+static rd_kafka_LogDirTopicDescription_t *
+rd_kafka_LogDirTopicDescription_new(const char *topic, int partition_cnt) {
+        rd_kafka_LogDirTopicDescription_t *topic_desc;
+        topic_desc                = rd_calloc(1, sizeof(*topic_desc));
+        topic_desc->topic         = rd_strdup(topic);
+        topic_desc->partition_cnt = partition_cnt;
+        if (partition_cnt > 0)
+                topic_desc->partitions =
+                    rd_calloc(partition_cnt, sizeof(*topic_desc->partitions));
+        return topic_desc;
+}
+
+static void rd_kafka_LogDirTopicDescription_destroy(
+    rd_kafka_LogDirTopicDescription_t *topic_desc) {
+        int i;
+        for (i = 0; i < topic_desc->partition_cnt; i++)
+                rd_kafka_LogDirPartitionDescription_destroy(
+                    topic_desc->partitions[i]);
+        rd_free(topic_desc->partitions);
+        rd_free(topic_desc->topic);
+        rd_free(topic_desc);
+}
+
+static rd_kafka_LogDirDescription_t *
+rd_kafka_LogDirDescription_new(rd_kafka_error_t *error,
+                               const char *log_dir,
+                               int topic_cnt) {
+        rd_kafka_LogDirDescription_t *logdir;
+        logdir = rd_calloc(1, sizeof(*logdir));
+        if (error)
+                logdir->error = rd_kafka_error_copy(error);
+        logdir->log_dir   = rd_strdup(log_dir);
+        logdir->topic_cnt = topic_cnt;
+        if (topic_cnt > 0)
+                logdir->topics = rd_calloc(topic_cnt, sizeof(*logdir->topics));
+        return logdir;
+}
+
+static void
+rd_kafka_LogDirDescription_destroy(rd_kafka_LogDirDescription_t *logdir) {
+        int i;
+        for (i = 0; i < logdir->topic_cnt; i++)
+                rd_kafka_LogDirTopicDescription_destroy(logdir->topics[i]);
+        rd_free(logdir->topics);
+        RD_IF_FREE(logdir->error, rd_kafka_error_destroy);
+        rd_free(logdir->log_dir);
+        rd_free(logdir);
+}
+
+static void rd_kafka_LogDirDescription_free(void *ptr) {
+        rd_kafka_LogDirDescription_destroy(ptr);
+}
+
+const rd_kafka_error_t *
+rd_kafka_LogDirDescription_error(const rd_kafka_LogDirDescription_t *logdir) {
+        return logdir->error;
+}
+
+const char *
+rd_kafka_LogDirDescription_log_dir(const rd_kafka_LogDirDescription_t *logdir) {
+        return logdir->log_dir;
+}
+
+const rd_kafka_LogDirTopicDescription_t **
+rd_kafka_LogDirDescription_topics(const rd_kafka_LogDirDescription_t *logdir,
+                                  size_t *cntp) {
+        *cntp = logdir->topic_cnt;
+        return (const rd_kafka_LogDirTopicDescription_t **)logdir->topics;
+}
+
+const char *rd_kafka_LogDirTopicDescription_topic(
+    const rd_kafka_LogDirTopicDescription_t *topic_desc) {
+        return topic_desc->topic;
+}
+
+const rd_kafka_LogDirPartitionDescription_t **
+rd_kafka_LogDirTopicDescription_partitions(
+    const rd_kafka_LogDirTopicDescription_t *topic_desc,
+    size_t *cntp) {
+        *cntp = topic_desc->partition_cnt;
+        return (const rd_kafka_LogDirPartitionDescription_t **)
+            topic_desc->partitions;
+}
+
+int32_t rd_kafka_LogDirPartitionDescription_partition(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc) {
+        return partition_desc->partition;
+}
+
+int64_t rd_kafka_LogDirPartitionDescription_size(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc) {
+        return partition_desc->size;
+}
+
+int64_t rd_kafka_LogDirPartitionDescription_offset_lag(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc) {
+        return partition_desc->offset_lag;
+}
+
+int rd_kafka_LogDirPartitionDescription_is_future(
+    const rd_kafka_LogDirPartitionDescription_t *partition_desc) {
+        return partition_desc->is_future ? 1 : 0;
+}
+
+const rd_kafka_LogDirDescription_t **
+rd_kafka_DescribeLogDirs_result_descriptions(
+    const rd_kafka_DescribeLogDirs_result_t *result,
+    size_t *cntp) {
+        *cntp = rd_list_cnt(&result->rko_u.admin_result.results);
+        return (const rd_kafka_LogDirDescription_t **)
+            result->rko_u.admin_result.results.rl_elems;
+}
+
+/**
+ * @brief Parse DescribeLogDirsResponse and create ADMIN_RESULT op.
+ */
+static rd_kafka_resp_err_t
+rd_kafka_DescribeLogDirsResponse_parse(rd_kafka_op_t *rko_req,
+                                       rd_kafka_op_t **rko_resultp,
+                                       rd_kafka_buf_t *reply,
+                                       char *errstr,
+                                       size_t errstr_size) {
+        const int log_decode_errors = LOG_ERR;
+        rd_kafka_op_t *rko_result   = NULL;
+        int32_t LogDirArrayCnt;
+        int i;
+
+        rd_kafka_buf_read_throttle_time(reply);
+
+        /* ErrorCode (versions 3+, KIP-784) */
+        if (rd_kafka_buf_ApiVersion(reply) >= 3) {
+                int16_t error_code;
+                rd_kafka_buf_read_i16(reply, &error_code);
+                if (error_code) {
+                        rd_snprintf(errstr, errstr_size,
+                                    "DescribeLogDirs response error: %s",
+                                    rd_kafka_err2str(error_code));
+                        return error_code;
+                }
+        }
+
+        /* #LogDirs */
+        rd_kafka_buf_read_arraycnt(reply, &LogDirArrayCnt, 10000);
+
+        rko_result = rd_kafka_admin_result_new(rko_req);
+        rd_list_init(&rko_result->rko_u.admin_result.results, LogDirArrayCnt,
+                     rd_kafka_LogDirDescription_free);
+
+        for (i = 0; i < LogDirArrayCnt; i++) {
+                int16_t error_code;
+                rd_kafkap_str_t klogdir;
+                char *log_dir;
+                int32_t TopicArrayCnt;
+                rd_kafka_LogDirDescription_t *logdir_desc;
+                int j;
+
+                rd_kafka_buf_read_i16(reply, &error_code);
+                rd_kafka_buf_read_str(reply, &klogdir);
+                RD_KAFKAP_STR_DUPA(&log_dir, &klogdir);
+
+                rd_kafka_buf_read_arraycnt(reply, &TopicArrayCnt,
+                                           RD_KAFKAP_TOPICS_MAX);
+
+                if (error_code) {
+                        rd_kafka_error_t *error = rd_kafka_error_new(
+                            error_code, "%s", rd_kafka_err2str(error_code));
+                        logdir_desc = rd_kafka_LogDirDescription_new(
+                            error, log_dir, TopicArrayCnt);
+                        rd_kafka_error_destroy(error);
+                } else {
+                        logdir_desc = rd_kafka_LogDirDescription_new(
+                            NULL, log_dir, TopicArrayCnt);
+                }
+
+                for (j = 0; j < TopicArrayCnt; j++) {
+                        rd_kafkap_str_t ktopic;
+                        char *topic;
+                        int32_t PartArrayCnt;
+                        rd_kafka_LogDirTopicDescription_t *topic_desc;
+                        int k;
+
+                        rd_kafka_buf_read_str(reply, &ktopic);
+                        RD_KAFKAP_STR_DUPA(&topic, &ktopic);
+
+                        rd_kafka_buf_read_arraycnt(reply, &PartArrayCnt,
+                                                   RD_KAFKAP_PARTITIONS_MAX);
+
+                        topic_desc = rd_kafka_LogDirTopicDescription_new(
+                            topic, PartArrayCnt);
+
+                        for (k = 0; k < PartArrayCnt; k++) {
+                                int32_t partition;
+                                int64_t size;
+                                int64_t offset_lag;
+                                rd_bool_t is_future;
+
+                                rd_kafka_buf_read_i32(reply, &partition);
+                                rd_kafka_buf_read_i64(reply, &size);
+                                rd_kafka_buf_read_i64(reply, &offset_lag);
+                                rd_kafka_buf_read_bool(reply, &is_future);
+
+                                rd_kafka_buf_skip_tags(reply);
+
+                                topic_desc->partitions[k] =
+                                    rd_kafka_LogDirPartitionDescription_new(
+                                        partition, size, offset_lag, is_future);
+                        }
+
+                        rd_kafka_buf_skip_tags(reply);
+
+                        logdir_desc->topics[j] = topic_desc;
+                }
+
+                rd_kafka_buf_skip_tags(reply);
+
+                rd_list_add(&rko_result->rko_u.admin_result.results,
+                            logdir_desc);
+        }
+
+        rd_kafka_buf_skip_tags(reply);
+
+        *rko_resultp = rko_result;
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+err_parse:
+        if (rko_result)
+                rd_kafka_op_destroy(rko_result);
+
+        rd_snprintf(errstr, errstr_size,
+                    "DescribeLogDirs response protocol parse failure: %s",
+                    rd_kafka_err2str(reply->rkbuf_err));
+
+        return reply->rkbuf_err;
+}
+
+static void rd_kafka_DescribeLogDirs_topics_free(void *ptr) {
+        rd_kafka_topic_partition_list_destroy(ptr);
+}
+
+void rd_kafka_DescribeLogDirs(rd_kafka_t *rk,
+                              const rd_kafka_topic_partition_list_t *topics,
+                              const rd_kafka_AdminOptions_t *options,
+                              rd_kafka_queue_t *rkqu) {
+        rd_kafka_op_t *rko;
+
+        static const struct rd_kafka_admin_worker_cbs cbs = {
+            rd_kafka_DescribeLogDirsRequest,
+            rd_kafka_DescribeLogDirsResponse_parse,
+        };
+
+        rd_assert(rkqu);
+
+        rko = rd_kafka_admin_request_op_new(
+            rk, RD_KAFKA_OP_DESCRIBELOGDIRS,
+            RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT, &cbs, options, rkqu->rkqu_q);
+
+        rd_list_init(&rko->rko_u.admin_request.args, 1,
+                     rd_kafka_DescribeLogDirs_topics_free);
+
+        if (topics) {
+                rd_list_add(&rko->rko_u.admin_request.args,
+                            rd_kafka_topic_partition_list_copy(topics));
+        }
+
+        rd_kafka_q_enq(rk->rk_ops, rko);
+}
+
+/**@}*/

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -655,4 +655,40 @@ typedef struct rd_kafka_ElectLeadersResult_s {
 
 /**@}*/
 
+/**
+ * @name DescribeLogDirs
+ * @{
+ */
+
+/**
+ * @struct DescribeLogDirs partition result
+ */
+struct rd_kafka_LogDirPartitionDescription_s {
+        int32_t partition;
+        int64_t size;
+        int64_t offset_lag;
+        rd_bool_t is_future;
+};
+
+/**
+ * @struct DescribeLogDirs topic result
+ */
+struct rd_kafka_LogDirTopicDescription_s {
+        char *topic;
+        rd_kafka_LogDirPartitionDescription_t **partitions;
+        int partition_cnt;
+};
+
+/**
+ * @struct DescribeLogDirs log dir result
+ */
+struct rd_kafka_LogDirDescription_s {
+        rd_kafka_error_t *error;
+        char *log_dir;
+        rd_kafka_LogDirTopicDescription_t **topics;
+        int topic_cnt;
+};
+
+/**@}*/
+
 #endif /* _RDKAFKA_ADMIN_H_ */

--- a/src/rdkafka_event.c
+++ b/src/rdkafka_event.c
@@ -99,6 +99,8 @@ const char *rd_kafka_event_name(const rd_kafka_event_t *rkev) {
                 return "ListOffsetsResult";
         case RD_KAFKA_EVENT_ELECTLEADERS_RESULT:
                 return "ElectLeadersResult";
+        case RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT:
+                return "DescribeLogDirsResult";
         default:
                 return "?unknown?";
         }
@@ -499,4 +501,12 @@ rd_kafka_event_ElectLeaders_result(rd_kafka_event_t *rkev) {
                 return NULL;
         else
                 return (const rd_kafka_ElectLeaders_result_t *)rkev;
+}
+
+const rd_kafka_DescribeLogDirs_result_t *
+rd_kafka_event_DescribeLogDirs_result(rd_kafka_event_t *rkev) {
+        if (!rkev || rkev->rko_evtype != RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT)
+                return NULL;
+        else
+                return (const rd_kafka_DescribeLogDirs_result_t *)rkev;
 }

--- a/src/rdkafka_event.h
+++ b/src/rdkafka_event.h
@@ -118,6 +118,7 @@ static RD_UNUSED RD_INLINE int rd_kafka_event_setup(rd_kafka_t *rk,
         case RD_KAFKA_EVENT_ALTERUSERSCRAMCREDENTIALS_RESULT:
         case RD_KAFKA_EVENT_LISTOFFSETS_RESULT:
         case RD_KAFKA_EVENT_ELECTLEADERS_RESULT:
+        case RD_KAFKA_EVENT_DESCRIBELOGDIRS_RESULT:
                 return 1;
 
         default:

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -122,7 +122,8 @@ const char *rd_kafka_op2str(rd_kafka_op_type_t type) {
                 "REPLY:RD_KAFKA_OP_SET_TELEMETRY_BROKER",
             [RD_KAFKA_OP_TERMINATE_TELEMETRY] =
                 "REPLY:RD_KAFKA_OP_TERMINATE_TELEMETRY",
-            [RD_KAFKA_OP_ELECTLEADERS] = "REPLY:ELECTLEADERS",
+            [RD_KAFKA_OP_ELECTLEADERS]    = "REPLY:ELECTLEADERS",
+            [RD_KAFKA_OP_DESCRIBELOGDIRS] = "REPLY:DESCRIBELOGDIRS",
         };
 
         if (type & RD_KAFKA_OP_REPLY)
@@ -286,7 +287,8 @@ rd_kafka_op_t *rd_kafka_op_new0(const char *source, rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_SET_TELEMETRY_BROKER] =
                 sizeof(rko->rko_u.telemetry_broker),
             [RD_KAFKA_OP_TERMINATE_TELEMETRY] = _RD_KAFKA_OP_EMPTY,
-            [RD_KAFKA_OP_ELECTLEADERS] = sizeof(rko->rko_u.admin_request),
+            [RD_KAFKA_OP_ELECTLEADERS]    = sizeof(rko->rko_u.admin_request),
+            [RD_KAFKA_OP_DESCRIBELOGDIRS] = sizeof(rko->rko_u.admin_request),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 
@@ -441,6 +443,7 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_DESCRIBEUSERSCRAMCREDENTIALS:
         case RD_KAFKA_OP_LISTOFFSETS:
         case RD_KAFKA_OP_ELECTLEADERS:
+        case RD_KAFKA_OP_DESCRIBELOGDIRS:
                 rd_kafka_replyq_destroy(&rko->rko_u.admin_request.replyq);
                 rd_list_destroy(&rko->rko_u.admin_request.args);
                 if (rko->rko_u.admin_request.options.match_consumer_group_states

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -189,6 +189,9 @@ typedef enum {
         RD_KAFKA_OP_ELECTLEADERS,         /**< Admin:
                                            *   ElectLeaders
                                            *   u.admin_request */
+        RD_KAFKA_OP_DESCRIBELOGDIRS,      /**< Admin:
+                                           *   DescribeLogDirs
+                                           *   u.admin_request */
         RD_KAFKA_OP__END
 } rd_kafka_op_type_t;
 

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6120,6 +6120,68 @@ rd_kafka_resp_err_t rd_kafka_ElectLeadersRequest(
 }
 
 /**
+ * @brief Construct and send DescribeLogDirsRequest to \p rkb.
+ *
+ * @param topics list containing a single
+ *        rd_kafka_topic_partition_list_t* element (or empty for all topics).
+ */
+rd_kafka_resp_err_t
+rd_kafka_DescribeLogDirsRequest(rd_kafka_broker_t *rkb,
+                                const rd_list_t *topics,
+                                rd_kafka_AdminOptions_t *options,
+                                char *errstr,
+                                size_t errstr_size,
+                                rd_kafka_replyq_t replyq,
+                                rd_kafka_resp_cb_t *resp_cb,
+                                void *opaque) {
+        rd_kafka_buf_t *rkbuf;
+        int16_t ApiVersion;
+        const rd_kafka_topic_partition_list_t *partitions = NULL;
+        int rd_buf_size_estimate;
+
+        ApiVersion = rd_kafka_broker_ApiVersion_supported(
+            rkb, RD_KAFKAP_DescribeLogDirs, 0, 4, NULL);
+        if (ApiVersion == -1) {
+                rd_snprintf(errstr, errstr_size,
+                            "DescribeLogDirs Admin API (KIP-113) not supported "
+                            "by broker, requires broker version >= 1.1.0");
+                rd_kafka_replyq_destroy(&replyq);
+                return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
+        }
+
+        if (rd_list_cnt(topics) > 0)
+                partitions = rd_list_elem(topics, 0);
+
+        rd_buf_size_estimate = 4 /* #Topics array */;
+        if (partitions)
+                rd_buf_size_estimate += (50 + 4) * partitions->cnt;
+
+        rkbuf = rd_kafka_buf_new_flexver_request(rkb, RD_KAFKAP_DescribeLogDirs,
+                                                 1, rd_buf_size_estimate,
+                                                 ApiVersion >= 2);
+
+        if (!partitions) {
+                /* Null array = describe all topics */
+                rd_kafka_buf_write_arraycnt(rkbuf, -1);
+        } else {
+                const rd_kafka_topic_partition_field_t fields[] = {
+                    RD_KAFKA_TOPIC_PARTITION_FIELD_PARTITION,
+                    RD_KAFKA_TOPIC_PARTITION_FIELD_END};
+                rd_kafka_buf_write_topic_partitions(
+                    rkbuf, partitions, rd_false /*don't skip invalid offsets*/,
+                    rd_false /* any offset */,
+                    rd_false /* don't use topic_id */,
+                    rd_true /* use topic_names */, fields);
+        }
+
+        rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
+
+        rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+/**
  * @brief Construct and send ConsumerGroupDescribe requests
  *        to \p rkb with the groups (const char *) in \p groups.
  *        Uses \p include_authorized_operations to get

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -645,6 +645,16 @@ rd_kafka_resp_err_t rd_kafka_ElectLeadersRequest(
     rd_kafka_resp_cb_t *resp_cb,
     void *opaque);
 
+rd_kafka_resp_err_t rd_kafka_DescribeLogDirsRequest(
+    rd_kafka_broker_t *rkb,
+    const rd_list_t *topics /*(rd_kafka_topic_partition_list_t*)*/,
+    rd_kafka_AdminOptions_t *options,
+    char *errstr,
+    size_t errstr_size,
+    rd_kafka_replyq_t replyq,
+    rd_kafka_resp_cb_t *resp_cb,
+    void *opaque);
+
 rd_kafka_error_t *
 rd_kafka_ConsumerGroupDescribeRequest(rd_kafka_broker_t *rkb,
                                       char **groups,

--- a/tests/0080-admin_ut.c
+++ b/tests/0080-admin_ut.c
@@ -2377,6 +2377,104 @@ static void do_test_AlterUserScramCredentials(const char *what,
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Test DescribeLogDirs
+ */
+static void do_test_DescribeLogDirs(const char *what,
+                                    rd_kafka_t *rk,
+                                    rd_kafka_queue_t *useq,
+                                    int with_options,
+                                    int with_topics) {
+        rd_kafka_queue_t *q;
+        rd_kafka_AdminOptions_t *options = NULL;
+        rd_kafka_event_t *rkev;
+        rd_kafka_resp_err_t err;
+        const rd_kafka_DescribeLogDirs_result_t *res;
+        const rd_kafka_LogDirDescription_t **logdirs;
+        size_t logdir_cnt;
+        int exp_timeout = MY_SOCKET_TIMEOUT_MS;
+        test_timing_t timing;
+        char errstr[512];
+        const char *errstr2;
+        void *my_opaque                         = NULL, *opaque;
+        rd_kafka_topic_partition_list_t *topics = NULL;
+
+        SUB_TEST_QUICK("%s DescribeLogDirs with %s, timeout %dms",
+                       rd_kafka_name(rk), what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        if (with_topics) {
+                topics = rd_kafka_topic_partition_list_new(2);
+                rd_kafka_topic_partition_list_add(topics, "test_topic1", 0);
+                rd_kafka_topic_partition_list_add(topics, "test_topic2", 1);
+        }
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(
+                    rk, RD_KAFKA_ADMIN_OP_DESCRIBELOGDIRS);
+
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+
+                err = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+
+                if (useq) {
+                        my_opaque = (void *)456;
+                        rd_kafka_AdminOptions_set_opaque(options, my_opaque);
+                }
+        }
+
+        TIMING_START(&timing, "DescribeLogDirs");
+        TEST_SAY("Call DescribeLogDirs, timeout is %dms\n", exp_timeout);
+        rd_kafka_DescribeLogDirs(rk, topics, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "DescribeLogDirs.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("DescribeLogDirs: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Convert event to proper result */
+        res = rd_kafka_event_DescribeLogDirs_result(rkev);
+        TEST_ASSERT(res, "expected DescribeLogDirs_result, not %s",
+                    rd_kafka_event_name(rkev));
+        opaque = rd_kafka_event_opaque(rkev);
+        TEST_ASSERT(opaque == my_opaque, "expected opaque to be %p, not %p",
+                    my_opaque, opaque);
+
+        /* Expecting error (no real broker) */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err, "expected DescribeLogDirs to fail");
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected RD_KAFKA_RESP_ERR__TIMED_OUT, not %s",
+                    rd_kafka_err2name(err));
+        TEST_SAY("DescribeLogDirs error: %s\n", errstr2);
+
+        /* Validate result accessor returns 0 entries on error */
+        logdirs =
+            rd_kafka_DescribeLogDirs_result_descriptions(res, &logdir_cnt);
+        TEST_ASSERT(!logdirs && logdir_cnt == 0,
+                    "expected no result logdirs, got %p cnt %" PRIusz, logdirs,
+                    logdir_cnt);
+
+        rd_kafka_event_destroy(rkev);
+
+        if (topics)
+                rd_kafka_topic_partition_list_destroy(topics);
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+        SUB_TEST_PASS();
+}
+
 static void do_test_ElectLeaders(const char *what,
                                  rd_kafka_t *rk,
                                  rd_kafka_queue_t *useq,
@@ -3037,6 +3135,17 @@ static void do_test_apis(rd_kafka_type_t cltype) {
 
         do_test_AlterUserScramCredentials("main queue", rk, mainq);
         do_test_AlterUserScramCredentials("temp queue", rk, NULL);
+
+        do_test_DescribeLogDirs("temp queue, no options, no topics", rk, NULL,
+                                0, 0);
+        do_test_DescribeLogDirs("temp queue, options, no topics", rk, NULL, 1,
+                                0);
+        do_test_DescribeLogDirs("temp queue, options, with topics", rk, NULL, 1,
+                                1);
+        do_test_DescribeLogDirs("main queue, options, no topics", rk, mainq, 1,
+                                0);
+        do_test_DescribeLogDirs("main queue, options, with topics", rk, mainq,
+                                1, 1);
 
         do_test_ElectLeaders("main queue, options, Preffered Elections", rk,
                              mainq, 1, RD_KAFKA_ELECTION_TYPE_PREFERRED);


### PR DESCRIPTION
## Summary

Implements the DescribeLogDirs admin API (Kafka API key 35, KIP-113)
to allow querying partition sizes in bytes on disk.

- Follows the ElectLeaders pattern (self-contained protocol request/response)
- Supports protocol versions 0-4 with flexible version negotiation (v2+)
- `topics` parameter accepts a topic-partition list to filter, or NULL for all
- Request targets a specific broker via `AdminOptions_set_broker()`, defaults to controller

Resolves #5192

A companion confluent-kafka-python PR with Python bindings and `describe_log_dirs()` will follow once this is merged.