### PR TITLE
rdkafka_performance: Add warmup flag

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -76,6 +76,7 @@ static int partition_cnt    = 0;
 static int eof_cnt          = 0;
 static int with_dr          = 1;
 static int read_hdrs        = 0;
+static int warmup_cnt       = 0;
 
 
 static void stop(int sig) {
@@ -511,6 +512,27 @@ print_stats(rd_kafka_t *rk, int mode, int otype, const char *compression) {
         int extra_of = 0;
         *extra       = '\0';
 
+        if (warmup_cnt > 0) {
+                if ((int)cnt.msgs < warmup_cnt)
+                        return;
+
+                /* Warmup count reached: flush pending delivery reports
+                 * so that memset can cleanly zero all counters without
+                 * late-arriving warmup DRs polluting benchmark stats. */
+                if (mode == 'P' && rk)
+                        rd_kafka_flush(rk, 10000);
+                if (msgcnt != -1)
+                        msgcnt -= (int)cnt.msgs;
+                memset(&cnt, 0, sizeof(cnt));
+                cnt.t_start = rd_clock();
+                cnt.t_last  = cnt.t_start;
+                warmup_cnt  = 0;
+                if (verbosity >= 1)
+                        printf(
+                            "%% Warmup complete, collecting "
+                            "benchmark stats\n");
+        }
+
         if (!(otype & _OTYPE_FORCE) &&
             (((otype & _OTYPE_SUMMARY) && verbosity == 0) ||
              cnt.t_last + dispintvl > now))
@@ -894,7 +916,7 @@ int main(int argc, char **argv) {
 
         while ((opt = getopt(argc, argv,
                              "PCG:t:p:b:s:k:c:fi:MDd:m:S:x:"
-                             "R:a:z:o:X:B:eT:Y:qvIur:lA:OwNH:")) != -1) {
+                             "R:a:z:o:X:B:eT:Y:qvIur:w:lA:OwNH:")) != -1) {
                 switch (opt) {
                 case 'G':
                         if (rd_kafka_conf_set(conf, "group.id", optarg, errstr,
@@ -1098,6 +1120,15 @@ int main(int argc, char **argv) {
                         rate_sleep = (int)(1000000.0 / dtmp);
                         break;
 
+                case 'w':
+                        warmup_cnt = atoi(optarg);
+                        if (warmup_cnt <= 0) {
+                                fprintf(stderr, "%% Invalid warmup count: %s\n",
+                                        optarg);
+                                exit(1);
+                        }
+                        break;
+
                 case 'l':
                         latency_mode = 1;
                         break;
@@ -1178,6 +1209,8 @@ int main(int argc, char **argv) {
                     "  -v           Increase verbosity (default 1)\n"
                     "  -u           Output stats in table format\n"
                     "  -r <rate>    Producer msg/s limit\n"
+                    "  -w <cnt>     Warmup message count. The first <cnt>\n"
+                    "               messages are excluded from stats.\n"
                     "  -l           Latency measurement.\n"
                     "               Needs two matching instances, one\n"
                     "               consumer and one producer, both\n"
@@ -1330,6 +1363,16 @@ int main(int argc, char **argv) {
                               sizeof(errstr)) != RD_KAFKA_CONF_OK) {
                 fprintf(stderr, "%% %s\n", errstr);
                 exit(1);
+        }
+
+        if (warmup_cnt > 0) {
+                if (msgcnt != -1)
+                        msgcnt += warmup_cnt;
+                if (verbosity >= 1)
+                        printf(
+                            "%% Warming up for %d messages before "
+                            "collecting benchmark stats\n",
+                            warmup_cnt);
         }
 
         if (mode == 'P') {


### PR DESCRIPTION
Add flag to produce/consume additional N warmup messages. Stats are only
accounted after the warmup messages have been produced/consumed.

This makes the stats a lot more useful as it avoids noise from initial
message bursts.

Basically this prevents patterns like these:

```
~/librdkafka/examples/rdkafka_performance -P -t foo -c 4000000 ... -u
% Sending 4000000 messages of size 100 bytes
|    elapsed |       msgs |      bytes |        rtt |         dr |     dr_m/s |    dr_MB/s |     dr_err |     tx_err |       outq |     offset
|       1000 |      53244 |    5324400 |          0 |      52247 |      52246 |       5.22 |          0 |      39854 |        997 |    1676611
|       2000 |     156593 |   15659300 |          0 |     155594 |      77796 |       7.78 |          0 |     119926 |       1000 |    1679692
|       3000 |     261605 |   26160500 |          0 |     260606 |      86868 |       8.69 |          0 |     204584 |        999 |    1688160
|       4000 |     367411 |   36741100 |          0 |     366413 |      91602 |       9.16 |          0 |     291071 |        999 |    1692104
|       5000 |     471801 |   47180100 |          0 |     470804 |      94160 |       9.42 |          0 |     374877 |        998 |    1700897
|       6000 |     575822 |   57582200 |          0 |     574823 |      95803 |       9.58 |          0 |     458438 |        999 |    1704330
|       7000 |     679726 |   67972600 |          0 |     678728 |      96960 |       9.70 |          0 |     542196 |       1000 |    1710758
```

Now we immediately get proper steady state stats:

```
~/librdkafka/examples/rdkafka_performance -P -t foo -c 4000000 ...  -u -w 500000
% Sending 4500000 messages of size 100 bytes
|    elapsed |       msgs |      bytes |        rtt |         dr |     dr_m/s |    dr_MB/s |     dr_err |     tx_err |       outq |     offset
|       1000 |     106054 |   10605400 |          0 |     106052 |     106047 |      10.60 |          0 |      95080 |       1002 |    1780260
|       2000 |     212116 |   21211600 |          0 |     212114 |     106054 |      10.61 |          0 |     189620 |        999 |    1785319
|       3000 |     318316 |   31831600 |          0 |     318314 |     106102 |      10.61 |          0 |     284414 |       1001 |    1791383
|       4000 |     424627 |   42462700 |          0 |     424625 |     106154 |      10.62 |          0 |     379057 |       1002 |    1798530
|       5000 |     531569 |   53156900 |          0 |     531567 |     106311 |      10.63 |          0 |     474389 |       1000 |    1801665
|       6000 |     637679 |   63767900 |          0 |     637678 |     106278 |      10.63 |          0 |     569161 |        998 |    1810564
|       7000 |     743458 |   74345800 |          0 |     743456 |     106206 |      10.62 |          0 |     663704 |       1000 |    1818493
```
