### PR TITLE
FIX: Modify test 0155-share_group_heartbeat_mock.c to use share consumer instead of normal consumer

### DIFF
--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -29,21 +29,20 @@ static int wait_share_heartbeats(rd_kafka_mock_cluster_t *mcluster,
 /**
  * @brief Create a share consumer connected to mock cluster.
  */
-static rd_kafka_t *create_share_consumer(const char *bootstraps,
-                                         const char *group_id) {
+static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
+                                               const char *group_id) {
         rd_kafka_conf_t *conf;
-        rd_kafka_t *rk;
+        rd_kafka_share_t *rk;
         char errstr[512];
 
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", bootstraps);
         test_conf_set(conf, "group.id", group_id);
-        test_conf_set(conf, "share.consumer", "true");
-        test_conf_set(conf, "group.protocol", "consumer");
         test_conf_set(conf, "auto.offset.reset", "earliest");
 
-        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        rk = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(rk != NULL, "Failed to create share consumer: %s", errstr);
+        rd_kafka_share_poll_set_consumer(rk);
 
         return rk;
 }
@@ -56,7 +55,7 @@ static void do_test_share_group_heartbeat_basic(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group";
@@ -74,7 +73,7 @@ static void do_test_share_group_heartbeat_basic(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for join heartbeat */
@@ -83,12 +82,13 @@ static void do_test_share_group_heartbeat_basic(void) {
                     "Expected at least 1 heartbeat, got %d", found_heartbeats);
 
         /* Poll to process response and trigger more heartbeats */
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify assignment received (matches testReconcileNewPartitions) */
         {
                 rd_kafka_topic_partition_list_t *assignment;
-                TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+                TEST_CALL_ERR__(rd_kafka_assignment(
+                    test_share_consumer_get_rk(c), &assignment));
                 TEST_ASSERT(assignment->cnt == 3,
                             "Expected 3 partitions assigned, got %d",
                             assignment->cnt);
@@ -101,8 +101,8 @@ static void do_test_share_group_heartbeat_basic(void) {
                     "Expected at least 2 heartbeats, got %d", found_heartbeats);
 
         /* Close consumer (sends leave heartbeat) */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         /* Verify leave heartbeat was sent */
         found_heartbeats = wait_share_heartbeats(mcluster, 3, 200);
@@ -130,7 +130,7 @@ static void do_test_share_group_assignment_rebalance(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_topic_partition_list_t *c1_assignment, *c2_assignment;
-        rd_kafka_t *c1, *c2;
+        rd_kafka_share_t *c1, *c2;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-rebalance";
 
@@ -147,13 +147,14 @@ static void do_test_share_group_assignment_rebalance(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
 
         /* C1 joins - should get all 3 partitions */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c1, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(c1),
+                                            &c1_assignment));
         TEST_ASSERT(c1_assignment->cnt == 3,
                     "Expected C1 to have 3 partitions, got %d",
                     c1_assignment->cnt);
@@ -161,15 +162,17 @@ static void do_test_share_group_assignment_rebalance(void) {
 
         /* C2 joins - partitions should be redistributed */
         c2 = create_share_consumer(bootstraps, group);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assignment));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(c1),
+                                            &c1_assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(c2),
+                                            &c2_assignment));
         TEST_ASSERT(c1_assignment->cnt + c2_assignment->cnt == 3,
                     "Expected total 3 partitions, got %d + %d = %d",
                     c1_assignment->cnt, c2_assignment->cnt,
@@ -182,20 +185,21 @@ static void do_test_share_group_assignment_rebalance(void) {
         rd_kafka_topic_partition_list_destroy(c2_assignment);
 
         /* C2 leaves - C1 should get all partitions back */
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c2);
 
-        rd_kafka_consumer_poll(c1, 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 6000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(c1),
+                                            &c1_assignment));
         TEST_ASSERT(c1_assignment->cnt == 3,
                     "Expected C1 to have 3 partitions after C2 left, got %d",
                     c1_assignment->cnt);
         rd_kafka_topic_partition_list_destroy(c1_assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_destroy(c1);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_destroy(c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -222,7 +226,7 @@ static void do_test_share_group_multi_topic_assignment(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *sub_both, *sub_orders, *sub_events;
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign, *c3_assign;
-        rd_kafka_t *c1, *c2, *c3;
+        rd_kafka_share_t *c1, *c2, *c3;
         const char *topic_orders = "test-orders";
         const char *topic_events = "test-events";
         const char *group        = "test-share-group-multi";
@@ -253,24 +257,27 @@ static void do_test_share_group_multi_topic_assignment(void) {
 
         /* C1 joins (both topics) - should get all 6 partitions */
         c1 = create_share_consumer(bootstraps, group);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, sub_both));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, sub_both));
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c1, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
         TEST_ASSERT(c1_assign->cnt == 6,
                     "C1 should have all 6 partitions, got %d", c1_assign->cnt);
         rd_kafka_topic_partition_list_destroy(c1_assign);
 
         /* C2 joins (orders only) - orders should split */
         c2 = create_share_consumer(bootstraps, group);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, sub_orders));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, sub_orders));
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
 
         total_orders = count_topic_partitions(c1_assign, topic_orders) +
                        count_topic_partitions(c2_assign, topic_orders);
@@ -289,15 +296,18 @@ static void do_test_share_group_multi_topic_assignment(void) {
 
         /* C3 joins (events only) - events should split */
         c3 = create_share_consumer(bootstraps, group);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c3, sub_events));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c3, sub_events));
         wait_share_heartbeats(mcluster, 5, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
-        rd_kafka_consumer_poll(c3, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c3, &c3_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c3), &c3_assign));
 
         total_orders = count_topic_partitions(c1_assign, topic_orders) +
                        count_topic_partitions(c2_assign, topic_orders) +
@@ -318,14 +328,16 @@ static void do_test_share_group_multi_topic_assignment(void) {
         rd_kafka_topic_partition_list_destroy(c3_assign);
 
         /* C1 leaves - C2 should get all orders, C3 all events */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_destroy(c1);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_destroy(c1);
 
-        rd_kafka_consumer_poll(c2, 6000);
-        rd_kafka_consumer_poll(c3, 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 6000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c3, &c3_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c3), &c3_assign));
 
         TEST_ASSERT(count_topic_partitions(c2_assign, topic_orders) == 4,
                     "C2 should have all 4 orders partitions, got %d",
@@ -338,12 +350,13 @@ static void do_test_share_group_multi_topic_assignment(void) {
         rd_kafka_topic_partition_list_destroy(c3_assign);
 
         /* C2 leaves - C3 should still have events only */
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c2);
 
-        rd_kafka_consumer_poll(c3, 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 6000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c3, &c3_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c3), &c3_assign));
         TEST_ASSERT(count_topic_partitions(c3_assign, topic_events) == 2,
                     "C3 should still have 2 events partitions, got %d",
                     count_topic_partitions(c3_assign, topic_events));
@@ -354,8 +367,8 @@ static void do_test_share_group_multi_topic_assignment(void) {
         rd_kafka_topic_partition_list_destroy(c3_assign);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c3);
-        rd_kafka_destroy(c3);
+        rd_kafka_share_consumer_close(c3);
+        rd_kafka_share_destroy(c3);
 
         rd_kafka_topic_partition_list_destroy(sub_both);
         rd_kafka_topic_partition_list_destroy(sub_orders);
@@ -377,7 +390,7 @@ static void do_test_share_group_error_injection(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -396,15 +409,16 @@ static void do_test_share_group_error_injection(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -417,10 +431,11 @@ static void do_test_share_group_error_injection(void) {
             RD_KAFKA_RESP_ERR_INVALID_REQUEST, 0);
 
         /* Poll - consumer should enter fatal state */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify consumer entered fatal state */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected consumer to be in fatal state after "
                     "INVALID_REQUEST error");
@@ -428,8 +443,8 @@ static void do_test_share_group_error_injection(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -447,7 +462,7 @@ static void do_test_share_group_rtt_injection(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_conf_t *conf;
         char errstr[512];
         int found_heartbeats;
@@ -465,28 +480,28 @@ static void do_test_share_group_rtt_injection(void) {
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", bootstraps);
         test_conf_set(conf, "group.id", group);
-        test_conf_set(conf, "share.consumer", "true");
-        test_conf_set(conf, "group.protocol", "consumer");
         test_conf_set(conf, "auto.offset.reset", "earliest");
         test_conf_set(conf, "socket.timeout.ms", "3000");
 
-        c = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        c = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(c != NULL, "Failed to create share consumer: %s", errstr);
+        rd_kafka_share_poll_set_consumer(c);
 
         subscription = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subscription, topic,
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -498,7 +513,7 @@ static void do_test_share_group_rtt_injection(void) {
             RD_KAFKA_RESP_ERR_NO_ERROR, 5000);
 
         /* Poll through the timeout period - consumer should recover */
-        rd_kafka_consumer_poll(c, 5000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 5000);
 
         /* Verify heartbeats resumed after timeout recovery */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 1000);
@@ -507,18 +522,19 @@ static void do_test_share_group_rtt_injection(void) {
                     found_heartbeats);
 
         /* Poll more to allow assignment to be restored */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify consumer recovered and still has assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after timeout recovery, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -539,7 +555,7 @@ static void do_test_share_group_session_timeout(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign;
-        rd_kafka_t *c1, *c2;
+        rd_kafka_share_t *c1, *c2;
         int c1_initial, c2_initial;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-timeout";
@@ -562,18 +578,20 @@ static void do_test_share_group_session_timeout(void) {
 
         rd_kafka_mock_start_request_tracking(mcluster);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for both to join and rebalance to complete */
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
 
         /* Verify initial distribution */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
         c1_initial = c1_assign->cnt;
         c2_initial = c2_assign->cnt;
         TEST_ASSERT(c1_initial + c2_initial == 4,
@@ -585,20 +603,21 @@ static void do_test_share_group_session_timeout(void) {
         rd_kafka_topic_partition_list_destroy(c2_assign);
 
         /* Destroy C2 without close to simulate crash */
-        rd_kafka_destroy(c2);
+        rd_kafka_share_destroy(c2);
 
         /* Poll C1 for 5 seconds - enough for C2 to timeout */
-        rd_kafka_consumer_poll(c1, 5000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 5000);
 
         /* Verify C1 got all partitions after C2 timed out */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
         TEST_ASSERT(c1_assign->cnt == 4,
                     "C1 should have all 4 partitions after C2 timeout, got %d",
                     c1_assign->cnt);
         rd_kafka_topic_partition_list_destroy(c1_assign);
 
-        rd_kafka_consumer_close(c1);
-        rd_kafka_destroy(c1);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_destroy(c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -622,7 +641,7 @@ static void do_test_share_group_target_assignment(void) {
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign;
         rd_kafka_topic_partition_list_t *target_c1, *target_c2;
         rd_kafka_topic_partition_list_t *assignments[2];
-        rd_kafka_t *c1, *c2;
+        rd_kafka_share_t *c1, *c2;
         char **member_ids;
         size_t member_cnt;
         rd_kafka_resp_err_t err;
@@ -644,18 +663,20 @@ static void do_test_share_group_target_assignment(void) {
 
         rd_kafka_mock_start_request_tracking(mcluster);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for both to join and rebalance to complete */
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 3000);
-        rd_kafka_consumer_poll(c2, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 3000);
 
         /* Verify initial automatic assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
         TEST_ASSERT(c1_assign->cnt + c2_assign->cnt == 4,
                     "Total should be 4 partitions, got %d",
                     c1_assign->cnt + c2_assign->cnt);
@@ -690,12 +711,14 @@ static void do_test_share_group_target_assignment(void) {
         rd_kafka_topic_partition_list_destroy(target_c2);
 
         /* Poll to receive new assignment */
-        rd_kafka_consumer_poll(c1, 6000);
-        rd_kafka_consumer_poll(c2, 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 6000);
 
         /* Verify manual assignment was applied */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
 
         TEST_ASSERT(c1_assign->cnt + c2_assign->cnt == 4,
                     "Total should still be 4 partitions, got %d",
@@ -715,10 +738,10 @@ static void do_test_share_group_target_assignment(void) {
         rd_free(member_ids);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c1);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c1);
+        rd_kafka_share_destroy(c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -740,7 +763,7 @@ static void do_test_share_group_no_spurious_fencing(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-no-fence";
         int i;
@@ -757,13 +780,14 @@ static void do_test_share_group_no_spurious_fencing(void) {
         subscription = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subscription, topic,
                                           RD_KAFKA_PARTITION_UA);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for join and initial assignment. */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -773,10 +797,11 @@ static void do_test_share_group_no_spurious_fencing(void) {
          * members, the assignment will drop. */
         TEST_SAY("Polling for 10 seconds with 2s session timeout...\n");
         for (i = 0; i < 10; i++) {
-                rd_kafka_consumer_poll(c, 1000);
+                rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 1000);
 
                 /* Verify assignment is still intact */
-                TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+                TEST_CALL_ERR__(rd_kafka_assignment(
+                    test_share_consumer_get_rk(c), &assignment));
                 TEST_ASSERT(assignment->cnt == 3,
                             "Assignment dropped at %ds (spurious fencing!)",
                             i + 1);
@@ -786,8 +811,8 @@ static void do_test_share_group_no_spurious_fencing(void) {
         TEST_SAY("No spurious fencing after 10 seconds\n");
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -807,7 +832,7 @@ static void do_test_unknown_member_id_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-unknown-member";
@@ -825,15 +850,16 @@ static void do_test_unknown_member_id_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -844,7 +870,7 @@ static void do_test_unknown_member_id_error(void) {
             RD_KAFKA_RESP_ERR_UNKNOWN_MEMBER_ID, 0);
 
         /* Poll - consumer should handle error and rejoin */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify heartbeats continue (rejoin happened) */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 500);
@@ -854,16 +880,17 @@ static void do_test_unknown_member_id_error(void) {
                     found_heartbeats);
 
         /* Verify consumer eventually gets assignment back */
-        rd_kafka_consumer_poll(c, 2000);
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after rejoin, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -881,7 +908,7 @@ static void do_test_fenced_member_epoch_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-fenced";
@@ -899,15 +926,16 @@ static void do_test_fenced_member_epoch_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -918,7 +946,7 @@ static void do_test_fenced_member_epoch_error(void) {
             RD_KAFKA_RESP_ERR_FENCED_MEMBER_EPOCH, 0);
 
         /* Poll - consumer should handle error and rejoin */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify heartbeats continue (rejoin happened) */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 500);
@@ -929,16 +957,17 @@ static void do_test_fenced_member_epoch_error(void) {
             found_heartbeats);
 
         /* Verify consumer eventually gets assignment back */
-        rd_kafka_consumer_poll(c, 2000);
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after rejoin, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -956,7 +985,7 @@ static void do_test_coordinator_not_available_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-coord-unavail";
@@ -974,15 +1003,16 @@ static void do_test_coordinator_not_available_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -993,7 +1023,7 @@ static void do_test_coordinator_not_available_error(void) {
             RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE, 0);
 
         /* Poll - consumer should handle transient error and retry */
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify heartbeats continue after transient error */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 500);
@@ -1004,15 +1034,16 @@ static void do_test_coordinator_not_available_error(void) {
             found_heartbeats);
 
         /* Verify consumer still has assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after retry, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1029,7 +1060,7 @@ static void do_test_not_coordinator_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-not-coord";
@@ -1047,15 +1078,16 @@ static void do_test_not_coordinator_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1068,7 +1100,7 @@ static void do_test_not_coordinator_error(void) {
         /* Poll - consumer should find new coordinator and continue.
          * NOT_COORDINATOR triggers coordinator rediscovery which may take
          * longer than COORDINATOR_NOT_AVAILABLE. */
-        rd_kafka_consumer_poll(c, 5000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 5000);
 
         /* Verify heartbeats continue after finding coordinator */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 1000);
@@ -1078,15 +1110,16 @@ static void do_test_not_coordinator_error(void) {
                     found_heartbeats);
 
         /* Verify consumer still has assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after finding coordinator, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1104,7 +1137,7 @@ static void do_test_group_authorization_failed_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -1123,12 +1156,12 @@ static void do_test_group_authorization_failed_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Inject GROUP_AUTHORIZATION_FAILED error (fatal) */
         rd_kafka_mock_broker_push_request_error_rtts(
@@ -1136,10 +1169,11 @@ static void do_test_group_authorization_failed_error(void) {
             RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED, 0);
 
         /* Poll - should trigger fatal error */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify consumer entered fatal state */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected consumer to be in fatal state after "
                     "GROUP_AUTHORIZATION_FAILED");
@@ -1147,8 +1181,8 @@ static void do_test_group_authorization_failed_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1166,7 +1200,7 @@ static void do_test_group_max_size_reached_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c1, *c2;
+        rd_kafka_share_t *c1, *c2;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -1187,13 +1221,14 @@ static void do_test_group_max_size_reached_error(void) {
 
         rd_kafka_mock_start_request_tracking(mcluster);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
 
         /* Wait for c1 to fully join and stabilize */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c1, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &assignment));
         TEST_ASSERT(assignment->cnt == 4,
                     "Expected c1 to have 4 partitions, got %d",
                     assignment->cnt);
@@ -1209,13 +1244,14 @@ static void do_test_group_max_size_reached_error(void) {
 
         /* Create second consumer - should be rejected */
         c2 = create_share_consumer(bootstraps, group);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
 
         /* Poll c2 - should get fatal error */
-        rd_kafka_consumer_poll(c2, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 3000);
 
         /* Verify c2 entered fatal state */
-        fatal_err = rd_kafka_fatal_error(c2, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c2), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected c2 to be in fatal state after "
                     "GROUP_MAX_SIZE_REACHED");
@@ -1225,10 +1261,10 @@ static void do_test_group_max_size_reached_error(void) {
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c1);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c1);
+        rd_kafka_share_destroy(c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1246,7 +1282,7 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-rejoin";
@@ -1264,15 +1300,16 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment (member is now in stable state) */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1284,7 +1321,7 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
             RD_KAFKA_RESP_ERR_UNKNOWN_MEMBER_ID, 0);
 
         /* Poll - consumer should rejoin with epoch=0 */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify rejoin heartbeats */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 500);
@@ -1292,16 +1329,17 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
                     found_heartbeats);
 
         /* Verify consumer gets assignment back */
-        rd_kafka_consumer_poll(c, 2000);
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after rejoin, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1320,7 +1358,7 @@ static void do_test_leaving_member_bumps_group_epoch(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign;
-        rd_kafka_t *c1, *c2;
+        rd_kafka_share_t *c1, *c2;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-epoch";
 
@@ -1339,18 +1377,20 @@ static void do_test_leaving_member_bumps_group_epoch(void) {
 
         rd_kafka_mock_start_request_tracking(mcluster);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for both to join */
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
 
         /* Verify initial distribution */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
         TEST_ASSERT(c1_assign->cnt + c2_assign->cnt == 4,
                     "Total should be 4 partitions, got %d",
                     c1_assign->cnt + c2_assign->cnt);
@@ -1360,22 +1400,23 @@ static void do_test_leaving_member_bumps_group_epoch(void) {
         rd_kafka_topic_partition_list_destroy(c2_assign);
 
         /* C2 leaves (sends epoch=-1 leave heartbeat) */
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c2);
 
         /* Poll C1 to receive updated assignment (group epoch bumped) */
-        rd_kafka_consumer_poll(c1, 6000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 6000);
 
         /* Verify C1 got all partitions after C2 left */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
         TEST_ASSERT(c1_assign->cnt == 4,
                     "C1 should have all 4 partitions after C2 left, got %d",
                     c1_assign->cnt);
         rd_kafka_topic_partition_list_destroy(c1_assign);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_destroy(c1);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_destroy(c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1393,7 +1434,7 @@ static void do_test_partition_assignment_with_multiple_topics(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         const char *topic1 = "test-multi-topic-1";
         const char *topic2 = "test-multi-topic-2";
         const char *group  = "test-share-group-multi-topic-sub";
@@ -1416,15 +1457,16 @@ static void do_test_partition_assignment_with_multiple_topics(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify assignment includes partitions from both topics */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 5, "Expected 5 partitions (3+2), got %d",
                     assignment->cnt);
 
@@ -1442,8 +1484,8 @@ static void do_test_partition_assignment_with_multiple_topics(void) {
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1465,7 +1507,7 @@ static void do_test_multiple_members_partition_distribution(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign, *c3_assign;
-        rd_kafka_t *c1, *c2, *c3;
+        rd_kafka_share_t *c1, *c2, *c3;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-distribution";
         int total_partitions;
@@ -1486,21 +1528,24 @@ static void do_test_multiple_members_partition_distribution(void) {
 
         rd_kafka_mock_start_request_tracking(mcluster);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c3, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c3, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for all to join */
         wait_share_heartbeats(mcluster, 5, 500);
-        rd_kafka_consumer_poll(c1, 3000);
-        rd_kafka_consumer_poll(c2, 3000);
-        rd_kafka_consumer_poll(c3, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 3000);
 
         /* Get assignments */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c3, &c3_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c3), &c3_assign));
 
         total_partitions = c1_assign->cnt + c2_assign->cnt + c3_assign->cnt;
 
@@ -1529,12 +1574,12 @@ static void do_test_multiple_members_partition_distribution(void) {
         rd_kafka_topic_partition_list_destroy(c3_assign);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_consumer_close(c2);
-        rd_kafka_consumer_close(c3);
-        rd_kafka_destroy(c1);
-        rd_kafka_destroy(c2);
-        rd_kafka_destroy(c3);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_consumer_close(c3);
+        rd_kafka_share_destroy(c1);
+        rd_kafka_share_destroy(c2);
+        rd_kafka_share_destroy(c3);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1552,7 +1597,7 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t err;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-success";
@@ -1570,15 +1615,16 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1586,12 +1632,12 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         /* Leave group - should send leave heartbeat and complete.
          * Note: After close(), we cannot call rd_kafka_assignment() anymore
          * as the broker handle is destroyed. */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         TEST_ASSERT(!err, "Expected close to succeed, got %s",
                     rd_kafka_err2str(err));
 
         /* Cleanup */
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1609,7 +1655,7 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t err;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-error";
@@ -1627,15 +1673,16 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1648,7 +1695,7 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         /* Leave group - should still complete despite error (best effort).
          * The key behavior: close() must not hang even when the leave
          * heartbeat gets an error response. */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         /* Close completed (didn't hang) - this is the primary assertion.
          * The return code may vary depending on whether the error was
          * processed during leave. */
@@ -1656,7 +1703,7 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
                  rd_kafka_err2str(err));
 
         /* Cleanup */
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1674,7 +1721,7 @@ static void do_test_subscription_change(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_topicA = 0, found_topicB = 0, i;
         const char *topicA = "test-sub-change-topic-A";
         const char *topicB = "test-sub-change-topic-B";
@@ -1695,15 +1742,16 @@ static void do_test_subscription_change(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for assignment to topic A */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify assignment has topic A only */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 2,
                     "Expected 2 partitions from topicA, got %d",
                     assignment->cnt);
@@ -1718,16 +1766,17 @@ static void do_test_subscription_change(void) {
         subscription = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subscription, topicB,
                                           RD_KAFKA_PARTITION_UA);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for assignment update */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
         wait_share_heartbeats(mcluster, 2, 500);
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify assignment now has topic B only */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         found_topicA = 0;
         found_topicB = 0;
         for (i = 0; i < assignment->cnt; i++) {
@@ -1745,8 +1794,8 @@ static void do_test_subscription_change(void) {
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1765,7 +1814,7 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t err, fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -1784,15 +1833,16 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1800,8 +1850,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         /* Unsubscribe first to transition to unsubscribed state.
          * The Java test has member in UNSUBSCRIBED state when the
          * error arrives. */
-        TEST_CALL_ERR__(rd_kafka_unsubscribe(c));
-        rd_kafka_consumer_poll(c, 2000);
+        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(c));
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Now inject GROUP_ID_NOT_FOUND.
          * Since the member is unsubscribed, this should be benign. */
@@ -1810,21 +1860,22 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
             RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND, 0);
 
         /* Poll to process the error */
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify consumer is NOT in fatal state - error should be benign */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected no fatal error when GROUP_ID_NOT_FOUND arrives "
                     "while unsubscribed, but got: %s (%s)",
                     rd_kafka_err2str(fatal_err), errstr);
 
         /* Close consumer */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         TEST_SAY("Close returned: %s\n", rd_kafka_err2str(err));
 
         /* Cleanup */
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1846,7 +1897,7 @@ static void do_test_group_id_not_found_while_stable_is_fatal(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -1865,15 +1916,16 @@ static void do_test_group_id_not_found_while_stable_is_fatal(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment - member is in stable state */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1885,14 +1937,15 @@ static void do_test_group_id_not_found_while_stable_is_fatal(void) {
             RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND, 0);
 
         /* Poll - should trigger fatal error */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Check if consumer entered fatal state.
          * KNOWN ISSUE: GROUP_ID_NOT_FOUND is not in the SGHB fatal error
          * list in rdkafka_cgrp.c. It falls through to the default case
          * and is treated as a permanent (non-fatal) error.
          * See sghb_test_discrepancies.txt for details. */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         if (fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR)
                 TEST_SAY("Consumer entered fatal state: %s (%s)\n",
                          rd_kafka_err2str(fatal_err), errstr);
@@ -1903,8 +1956,8 @@ static void do_test_group_id_not_found_while_stable_is_fatal(void) {
                     "(see sghb_test_discrepancies.txt)\n");
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1922,7 +1975,7 @@ static void do_test_invalid_request_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -1941,12 +1994,12 @@ static void do_test_invalid_request_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Inject INVALID_REQUEST error (fatal) */
         rd_kafka_mock_broker_push_request_error_rtts(
@@ -1954,10 +2007,11 @@ static void do_test_invalid_request_error(void) {
             RD_KAFKA_RESP_ERR_INVALID_REQUEST, 0);
 
         /* Poll - should trigger fatal error */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify consumer entered fatal state */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected consumer to be in fatal state after "
                     "INVALID_REQUEST");
@@ -1965,8 +2019,8 @@ static void do_test_invalid_request_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1984,7 +2038,7 @@ static void do_test_unsupported_version_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -2003,12 +2057,12 @@ static void do_test_unsupported_version_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Inject UNSUPPORTED_VERSION error (fatal) */
         rd_kafka_mock_broker_push_request_error_rtts(
@@ -2016,10 +2070,11 @@ static void do_test_unsupported_version_error(void) {
             RD_KAFKA_RESP_ERR_UNSUPPORTED_VERSION, 0);
 
         /* Poll - should trigger fatal error */
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify consumer entered fatal state */
-        fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(c), errstr,
+                                         sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected consumer to be in fatal state after "
                     "UNSUPPORTED_VERSION");
@@ -2027,8 +2082,8 @@ static void do_test_unsupported_version_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2046,7 +2101,7 @@ static void do_test_coordinator_load_in_progress_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-coord-load";
@@ -2064,15 +2119,16 @@ static void do_test_coordinator_load_in_progress_error(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -2083,7 +2139,7 @@ static void do_test_coordinator_load_in_progress_error(void) {
             RD_KAFKA_RESP_ERR_COORDINATOR_LOAD_IN_PROGRESS, 0);
 
         /* Poll - consumer should handle transient error and retry */
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify heartbeats continue after transient error */
         found_heartbeats = wait_share_heartbeats(mcluster, 2, 500);
@@ -2093,15 +2149,16 @@ static void do_test_coordinator_load_in_progress_error(void) {
                     found_heartbeats);
 
         /* Verify consumer still has assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after retry, got %d",
                     assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2119,7 +2176,7 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_resp_err_t err;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
@@ -2138,15 +2195,16 @@ static void do_test_graceful_shutdown_stable_state(void) {
                                           RD_KAFKA_PARTITION_UA);
 
         rd_kafka_mock_start_request_tracking(mcluster);
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial join and assignment */
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify initial assignment - member is in stable state */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -2157,7 +2215,7 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* Close consumer gracefully - should send leave heartbeat */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         TEST_ASSERT(!err, "Expected close to succeed, got %s",
                     rd_kafka_err2str(err));
 
@@ -2166,7 +2224,7 @@ static void do_test_graceful_shutdown_stable_state(void) {
         TEST_SAY("Found %d heartbeats during shutdown\n", found_heartbeats);
 
         /* Cleanup */
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2183,7 +2241,7 @@ static void do_test_resubscribe_after_unsubscribe(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-resubscribe";
 
@@ -2202,11 +2260,12 @@ static void do_test_resubscribe_after_unsubscribe(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* First subscribe */
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         wait_share_heartbeats(mcluster, 1, 500);
-        rd_kafka_consumer_poll(c, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions on first subscribe, got %d",
                     assignment->cnt);
@@ -2214,11 +2273,12 @@ static void do_test_resubscribe_after_unsubscribe(void) {
 
         /* Unsubscribe */
         TEST_SAY("Unsubscribing...\n");
-        TEST_CALL_ERR__(rd_kafka_unsubscribe(c));
-        rd_kafka_consumer_poll(c, 2000);
+        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(c));
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 2000);
 
         /* Verify no assignment after unsubscribe */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_ASSERT(assignment->cnt == 0,
                     "Expected 0 partitions after unsubscribe, got %d",
                     assignment->cnt);
@@ -2226,14 +2286,15 @@ static void do_test_resubscribe_after_unsubscribe(void) {
 
         /* Resubscribe */
         TEST_SAY("Resubscribing...\n");
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         wait_share_heartbeats(mcluster, 2, 500);
-        rd_kafka_consumer_poll(c, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 3000);
 
         /* Verify assignment restored */
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_SAY("Assignment after resubscribe: %d partitions\n",
                  assignment->cnt);
         TEST_ASSERT(assignment->cnt == 3,
@@ -2242,8 +2303,8 @@ static void do_test_resubscribe_after_unsubscribe(void) {
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2261,7 +2322,7 @@ static void do_test_consumer_leave_rebalance(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_topic_partition_list_t *c1_assign, *c2_assign;
-        rd_kafka_t *c1, *c2, *c3;
+        rd_kafka_share_t *c1, *c2, *c3;
         int final_total;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-rebalance";
@@ -2283,25 +2344,27 @@ static void do_test_consumer_leave_rebalance(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* All three join */
-        TEST_CALL_ERR__(rd_kafka_subscribe(c1, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c2, subscription));
-        TEST_CALL_ERR__(rd_kafka_subscribe(c3, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c1, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c2, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c3, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Wait for initial balance */
         wait_share_heartbeats(mcluster, 4, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
-        rd_kafka_consumer_poll(c3, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 2000);
 
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 2000);
-        rd_kafka_consumer_poll(c2, 2000);
-        rd_kafka_consumer_poll(c3, 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 2000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c3), 2000);
 
         /* Get initial assignments */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
         TEST_SAY("Initial: c1=%d, c2=%d (before c3 leaves)\n", c1_assign->cnt,
                  c2_assign->cnt);
         rd_kafka_topic_partition_list_destroy(c1_assign);
@@ -2309,17 +2372,19 @@ static void do_test_consumer_leave_rebalance(void) {
 
         /* c3 leaves */
         TEST_SAY("Consumer c3 leaving...\n");
-        rd_kafka_consumer_close(c3);
-        rd_kafka_destroy(c3);
+        rd_kafka_share_consumer_close(c3);
+        rd_kafka_share_destroy(c3);
 
         /* Poll remaining consumers for rebalance */
         wait_share_heartbeats(mcluster, 3, 500);
-        rd_kafka_consumer_poll(c1, 3000);
-        rd_kafka_consumer_poll(c2, 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c1), 3000);
+        rd_kafka_consumer_poll(test_share_consumer_get_rk(c2), 3000);
 
         /* Get new assignments */
-        TEST_CALL_ERR__(rd_kafka_assignment(c1, &c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(c2, &c2_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c1), &c1_assign));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c2), &c2_assign));
         final_total = c1_assign->cnt + c2_assign->cnt;
         TEST_SAY("After c3 leave: c1=%d, c2=%d\n", c1_assign->cnt,
                  c2_assign->cnt);
@@ -2333,10 +2398,10 @@ static void do_test_consumer_leave_rebalance(void) {
         rd_kafka_topic_partition_list_destroy(c2_assign);
 
         /* Cleanup */
-        rd_kafka_consumer_close(c1);
-        rd_kafka_consumer_close(c2);
-        rd_kafka_destroy(c1);
-        rd_kafka_destroy(c2);
+        rd_kafka_share_consumer_close(c1);
+        rd_kafka_share_consumer_close(c2);
+        rd_kafka_share_destroy(c1);
+        rd_kafka_share_destroy(c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2352,7 +2417,7 @@ static void do_test_double_close(void) {
         const char *bootstraps;
         const char *topic    = test_mk_topic_name(__FUNCTION__, 1);
         const char *group_id = topic;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_resp_err_t err;
 
@@ -2368,23 +2433,23 @@ static void do_test_double_close(void) {
         rd_kafka_topic_partition_list_add(subscription, topic,
                                           RD_KAFKA_PARTITION_UA);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         wait_share_heartbeats(mcluster, 3, 500);
 
         /* First close - should succeed */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         TEST_ASSERT(!err, "Expected first close to succeed, got %s",
                     rd_kafka_err2str(err));
 
         /* Second close - should handle gracefully without crashing.
          * The Java equivalent tests verify the CompletableFuture
          * completes immediately on double-leave. */
-        err = rd_kafka_consumer_close(c);
+        err = rd_kafka_share_consumer_close(c);
         TEST_SAY("Second close returned: %s (no crash - correct)\n",
                  rd_kafka_err2str(err));
 
         rd_kafka_topic_partition_list_destroy(subscription);
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2400,7 +2465,7 @@ static void do_test_empty_topic_subscription(void) {
         const char *bootstraps;
         const char *topic    = test_mk_topic_name(__FUNCTION__, 1);
         const char *group_id = topic;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
         rd_kafka_message_t *msg;
         int i, msg_count = 0;
@@ -2417,12 +2482,13 @@ static void do_test_empty_topic_subscription(void) {
         rd_kafka_topic_partition_list_add(subscription, topic,
                                           RD_KAFKA_PARTITION_UA);
 
-        TEST_CALL_ERR__(rd_kafka_subscribe(c, subscription));
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(c, subscription));
         wait_share_heartbeats(mcluster, 3, 500);
 
         /* Poll empty topic - should get assignment but no messages */
         for (i = 0; i < 10; i++) {
-                msg = rd_kafka_consumer_poll(c, 200);
+                msg =
+                    rd_kafka_consumer_poll(test_share_consumer_get_rk(c), 200);
                 if (msg) {
                         if (!msg->err)
                                 msg_count++;
@@ -2430,7 +2496,8 @@ static void do_test_empty_topic_subscription(void) {
                 }
         }
 
-        TEST_CALL_ERR__(rd_kafka_assignment(c, &assignment));
+        TEST_CALL_ERR__(
+            rd_kafka_assignment(test_share_consumer_get_rk(c), &assignment));
         TEST_SAY("Empty topic: %d partitions, %d messages\n", assignment->cnt,
                  msg_count);
         TEST_ASSERT(assignment->cnt == 3, "Expected 3 partitions, got %d",
@@ -2438,8 +2505,8 @@ static void do_test_empty_topic_subscription(void) {
 
         rd_kafka_topic_partition_list_destroy(subscription);
         rd_kafka_topic_partition_list_destroy(assignment);
-        rd_kafka_consumer_close(c);
-        rd_kafka_destroy(c);
+        rd_kafka_share_consumer_close(c);
+        rd_kafka_share_destroy(c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2458,7 +2525,7 @@ static void do_test_empty_topic_subscription(void) {
 static void do_test_empty_topic_list_subscription(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
-        rd_kafka_t *c;
+        rd_kafka_share_t *c;
         rd_kafka_topic_partition_list_t *empty_list;
         rd_kafka_resp_err_t err;
         const char *group = "test-share-group-empty-topic-list";
@@ -2471,7 +2538,7 @@ static void do_test_empty_topic_list_subscription(void) {
 
         /* Subscribe with empty topic list - should return INVALID_ARG */
         empty_list = rd_kafka_topic_partition_list_new(0);
-        err        = rd_kafka_subscribe(c, empty_list);
+        err        = rd_kafka_share_subscribe(c, empty_list);
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG from subscribe(empty_list), got %s",
                     rd_kafka_err2str(err));
@@ -2479,7 +2546,7 @@ static void do_test_empty_topic_list_subscription(void) {
                  rd_kafka_err2str(err));
 
         rd_kafka_topic_partition_list_destroy(empty_list);
-        rd_kafka_destroy(c);
+        rd_kafka_share_destroy(c);
 
         test_mock_cluster_destroy(mcluster);
 
@@ -2527,8 +2594,7 @@ int main_0155_share_group_heartbeat_mock(int argc, char **argv) {
         do_test_empty_topic_list_subscription();
 
         do_test_group_id_not_found_while_unsubscribed();
-        /* NOT YET COMPATIBLE */
-        /* do_test_group_id_not_found_while_stable_is_fatal(); */
+        do_test_group_id_not_found_while_stable_is_fatal();
 
         return 0;
 }


### PR DESCRIPTION
- The 0155 ShareGroupHeartbeat mock tests were incorrectly using the normal
  consumer API (`rd_kafka_new(RD_KAFKA_CONSUMER)`) with config hacks
  (`share.consumer=true`, `group.protocol=consumer`) instead of the proper
  share consumer API (`rd_kafka_share_consumer_new()`).
- Converted the entire file to use `rd_kafka_share_t` and the share consumer
  API surface: `rd_kafka_share_subscribe()`, `rd_kafka_share_unsubscribe()`,
  `rd_kafka_share_consumer_close()`, `rd_kafka_share_destroy()`.
- For APIs without share-specific equivalents (`rd_kafka_consumer_poll`,
  `rd_kafka_assignment`, `rd_kafka_fatal_error`), the underlying
  `rd_kafka_t` handle is accessed via `test_share_consumer_get_rk()`.

