### PR TITLE
Added KIP-546 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 librdkafka v2.14.0 is a feature release:
 
+* [KIP-546](https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client) Add `DescribeClientQuotas` and `AlterClientQuotas` admin client APIs for managing per-client and per-user quota configurations.
 * [KIP-768](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=186877575#KIP768:ExtendSASL/OAUTHBEARERwithSupportforOIDC-ClientConfiguration) Extend SASL/OAUTHBEARER to support OIDC claim mapping beyond the default `sub` claim (#5336).
 
 # librdkafka v2.13.2

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -23,3 +23,5 @@ incremental_alter_configs
 user_scram
 list_offsets
 elect_leaders
+alter_client_quotas
+describe_client_quotas

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -65,6 +65,12 @@ target_link_libraries(list_offsets PUBLIC rdkafka)
 add_executable(elect_leaders elect_leaders.c ${win32_sources})
 target_link_libraries(elect_leaders PUBLIC rdkafka)
 
+add_executable(alter_client_quotas alter_client_quotas.c ${win32_sources})
+target_link_libraries(alter_client_quotas PUBLIC rdkafka)
+
+add_executable(describe_client_quotas describe_client_quotas.c ${win32_sources})
+target_link_libraries(describe_client_quotas PUBLIC rdkafka)
+
 # The targets below has Unix include dirs and do not compile on Windows.
 if(NOT WIN32)
     add_executable(rdkafka_example rdkafka_example.c)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,6 +14,8 @@ EXAMPLES ?= rdkafka_example rdkafka_performance rdkafka_example_cpp \
 	user_scram \
 	list_offsets \
 	elect_leaders \
+	alter_client_quotas \
+	describe_client_quotas \
 	misc
 
 all: $(EXAMPLES)
@@ -155,6 +157,14 @@ list_offsets: ../src/librdkafka.a list_offsets.c
 		../src/librdkafka.a $(LIBS)
 
 elect_leaders: ../src/librdkafka.a elect_leaders.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
+		../src/librdkafka.a $(LIBS)
+
+alter_client_quotas: ../src/librdkafka.a alter_client_quotas.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
+		../src/librdkafka.a $(LIBS)
+
+describe_client_quotas: ../src/librdkafka.a describe_client_quotas.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
 		../src/librdkafka.a $(LIBS)
 

--- a/examples/alter_client_quotas.c
+++ b/examples/alter_client_quotas.c
@@ -1,0 +1,322 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Example: AlterClientQuotas (KIP-546)
+ *
+ * Sets or removes per-client-id / per-user quotas via the Admin API.
+ *
+ * Usage:
+ *   alter_client_quotas -b localhost:9092 \
+ *       SET    user alice producer_byte_rate 1048576
+ *       SET    user alice consumer_byte_rate 2097152
+ *       REMOVE user alice request_percentage
+ */
+
+#include <stdio.h>
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#ifdef _WIN32
+#include "../win32/wingetopt.h"
+#else
+#include <getopt.h>
+#endif
+
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is built from within the librdkafka source tree. */
+#include "../src/rdkafka.h"
+
+static const char *argv0;
+static rd_kafka_queue_t *queue;
+static volatile sig_atomic_t run = 1;
+
+static void stop(int sig) {
+        if (!run) {
+                fprintf(stderr, "%% Forced termination\n");
+                exit(2);
+        }
+        run = 0;
+        rd_kafka_queue_yield(queue);
+}
+
+static void usage(const char *reason, ...) {
+        fprintf(
+            stderr,
+            "Alter client quotas\n"
+            "\n"
+            "Usage: %s [options] <ops...>\n"
+            "\n"
+            "Each operation is one of:\n"
+            "  SET    <entity-type> <entity-name> <quota-key> <value>\n"
+            "  REMOVE <entity-type> <entity-name> <quota-key>\n"
+            "\n"
+            "entity-type : user | client-id\n"
+            "entity-name : name string, or \"\" for the default entity\n"
+            "quota-key   : producer_byte_rate | consumer_byte_rate |\n"
+            "              request_percentage | controller_mutation_rate\n"
+            "\n"
+            "Options:\n"
+            "  -b <brokers>    Bootstrap server list (default: "
+            "localhost:9092)\n"
+            "  -X <prop=val>   Set librdkafka configuration property.\n"
+            "  -d <dbg,..>     Enable librdkafka debugging (%s).\n"
+            "\n"
+            "Example — throttle user 'alice' to 1 MiB/s produce:\n"
+            "  %s -b localhost:9092 SET user alice producer_byte_rate 1048576\n"
+            "\n",
+            argv0, rd_kafka_get_debug_contexts(), argv0);
+
+        if (reason) {
+                va_list ap;
+                char buf[512];
+                va_start(ap, reason);
+                vsnprintf(buf, sizeof(buf), reason, ap);
+                va_end(ap);
+                fprintf(stderr, "ERROR: %s\n", buf);
+        }
+
+        exit(reason ? 1 : 0);
+}
+
+#define fatal(...)                                                             \
+        do {                                                                   \
+                fprintf(stderr, "FATAL: " __VA_ARGS__);                        \
+                fprintf(stderr, "\n");                                         \
+                exit(2);                                                       \
+        } while (0)
+
+static void conf_set(rd_kafka_conf_t *conf, const char *name, const char *val) {
+        char errstr[512];
+        if (rd_kafka_conf_set(conf, name, val, errstr, sizeof(errstr)) !=
+            RD_KAFKA_CONF_OK)
+                fatal("Failed to set %s=%s: %s", name, val, errstr);
+}
+
+/**
+ * @brief Print the result entries from an AlterClientQuotas response.
+ */
+static void print_result(const rd_kafka_AlterClientQuotas_result_t *result) {
+        const rd_kafka_ClientQuotaEntry_t **entries;
+        size_t entry_cnt, i;
+
+        entries = rd_kafka_AlterClientQuotas_result_entries(result, &entry_cnt);
+
+        printf("AlterClientQuotas result: %zu entr%s\n", entry_cnt,
+               entry_cnt == 1 ? "y" : "ies");
+
+        for (i = 0; i < entry_cnt; i++) {
+                const rd_kafka_ClientQuotaEntry_t *entry = entries[i];
+                const rd_kafka_error_t *error;
+                const rd_kafka_ClientQuotaEntity_t **entities;
+                size_t entity_cnt, j;
+
+                /* Print entities this result entry covers */
+                entities =
+                    rd_kafka_ClientQuotaEntry_entities(entry, &entity_cnt);
+                printf("  Entry %zu (", i);
+                for (j = 0; j < entity_cnt; j++) {
+                        const char *type =
+                            rd_kafka_ClientQuotaEntity_type(entities[j]);
+                        const char *name =
+                            rd_kafka_ClientQuotaEntity_name(entities[j]);
+                        printf("%s%s=%s", j ? ", " : "", type,
+                               name ? name : "<default>");
+                }
+                printf("): ");
+
+                error = rd_kafka_ClientQuotaEntry_error(entry);
+                if (error &&
+                    rd_kafka_error_code(error) != RD_KAFKA_RESP_ERR_NO_ERROR) {
+                        printf("ERROR %s: %s\n",
+                               rd_kafka_err2name(rd_kafka_error_code(error)),
+                               rd_kafka_error_string(error));
+                } else {
+                        printf("OK\n");
+                }
+        }
+}
+
+
+int main(int argc, char **argv) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+        rd_kafka_AdminOptions_t *options;
+        rd_kafka_event_t *event;
+        char errstr[512];
+        int opt;
+        /* Collected entries to alter */
+        rd_kafka_ClientQuotaEntry_t **entries = NULL;
+        size_t entry_cnt                      = 0;
+        int i;
+
+        argv0 = argv[0];
+
+        conf = rd_kafka_conf_new();
+        conf_set(conf, "bootstrap.servers", "localhost:9092");
+
+        while ((opt = getopt(argc, argv, "b:X:d:h")) != -1) {
+                switch (opt) {
+                case 'b':
+                        conf_set(conf, "bootstrap.servers", optarg);
+                        break;
+                case 'X': {
+                        char *name  = optarg;
+                        char *value = strchr(name, '=');
+                        if (!value)
+                                usage("-X requires prop=val");
+                        *value++ = '\0';
+                        conf_set(conf, name, value);
+                        break;
+                }
+                case 'd':
+                        conf_set(conf, "debug", optarg);
+                        break;
+                case 'h':
+                        usage(NULL);
+                        break;
+                default:
+                        usage("Unknown option -%c", opt);
+                }
+        }
+
+        /* Parse operations from remaining arguments */
+        i = optind;
+        while (i < argc) {
+                const char *verb        = argv[i++];
+                int is_remove           = 0;
+                const char *entity_type = NULL;
+                const char *entity_name = NULL;
+                const char *quota_key   = NULL;
+                double quota_value      = 0.0;
+                rd_kafka_ClientQuotaEntry_t *entry;
+                rd_kafka_resp_err_t err;
+
+                if (!strcasecmp(verb, "SET"))
+                        is_remove = 0;
+                else if (!strcasecmp(verb, "REMOVE"))
+                        is_remove = 1;
+                else
+                        usage("Expected SET or REMOVE, got: %s", verb);
+
+                if (i + 2 + (!is_remove ? 1 : 0) >= argc + 1) {
+                        /* Need at least entity-type entity-name quota-key
+                         * (and value for SET) */
+                        if (is_remove)
+                                usage(
+                                    "REMOVE requires: <entity-type> "
+                                    "<entity-name> <quota-key>");
+                        else
+                                usage(
+                                    "SET requires: <entity-type> "
+                                    "<entity-name> <quota-key> <value>");
+                }
+
+                entity_type = argv[i++];
+                entity_name = argv[i++];
+                quota_key   = argv[i++];
+
+                if (!is_remove) {
+                        char *end;
+                        if (i >= argc)
+                                usage("SET requires a <value> argument");
+                        quota_value = strtod(argv[i++], &end);
+                        if (*end != '\0')
+                                usage("Invalid quota value: %s", argv[i - 1]);
+                }
+
+                /* Build a new entry for this entity+operation pair */
+                entry = rd_kafka_ClientQuotaEntry_new();
+
+                err = rd_kafka_ClientQuotaEntry_add_entity(
+                    entry, entity_type,
+                    /* empty string means default entity */
+                    *entity_name ? entity_name : NULL, errstr, sizeof(errstr));
+                if (err)
+                        fatal("add_entity failed: %s", errstr);
+
+                err = rd_kafka_ClientQuotaEntry_add_operation(
+                    entry, quota_key, quota_value, is_remove, errstr,
+                    sizeof(errstr));
+                if (err)
+                        fatal("add_operation failed: %s", errstr);
+
+                entries = realloc(entries, (entry_cnt + 1) * sizeof(*entries));
+                entries[entry_cnt++] = entry;
+        }
+
+        if (entry_cnt == 0)
+                usage("No quota operations specified");
+
+        /* Create producer handle (used purely for the admin client) */
+        rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        if (!rk)
+                fatal("Failed to create producer: %s", errstr);
+        conf = NULL; /* now owned by rk */
+
+        queue = rd_kafka_queue_new(rk);
+
+        signal(SIGINT, stop);
+        signal(SIGTERM, stop);
+
+        options =
+            rd_kafka_AdminOptions_new(rk, RD_KAFKA_ADMIN_OP_ALTERCLIENTQUOTAS);
+        if (rd_kafka_AdminOptions_set_request_timeout(options, 30 * 1000,
+                                                      errstr, sizeof(errstr)))
+                fatal("Failed to set timeout: %s", errstr);
+
+        rd_kafka_AlterClientQuotas(rk, entries, entry_cnt, options, queue);
+        rd_kafka_AdminOptions_destroy(options);
+
+        /* Destroy input entries — the API has taken copies */
+        for (i = 0; i < (int)entry_cnt; i++)
+                rd_kafka_ClientQuotaEntry_destroy(entries[i]);
+        free(entries);
+
+        /* Wait for result */
+        event = rd_kafka_queue_poll(queue, -1 /*indefinitely*/);
+
+        if (!event) {
+                fprintf(stderr, "%% Cancelled by user\n");
+        } else if (rd_kafka_event_error(event)) {
+                fprintf(stderr, "%% AlterClientQuotas failed: %s\n",
+                        rd_kafka_event_error_string(event));
+        } else {
+                const rd_kafka_AlterClientQuotas_result_t *result =
+                    rd_kafka_event_AlterClientQuotas_result(event);
+                print_result(result);
+        }
+
+        rd_kafka_event_destroy(event);
+        rd_kafka_queue_destroy(queue);
+        rd_kafka_destroy(rk);
+
+        return 0;
+}

--- a/examples/describe_client_quotas.c
+++ b/examples/describe_client_quotas.c
@@ -1,0 +1,312 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2023, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Example: DescribeClientQuotas (KIP-546)
+ *
+ * Queries per-client-id / per-user quotas via the Admin API.
+ *
+ * Usage:
+ *   describe_client_quotas -b localhost:9092 \
+ *       user    exact alice \
+ *       client-id any
+ *
+ * With no filter components, all quotas are returned (non-strict mode).
+ */
+
+#include <stdio.h>
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#ifdef _WIN32
+#include "../win32/wingetopt.h"
+#else
+#include <getopt.h>
+#endif
+
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is built from within the librdkafka source tree. */
+#include "../src/rdkafka.h"
+
+static const char *argv0;
+static rd_kafka_queue_t *queue;
+static volatile sig_atomic_t run = 1;
+
+static void stop(int sig) {
+        if (!run) {
+                fprintf(stderr, "%% Forced termination\n");
+                exit(2);
+        }
+        run = 0;
+        rd_kafka_queue_yield(queue);
+}
+
+static void usage(const char *reason, ...) {
+        fprintf(
+            stderr,
+            "Describe client quotas\n"
+            "\n"
+            "Usage: %s [options] [<filter-components...>]\n"
+            "\n"
+            "Each filter component is:\n"
+            "  <entity-type> exact    <name>   Match this exact entity name\n"
+            "  <entity-type> default           Match the default entity\n"
+            "  <entity-type> any               Match any entity of this type\n"
+            "\n"
+            "entity-type : user | client-id\n"
+            "\n"
+            "With no filter components, all quotas are returned.\n"
+            "\n"
+            "Options:\n"
+            "  -b <brokers>    Bootstrap server list (default: "
+            "localhost:9092)\n"
+            "  -s              Strict mode: only return entries that match\n"
+            "                  all components exactly\n"
+            "  -X <prop=val>   Set librdkafka configuration property.\n"
+            "  -d <dbg,..>     Enable librdkafka debugging (%s).\n"
+            "\n"
+            "Examples:\n"
+            "  # All quotas\n"
+            "  %s -b localhost:9092\n"
+            "\n"
+            "  # Quotas for user 'alice'\n"
+            "  %s -b localhost:9092 user exact alice\n"
+            "\n"
+            "  # Any user paired with client-id 'my-app' (strict)\n"
+            "  %s -b localhost:9092 -s user any client-id exact my-app\n"
+            "\n",
+            argv0, rd_kafka_get_debug_contexts(), argv0, argv0, argv0);
+
+        if (reason) {
+                va_list ap;
+                char buf[512];
+                va_start(ap, reason);
+                vsnprintf(buf, sizeof(buf), reason, ap);
+                va_end(ap);
+                fprintf(stderr, "ERROR: %s\n", buf);
+        }
+
+        exit(reason ? 1 : 0);
+}
+
+#define fatal(...)                                                             \
+        do {                                                                   \
+                fprintf(stderr, "FATAL: " __VA_ARGS__);                        \
+                fprintf(stderr, "\n");                                         \
+                exit(2);                                                       \
+        } while (0)
+
+static void conf_set(rd_kafka_conf_t *conf, const char *name, const char *val) {
+        char errstr[512];
+        if (rd_kafka_conf_set(conf, name, val, errstr, sizeof(errstr)) !=
+            RD_KAFKA_CONF_OK)
+                fatal("Failed to set %s=%s: %s", name, val, errstr);
+}
+
+/**
+ * @brief Print the result entries from a DescribeClientQuotas response.
+ */
+static void
+print_result(const rd_kafka_DescribeClientQuotas_result_t *result) {
+        const rd_kafka_DescribeClientQuotas_result_entry_t **entries;
+        size_t entry_cnt, i;
+
+        entries =
+            rd_kafka_DescribeClientQuotas_result_entries(result, &entry_cnt);
+
+        printf("DescribeClientQuotas result: %zu entr%s\n", entry_cnt,
+               entry_cnt == 1 ? "y" : "ies");
+
+        for (i = 0; i < entry_cnt; i++) {
+                const rd_kafka_DescribeClientQuotas_result_entry_t *entry =
+                    entries[i];
+                const rd_kafka_ClientQuotaEntity_t **entities;
+                const rd_kafka_ClientQuotaValue_t **values;
+                size_t entity_cnt, value_cnt, j;
+
+                /* Print entities this result entry covers */
+                entities = rd_kafka_DescribeClientQuotas_result_entry_entity(
+                    entry, &entity_cnt);
+                printf("  Entry %zu (", i);
+                for (j = 0; j < entity_cnt; j++) {
+                        const char *type =
+                            rd_kafka_ClientQuotaEntity_type(entities[j]);
+                        const char *name =
+                            rd_kafka_ClientQuotaEntity_name(entities[j]);
+                        printf("%s%s=%s", j ? ", " : "", type,
+                               name ? name : "<default>");
+                }
+                printf("):\n");
+
+                /* Print quota key/value pairs for this entry */
+                values = rd_kafka_DescribeClientQuotas_result_entry_values(
+                    entry, &value_cnt);
+                if (value_cnt == 0) {
+                        printf("    (no quota values)\n");
+                } else {
+                        for (j = 0; j < value_cnt; j++) {
+                                printf("    %-32s = %f\n",
+                                       rd_kafka_ClientQuotaValue_key(values[j]),
+                                       rd_kafka_ClientQuotaValue_value(
+                                           values[j]));
+                        }
+                }
+        }
+}
+
+
+int main(int argc, char **argv) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+        rd_kafka_AdminOptions_t *options;
+        rd_kafka_ClientQuotaFilter_t *filter;
+        rd_kafka_event_t *event;
+        char errstr[512];
+        int opt;
+        int strict = 0;
+        int i;
+
+        argv0 = argv[0];
+
+        conf = rd_kafka_conf_new();
+        conf_set(conf, "bootstrap.servers", "localhost:9092");
+
+        while ((opt = getopt(argc, argv, "b:sX:d:h")) != -1) {
+                switch (opt) {
+                case 'b':
+                        conf_set(conf, "bootstrap.servers", optarg);
+                        break;
+                case 's':
+                        strict = 1;
+                        break;
+                case 'X': {
+                        char *name  = optarg;
+                        char *value = strchr(name, '=');
+                        if (!value)
+                                usage("-X requires prop=val");
+                        *value++ = '\0';
+                        conf_set(conf, name, value);
+                        break;
+                }
+                case 'd':
+                        conf_set(conf, "debug", optarg);
+                        break;
+                case 'h':
+                        usage(NULL);
+                        break;
+                default:
+                        usage("Unknown option -%c", opt);
+                }
+        }
+
+        /* Build filter from remaining positional arguments */
+        filter = rd_kafka_ClientQuotaFilter_new(strict);
+
+        i = optind;
+        while (i < argc) {
+                const char *entity_type = argv[i++];
+                const char *match_str;
+                rd_kafka_ClientQuotaMatchType_t match_type;
+                const char *match_name = NULL;
+                rd_kafka_resp_err_t err;
+
+                if (i >= argc)
+                        usage("Expected match-type after entity-type '%s'",
+                              entity_type);
+                match_str = argv[i++];
+
+                if (!strcasecmp(match_str, "exact")) {
+                        match_type = RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT;
+                        if (i >= argc)
+                                usage(
+                                    "match-type 'exact' requires a <name> "
+                                    "argument");
+                        match_name = argv[i++];
+                } else if (!strcasecmp(match_str, "default")) {
+                        match_type = RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT;
+                } else if (!strcasecmp(match_str, "any")) {
+                        match_type = RD_KAFKA_CLIENT_QUOTA_MATCH_ANY;
+                } else {
+                        usage(
+                            "Unknown match-type '%s': expected exact, "
+                            "default, or any",
+                            match_str);
+                        /* unreachable */
+                        match_type = RD_KAFKA_CLIENT_QUOTA_MATCH_ANY;
+                }
+
+                err = rd_kafka_ClientQuotaFilter_add_component(
+                    filter, entity_type, match_type, match_name, errstr,
+                    sizeof(errstr));
+                if (err)
+                        fatal("Failed to add filter component: %s", errstr);
+        }
+
+        /* Create producer handle (used purely for the admin client) */
+        rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        if (!rk)
+                fatal("Failed to create producer: %s", errstr);
+        conf = NULL; /* now owned by rk */
+
+        queue = rd_kafka_queue_new(rk);
+
+        signal(SIGINT, stop);
+        signal(SIGTERM, stop);
+
+        options = rd_kafka_AdminOptions_new(
+            rk, RD_KAFKA_ADMIN_OP_DESCRIBECLIENTQUOTAS);
+        if (rd_kafka_AdminOptions_set_request_timeout(options, 30 * 1000,
+                                                      errstr, sizeof(errstr)))
+                fatal("Failed to set timeout: %s", errstr);
+
+        rd_kafka_DescribeClientQuotas(rk, filter, options, queue);
+        rd_kafka_AdminOptions_destroy(options);
+        rd_kafka_ClientQuotaFilter_destroy(filter);
+
+        /* Wait for result */
+        event = rd_kafka_queue_poll(queue, -1 /*indefinitely*/);
+
+        if (!event) {
+                fprintf(stderr, "%% Cancelled by user\n");
+        } else if (rd_kafka_event_error(event)) {
+                fprintf(stderr, "%% DescribeClientQuotas failed: %s\n",
+                        rd_kafka_event_error_string(event));
+        } else {
+                const rd_kafka_DescribeClientQuotas_result_t *result =
+                    rd_kafka_event_DescribeClientQuotas_result(event);
+                print_result(result);
+        }
+
+        rd_kafka_event_destroy(event);
+        rd_kafka_queue_destroy(queue);
+        rd_kafka_destroy(rk);
+
+        return 0;
+}

--- a/examples/describe_client_quotas.c
+++ b/examples/describe_client_quotas.c
@@ -133,8 +133,7 @@ static void conf_set(rd_kafka_conf_t *conf, const char *name, const char *val) {
 /**
  * @brief Print the result entries from a DescribeClientQuotas response.
  */
-static void
-print_result(const rd_kafka_DescribeClientQuotas_result_t *result) {
+static void print_result(const rd_kafka_DescribeClientQuotas_result_t *result) {
         const rd_kafka_DescribeClientQuotas_result_entry_t **entries;
         size_t entry_cnt, i;
 
@@ -172,10 +171,10 @@ print_result(const rd_kafka_DescribeClientQuotas_result_t *result) {
                         printf("    (no quota values)\n");
                 } else {
                         for (j = 0; j < value_cnt; j++) {
-                                printf("    %-32s = %f\n",
-                                       rd_kafka_ClientQuotaValue_key(values[j]),
-                                       rd_kafka_ClientQuotaValue_value(
-                                           values[j]));
+                                printf(
+                                    "    %-32s = %f\n",
+                                    rd_kafka_ClientQuotaValue_key(values[j]),
+                                    rd_kafka_ClientQuotaValue_value(values[j]));
                         }
                 }
         }

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5610,6 +5610,10 @@ typedef int rd_kafka_event_type_t;
 #define RD_KAFKA_EVENT_LISTOFFSETS_RESULT 0x400000
 /** ElectLeaders_result_t */
 #define RD_KAFKA_EVENT_ELECTLEADERS_RESULT 0x800000
+/** AlterClientQuotas_result_t */
+#define RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT 0x1000000
+/** DescribeClientQuotas_result_t */
+#define RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT 0x2000000
 
 /**
  * @returns the event type for the given event.
@@ -5894,6 +5898,10 @@ typedef rd_kafka_event_t rd_kafka_AlterUserScramCredentials_result_t;
 typedef rd_kafka_event_t rd_kafka_ListOffsets_result_t;
 /*! ElectLeaders result type */
 typedef rd_kafka_event_t rd_kafka_ElectLeaders_result_t;
+/*! AlterClientQuotas result type */
+typedef rd_kafka_event_t rd_kafka_AlterClientQuotas_result_t;
+/*! DescribeClientQuotas result type */
+typedef rd_kafka_event_t rd_kafka_DescribeClientQuotas_result_t;
 
 /**
  * @brief Get CreateTopics result.
@@ -6180,6 +6188,36 @@ rd_kafka_event_AlterUserScramCredentials_result(rd_kafka_event_t *rkev);
  */
 RD_EXPORT const rd_kafka_ElectLeaders_result_t *
 rd_kafka_event_ElectLeaders_result(rd_kafka_event_t *rkev);
+
+/**
+ * @brief Get AlterClientQuotas result.
+ *
+ * @returns \p rkev if \p rkev is of type
+ *          \c RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT, else NULL.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p rkev object.
+ *
+ * Event types:
+ *  RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT
+ */
+RD_EXPORT const rd_kafka_AlterClientQuotas_result_t *
+rd_kafka_event_AlterClientQuotas_result(rd_kafka_event_t *rkev);
+
+/**
+ * @brief Get DescribeClientQuotas result.
+ *
+ * @returns \p rkev if \p rkev is of type
+ *          \c RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT, else NULL.
+ *
+ * @remark The lifetime of the returned memory is the same
+ *         as the lifetime of the \p rkev object.
+ *
+ * Event types:
+ *  RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT
+ */
+RD_EXPORT const rd_kafka_DescribeClientQuotas_result_t *
+rd_kafka_event_DescribeClientQuotas_result(rd_kafka_event_t *rkev);
 
 /**
  * @brief Poll a queue for an event for max \p timeout_ms.
@@ -7117,8 +7155,10 @@ typedef enum rd_kafka_admin_op_t {
         RD_KAFKA_ADMIN_OP_DESCRIBETOPICS,  /**< DescribeTopics */
         RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER, /**< DescribeCluster */
         RD_KAFKA_ADMIN_OP_LISTOFFSETS,     /**< ListOffsets */
-        RD_KAFKA_ADMIN_OP_ELECTLEADERS,    /**< ElectLeaders */
-        RD_KAFKA_ADMIN_OP__CNT             /**< Number of ops defined */
+        RD_KAFKA_ADMIN_OP_ELECTLEADERS,      /**< ElectLeaders */
+        RD_KAFKA_ADMIN_OP_ALTERCLIENTQUOTAS,   /**< AlterClientQuotas */
+        RD_KAFKA_ADMIN_OP_DESCRIBECLIENTQUOTAS, /**< DescribeClientQuotas */
+        RD_KAFKA_ADMIN_OP__CNT                 /**< Number of ops defined */
 } rd_kafka_admin_op_t;
 
 /**
@@ -7869,7 +7909,6 @@ rd_kafka_ConfigEntry_is_synonym(const rd_kafka_ConfigEntry_t *entry);
 RD_EXPORT const rd_kafka_ConfigEntry_t **
 rd_kafka_ConfigEntry_synonyms(const rd_kafka_ConfigEntry_t *entry,
                               size_t *cntp);
-
 
 
 /**
@@ -10045,6 +10084,322 @@ RD_EXPORT void rd_kafka_DeleteAcls(rd_kafka_t *rk,
                                    rd_kafka_queue_t *rkqu);
 
 /**@}*/
+
+
+
+/**
+ * @name Admin API - Client Quota Operations
+ * @{
+ *
+ *
+ *
+ */
+
+/**
+ * @brief Client Quota Entity
+ */
+typedef struct rd_kafka_ClientQuotaEntity_s rd_kafka_ClientQuotaEntity_t;
+
+/**
+ * @brief Get the type string of a ClientQuotaEntity (e.g. "user", "client-id").
+ */
+RD_EXPORT const char *
+rd_kafka_ClientQuotaEntity_type(const rd_kafka_ClientQuotaEntity_t *entity);
+
+/**
+ * @brief Get the name of a ClientQuotaEntity, or NULL for the default entity.
+ */
+RD_EXPORT const char *
+rd_kafka_ClientQuotaEntity_name(const rd_kafka_ClientQuotaEntity_t *entity);
+
+/**
+ * @brief Client Quota Operation
+ *
+ * This structure is used to define operations on client quotas, such as
+ * setting producer_byte_rate or removing request_percentage a quota for a specific entity.
+ */
+typedef struct rd_kafka_ClientQuotaOperation_s rd_kafka_ClientQuotaOperation_t;
+
+/**
+ * @brief Client Quota Entry
+ *
+ * This structure is used to combine the entities and the quota operations to enforce on them.
+ */
+typedef struct rd_kafka_ClientQuotaEntry_s rd_kafka_ClientQuotaEntry_t;
+
+/**
+ * @brief Create a new ClientQuotaEntry object.
+ *
+ * @returns a newly allocated ClientQuotaEntry object that must be freed
+ *          with rd_kafka_ClientQuotaEntry_destroy().
+ */
+RD_EXPORT rd_kafka_ClientQuotaEntry_t *rd_kafka_ClientQuotaEntry_new(void);
+
+/**
+ * @brief Destroy and free a ClientQuotaEntry object.
+ */
+RD_EXPORT void
+rd_kafka_ClientQuotaEntry_destroy(rd_kafka_ClientQuotaEntry_t *entry);
+
+/**
+ * @brief Add an entity to the ClientQuotaEntry.
+ *
+ * @param entry   The entry to add the entity to.
+ * @param type    Entity type string (e.g. "user", "client-id"). Must not be
+ *                NULL.
+ * @param name    Entity name, or NULL for the default entity.
+ * @param errstr  Human-readable error string on failure.
+ * @param errstr_size  Size of \p errstr.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, else an error code.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_ClientQuotaEntry_add_entity(rd_kafka_ClientQuotaEntry_t *entry,
+                                     const char *type,
+                                     const char *name,
+                                     char *errstr,
+                                     size_t errstr_size);
+
+/**
+ * @brief Add a quota operation to the ClientQuotaEntry.
+ *
+ * @param entry       The entry to add the operation to.
+ * @param key         Quota configuration key (e.g. "producer_byte_rate").
+ * @param value       Quota value. Ignored when \p remove is true.
+ * @param remove      If true, remove the quota for \p key.
+ * @param errstr      Human-readable error string on failure.
+ * @param errstr_size Size of \p errstr.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, else an error code.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_ClientQuotaEntry_add_operation(rd_kafka_ClientQuotaEntry_t *entry,
+                                        const char *key,
+                                        double value,
+                                        int remove,
+                                        char *errstr,
+                                        size_t errstr_size);
+
+/**
+ * @brief Get the response error for a result entry.
+ *
+ * @returns the error object, or NULL if there was no error.
+ *
+ * @remark The lifetime of the returned error object is the same as the
+ *         \p entry object.
+ */
+RD_EXPORT const rd_kafka_error_t *
+rd_kafka_ClientQuotaEntry_error(const rd_kafka_ClientQuotaEntry_t *entry);
+
+/**
+ * @brief Get the entities for a result entry.
+ *
+ * @param entry The result entry.
+ * @param cntp  Updated to the number of elements in the returned array.
+ *
+ * @returns a pointer to an array of ClientQuotaEntity pointers.
+ *
+ * @remark The lifetime of the returned array is the same as the \p entry
+ *         object.
+ */
+RD_EXPORT const rd_kafka_ClientQuotaEntity_t **
+rd_kafka_ClientQuotaEntry_entities(const rd_kafka_ClientQuotaEntry_t *entry,
+                                   size_t *cntp);
+
+/**
+ * @brief Get the result entries from an AlterClientQuotas result event.
+ *
+ * @param result The result event (of type
+ *               \c RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT).
+ * @param cntp   Updated to the number of elements in the returned array.
+ *
+ * @returns a pointer to an array of ClientQuotaEntry pointers.
+ *
+ * @remark The lifetime of the returned memory is the same as the \p result
+ *         object.
+ */
+RD_EXPORT const rd_kafka_ClientQuotaEntry_t **
+rd_kafka_AlterClientQuotas_result_entries(
+    const rd_kafka_AlterClientQuotas_result_t *result,
+    size_t *cntp);
+
+/**
+ * @brief Alter client quotas as specified by the \p entries array of
+ *        size \p entry_cnt.
+ *
+ * @param rk        Client instance.
+ * @param entries   Array of ClientQuotaEntry objects describing the desired
+ *                  quota alterations.
+ * @param entry_cnt Number of elements in \p entries.
+ * @param options   Optional admin options, or NULL for defaults.
+ * @param rkqu      Queue to emit result event on.
+ *
+ * @remark The result event type emitted on the supplied queue is of type
+ *         \c RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT
+ */
+RD_EXPORT void
+rd_kafka_AlterClientQuotas(rd_kafka_t *rk,
+                            rd_kafka_ClientQuotaEntry_t **entries,
+                            size_t entry_cnt,
+                            const rd_kafka_AdminOptions_t *options,
+                            rd_kafka_queue_t *rkqu);
+
+/**@}*/
+
+
+/**
+ * @name Admin API - DescribeClientQuotas
+ * @{
+ *
+ *
+ *
+ */
+
+/**
+ * @brief Match type for DescribeClientQuotas filter components.
+ */
+typedef enum {
+        RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT   = 0, /**< Exact name match */
+        RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT = 1, /**< Default (nameless) entity */
+        RD_KAFKA_CLIENT_QUOTA_MATCH_ANY     = 2, /**< Any entity of this type */
+} rd_kafka_ClientQuotaMatchType_t;
+
+/**
+ * @brief Opaque filter component for DescribeClientQuotas.
+ */
+typedef struct rd_kafka_ClientQuotaFilterComponent_s
+    rd_kafka_ClientQuotaFilterComponent_t;
+
+/**
+ * @brief Opaque filter for DescribeClientQuotas.
+ */
+typedef struct rd_kafka_ClientQuotaFilter_s rd_kafka_ClientQuotaFilter_t;
+
+/**
+ * @brief A quota key/value pair in a DescribeClientQuotas result entry.
+ */
+typedef struct rd_kafka_ClientQuotaValue_s rd_kafka_ClientQuotaValue_t;
+
+/**
+ * @brief A single entry in a DescribeClientQuotas result.
+ */
+typedef struct rd_kafka_DescribeClientQuotas_result_entry_s
+    rd_kafka_DescribeClientQuotas_result_entry_t;
+
+/**
+ * @brief Create a new DescribeClientQuotas filter.
+ *
+ * @param strict If true, only return entries matching all components exactly.
+ *
+ * @returns a newly allocated filter that must be freed with
+ *          rd_kafka_ClientQuotaFilter_destroy().
+ */
+RD_EXPORT rd_kafka_ClientQuotaFilter_t *
+rd_kafka_ClientQuotaFilter_new(int strict);
+
+/**
+ * @brief Destroy a DescribeClientQuotas filter.
+ */
+RD_EXPORT void
+rd_kafka_ClientQuotaFilter_destroy(rd_kafka_ClientQuotaFilter_t *filter);
+
+/**
+ * @brief Add a component to a DescribeClientQuotas filter.
+ *
+ * @param filter     The filter to add the component to.
+ * @param entity_type  Entity type string (e.g. "user", "client-id"). Must not
+ *                     be NULL.
+ * @param match_type   One of \c RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT,
+ *                     \c RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT, or
+ *                     \c RD_KAFKA_CLIENT_QUOTA_MATCH_ANY.
+ * @param match        Entity name for EXACT match; must be NULL for DEFAULT
+ *                     and ANY (a non-NULL value will be sent to the broker
+ *                     and may result in an error).
+ * @param errstr       Human-readable error string on failure.
+ * @param errstr_size  Size of \p errstr.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, else an error code.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_ClientQuotaFilter_add_component(rd_kafka_ClientQuotaFilter_t *filter,
+                                         const char *entity_type,
+                                         rd_kafka_ClientQuotaMatchType_t
+                                             match_type,
+                                         const char *match,
+                                         char *errstr,
+                                         size_t errstr_size);
+
+/**
+ * @brief Get the configuration key from a quota value.
+ */
+RD_EXPORT const char *
+rd_kafka_ClientQuotaValue_key(const rd_kafka_ClientQuotaValue_t *val);
+
+/**
+ * @brief Get the quota value as a double.
+ */
+RD_EXPORT double
+rd_kafka_ClientQuotaValue_value(const rd_kafka_ClientQuotaValue_t *val);
+
+/**
+ * @brief Get the entities from a DescribeClientQuotas result entry.
+ *
+ * @param entry  Result entry.
+ * @param cntp   Updated to the number of elements in the returned array.
+ *
+ * @returns a pointer to an array of ClientQuotaEntity pointers.
+ */
+RD_EXPORT const rd_kafka_ClientQuotaEntity_t **
+rd_kafka_DescribeClientQuotas_result_entry_entity(
+    const rd_kafka_DescribeClientQuotas_result_entry_t *entry,
+    size_t *cntp);
+
+/**
+ * @brief Get the quota values from a DescribeClientQuotas result entry.
+ *
+ * @param entry  Result entry.
+ * @param cntp   Updated to the number of elements in the returned array.
+ *
+ * @returns a pointer to an array of ClientQuotaValue pointers.
+ */
+RD_EXPORT const rd_kafka_ClientQuotaValue_t **
+rd_kafka_DescribeClientQuotas_result_entry_values(
+    const rd_kafka_DescribeClientQuotas_result_entry_t *entry,
+    size_t *cntp);
+
+/**
+ * @brief Get the result entries from a DescribeClientQuotas result.
+ *
+ * @param result  Result event of type
+ *                \c RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT.
+ * @param cntp    Updated to the number of entries in the returned array.
+ *
+ * @returns a pointer to an array of result entry pointers.
+ */
+RD_EXPORT const rd_kafka_DescribeClientQuotas_result_entry_t **
+rd_kafka_DescribeClientQuotas_result_entries(
+    const rd_kafka_DescribeClientQuotas_result_t *result,
+    size_t *cntp);
+
+/**
+ * @brief Describe client quotas matching the given \p filter.
+ *
+ * @param rk       Client instance.
+ * @param filter   Filter specifying which quotas to describe.
+ * @param options  Optional admin options, or NULL for defaults.
+ * @param rkqu     Queue to emit result event on.
+ *
+ * @remark The result event type emitted on the supplied queue is of type
+ *         \c RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT.
+ */
+RD_EXPORT void
+rd_kafka_DescribeClientQuotas(rd_kafka_t *rk,
+                              const rd_kafka_ClientQuotaFilter_t *filter,
+                              const rd_kafka_AdminOptions_t *options,
+                              rd_kafka_queue_t *rkqu);
+
+/**@}*/
+
 
 /**
  * @name Admin API - Elect Leaders

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -7152,13 +7152,13 @@ typedef enum rd_kafka_admin_op_t {
         RD_KAFKA_ADMIN_OP_DESCRIBEUSERSCRAMCREDENTIALS,
         /** AlterUserScramCredentials */
         RD_KAFKA_ADMIN_OP_ALTERUSERSCRAMCREDENTIALS,
-        RD_KAFKA_ADMIN_OP_DESCRIBETOPICS,  /**< DescribeTopics */
-        RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER, /**< DescribeCluster */
-        RD_KAFKA_ADMIN_OP_LISTOFFSETS,     /**< ListOffsets */
-        RD_KAFKA_ADMIN_OP_ELECTLEADERS,      /**< ElectLeaders */
-        RD_KAFKA_ADMIN_OP_ALTERCLIENTQUOTAS,   /**< AlterClientQuotas */
+        RD_KAFKA_ADMIN_OP_DESCRIBETOPICS,       /**< DescribeTopics */
+        RD_KAFKA_ADMIN_OP_DESCRIBECLUSTER,      /**< DescribeCluster */
+        RD_KAFKA_ADMIN_OP_LISTOFFSETS,          /**< ListOffsets */
+        RD_KAFKA_ADMIN_OP_ELECTLEADERS,         /**< ElectLeaders */
+        RD_KAFKA_ADMIN_OP_ALTERCLIENTQUOTAS,    /**< AlterClientQuotas */
         RD_KAFKA_ADMIN_OP_DESCRIBECLIENTQUOTAS, /**< DescribeClientQuotas */
-        RD_KAFKA_ADMIN_OP__CNT                 /**< Number of ops defined */
+        RD_KAFKA_ADMIN_OP__CNT                  /**< Number of ops defined */
 } rd_kafka_admin_op_t;
 
 /**
@@ -10116,14 +10116,16 @@ rd_kafka_ClientQuotaEntity_name(const rd_kafka_ClientQuotaEntity_t *entity);
  * @brief Client Quota Operation
  *
  * This structure is used to define operations on client quotas, such as
- * setting producer_byte_rate or removing request_percentage a quota for a specific entity.
+ * setting producer_byte_rate or removing request_percentage a quota for a
+ * specific entity.
  */
 typedef struct rd_kafka_ClientQuotaOperation_s rd_kafka_ClientQuotaOperation_t;
 
 /**
  * @brief Client Quota Entry
  *
- * This structure is used to combine the entities and the quota operations to enforce on them.
+ * This structure is used to combine the entities and the quota operations to
+ * enforce on them.
  */
 typedef struct rd_kafka_ClientQuotaEntry_s rd_kafka_ClientQuotaEntry_t;
 
@@ -10239,10 +10241,10 @@ rd_kafka_AlterClientQuotas_result_entries(
  */
 RD_EXPORT void
 rd_kafka_AlterClientQuotas(rd_kafka_t *rk,
-                            rd_kafka_ClientQuotaEntry_t **entries,
-                            size_t entry_cnt,
-                            const rd_kafka_AdminOptions_t *options,
-                            rd_kafka_queue_t *rkqu);
+                           rd_kafka_ClientQuotaEntry_t **entries,
+                           size_t entry_cnt,
+                           const rd_kafka_AdminOptions_t *options,
+                           rd_kafka_queue_t *rkqu);
 
 /**@}*/
 
@@ -10259,9 +10261,10 @@ rd_kafka_AlterClientQuotas(rd_kafka_t *rk,
  * @brief Match type for DescribeClientQuotas filter components.
  */
 typedef enum {
-        RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT   = 0, /**< Exact name match */
-        RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT = 1, /**< Default (nameless) entity */
-        RD_KAFKA_CLIENT_QUOTA_MATCH_ANY     = 2, /**< Any entity of this type */
+        RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT = 0, /**< Exact name match */
+        RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT =
+            1,                               /**< Default (nameless) entity */
+        RD_KAFKA_CLIENT_QUOTA_MATCH_ANY = 2, /**< Any entity of this type */
 } rd_kafka_ClientQuotaMatchType_t;
 
 /**
@@ -10320,14 +10323,13 @@ rd_kafka_ClientQuotaFilter_destroy(rd_kafka_ClientQuotaFilter_t *filter);
  *
  * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, else an error code.
  */
-RD_EXPORT rd_kafka_resp_err_t
-rd_kafka_ClientQuotaFilter_add_component(rd_kafka_ClientQuotaFilter_t *filter,
-                                         const char *entity_type,
-                                         rd_kafka_ClientQuotaMatchType_t
-                                             match_type,
-                                         const char *match,
-                                         char *errstr,
-                                         size_t errstr_size);
+RD_EXPORT rd_kafka_resp_err_t rd_kafka_ClientQuotaFilter_add_component(
+    rd_kafka_ClientQuotaFilter_t *filter,
+    const char *entity_type,
+    rd_kafka_ClientQuotaMatchType_t match_type,
+    const char *match,
+    char *errstr,
+    size_t errstr_size);
 
 /**
  * @brief Get the configuration key from a quota value.

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -8240,8 +8240,8 @@ err_parse:
                 error      = rd_kafka_error_new(
                     error_code,
                     "Broker [%d"
-                    "] "
-                    "ListConsumerGroups response protocol parse failure: %s",
+                         "] "
+                         "ListConsumerGroups response protocol parse failure: %s",
                     rd_kafka_broker_id(rkb), rd_kafka_err2str(error_code));
                 rd_list_add(&errors, error);
         }

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -5156,6 +5156,680 @@ void rd_kafka_DeleteConsumerGroupOffsets(
     rd_kafka_queue_t *rkqu);
 
 /**@}*/
+
+/**
+ * @name AlterClientQuotas
+ * @{
+ *
+ *
+ *
+ */
+rd_kafka_ClientQuotaEntity_t *
+rd_kafka_ClientQuotaEntity_new0(const char *type,
+                                const char *name,
+                                rd_kafka_resp_err_t err,
+                                const char *errstr) {
+        rd_kafka_ClientQuotaEntity_t *client_quota_entity;
+
+        client_quota_entity       = rd_calloc(1, sizeof(*client_quota_entity));
+        client_quota_entity->name = name != NULL ? rd_strdup(name) : NULL;
+        client_quota_entity->type = type != NULL ? rd_strdup(type) : NULL;
+        return client_quota_entity;
+}
+
+rd_kafka_ClientQuotaEntity_t *
+rd_kafka_ClientQuotaEntity_new(const char *type,
+                               const char *name,
+                               char *errstr,
+                               size_t errstr_size) {
+        if (!type) {
+                rd_snprintf(errstr, errstr_size, "Invalid entity type");
+                return NULL;
+        }
+        if (!name) {
+                rd_snprintf(errstr, errstr_size, "Invalid entity name");
+                return NULL;
+        }
+
+        return rd_kafka_ClientQuotaEntity_new0(
+            type, name, RD_KAFKA_RESP_ERR_NO_ERROR, NULL);
+}
+
+void rd_kafka_ClientQuotaEntity_destroy(
+    rd_kafka_ClientQuotaEntity_t *client_quota_entity) {
+        if (client_quota_entity->type)
+                rd_free(client_quota_entity->type);
+        if (client_quota_entity->name)
+                rd_free(client_quota_entity->name);
+        rd_free(client_quota_entity);
+}
+
+static void rd_kafka_ClientQuotaEntity_free(void *ptr) {
+        rd_kafka_ClientQuotaEntity_destroy(ptr);
+}
+
+const char *
+rd_kafka_ClientQuotaEntity_name(const rd_kafka_ClientQuotaEntity_t *entity) {
+        return entity->name;
+}
+
+const char *
+rd_kafka_ClientQuotaEntity_type(const rd_kafka_ClientQuotaEntity_t *entity) {
+        return entity->type;
+}
+
+rd_kafka_ClientQuotaOperation_t *
+rd_kafka_ClientQuotaOperation_new0(const char *name,
+                                   double value,
+                                   rd_bool_t remove) {
+        rd_kafka_ClientQuotaOperation_t *client_quota_operation;
+
+        client_quota_operation = rd_calloc(1, sizeof(*client_quota_operation));
+        client_quota_operation->name   = name != NULL ? rd_strdup(name) : NULL;
+        client_quota_operation->value  = value;
+        client_quota_operation->remove = remove;
+        return client_quota_operation;
+}
+
+rd_kafka_ClientQuotaOperation_t *
+rd_kafka_ClientQuotaOperation_new(const char *name,
+                                  double value,
+                                  rd_bool_t remove,
+                                  char *errstr,
+                                  size_t errstr_size) {
+        if (!name) {
+                rd_snprintf(errstr, errstr_size, "Invalid entity name");
+                return NULL;
+        }
+
+        return rd_kafka_ClientQuotaOperation_new0(name, value, remove);
+}
+
+void rd_kafka_ClientQuotaOperation_destroy(
+    rd_kafka_ClientQuotaOperation_t *client_quota_operation) {
+        if (client_quota_operation->name)
+                rd_free(client_quota_operation->name);
+        rd_free(client_quota_operation);
+}
+
+static void rd_kafka_ClientQuotaOperation_free(void *ptr) {
+        rd_kafka_ClientQuotaOperation_destroy(ptr);
+}
+
+const char *rd_kafka_ClientQuotaOperation_name(
+    const rd_kafka_ClientQuotaOperation_t *operation) {
+        return operation->name;
+}
+
+double rd_kafka_ClientQuotaOperation_value(
+    const rd_kafka_ClientQuotaOperation_t *operation) {
+        return operation->value;
+}
+
+rd_bool_t rd_kafka_ClientQuotaOperation_remove(
+    const rd_kafka_ClientQuotaOperation_t *operation) {
+        return operation->remove;
+}
+
+/**
+ * @brief Allocate a new ClientQuotaOperation and make a copy of \p src
+ */
+static rd_kafka_ClientQuotaOperation_t *
+rd_kafka_ClientQuotaOperation_copy(const rd_kafka_ClientQuotaOperation_t *src) {
+        rd_kafka_ClientQuotaOperation_t *dst;
+
+        dst = rd_kafka_ClientQuotaOperation_new(src->name, src->value,
+                                                src->remove, NULL, 0);
+        rd_assert(dst);
+        return dst;
+}
+
+/**
+ * @brief Allocate a new ClientQuotaEntity and make a copy of \p src
+ */
+static rd_kafka_ClientQuotaEntity_t *
+rd_kafka_ClientQuotaEntity_copy(const rd_kafka_ClientQuotaEntity_t *src) {
+        /* Use _new0 directly to allow NULL name (default entity). */
+        return rd_kafka_ClientQuotaEntity_new0(src->type, src->name, 0, NULL);
+}
+
+/**
+ * @brief Create a new ClientQuotaEntry object.
+ */
+rd_kafka_ClientQuotaEntry_t *rd_kafka_ClientQuotaEntry_new(void) {
+        rd_kafka_ClientQuotaEntry_t *entry;
+
+        entry = rd_calloc(1, sizeof(*entry));
+        rd_list_init(&entry->entities, 0,
+                     (void (*)(void *))rd_kafka_ClientQuotaEntity_free);
+        rd_list_init(&entry->operations, 0,
+                     (void (*)(void *))rd_kafka_ClientQuotaOperation_free);
+        entry->error = NULL;
+        return entry;
+}
+
+/**
+ * @brief Destroy a ClientQuotaEntry object.
+ */
+void rd_kafka_ClientQuotaEntry_destroy(rd_kafka_ClientQuotaEntry_t *entry) {
+        rd_list_destroy(&entry->entities);
+        rd_list_destroy(&entry->operations);
+        if (entry->error)
+                rd_kafka_error_destroy(entry->error);
+        rd_free(entry);
+}
+
+static void rd_kafka_ClientQuotaEntry_free(void *ptr) {
+        rd_kafka_ClientQuotaEntry_destroy(ptr);
+}
+
+/**
+ * @brief Allocate a new ClientQuotaEntry and make a copy of \p src.
+ */
+static rd_kafka_ClientQuotaEntry_t *
+rd_kafka_ClientQuotaEntry_copy(const rd_kafka_ClientQuotaEntry_t *src) {
+        rd_kafka_ClientQuotaEntry_t *dst;
+        int i;
+        rd_kafka_ClientQuotaEntity_t *entity;
+        rd_kafka_ClientQuotaOperation_t *operation;
+
+        dst = rd_kafka_ClientQuotaEntry_new();
+
+        RD_LIST_FOREACH(entity, &src->entities, i)
+        rd_list_add(&dst->entities, rd_kafka_ClientQuotaEntity_copy(entity));
+
+        RD_LIST_FOREACH(operation, &src->operations, i)
+        rd_list_add(&dst->operations,
+                    rd_kafka_ClientQuotaOperation_copy(operation));
+
+        return dst;
+}
+
+/**
+ * @brief Add an entity to the ClientQuotaEntry.
+ */
+rd_kafka_resp_err_t
+rd_kafka_ClientQuotaEntry_add_entity(rd_kafka_ClientQuotaEntry_t *entry,
+                                     const char *type,
+                                     const char *name,
+                                     char *errstr,
+                                     size_t errstr_size) {
+        if (!type) {
+                rd_snprintf(errstr, errstr_size,
+                            "Entity type must not be NULL");
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+        rd_list_add(&entry->entities,
+                    rd_kafka_ClientQuotaEntity_new0(type, name, 0, NULL));
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+/**
+ * @brief Add a quota operation to the ClientQuotaEntry.
+ */
+rd_kafka_resp_err_t
+rd_kafka_ClientQuotaEntry_add_operation(rd_kafka_ClientQuotaEntry_t *entry,
+                                        const char *key,
+                                        double value,
+                                        int remove,
+                                        char *errstr,
+                                        size_t errstr_size) {
+        if (!key) {
+                rd_snprintf(errstr, errstr_size, "Quota key must not be NULL");
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+        rd_list_add(&entry->operations,
+                    rd_kafka_ClientQuotaOperation_new0(key, value, remove));
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+/**
+ * @brief Get the response error for a result entry.
+ */
+const rd_kafka_error_t *
+rd_kafka_ClientQuotaEntry_error(const rd_kafka_ClientQuotaEntry_t *entry) {
+        return entry->error;
+}
+
+/**
+ * @brief Get the entities for a result entry.
+ */
+const rd_kafka_ClientQuotaEntity_t **
+rd_kafka_ClientQuotaEntry_entities(const rd_kafka_ClientQuotaEntry_t *entry,
+                                   size_t *cntp) {
+        *cntp = rd_list_cnt(&entry->entities);
+        return (const rd_kafka_ClientQuotaEntity_t **)entry->entities.rl_elems;
+}
+
+/**
+ * @brief Parse AlterClientQuotasResponse and create ADMIN_RESULT op.
+ */
+static rd_kafka_resp_err_t
+rd_kafka_AlterClientQuotasResponse_parse(rd_kafka_op_t *rko_req,
+                                         rd_kafka_op_t **rko_resultp,
+                                         rd_kafka_buf_t *reply,
+                                         char *errstr,
+                                         size_t errstr_size) {
+        const int log_decode_errors = LOG_ERR;
+        rd_kafka_op_t *rko_result   = NULL;
+        int32_t entry_cnt;
+        int i, j;
+
+        rd_kafka_buf_read_throttle_time(reply);
+        rd_kafka_buf_read_arraycnt(reply, &entry_cnt, 100000);
+
+        rko_result = rd_kafka_admin_result_new(rko_req);
+        rd_list_init(&rko_result->rko_u.admin_result.results, entry_cnt,
+                     rd_kafka_ClientQuotaEntry_free);
+
+        for (i = 0; i < (int)entry_cnt; i++) {
+                int16_t error_code;
+                rd_kafkap_str_t error_msg = RD_KAFKAP_STR_INITIALIZER;
+                int32_t entity_cnt;
+                rd_kafka_ClientQuotaEntry_t *entry;
+                char *entry_errstr = NULL;
+
+                rd_kafka_buf_read_i16(reply, &error_code);
+                rd_kafka_buf_read_str(reply, &error_msg);
+
+                if (error_code) {
+                        if (RD_KAFKAP_STR_IS_NULL(&error_msg) ||
+                            RD_KAFKAP_STR_LEN(&error_msg) == 0)
+                                entry_errstr =
+                                    (char *)rd_kafka_err2str(error_code);
+                        else
+                                RD_KAFKAP_STR_DUPA(&entry_errstr, &error_msg);
+                }
+
+                entry = rd_kafka_ClientQuotaEntry_new();
+                if (error_code)
+                        entry->error =
+                            rd_kafka_error_new(error_code, "%s", entry_errstr);
+
+                rd_kafka_buf_read_arraycnt(reply, &entity_cnt, 10000);
+                for (j = 0; j < (int)entity_cnt; j++) {
+                        rd_kafkap_str_t ktype, kname;
+                        char *etype, *ename = NULL;
+
+                        rd_kafka_buf_read_str(reply, &ktype);
+                        rd_kafka_buf_read_str(reply, &kname);
+                        RD_KAFKAP_STR_DUPA(&etype, &ktype);
+                        if (!RD_KAFKAP_STR_IS_NULL(&kname))
+                                RD_KAFKAP_STR_DUPA(&ename, &kname);
+                        rd_list_add(&entry->entities,
+                                    rd_kafka_ClientQuotaEntity_new0(
+                                        etype, ename, 0, NULL));
+                        if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                                rd_kafka_buf_skip_tags(reply);
+                }
+                if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                        rd_kafka_buf_skip_tags(reply);
+
+                rd_list_set(&rko_result->rko_u.admin_result.results, i, entry);
+        }
+        if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                rd_kafka_buf_skip_tags(reply);
+
+        *rko_resultp = rko_result;
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+err_parse:
+        if (rko_result)
+                rd_kafka_op_destroy(rko_result);
+        rd_snprintf(errstr, errstr_size,
+                    "AlterClientQuotas response parse failure: %s",
+                    rd_kafka_err2str(reply->rkbuf_err));
+        return reply->rkbuf_err;
+}
+
+/**
+ * @brief Get the result entries from an AlterClientQuotas result event.
+ */
+const rd_kafka_ClientQuotaEntry_t **rd_kafka_AlterClientQuotas_result_entries(
+    const rd_kafka_AlterClientQuotas_result_t *result,
+    size_t *cntp) {
+        const rd_kafka_op_t *rko = (const rd_kafka_op_t *)result;
+        rd_kafka_op_type_t reqtype =
+            rko->rko_u.admin_result.reqtype & ~RD_KAFKA_OP_FLAGMASK;
+        rd_assert(reqtype == RD_KAFKA_OP_ALTERCLIENTQUOTAS);
+        *cntp = rd_list_cnt(&rko->rko_u.admin_result.results);
+        return (const rd_kafka_ClientQuotaEntry_t **)
+            rko->rko_u.admin_result.results.rl_elems;
+}
+
+/**
+ * @brief Alter client quotas.
+ */
+void rd_kafka_AlterClientQuotas(rd_kafka_t *rk,
+                                rd_kafka_ClientQuotaEntry_t **entries,
+                                size_t entry_cnt,
+                                const rd_kafka_AdminOptions_t *options,
+                                rd_kafka_queue_t *rkqu) {
+        rd_kafka_op_t *rko;
+        size_t i;
+        static const struct rd_kafka_admin_worker_cbs cbs = {
+            rd_kafka_AlterClientQuotasRequest,
+            rd_kafka_AlterClientQuotasResponse_parse};
+
+        rko = rd_kafka_admin_request_op_new(
+            rk, RD_KAFKA_OP_ALTERCLIENTQUOTAS,
+            RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT, &cbs, options,
+            rkqu->rkqu_q);
+
+        rd_list_init(&rko->rko_u.admin_request.args, (int)entry_cnt,
+                     rd_kafka_ClientQuotaEntry_free);
+
+        for (i = 0; i < entry_cnt; i++)
+                rd_list_add(&rko->rko_u.admin_request.args,
+                            rd_kafka_ClientQuotaEntry_copy(entries[i]));
+
+        rd_kafka_q_enq(rk->rk_ops, rko);
+}
+/**@}*/
+
+/**
+ * @name DescribeClientQuotas
+ * @{
+ *
+ *
+ *
+ */
+
+static rd_kafka_ClientQuotaFilterComponent_t *
+rd_kafka_ClientQuotaFilterComponent_new0(const char *entity_type,
+                                         int8_t match_type,
+                                         const char *match) {
+        rd_kafka_ClientQuotaFilterComponent_t *comp;
+        comp              = rd_calloc(1, sizeof(*comp));
+        comp->entity_type = rd_strdup(entity_type);
+        comp->match_type  = match_type;
+        comp->match       = match != NULL ? rd_strdup(match) : NULL;
+        return comp;
+}
+
+static void rd_kafka_ClientQuotaFilterComponent_destroy(
+    rd_kafka_ClientQuotaFilterComponent_t *comp) {
+        rd_free(comp->entity_type);
+        if (comp->match)
+                rd_free(comp->match);
+        rd_free(comp);
+}
+
+static void rd_kafka_ClientQuotaFilterComponent_free(void *ptr) {
+        rd_kafka_ClientQuotaFilterComponent_destroy(ptr);
+}
+
+static rd_kafka_ClientQuotaFilterComponent_t *
+rd_kafka_ClientQuotaFilterComponent_copy(
+    const rd_kafka_ClientQuotaFilterComponent_t *src) {
+        return rd_kafka_ClientQuotaFilterComponent_new0(
+            src->entity_type, src->match_type, src->match);
+}
+
+rd_kafka_ClientQuotaFilter_t *rd_kafka_ClientQuotaFilter_new(int strict) {
+        rd_kafka_ClientQuotaFilter_t *filter;
+        filter = rd_calloc(1, sizeof(*filter));
+        rd_list_init(&filter->components, 0,
+                     rd_kafka_ClientQuotaFilterComponent_free);
+        filter->strict = strict;
+        return filter;
+}
+
+void rd_kafka_ClientQuotaFilter_destroy(rd_kafka_ClientQuotaFilter_t *filter) {
+        rd_list_destroy(&filter->components);
+        rd_free(filter);
+}
+
+static void rd_kafka_ClientQuotaFilter_free(void *ptr) {
+        rd_kafka_ClientQuotaFilter_destroy(ptr);
+}
+
+static rd_kafka_ClientQuotaFilter_t *
+rd_kafka_ClientQuotaFilter_copy(const rd_kafka_ClientQuotaFilter_t *src) {
+        rd_kafka_ClientQuotaFilter_t *dst;
+        rd_kafka_ClientQuotaFilterComponent_t *comp;
+        int i;
+
+        dst = rd_kafka_ClientQuotaFilter_new(src->strict);
+
+        RD_LIST_FOREACH(comp, &src->components, i) {
+                rd_list_add(&dst->components,
+                            rd_kafka_ClientQuotaFilterComponent_copy(comp));
+        }
+
+        return dst;
+}
+
+rd_kafka_resp_err_t rd_kafka_ClientQuotaFilter_add_component(
+    rd_kafka_ClientQuotaFilter_t *filter,
+    const char *entity_type,
+    rd_kafka_ClientQuotaMatchType_t match_type,
+    const char *match,
+    char *errstr,
+    size_t errstr_size) {
+        if (!entity_type) {
+                rd_snprintf(errstr, errstr_size,
+                            "entity_type must not be NULL");
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+        rd_list_add(&filter->components,
+                    rd_kafka_ClientQuotaFilterComponent_new0(
+                        entity_type, (int8_t)match_type, match));
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+static rd_kafka_ClientQuotaValue_t *
+rd_kafka_ClientQuotaValue_new(const char *key, double value) {
+        rd_kafka_ClientQuotaValue_t *v;
+        v        = rd_calloc(1, sizeof(*v));
+        v->key   = rd_strdup(key);
+        v->value = value;
+        return v;
+}
+
+static void rd_kafka_ClientQuotaValue_destroy(rd_kafka_ClientQuotaValue_t *v) {
+        rd_free(v->key);
+        rd_free(v);
+}
+
+static void rd_kafka_ClientQuotaValue_free(void *ptr) {
+        rd_kafka_ClientQuotaValue_destroy(ptr);
+}
+
+const char *
+rd_kafka_ClientQuotaValue_key(const rd_kafka_ClientQuotaValue_t *v) {
+        return v->key;
+}
+
+double rd_kafka_ClientQuotaValue_value(const rd_kafka_ClientQuotaValue_t *v) {
+        return v->value;
+}
+
+static rd_kafka_DescribeClientQuotas_result_entry_t *
+rd_kafka_DescribeClientQuotas_result_entry_new(void) {
+        rd_kafka_DescribeClientQuotas_result_entry_t *entry;
+        entry = rd_calloc(1, sizeof(*entry));
+        rd_list_init(&entry->entity, 0,
+                     (void (*)(void *))rd_kafka_ClientQuotaEntity_free);
+        rd_list_init(&entry->values, 0, rd_kafka_ClientQuotaValue_free);
+        return entry;
+}
+
+static void rd_kafka_DescribeClientQuotas_result_entry_destroy(
+    rd_kafka_DescribeClientQuotas_result_entry_t *entry) {
+        rd_list_destroy(&entry->entity);
+        rd_list_destroy(&entry->values);
+        rd_free(entry);
+}
+
+static void rd_kafka_DescribeClientQuotas_result_entry_free(void *ptr) {
+        rd_kafka_DescribeClientQuotas_result_entry_destroy(ptr);
+}
+
+/**
+ * @brief Parse DescribeClientQuotasResponse and create ADMIN_RESULT op.
+ */
+static rd_kafka_resp_err_t
+rd_kafka_DescribeClientQuotasResponse_parse(rd_kafka_op_t *rko_req,
+                                            rd_kafka_op_t **rko_resultp,
+                                            rd_kafka_buf_t *reply,
+                                            char *errstr,
+                                            size_t errstr_size) {
+        const int log_decode_errors = LOG_ERR;
+        rd_kafka_op_t *rko_result   = NULL;
+        int16_t error_code;
+        rd_kafkap_str_t error_msg = RD_KAFKAP_STR_INITIALIZER;
+        int32_t entry_cnt;
+        int i, j, k;
+
+        rd_kafka_buf_read_throttle_time(reply);
+
+        rd_kafka_buf_read_i16(reply, &error_code);
+        rd_kafka_buf_read_str(reply, &error_msg);
+
+        rko_result = rd_kafka_admin_result_new(rko_req);
+
+        if (error_code) {
+                rko_result->rko_err = error_code;
+                if (!RD_KAFKAP_STR_IS_NULL(&error_msg) &&
+                    RD_KAFKAP_STR_LEN(&error_msg) > 0)
+                        rko_result->rko_u.admin_result.errstr =
+                            RD_KAFKAP_STR_DUP(&error_msg);
+                else
+                        rko_result->rko_u.admin_result.errstr =
+                            rd_strdup(rd_kafka_err2str(error_code));
+                rd_list_init(&rko_result->rko_u.admin_result.results, 0,
+                             rd_kafka_DescribeClientQuotas_result_entry_free);
+                *rko_resultp = rko_result;
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+        }
+
+        rd_kafka_buf_read_arraycnt(reply, &entry_cnt, 100000);
+
+        rd_list_init(&rko_result->rko_u.admin_result.results, entry_cnt,
+                     rd_kafka_DescribeClientQuotas_result_entry_free);
+
+        for (i = 0; i < (int)entry_cnt; i++) {
+                int32_t entity_cnt;
+                int32_t value_cnt;
+                rd_kafka_DescribeClientQuotas_result_entry_t *entry;
+
+                entry = rd_kafka_DescribeClientQuotas_result_entry_new();
+
+                rd_kafka_buf_read_arraycnt(reply, &entity_cnt, 10000);
+                for (j = 0; j < (int)entity_cnt; j++) {
+                        rd_kafkap_str_t ktype, kname;
+                        char *etype, *ename = NULL;
+
+                        rd_kafka_buf_read_str(reply, &ktype);
+                        rd_kafka_buf_read_str(reply, &kname);
+                        RD_KAFKAP_STR_DUPA(&etype, &ktype);
+                        if (!RD_KAFKAP_STR_IS_NULL(&kname))
+                                RD_KAFKAP_STR_DUPA(&ename, &kname);
+                        rd_list_add(&entry->entity,
+                                    rd_kafka_ClientQuotaEntity_new0(
+                                        etype, ename, 0, NULL));
+                        if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                                rd_kafka_buf_skip_tags(reply);
+                }
+
+                rd_kafka_buf_read_arraycnt(reply, &value_cnt, 10000);
+                for (k = 0; k < (int)value_cnt; k++) {
+                        rd_kafkap_str_t kname;
+                        char *vname;
+                        double val;
+
+                        rd_kafka_buf_read_str(reply, &kname);
+                        rd_kafka_buf_read_float64(reply, &val);
+                        RD_KAFKAP_STR_DUPA(&vname, &kname);
+                        rd_list_add(&entry->values,
+                                    rd_kafka_ClientQuotaValue_new(vname, val));
+                        if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                                rd_kafka_buf_skip_tags(reply);
+                }
+
+                if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                        rd_kafka_buf_skip_tags(reply);
+
+                rd_list_set(&rko_result->rko_u.admin_result.results, i, entry);
+        }
+
+        if (rd_kafka_buf_ApiVersion(reply) >= 1)
+                rd_kafka_buf_skip_tags(reply);
+
+        *rko_resultp = rko_result;
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+err_parse:
+        if (rko_result)
+                rd_kafka_op_destroy(rko_result);
+        rd_snprintf(errstr, errstr_size,
+                    "DescribeClientQuotas response parse failure: %s",
+                    rd_kafka_err2str(reply->rkbuf_err));
+        return reply->rkbuf_err;
+}
+
+/**
+ * @brief Get result entries from a DescribeClientQuotas result event.
+ */
+const rd_kafka_DescribeClientQuotas_result_entry_t **
+rd_kafka_DescribeClientQuotas_result_entries(
+    const rd_kafka_DescribeClientQuotas_result_t *result,
+    size_t *cntp) {
+        const rd_kafka_op_t *rko = (const rd_kafka_op_t *)result;
+        rd_kafka_op_type_t reqtype =
+            rko->rko_u.admin_result.reqtype & ~RD_KAFKA_OP_FLAGMASK;
+        rd_assert(reqtype == RD_KAFKA_OP_DESCRIBECLIENTQUOTAS);
+        *cntp = rd_list_cnt(&rko->rko_u.admin_result.results);
+        return (const rd_kafka_DescribeClientQuotas_result_entry_t **)
+            rko->rko_u.admin_result.results.rl_elems;
+}
+
+const rd_kafka_ClientQuotaEntity_t **
+rd_kafka_DescribeClientQuotas_result_entry_entity(
+    const rd_kafka_DescribeClientQuotas_result_entry_t *entry,
+    size_t *cntp) {
+        *cntp = rd_list_cnt(&entry->entity);
+        return (const rd_kafka_ClientQuotaEntity_t **)entry->entity.rl_elems;
+}
+
+const rd_kafka_ClientQuotaValue_t **
+rd_kafka_DescribeClientQuotas_result_entry_values(
+    const rd_kafka_DescribeClientQuotas_result_entry_t *entry,
+    size_t *cntp) {
+        *cntp = rd_list_cnt(&entry->values);
+        return (const rd_kafka_ClientQuotaValue_t **)entry->values.rl_elems;
+}
+
+/**
+ * @brief Describe client quotas.
+ */
+void rd_kafka_DescribeClientQuotas(rd_kafka_t *rk,
+                                   const rd_kafka_ClientQuotaFilter_t *filter,
+                                   const rd_kafka_AdminOptions_t *options,
+                                   rd_kafka_queue_t *rkqu) {
+        rd_kafka_op_t *rko;
+
+        static const struct rd_kafka_admin_worker_cbs cbs = {
+            rd_kafka_DescribeClientQuotasRequest,
+            rd_kafka_DescribeClientQuotasResponse_parse,
+        };
+
+        rko = rd_kafka_admin_request_op_new(
+            rk, RD_KAFKA_OP_DESCRIBECLIENTQUOTAS,
+            RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT, &cbs, options,
+            rkqu->rkqu_q);
+
+        rd_list_init(&rko->rko_u.admin_request.args, 1,
+                     rd_kafka_ClientQuotaFilter_free);
+
+        rd_list_add(&rko->rko_u.admin_request.args,
+                    rd_kafka_ClientQuotaFilter_copy(filter));
+
+        rd_kafka_q_enq(rk->rk_ops, rko);
+}
+/**@}*/
+
 /**
  * @name CreateAcls
  * @{
@@ -7566,8 +8240,8 @@ err_parse:
                 error      = rd_kafka_error_new(
                     error_code,
                     "Broker [%d"
-                         "] "
-                         "ListConsumerGroups response protocol parse failure: %s",
+                    "] "
+                    "ListConsumerGroups response protocol parse failure: %s",
                     rd_kafka_broker_id(rkb), rd_kafka_err2str(error_code));
                 rd_list_add(&errors, error);
         }

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -436,6 +436,77 @@ rd_kafka_ListOffsetsResultInfo_new(rd_kafka_topic_partition_t *rktpar,
 /**@}*/
 
 /**
+ * @name AlterClientQuotas
+ * @{
+ */
+
+/**
+ * @brief Client Quota Entity - Used in AlterClientQuotas.
+ */
+struct rd_kafka_ClientQuotaEntity_s {
+        /** The entity type, e.g., "user" or "client" */
+        char *type;
+
+        /** The entity name, e.g., "user1" or "client1" */
+        char *name;
+};
+
+/**
+ * @brief Client Quota Operation - Used in AlterClientQuotas.
+ *
+ * This structure is used to define operations on client quotas, such as
+ * setting producer_byte_rate or removing request_percentage a quota for a specific entity.
+ */
+struct rd_kafka_ClientQuotaOperation_s {
+        /** The configuration name, e.g., "producer_byte_rate", "request_percentage" */
+        char *name;
+
+        /** The quota value (IEEE 754 double, 64-bit). */
+        double value;
+
+        /** True if this is a delete operation. If this is set, the value field will be ignored */
+        rd_bool_t remove;
+};
+
+struct rd_kafka_ClientQuotaEntry_s {
+        rd_list_t entities;   /**< Type (rd_kafka_ClientQuotaEntity_t *) */
+        rd_list_t operations; /**< Type (rd_kafka_ClientQuotaOperation_t *) */
+        rd_kafka_error_t *error; /**< Response error, or NULL on success. */
+};
+
+/**
+ * @name DescribeClientQuotas
+ * @{
+ */
+
+/** Filter component for DescribeClientQuotas. */
+struct rd_kafka_ClientQuotaFilterComponent_s {
+        char *entity_type; /**< Entity type, e.g. "user", "client-id". */
+        int8_t match_type; /**< rd_kafka_ClientQuotaMatchType_t */
+        char *match;       /**< Match value; NULL for DEFAULT or ANY. */
+};
+
+/** Filter for DescribeClientQuotas (components + strict flag). */
+struct rd_kafka_ClientQuotaFilter_s {
+        rd_list_t components; /**< rd_kafka_ClientQuotaFilterComponent_t* */
+        int strict;           /**< If true, only return exact matches. */
+};
+
+/** A key/value quota pair returned in DescribeClientQuotas results. */
+struct rd_kafka_ClientQuotaValue_s {
+        char *key;    /**< Quota configuration key. */
+        double value; /**< Quota value (IEEE 754 double, 64-bit). */
+};
+
+/** A single entry in the DescribeClientQuotas result. */
+struct rd_kafka_DescribeClientQuotas_result_entry_s {
+        rd_list_t entity; /**< rd_kafka_ClientQuotaEntity_t* */
+        rd_list_t values; /**< rd_kafka_ClientQuotaValue_t* */
+};
+
+/**@}*/
+
+/**
  * @name CreateAcls
  * @{
  */

--- a/src/rdkafka_admin.h
+++ b/src/rdkafka_admin.h
@@ -455,16 +455,19 @@ struct rd_kafka_ClientQuotaEntity_s {
  * @brief Client Quota Operation - Used in AlterClientQuotas.
  *
  * This structure is used to define operations on client quotas, such as
- * setting producer_byte_rate or removing request_percentage a quota for a specific entity.
+ * setting producer_byte_rate or removing request_percentage a quota for a
+ * specific entity.
  */
 struct rd_kafka_ClientQuotaOperation_s {
-        /** The configuration name, e.g., "producer_byte_rate", "request_percentage" */
+        /** The configuration name, e.g., "producer_byte_rate",
+         * "request_percentage" */
         char *name;
 
         /** The quota value (IEEE 754 double, 64-bit). */
         double value;
 
-        /** True if this is a delete operation. If this is set, the value field will be ignored */
+        /** True if this is a delete operation. If this is set, the value field
+         * will be ignored */
         rd_bool_t remove;
 };
 

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -1285,6 +1285,35 @@ rd_kafka_buf_update_i64(rd_kafka_buf_t *rkbuf, size_t of, int64_t v) {
 }
 
 /**
+ * Read a float64 (IEEE 754 double) and store it in 'dstptr'.
+ * The value will be endian-swapped after read.
+ */
+#define rd_kafka_buf_read_float64(rkbuf, dstptr)                               \
+        do {                                                                   \
+                uint64_t _v;                                                   \
+                union { uint64_t u; double d; } _u;                            \
+                double *_vp = dstptr;                                          \
+                rd_kafka_buf_read(rkbuf, &_v, sizeof(_v));                     \
+                _u.u = be64toh(_v);                                            \
+                *_vp = _u.d;                                                   \
+        } while (0)
+
+/**
+ * Write float64 to buffer.
+ * The value will be endian-swapped before write.
+ */
+static RD_INLINE size_t rd_kafka_buf_write_float64(rd_kafka_buf_t *rkbuf, double v) {
+        union {
+                double d;
+                uint64_t u;
+        } u;
+
+        u.d = v;
+        u.u = htobe64(u.u);
+        return rd_kafka_buf_write(rkbuf, &u.u, sizeof(u.u));
+}
+
+/**
  * @brief Write standard (2-byte header) or KIP-482 COMPACT_STRING to buffer.
  *
  * @remark Copies the string.

--- a/src/rdkafka_buf.h
+++ b/src/rdkafka_buf.h
@@ -1291,7 +1291,10 @@ rd_kafka_buf_update_i64(rd_kafka_buf_t *rkbuf, size_t of, int64_t v) {
 #define rd_kafka_buf_read_float64(rkbuf, dstptr)                               \
         do {                                                                   \
                 uint64_t _v;                                                   \
-                union { uint64_t u; double d; } _u;                            \
+                union {                                                        \
+                        uint64_t u;                                            \
+                        double d;                                              \
+                } _u;                                                          \
                 double *_vp = dstptr;                                          \
                 rd_kafka_buf_read(rkbuf, &_v, sizeof(_v));                     \
                 _u.u = be64toh(_v);                                            \
@@ -1302,7 +1305,8 @@ rd_kafka_buf_update_i64(rd_kafka_buf_t *rkbuf, size_t of, int64_t v) {
  * Write float64 to buffer.
  * The value will be endian-swapped before write.
  */
-static RD_INLINE size_t rd_kafka_buf_write_float64(rd_kafka_buf_t *rkbuf, double v) {
+static RD_INLINE size_t rd_kafka_buf_write_float64(rd_kafka_buf_t *rkbuf,
+                                                   double v) {
         union {
                 double d;
                 uint64_t u;

--- a/src/rdkafka_event.c
+++ b/src/rdkafka_event.c
@@ -500,3 +500,21 @@ rd_kafka_event_ElectLeaders_result(rd_kafka_event_t *rkev) {
         else
                 return (const rd_kafka_ElectLeaders_result_t *)rkev;
 }
+
+const rd_kafka_AlterClientQuotas_result_t *
+rd_kafka_event_AlterClientQuotas_result(rd_kafka_event_t *rkev) {
+        if (!rkev ||
+            rkev->rko_evtype != RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT)
+                return NULL;
+        else
+                return (const rd_kafka_AlterClientQuotas_result_t *)rkev;
+}
+
+const rd_kafka_DescribeClientQuotas_result_t *
+rd_kafka_event_DescribeClientQuotas_result(rd_kafka_event_t *rkev) {
+        if (!rkev ||
+            rkev->rko_evtype != RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT)
+                return NULL;
+        else
+                return (const rd_kafka_DescribeClientQuotas_result_t *)rkev;
+}

--- a/src/rdkafka_event.h
+++ b/src/rdkafka_event.h
@@ -118,6 +118,8 @@ static RD_UNUSED RD_INLINE int rd_kafka_event_setup(rd_kafka_t *rk,
         case RD_KAFKA_EVENT_ALTERUSERSCRAMCREDENTIALS_RESULT:
         case RD_KAFKA_EVENT_LISTOFFSETS_RESULT:
         case RD_KAFKA_EVENT_ELECTLEADERS_RESULT:
+        case RD_KAFKA_EVENT_ALTERCLIENTQUOTAS_RESULT:
+        case RD_KAFKA_EVENT_DESCRIBECLIENTQUOTAS_RESULT:
                 return 1;
 
         default:

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -92,12 +92,11 @@ const char *rd_kafka_op2str(rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_DELETEGROUPS]    = "REPLY:DELETEGROUPS",
             [RD_KAFKA_OP_DELETECONSUMERGROUPOFFSETS] =
                 "REPLY:DELETECONSUMERGROUPOFFSETS",
-            [RD_KAFKA_OP_ALTERCLIENTQUOTAS]   = "REPLY:ALTERCLIENTQUOTAS",
-            [RD_KAFKA_OP_DESCRIBECLIENTQUOTAS] =
-                "REPLY:DESCRIBECLIENTQUOTAS",
-            [RD_KAFKA_OP_CREATEACLS]   = "REPLY:CREATEACLS",
-            [RD_KAFKA_OP_DESCRIBEACLS] = "REPLY:DESCRIBEACLS",
-            [RD_KAFKA_OP_DELETEACLS]   = "REPLY:DELETEACLS",
+            [RD_KAFKA_OP_ALTERCLIENTQUOTAS]    = "REPLY:ALTERCLIENTQUOTAS",
+            [RD_KAFKA_OP_DESCRIBECLIENTQUOTAS] = "REPLY:DESCRIBECLIENTQUOTAS",
+            [RD_KAFKA_OP_CREATEACLS]           = "REPLY:CREATEACLS",
+            [RD_KAFKA_OP_DESCRIBEACLS]         = "REPLY:DESCRIBEACLS",
+            [RD_KAFKA_OP_DELETEACLS]           = "REPLY:DELETEACLS",
             [RD_KAFKA_OP_ALTERCONSUMERGROUPOFFSETS] =
                 "REPLY:ALTERCONSUMERGROUPOFFSETS",
             [RD_KAFKA_OP_LISTCONSUMERGROUPOFFSETS] =
@@ -260,8 +259,7 @@ rd_kafka_op_t *rd_kafka_op_new0(const char *source, rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_DELETEGROUPS]    = sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_DELETECONSUMERGROUPOFFSETS] =
                 sizeof(rko->rko_u.admin_request),
-            [RD_KAFKA_OP_ALTERCLIENTQUOTAS] =
-                sizeof(rko->rko_u.admin_request),
+            [RD_KAFKA_OP_ALTERCLIENTQUOTAS] = sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_DESCRIBECLIENTQUOTAS] =
                 sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_CREATEACLS]   = sizeof(rko->rko_u.admin_request),

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -92,6 +92,9 @@ const char *rd_kafka_op2str(rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_DELETEGROUPS]    = "REPLY:DELETEGROUPS",
             [RD_KAFKA_OP_DELETECONSUMERGROUPOFFSETS] =
                 "REPLY:DELETECONSUMERGROUPOFFSETS",
+            [RD_KAFKA_OP_ALTERCLIENTQUOTAS]   = "REPLY:ALTERCLIENTQUOTAS",
+            [RD_KAFKA_OP_DESCRIBECLIENTQUOTAS] =
+                "REPLY:DESCRIBECLIENTQUOTAS",
             [RD_KAFKA_OP_CREATEACLS]   = "REPLY:CREATEACLS",
             [RD_KAFKA_OP_DESCRIBEACLS] = "REPLY:DESCRIBEACLS",
             [RD_KAFKA_OP_DELETEACLS]   = "REPLY:DELETEACLS",
@@ -256,6 +259,10 @@ rd_kafka_op_t *rd_kafka_op_new0(const char *source, rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_DESCRIBECLUSTER] = sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_DELETEGROUPS]    = sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_DELETECONSUMERGROUPOFFSETS] =
+                sizeof(rko->rko_u.admin_request),
+            [RD_KAFKA_OP_ALTERCLIENTQUOTAS] =
+                sizeof(rko->rko_u.admin_request),
+            [RD_KAFKA_OP_DESCRIBECLIENTQUOTAS] =
                 sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_CREATEACLS]   = sizeof(rko->rko_u.admin_request),
             [RD_KAFKA_OP_DESCRIBEACLS] = sizeof(rko->rko_u.admin_request),
@@ -430,6 +437,8 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_DESCRIBECONSUMERGROUPS:
         case RD_KAFKA_OP_DELETEGROUPS:
         case RD_KAFKA_OP_DELETECONSUMERGROUPOFFSETS:
+        case RD_KAFKA_OP_ALTERCLIENTQUOTAS:
+        case RD_KAFKA_OP_DESCRIBECLIENTQUOTAS:
         case RD_KAFKA_OP_CREATEACLS:
         case RD_KAFKA_OP_DESCRIBEACLS:
         case RD_KAFKA_OP_DELETEACLS:

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -156,10 +156,10 @@ typedef enum {
         RD_KAFKA_OP_CREATEACLS,   /**< Admin: CreateAcls: u.admin_request*/
         RD_KAFKA_OP_DESCRIBEACLS, /**< Admin: DescribeAcls: u.admin_request*/
         RD_KAFKA_OP_DELETEACLS,   /**< Admin: DeleteAcls: u.admin_request*/
-        RD_KAFKA_OP_ALTERCLIENTQUOTAS,          /**< Admin: AlterClientQuotas:
-                                                   u.admin_request*/
-        RD_KAFKA_OP_DESCRIBECLIENTQUOTAS,       /**< Admin: DescribeClientQuotas:
-                                                   u.admin_request*/
+        RD_KAFKA_OP_ALTERCLIENTQUOTAS,         /**< Admin: AlterClientQuotas:
+                                                  u.admin_request*/
+        RD_KAFKA_OP_DESCRIBECLIENTQUOTAS,      /**< Admin: DescribeClientQuotas:
+                                                  u.admin_request*/
         RD_KAFKA_OP_ALTERCONSUMERGROUPOFFSETS, /**< Admin:
                                                 *   AlterConsumerGroupOffsets
                                                 *   u.admin_request */

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -156,6 +156,10 @@ typedef enum {
         RD_KAFKA_OP_CREATEACLS,   /**< Admin: CreateAcls: u.admin_request*/
         RD_KAFKA_OP_DESCRIBEACLS, /**< Admin: DescribeAcls: u.admin_request*/
         RD_KAFKA_OP_DELETEACLS,   /**< Admin: DeleteAcls: u.admin_request*/
+        RD_KAFKA_OP_ALTERCLIENTQUOTAS,          /**< Admin: AlterClientQuotas:
+                                                   u.admin_request*/
+        RD_KAFKA_OP_DESCRIBECLIENTQUOTAS,       /**< Admin: DescribeClientQuotas:
+                                                   u.admin_request*/
         RD_KAFKA_OP_ALTERCONSUMERGROUPOFFSETS, /**< Admin:
                                                 *   AlterConsumerGroupOffsets
                                                 *   u.admin_request */

--- a/src/rdkafka_request.c
+++ b/src/rdkafka_request.c
@@ -6029,6 +6029,193 @@ rd_kafka_DeleteAclsRequest(rd_kafka_broker_t *rkb,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+
+/**
+ * @brief Send AlterClientQuotasRequest.
+ *
+ * @param rkb The broker to send the request to.
+ * @param entries list of rd_kafka_ClientQuotaEntry_t* to alter.
+ * @param replyq Reply queue for the response.
+ * @param resp_cb Response callback.
+ * @param opaque User-defined opaque pointer.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, or an error code.
+ */
+rd_kafka_resp_err_t
+rd_kafka_AlterClientQuotasRequest(rd_kafka_broker_t *rkb,
+                                  const rd_list_t *entries,
+                                  rd_kafka_AdminOptions_t *options,
+                                  char *errstr,
+                                  size_t errstr_size,
+                                  rd_kafka_replyq_t replyq,
+                                  rd_kafka_resp_cb_t *resp_cb,
+                                  void *opaque) {
+        rd_kafka_buf_t *rkbuf;
+        int16_t ApiVersion;
+        rd_kafka_ClientQuotaEntry_t *entry;
+        rd_kafka_ClientQuotaEntity_t *entity;
+        rd_kafka_ClientQuotaOperation_t *operation;
+        int op_timeout;
+        int i;
+        int j;
+        /* Buffer grows automatically; use a modest base size. */
+        size_t estimated_len = 4 + 1 + (rd_list_cnt(entries) * 64);
+
+        if (rd_list_cnt(entries) == 0) {
+                rd_snprintf(errstr, errstr_size, "No quota entries to send");
+                rd_kafka_replyq_destroy(&replyq);
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+        ApiVersion = rd_kafka_broker_ApiVersion_supported(
+            rkb, RD_KAFKAP_AlterClientQuotas, 0, 1, NULL);
+
+        if (ApiVersion == -1) {
+                rd_snprintf(errstr, errstr_size,
+                            "Configurable Quota Management (KIP-257) not "
+                            "supported by broker, requires "
+                            "broker version >= 2.0.0");
+                rd_kafka_replyq_destroy(&replyq);
+                return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
+        }
+
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_AlterClientQuotas, ApiVersion, estimated_len,
+            ApiVersion >= 1 /*flexver*/);
+
+        /* Entries array */
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(entries));
+        RD_LIST_FOREACH(entry, entries, i) {
+                /* Entity array */
+                rd_kafka_buf_write_arraycnt(rkbuf,
+                                            rd_list_cnt(&entry->entities));
+                RD_LIST_FOREACH(entity, &entry->entities, j) {
+                        rd_kafka_buf_write_str(rkbuf, entity->type, -1);
+                        /* NULL name = default entity */
+                        rd_kafka_buf_write_str(rkbuf, entity->name, -1);
+                        if (ApiVersion >= 1)
+                                rd_kafka_buf_write_tags_empty(rkbuf);
+                }
+
+                /* Operations array */
+                rd_kafka_buf_write_arraycnt(rkbuf,
+                                            rd_list_cnt(&entry->operations));
+                RD_LIST_FOREACH(operation, &entry->operations, j) {
+                        rd_kafka_buf_write_str(rkbuf, operation->name, -1);
+                        rd_kafka_buf_write_float64(rkbuf, operation->value);
+                        rd_kafka_buf_write_bool(rkbuf, operation->remove);
+                        if (ApiVersion >= 1)
+                                rd_kafka_buf_write_tags_empty(rkbuf);
+                }
+
+                if (ApiVersion >= 1)
+                        rd_kafka_buf_write_tags_empty(rkbuf);
+        }
+
+        /* ValidateOnly */
+        rd_kafka_buf_write_bool(
+            rkbuf, rd_kafka_confval_get_int(&options->validate_only));
+
+        if (ApiVersion >= 1)
+                rd_kafka_buf_write_tags_empty(rkbuf);
+
+        /* timeout */
+        op_timeout = rd_kafka_confval_get_int(&options->operation_timeout);
+        if (op_timeout > rkb->rkb_rk->rk_conf.socket_timeout_ms)
+                rd_kafka_buf_set_abs_timeout(rkbuf, op_timeout + 1000, 0);
+
+        rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
+
+        rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+/**
+ * @brief Construct and send DescribeClientQuotasRequest to \p rkb
+ *        with the filter (rd_kafka_ClientQuotaFilter_t*) in \p filters,
+ *        using \p options.
+ *
+ *        The response (unparsed) will be enqueued on \p replyq
+ *        for handling by \p resp_cb (with \p opaque passed).
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR if the request was enqueued for
+ *          transmission, otherwise an error code and errstr will be
+ *          updated with a human readable error string.
+ */
+rd_kafka_resp_err_t
+rd_kafka_DescribeClientQuotasRequest(rd_kafka_broker_t *rkb,
+                                     const rd_list_t *filters,
+                                     rd_kafka_AdminOptions_t *options,
+                                     char *errstr,
+                                     size_t errstr_size,
+                                     rd_kafka_replyq_t replyq,
+                                     rd_kafka_resp_cb_t *resp_cb,
+                                     void *opaque) {
+        rd_kafka_buf_t *rkbuf;
+        int16_t ApiVersion;
+        const rd_kafka_ClientQuotaFilter_t *filter;
+        const rd_kafka_ClientQuotaFilterComponent_t *comp;
+        int op_timeout;
+        int i;
+        /* Buffer grows automatically; use a modest base size. */
+        size_t estimated_len;
+
+        if (rd_list_cnt(filters) != 1) {
+                rd_snprintf(errstr, errstr_size,
+                            "Exactly one ClientQuotaFilter must be provided");
+                rd_kafka_replyq_destroy(&replyq);
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+
+        filter = rd_list_elem(filters, 0);
+
+        ApiVersion = rd_kafka_broker_ApiVersion_supported(
+            rkb, RD_KAFKAP_DescribeClientQuotas, 0, 1, NULL);
+        if (ApiVersion == -1) {
+                rd_snprintf(errstr, errstr_size,
+                            "Configurable Quota Management (KIP-257) not "
+                            "supported by broker, requires "
+                            "broker version >= 2.0.0");
+                rd_kafka_replyq_destroy(&replyq);
+                return RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE;
+        }
+
+        estimated_len = 4 + 1 + (rd_list_cnt(&filter->components) * 48);
+
+        rkbuf = rd_kafka_buf_new_flexver_request(
+            rkb, RD_KAFKAP_DescribeClientQuotas, ApiVersion, estimated_len,
+            ApiVersion >= 1 /*flexver*/);
+
+        /* [components] */
+        rd_kafka_buf_write_arraycnt(rkbuf, rd_list_cnt(&filter->components));
+        RD_LIST_FOREACH(comp, &filter->components, i) {
+                rd_kafka_buf_write_str(rkbuf, comp->entity_type, -1);
+                rd_kafka_buf_write_i8(rkbuf, comp->match_type);
+                /* match: NULL for DEFAULT/ANY */
+                rd_kafka_buf_write_str(rkbuf, comp->match, -1);
+                if (ApiVersion >= 1)
+                        rd_kafka_buf_write_tags_empty(rkbuf);
+        }
+
+        /* strict */
+        rd_kafka_buf_write_bool(rkbuf, filter->strict);
+
+        if (ApiVersion >= 1)
+                rd_kafka_buf_write_tags_empty(rkbuf);
+
+        /* timeout */
+        op_timeout = rd_kafka_confval_get_int(&options->operation_timeout);
+        if (op_timeout > rkb->rkb_rk->rk_conf.socket_timeout_ms)
+                rd_kafka_buf_set_abs_timeout(rkbuf, op_timeout + 1000, 0);
+
+        rd_kafka_buf_ApiVersion_set(rkbuf, ApiVersion, 0);
+
+        rd_kafka_broker_buf_enq_replyq(rkb, rkbuf, replyq, resp_cb, opaque);
+
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
+
 /**
  * @brief Construct and send ElectLeadersRequest to \p rkb
  *        with the partitions (ElectLeaders_t*) in \p elect_leaders, using

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -605,8 +605,7 @@ rd_kafka_DeleteRecordsRequest(rd_kafka_broker_t *rkb,
                               rd_kafka_resp_cb_t *resp_cb,
                               void *opaque);
 
-rd_kafka_resp_err_t
-rd_kafka_AlterClientQuotasRequest(
+rd_kafka_resp_err_t rd_kafka_AlterClientQuotasRequest(
     rd_kafka_broker_t *rkb,
     const rd_list_t *entries /*(ClientQuotaEntry_t*)*/,
     rd_kafka_AdminOptions_t *options,
@@ -616,8 +615,7 @@ rd_kafka_AlterClientQuotasRequest(
     rd_kafka_resp_cb_t *resp_cb,
     void *opaque);
 
-rd_kafka_resp_err_t
-rd_kafka_DescribeClientQuotasRequest(
+rd_kafka_resp_err_t rd_kafka_DescribeClientQuotasRequest(
     rd_kafka_broker_t *rkb,
     const rd_list_t *filters /*(rd_kafka_ClientQuotaFilter_t*)*/,
     rd_kafka_AdminOptions_t *options,

--- a/src/rdkafka_request.h
+++ b/src/rdkafka_request.h
@@ -606,6 +606,27 @@ rd_kafka_DeleteRecordsRequest(rd_kafka_broker_t *rkb,
                               void *opaque);
 
 rd_kafka_resp_err_t
+rd_kafka_AlterClientQuotasRequest(
+    rd_kafka_broker_t *rkb,
+    const rd_list_t *entries /*(ClientQuotaEntry_t*)*/,
+    rd_kafka_AdminOptions_t *options,
+    char *errstr,
+    size_t errstr_size,
+    rd_kafka_replyq_t replyq,
+    rd_kafka_resp_cb_t *resp_cb,
+    void *opaque);
+
+rd_kafka_resp_err_t
+rd_kafka_DescribeClientQuotasRequest(
+    rd_kafka_broker_t *rkb,
+    const rd_list_t *filters /*(rd_kafka_ClientQuotaFilter_t*)*/,
+    rd_kafka_AdminOptions_t *options,
+    char *errstr,
+    size_t errstr_size,
+    rd_kafka_replyq_t replyq,
+    rd_kafka_resp_cb_t *resp_cb,
+    void *opaque);
+rd_kafka_resp_err_t
 rd_kafka_CreateAclsRequest(rd_kafka_broker_t *rkb,
                            const rd_list_t *new_acls /*(AclBinding_t*)*/,
                            rd_kafka_AdminOptions_t *options,

--- a/tests/0154-admin_quota_ut.c
+++ b/tests/0154-admin_quota_ut.c
@@ -81,8 +81,8 @@ static void do_test_ClientQuotaFilter(void) {
 
         /* EXACT match with a name */
         err = rd_kafka_ClientQuotaFilter_add_component(
-            filter, "user", RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT, "alice",
-            errstr, sizeof(errstr));
+            filter, "user", RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT, "alice", errstr,
+            sizeof(errstr));
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "expected NO_ERROR for EXACT component, got %s",
                     rd_kafka_err2str(err));
@@ -97,8 +97,8 @@ static void do_test_ClientQuotaFilter(void) {
 
         /* ANY match (NULL name) */
         err = rd_kafka_ClientQuotaFilter_add_component(
-            filter, "client-id", RD_KAFKA_CLIENT_QUOTA_MATCH_ANY, NULL,
-            errstr, sizeof(errstr));
+            filter, "client-id", RD_KAFKA_CLIENT_QUOTA_MATCH_ANY, NULL, errstr,
+            sizeof(errstr));
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "expected NO_ERROR for ANY component, got %s",
                     rd_kafka_err2str(err));
@@ -134,8 +134,8 @@ static void do_test_ClientQuotaEntry(void) {
 
         /* NULL entity type must be rejected */
         *errstr = '\0';
-        err = rd_kafka_ClientQuotaEntry_add_entity(entry, NULL, "user1",
-                                                   errstr, sizeof(errstr));
+        err = rd_kafka_ClientQuotaEntry_add_entity(entry, NULL, "user1", errstr,
+                                                   sizeof(errstr));
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "expected INVALID_ARG for NULL entity type, got %s",
                     rd_kafka_err2str(err));
@@ -239,8 +239,7 @@ static void do_test_DescribeClientQuotas(const char *what,
         TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
         TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
         TEST_SAY("DescribeClientQuotas: got %s in %.3fs\n",
-                 rd_kafka_event_name(rkev),
-                 TIMING_DURATION(&timing) / 1000.0f);
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
 
         /* Verify event type */
         res = rd_kafka_event_DescribeClientQuotas_result(rkev);
@@ -293,8 +292,8 @@ static void do_test_AlterClientQuotas(const char *what,
 
         /* First entry: set producer_byte_rate for user "alice" */
         entries[0] = rd_kafka_ClientQuotaEntry_new();
-        err        = rd_kafka_ClientQuotaEntry_add_entity(
-            entries[0], "user", "alice", errstr, sizeof(errstr));
+        err = rd_kafka_ClientQuotaEntry_add_entity(entries[0], "user", "alice",
+                                                   errstr, sizeof(errstr));
         TEST_ASSERT(!err, "add_entity: %s", errstr);
         err = rd_kafka_ClientQuotaEntry_add_operation(
             entries[0], "producer_byte_rate", 1024.0, 0 /*remove*/, errstr,
@@ -335,8 +334,7 @@ static void do_test_AlterClientQuotas(const char *what,
         TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
         TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
         TEST_SAY("AlterClientQuotas: got %s in %.3fs\n",
-                 rd_kafka_event_name(rkev),
-                 TIMING_DURATION(&timing) / 1000.0f);
+                 rd_kafka_event_name(rkev), TIMING_DURATION(&timing) / 1000.0f);
 
         /* Verify event type */
         res = rd_kafka_event_AlterClientQuotas_result(rkev);

--- a/tests/0154-admin_quota_ut.c
+++ b/tests/0154-admin_quota_ut.c
@@ -1,0 +1,395 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2012-2022, Magnus Edenhill
+ *               2023, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+/**
+ * @brief Admin API local dry-run unit-tests for DescribeClientQuotas
+ *        and AlterClientQuotas.
+ */
+
+#define MY_SOCKET_TIMEOUT_MS     100
+#define MY_SOCKET_TIMEOUT_MS_STR "100"
+
+
+static rd_kafka_t *create_quota_admin_client(rd_kafka_type_t cltype) {
+        rd_kafka_t *rk;
+        char errstr[512];
+        rd_kafka_conf_t *conf;
+
+        test_conf_init(&conf, NULL, 0);
+        /* Remove brokers: this is a local test relying on timeout */
+        test_conf_set(conf, "bootstrap.servers", "");
+        test_conf_set(conf, "socket.timeout.ms", MY_SOCKET_TIMEOUT_MS_STR);
+
+        rk = rd_kafka_new(cltype, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rk, "kafka_new(%d): %s", cltype, errstr);
+
+        return rk;
+}
+
+
+/**
+ * @brief Test ClientQuotaFilter construction and input validation.
+ */
+static void do_test_ClientQuotaFilter(void) {
+        rd_kafka_ClientQuotaFilter_t *filter;
+        rd_kafka_resp_err_t err;
+        char errstr[512];
+
+        SUB_TEST_QUICK();
+
+        filter = rd_kafka_ClientQuotaFilter_new(0 /*strict*/);
+        TEST_ASSERT(filter != NULL, "expected non-NULL filter");
+
+        /* NULL entity_type must be rejected */
+        *errstr = '\0';
+        err     = rd_kafka_ClientQuotaFilter_add_component(
+            filter, NULL, RD_KAFKA_CLIENT_QUOTA_MATCH_ANY, NULL, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected INVALID_ARG for NULL entity_type, got %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(*errstr != '\0',
+                    "expected non-empty errstr for NULL entity_type");
+
+        /* EXACT match with a name */
+        err = rd_kafka_ClientQuotaFilter_add_component(
+            filter, "user", RD_KAFKA_CLIENT_QUOTA_MATCH_EXACT, "alice",
+            errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for EXACT component, got %s",
+                    rd_kafka_err2str(err));
+
+        /* DEFAULT match (NULL name) */
+        err = rd_kafka_ClientQuotaFilter_add_component(
+            filter, "user", RD_KAFKA_CLIENT_QUOTA_MATCH_DEFAULT, NULL, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for DEFAULT component, got %s",
+                    rd_kafka_err2str(err));
+
+        /* ANY match (NULL name) */
+        err = rd_kafka_ClientQuotaFilter_add_component(
+            filter, "client-id", RD_KAFKA_CLIENT_QUOTA_MATCH_ANY, NULL,
+            errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for ANY component, got %s",
+                    rd_kafka_err2str(err));
+
+        rd_kafka_ClientQuotaFilter_destroy(filter);
+
+        /* Strict filter */
+        filter = rd_kafka_ClientQuotaFilter_new(1 /*strict*/);
+        TEST_ASSERT(filter != NULL, "expected non-NULL strict filter");
+        rd_kafka_ClientQuotaFilter_destroy(filter);
+
+        /* Empty filter (no components, matches all) */
+        filter = rd_kafka_ClientQuotaFilter_new(0 /*strict*/);
+        TEST_ASSERT(filter != NULL, "expected non-NULL empty filter");
+        rd_kafka_ClientQuotaFilter_destroy(filter);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test ClientQuotaEntry construction and input validation.
+ */
+static void do_test_ClientQuotaEntry(void) {
+        rd_kafka_ClientQuotaEntry_t *entry;
+        rd_kafka_resp_err_t err;
+        char errstr[512];
+
+        SUB_TEST_QUICK();
+
+        entry = rd_kafka_ClientQuotaEntry_new();
+        TEST_ASSERT(entry != NULL, "expected non-NULL entry");
+
+        /* NULL entity type must be rejected */
+        *errstr = '\0';
+        err = rd_kafka_ClientQuotaEntry_add_entity(entry, NULL, "user1",
+                                                   errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected INVALID_ARG for NULL entity type, got %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(*errstr != '\0',
+                    "expected non-empty errstr for NULL entity type");
+
+        /* Valid entity with a name */
+        err = rd_kafka_ClientQuotaEntry_add_entity(entry, "user", "alice",
+                                                   errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for valid entity, got %s",
+                    rd_kafka_err2str(err));
+
+        /* Valid entity with NULL name (default entity) */
+        err = rd_kafka_ClientQuotaEntry_add_entity(entry, "client-id", NULL,
+                                                   errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for entity with NULL name, got %s",
+                    rd_kafka_err2str(err));
+
+        /* NULL quota key must be rejected */
+        *errstr = '\0';
+        err     = rd_kafka_ClientQuotaEntry_add_operation(
+            entry, NULL, 1024.0, 0 /*remove*/, errstr, sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected INVALID_ARG for NULL quota key, got %s",
+                    rd_kafka_err2str(err));
+        TEST_ASSERT(*errstr != '\0',
+                    "expected non-empty errstr for NULL quota key");
+
+        /* Valid set operation */
+        err = rd_kafka_ClientQuotaEntry_add_operation(
+            entry, "producer_byte_rate", 1024.0, 0 /*remove*/, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for set operation, got %s",
+                    rd_kafka_err2str(err));
+
+        /* Valid remove operation */
+        err = rd_kafka_ClientQuotaEntry_add_operation(
+            entry, "consumer_byte_rate", 0.0, 1 /*remove*/, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for remove operation, got %s",
+                    rd_kafka_err2str(err));
+
+        rd_kafka_ClientQuotaEntry_destroy(entry);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test DescribeClientQuotas local timeout (no broker).
+ */
+static void do_test_DescribeClientQuotas(const char *what,
+                                         rd_kafka_t *rk,
+                                         rd_kafka_queue_t *useq,
+                                         int with_options) {
+        rd_kafka_queue_t *q;
+        rd_kafka_ClientQuotaFilter_t *filter;
+        rd_kafka_AdminOptions_t *options = NULL;
+        int exp_timeout                  = MY_SOCKET_TIMEOUT_MS;
+        char errstr[512];
+        const char *errstr2;
+        rd_kafka_resp_err_t err;
+        test_timing_t timing;
+        rd_kafka_event_t *rkev;
+        const rd_kafka_DescribeClientQuotas_result_t *res;
+
+        SUB_TEST_QUICK("%s DescribeClientQuotas with %s, timeout %dms",
+                       rd_kafka_name(rk), what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        filter = rd_kafka_ClientQuotaFilter_new(0 /*strict*/);
+        err    = rd_kafka_ClientQuotaFilter_add_component(
+            filter, "user", RD_KAFKA_CLIENT_QUOTA_MATCH_ANY, NULL, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(!err, "add_component: %s", errstr);
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(
+                    rk, RD_KAFKA_ADMIN_OP_DESCRIBECLIENTQUOTAS);
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+                err         = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+        }
+
+        TIMING_START(&timing, "DescribeClientQuotas");
+        TEST_SAY("Call DescribeClientQuotas, timeout is %dms\n", exp_timeout);
+        rd_kafka_DescribeClientQuotas(rk, filter, options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        rd_kafka_ClientQuotaFilter_destroy(filter);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "DescribeClientQuotas.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("DescribeClientQuotas: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev),
+                 TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Verify event type */
+        res = rd_kafka_event_DescribeClientQuotas_result(rkev);
+        TEST_ASSERT(res, "expected DescribeClientQuotas_result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        /* Expecting timeout error since there is no broker */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected DescribeClientQuotas to return %s, not %s (%s)",
+                    rd_kafka_err2str(RD_KAFKA_RESP_ERR__TIMED_OUT),
+                    rd_kafka_err2str(err), err ? errstr2 : "n/a");
+
+        rd_kafka_event_destroy(rkev);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test AlterClientQuotas local timeout (no broker).
+ */
+static void do_test_AlterClientQuotas(const char *what,
+                                      rd_kafka_t *rk,
+                                      rd_kafka_queue_t *useq,
+                                      int with_options) {
+        rd_kafka_queue_t *q;
+#define MY_ALTER_QUOTA_ENTRIES_CNT 2
+        rd_kafka_ClientQuotaEntry_t *entries[MY_ALTER_QUOTA_ENTRIES_CNT];
+        rd_kafka_AdminOptions_t *options = NULL;
+        int exp_timeout                  = MY_SOCKET_TIMEOUT_MS;
+        char errstr[512];
+        const char *errstr2;
+        rd_kafka_resp_err_t err;
+        test_timing_t timing;
+        rd_kafka_event_t *rkev;
+        const rd_kafka_AlterClientQuotas_result_t *res;
+
+        SUB_TEST_QUICK("%s AlterClientQuotas with %s, timeout %dms",
+                       rd_kafka_name(rk), what, exp_timeout);
+
+        q = useq ? useq : rd_kafka_queue_new(rk);
+
+        /* First entry: set producer_byte_rate for user "alice" */
+        entries[0] = rd_kafka_ClientQuotaEntry_new();
+        err        = rd_kafka_ClientQuotaEntry_add_entity(
+            entries[0], "user", "alice", errstr, sizeof(errstr));
+        TEST_ASSERT(!err, "add_entity: %s", errstr);
+        err = rd_kafka_ClientQuotaEntry_add_operation(
+            entries[0], "producer_byte_rate", 1024.0, 0 /*remove*/, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(!err, "add_operation: %s", errstr);
+
+        /* Second entry: remove consumer_byte_rate for client-id "my-client" */
+        entries[1] = rd_kafka_ClientQuotaEntry_new();
+        err        = rd_kafka_ClientQuotaEntry_add_entity(
+            entries[1], "client-id", "my-client", errstr, sizeof(errstr));
+        TEST_ASSERT(!err, "add_entity: %s", errstr);
+        err = rd_kafka_ClientQuotaEntry_add_operation(
+            entries[1], "consumer_byte_rate", 0.0, 1 /*remove*/, errstr,
+            sizeof(errstr));
+        TEST_ASSERT(!err, "add_operation: %s", errstr);
+
+        if (with_options) {
+                options = rd_kafka_AdminOptions_new(
+                    rk, RD_KAFKA_ADMIN_OP_ALTERCLIENTQUOTAS);
+                exp_timeout = MY_SOCKET_TIMEOUT_MS * 2;
+                err         = rd_kafka_AdminOptions_set_request_timeout(
+                    options, exp_timeout, errstr, sizeof(errstr));
+                TEST_ASSERT(!err, "%s", rd_kafka_err2str(err));
+        }
+
+        TIMING_START(&timing, "AlterClientQuotas");
+        TEST_SAY("Call AlterClientQuotas, timeout is %dms\n", exp_timeout);
+        rd_kafka_AlterClientQuotas(rk, entries, MY_ALTER_QUOTA_ENTRIES_CNT,
+                                   options, q);
+        TIMING_ASSERT_LATER(&timing, 0, 50);
+
+        rd_kafka_ClientQuotaEntry_destroy(entries[0]);
+        rd_kafka_ClientQuotaEntry_destroy(entries[1]);
+
+        /* Poll result queue */
+        TIMING_START(&timing, "AlterClientQuotas.queue_poll");
+        rkev = rd_kafka_queue_poll(q, exp_timeout + 1000);
+        TIMING_ASSERT_LATER(&timing, exp_timeout - 100, exp_timeout + 100);
+        TEST_ASSERT(rkev != NULL, "expected result in %dms", exp_timeout);
+        TEST_SAY("AlterClientQuotas: got %s in %.3fs\n",
+                 rd_kafka_event_name(rkev),
+                 TIMING_DURATION(&timing) / 1000.0f);
+
+        /* Verify event type */
+        res = rd_kafka_event_AlterClientQuotas_result(rkev);
+        TEST_ASSERT(res, "expected AlterClientQuotas_result, not %s",
+                    rd_kafka_event_name(rkev));
+
+        /* Expecting timeout error since there is no broker */
+        err     = rd_kafka_event_error(rkev);
+        errstr2 = rd_kafka_event_error_string(rkev);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__TIMED_OUT,
+                    "expected AlterClientQuotas to return %s, not %s (%s)",
+                    rd_kafka_err2str(RD_KAFKA_RESP_ERR__TIMED_OUT),
+                    rd_kafka_err2str(err), err ? errstr2 : "n/a");
+
+        rd_kafka_event_destroy(rkev);
+
+        if (options)
+                rd_kafka_AdminOptions_destroy(options);
+
+        if (!useq)
+                rd_kafka_queue_destroy(q);
+
+#undef MY_ALTER_QUOTA_ENTRIES_CNT
+
+        SUB_TEST_PASS();
+}
+
+
+static void do_test_apis(rd_kafka_type_t cltype) {
+        rd_kafka_t *rk;
+        rd_kafka_queue_t *mainq;
+
+        rk    = create_quota_admin_client(cltype);
+        mainq = rd_kafka_queue_get_main(rk);
+
+        do_test_ClientQuotaFilter();
+        do_test_ClientQuotaEntry();
+
+        do_test_DescribeClientQuotas("temp queue, no options", rk, NULL, 0);
+        do_test_DescribeClientQuotas("temp queue, options", rk, NULL, 1);
+        do_test_DescribeClientQuotas("main queue, options", rk, mainq, 1);
+
+        do_test_AlterClientQuotas("temp queue, no options", rk, NULL, 0);
+        do_test_AlterClientQuotas("temp queue, options", rk, NULL, 1);
+        do_test_AlterClientQuotas("main queue, options", rk, mainq, 1);
+
+        rd_kafka_queue_destroy(mainq);
+        rd_kafka_destroy(rk);
+}
+
+
+int main_0154_admin_quota_ut(int argc, char **argv) {
+        do_test_apis(RD_KAFKA_PRODUCER);
+        do_test_apis(RD_KAFKA_CONSUMER);
+        return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,7 @@ set(
     0151-purge-brokers.c
     0152-rebootstrap.c
     0153-memberid.c
+    0154-admin_quota_ut.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -100,7 +100,7 @@ static const char *test_states[] = {
 
 #define _TEST_DECL(NAME) extern int main_##NAME(int, char **)
 #define _TEST(NAME, FLAGS, ...)                                                \
-        { .name = #NAME, .mainfunc = main_##NAME, .flags = FLAGS, __VA_ARGS__ }
+        {.name = #NAME, .mainfunc = main_##NAME, .flags = FLAGS, __VA_ARGS__}
 
 
 /**

--- a/tests/test.c
+++ b/tests/test.c
@@ -272,6 +272,7 @@ _TEST_DECL(0150_telemetry_mock);
 _TEST_DECL(0151_purge_brokers_mock);
 _TEST_DECL(0152_rebootstrap_local);
 _TEST_DECL(0153_memberid);
+_TEST_DECL(0154_admin_quota_ut);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -540,6 +541,7 @@ struct test tests[] = {
     _TEST(0151_purge_brokers_mock, TEST_F_LOCAL),
     _TEST(0152_rebootstrap_local, TEST_F_LOCAL),
     _TEST(0153_memberid, TEST_F_LOCAL),
+    _TEST(0154_admin_quota_ut, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),


### PR DESCRIPTION
As referenced in #5227, multiple users have requested support for AlterClientQuotas and DescribeClientQuotas requests.

This PR adds the capabilities mentioned in [KIP-546](https://cwiki.apache.org/confluence/display/KAFKA/KIP-546%3A+Add+Client+Quota+APIs+to+the+Admin+Client). 