### PR TITLE
partition: Fix data race on idx in rd_kafka_fetch_pos2str()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ librdkafka v2.14.0 is a feature release:
 ### General fixes
 
 * Fix data race on `idx` in `rd_kafka_fetch_pos2str()` when fetching
-  from multiple partitions concurrently.
+  from multiple partitions concurrently (#5367).
 
 # librdkafka v2.13.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ librdkafka v2.14.0 is a feature release:
 
 * [KIP-768](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=186877575#KIP768:ExtendSASL/OAUTHBEARERwithSupportforOIDC-ClientConfiguration) Extend SASL/OAUTHBEARER to support OIDC claim mapping beyond the default `sub` claim (#5336).
 
+## Fixes
+
+### General fixes
+
+* Fix data race on `idx` in `rd_kafka_fetch_pos2str()` when fetching
+  from multiple partitions concurrently.
+
 # librdkafka v2.13.2
 
 librdkafka v2.13.2 is a maintenance release:

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -4726,7 +4726,7 @@ void rd_kafka_partition_leader_destroy_free(void *ptr) {
 
 const char *rd_kafka_fetch_pos2str(const rd_kafka_fetch_pos_t fetchpos) {
         static RD_TLS char ret[2][64];
-        static int idx;
+        static RD_TLS int idx;
 
         idx = (idx + 1) % 2;
 


### PR DESCRIPTION
The static `idx` variable in rd_kafka_fetch_pos2str() was shared across threads, causing a data race when multiple threads fetched from different partitions concurrently. Mark it RD_TLS (thread-local storage) to give each thread its own index, consistent with the already thread-local `ret` buffer.