### PR TITLE
[KIP-932] Add rd_kafka_share_commit_sync() API

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,6 +2,7 @@ EXAMPLES ?= rdkafka_example rdkafka_performance rdkafka_example_cpp \
 	rdkafka_complex_consumer_example rdkafka_complex_consumer_example_cpp \
 	kafkatest_verifiable_client \
 	producer consumer share_consumer share_consumer_commit_async \
+	share_consumer_commit_sync \
 	idempotent_producer transactions \
 	delete_records \
 	openssl_engine_example_cpp \
@@ -60,6 +61,10 @@ share_consumer: ../src/librdkafka.a share_consumer.c
 		../src/librdkafka.a $(LIBS)
 
 share_consumer_commit_async: ../src/librdkafka.a share_consumer_commit_async.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
+		../src/librdkafka.a $(LIBS)
+
+share_consumer_commit_sync: ../src/librdkafka.a share_consumer_commit_sync.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $@.c -o $@ $(LDFLAGS) \
 		../src/librdkafka.a $(LIBS)
 

--- a/examples/share_consumer_commit_sync.c
+++ b/examples/share_consumer_commit_sync.c
@@ -1,0 +1,304 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Share consumer example using rd_kafka_share_commit_sync() to
+ * explicitly acknowledge and synchronously commit records.
+ *
+ * Usage:
+ *   share_consumer_commit_sync <broker> <group.id> <topic1> [topic2 ...]
+ *
+ * This example demonstrates:
+ *  - Consuming records with rd_kafka_share_consume_batch()
+ *  - Explicitly acknowledging individual records with
+ *    rd_kafka_share_acknowledge_type() using ACCEPT, RELEASE, or REJECT
+ *  - Committing acknowledgements synchronously with
+ *    rd_kafka_share_commit_sync() at ~10% rate mid-batch,
+ *    printing per-partition results
+ */
+
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 199309L
+#endif
+
+#include <stdio.h>
+#include <signal.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <time.h>
+
+/* Typical include path would be <librdkafka/rdkafka.h>, but this program
+ * is builtin from within the librdkafka source tree and thus differs. */
+#include "rdkafka.h"
+
+
+static volatile sig_atomic_t run = 1;
+
+/**
+ * @brief Signal termination of program
+ */
+static void stop(int sig) {
+        run = 0;
+}
+
+
+/**
+ * @returns 1 if all bytes are printable, else 0.
+ */
+static int is_printable(const char *buf, size_t size) {
+        size_t i;
+
+        for (i = 0; i < size; i++)
+                if (!isprint((int)buf[i]))
+                        return 0;
+
+        return 1;
+}
+
+static const char *ack_type_to_str(rd_kafka_share_AcknowledgeType_t type) {
+        switch (type) {
+        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT:
+                return "ACCEPT";
+        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE:
+                return "RELEASE";
+        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT:
+                return "REJECT";
+        default:
+                return "UNKNOWN";
+        }
+}
+
+
+int main(int argc, char **argv) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        rd_kafka_resp_err_t err;
+        char errstr[512];
+        const char *brokers;
+        const char *groupid;
+        char **topics;
+        int topic_cnt;
+        rd_kafka_topic_partition_list_t *subscription;
+        int i;
+
+        if (argc < 4) {
+                fprintf(stderr,
+                        "%% Usage: "
+                        "%s <broker> <group.id> <topic1> [topic2 ..]\n",
+                        argv[0]);
+                return 1;
+        }
+
+        brokers   = argv[1];
+        groupid   = argv[2];
+        topics    = &argv[3];
+        topic_cnt = argc - 3;
+
+        conf = rd_kafka_conf_new();
+
+        if (rd_kafka_conf_set(conf, "bootstrap.servers", brokers, errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                fprintf(stderr, "%s\n", errstr);
+                rd_kafka_conf_destroy(conf);
+                return 1;
+        }
+
+        if (rd_kafka_conf_set(conf, "group.id", groupid, errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                fprintf(stderr, "%s\n", errstr);
+                rd_kafka_conf_destroy(conf);
+                return 1;
+        }
+
+        if (rd_kafka_conf_set(conf, "share.acknowledgement.mode", "explicit",
+                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                fprintf(stderr, "%s\n", errstr);
+                rd_kafka_conf_destroy(conf);
+                return 1;
+        }
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        if (!rkshare) {
+                fprintf(stderr, "%% Failed to create new share consumer: %s\n",
+                        errstr);
+                return 1;
+        }
+
+        conf = NULL;
+
+        subscription = rd_kafka_topic_partition_list_new(topic_cnt);
+        for (i = 0; i < topic_cnt; i++)
+                rd_kafka_topic_partition_list_add(subscription, topics[i],
+                                                  RD_KAFKA_PARTITION_UA);
+
+        err = rd_kafka_share_subscribe(rkshare, subscription);
+        if (err) {
+                fprintf(stderr, "%% Failed to subscribe to %d topics: %s\n",
+                        subscription->cnt, rd_kafka_err2str(err));
+                rd_kafka_topic_partition_list_destroy(subscription);
+                rd_kafka_share_destroy(rkshare);
+                return 1;
+        }
+
+        fprintf(stderr,
+                "%% Subscribed to %d topic(s), "
+                "waiting for rebalance and messages...\n",
+                subscription->cnt);
+
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        signal(SIGINT, stop);
+
+        srand((unsigned int)time(NULL));
+
+        rd_kafka_message_t *rkmessages[10001];
+        while (run) {
+                size_t rcvd_msgs = 0;
+                rd_kafka_error_t *error;
+
+                printf("Calling rd_kafka_share_consume_batch()\n");
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd_msgs);
+
+                if (error) {
+                        fprintf(stderr, "%% Consume error: %s\n",
+                                rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                if (rcvd_msgs == 0)
+                        continue;
+
+                printf("Received %zu messages\n", rcvd_msgs);
+
+                for (i = 0; i < (int)rcvd_msgs; i++) {
+                        rd_kafka_message_t *rkm = rkmessages[i];
+                        rd_kafka_share_AcknowledgeType_t ack_type;
+                        int r;
+
+                        if (rkm->err) {
+                                fprintf(stderr, "%% Consumer error: %d: %s\n",
+                                        rkm->err, rd_kafka_message_errstr(rkm));
+                                rd_kafka_message_destroy(rkm);
+                                continue;
+                        }
+
+                        /* Randomly choose ack type:
+                         *   50% ACCEPT, 30% RELEASE, 20% REJECT */
+                        r = rand() % 100;
+                        if (r < 50)
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+                        else if (r < 80)
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
+                        else
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
+
+                        printf("Message on %s [%" PRId32 "] at offset %" PRId64
+                               " (delivery count: %" PRId16 ") -> %s",
+                               rd_kafka_topic_name(rkm->rkt), rkm->partition,
+                               rkm->offset,
+                               rd_kafka_message_delivery_count(rkm),
+                               ack_type_to_str(ack_type));
+
+                        if (rkm->key && is_printable(rkm->key, rkm->key_len))
+                                printf(" Key: %.*s", (int)rkm->key_len,
+                                       (const char *)rkm->key);
+
+                        if (rkm->payload &&
+                            is_printable(rkm->payload, rkm->len))
+                                printf(" Value: %.*s", (int)rkm->len,
+                                       (const char *)rkm->payload);
+
+                        printf("\n");
+
+                        err = rd_kafka_share_acknowledge_type(rkshare, rkm,
+                                                              ack_type);
+                        if (err)
+                                fprintf(stderr,
+                                        "%% Acknowledge error for "
+                                        "%s [%" PRId32 "] @ %" PRId64 ": %s\n",
+                                        rd_kafka_topic_name(rkm->rkt),
+                                        rkm->partition, rkm->offset,
+                                        rd_kafka_err2str(err));
+
+                        rd_kafka_message_destroy(rkm);
+
+                        /* Randomly commit ~10% of the time to
+                         * exercise sync commit mid-batch. */
+                        if (run && (rand() % 100) < 10) {
+                                rd_kafka_topic_partition_list_t *partitions =
+                                    NULL;
+
+                                printf(
+                                    "Calling "
+                                    "rd_kafka_share_commit_sync()\n");
+                                error = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                if (error) {
+                                        fprintf(stderr,
+                                                "%% Commit sync error: %s\n",
+                                                rd_kafka_error_string(error));
+                                        rd_kafka_error_destroy(error);
+                                } else if (partitions) {
+                                        int j;
+                                        printf(
+                                            "Commit sync results "
+                                            "(%d partitions):\n",
+                                            partitions->cnt);
+                                        for (j = 0; j < partitions->cnt; j++) {
+                                                rd_kafka_topic_partition_t
+                                                    *rktpar =
+                                                        &partitions->elems[j];
+                                                printf("  %s [%" PRId32
+                                                       "]: %s\n",
+                                                       rktpar->topic,
+                                                       rktpar->partition,
+                                                       rd_kafka_err2str(
+                                                           rktpar->err));
+                                        }
+                                        rd_kafka_topic_partition_list_destroy(
+                                            partitions);
+                                } else {
+                                        printf("No pending acks to commit\n");
+                                }
+                        }
+                }
+        }
+
+        fprintf(stderr, "%% Closing share consumer\n");
+        rd_kafka_share_consumer_close(rkshare);
+
+        rd_kafka_share_destroy(rkshare);
+
+        return 0;
+}

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3937,7 +3937,9 @@ static void rd_kafka_share_commit_sync_timeout_cb(rd_kafka_timers_t *rkts,
         }
         rd_kafka_rdunlock(rk);
 
-        /* Fill partitions still IN_PROGRESS with REQUEST_TIMED_OUT */
+        /* TODO: Verify that __TIMED_OUT (local timeout) is the correct
+         *  error here rather than REQUEST_TIMED_OUT (broker error). */
+        /* Fill partitions still IN_PROGRESS with __TIMED_OUT */
         results = rkcg->rkcg_commit_sync_request.results;
         for (i = 0; i < results->cnt; i++) {
                 rd_kafka_topic_partition_t *rktpar = &results->elems[i];

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3175,6 +3175,12 @@ rd_kafka_share_fetch_fanout_with_backoff(rd_kafka_t *rk,
                 rd_kafka_share_fetch_fanout_enqueue(rk, rko);
 }
 
+/* Forward declarations for commit_sync helpers used in reply handler */
+static void rd_kafka_share_commit_sync_maybe_complete(rd_kafka_t *rk,
+                                                      rd_kafka_cgrp_t *rkcg);
+static void rd_kafka_share_enqueue_sync_ack_op(rd_kafka_t *rk,
+                                               rd_kafka_broker_t *rkb);
+
 /**
  * Handles RD_KAFKA_OP_SHARE_FETCH | RD_KAFKA_OP_REPLY.
  * @locality main thread
@@ -3209,7 +3215,65 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                 rkcg->rkcg_share.share_fetch_more_records = rd_false;
 
         /*
-         * Step 2: If this was the fetch broker but no records were received,
+         * Step 2: Handle commit_sync reply if this op belongs to
+         * the current commit_sync request.
+         */
+        if (rko_orig->rko_u.share_fetch.commit_sync_request_id != 0 &&
+            rko_orig->rko_u.share_fetch.commit_sync_request_id ==
+                rkcg->rkcg_commit_sync_request.id) {
+                rd_kafka_topic_partition_list_t *ack_results =
+                    rko_orig->rko_u.share_fetch.ack_results;
+
+                if (ack_results) {
+                        int k;
+                        for (k = 0; k < ack_results->cnt; k++) {
+                                rd_kafka_topic_partition_t *src =
+                                    &ack_results->elems[k];
+                                rd_kafka_topic_partition_t *dst =
+                                    rd_kafka_topic_partition_list_find(
+                                        rkcg->rkcg_commit_sync_request.results,
+                                        src->topic, src->partition);
+                                if (dst)
+                                        dst->err = src->err;
+                        }
+                }
+
+                /* TODO KIP-932: When broker reply has a top-level error
+                 * (e.g. SHARE_SESSION_NOT_FOUND, __TRANSPORT, __DESTROY)
+                 * ack_results is NULL but partitions handled by this
+                 * broker remain as _IN_PROGRESS sentinel. Should map
+                 * rko_orig->rko_err to all partitions that were sent
+                 * to this broker so they don't leak _IN_PROGRESS to
+                 * the caller. */
+
+                rkcg->rkcg_commit_sync_request.wait_broker_result_count--;
+
+                rd_kafka_dbg(
+                    rk, CGRP, "SHARE",
+                    "Commit sync reply from broker %s: %s, "
+                    "remaining brokers: %d",
+                    rd_kafka_broker_name(reply_rkb),
+                    rd_kafka_err2str(rko_orig->rko_err),
+                    rkcg->rkcg_commit_sync_request.wait_broker_result_count);
+
+                rd_kafka_share_commit_sync_maybe_complete(rk, rkcg);
+        }
+
+        /*
+         * Step 3: Dispatch pending commit_sync to the replying broker
+         * (highest priority). Acks must always be sent.
+         */
+        if (!reply_rkb->rkb_share_fetch_enqueued &&
+            !rd_kafka_broker_or_instance_terminating(reply_rkb) &&
+            reply_rkb->rkb_pending_commit_sync.sync_ack_details) {
+                rd_kafka_dbg(rk, CGRP, "SHARE",
+                             "Dispatching pending sync acks to broker %s",
+                             rd_kafka_broker_name(reply_rkb));
+                rd_kafka_share_enqueue_sync_ack_op(rk, reply_rkb);
+        }
+
+        /*
+         * Step 4: If this was the fetch broker but no records were received,
          * try to select another broker to fetch from.
          *
          * TODO: KIP-932: Handle the case where all assignments are removed
@@ -3243,7 +3307,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 3: If the replying broker has cached ack details,
+         * Step 5: If the replying broker has cached async ack details,
          * send an ack-only SHARE_FETCH op to it.
          */
         if (reply_rkb->rkb_share_async_ack_details &&
@@ -3379,6 +3443,20 @@ static void rd_kafka_share_segregate_acks_by_leader(rd_kafka_t *rk,
                          * is then fully destroyed (freeing its entries). */
                         rd_kafka_share_ack_batch_entry_t *entry;
                         int j;
+                        /*
+                         * TODO KIP-932: Merge with overlapping offsets into
+                         * single entry with single type. For example, if
+                         * existing has an ACCEPT for offsets 0-50 and new
+                         * batch has ACCEPT for offsets 51-100, they can be
+                         * merged into a single ACCEPT for offsets 0-100.
+                         * Currently, we are blindly adding entries from the
+                         * new batch into the existing batch, which means we
+                         * may end up with multiple adjacent or overlapping
+                         * entries of the same type that could have been
+                         * merged. This is not incorrect, but it is less
+                         * efficient in terms of the network bandwidth in the
+                         * RPC call.
+                         */
                         RD_LIST_FOREACH(entry, &batch->entries, j) {
                                 rd_list_add(
                                     &existing->entries,
@@ -3724,6 +3802,411 @@ rd_kafka_op_res_t rd_kafka_share_commit_async_fanout_op(rd_kafka_t *rk,
 }
 
 /**
+ * @brief Merge ack batches from \p src_list into \p dst_list.
+ *
+ * For each batch in src_list, finds a matching topic-partition in
+ * dst_list. If found, deep-copies entries from src into existing
+ * batch and re-sorts by start_offset. If not found, moves the
+ * batch as-is.
+ *
+ * @param dst_list Destination list (rd_kafka_share_ack_batches_t*).
+ * @param src_list Source list (rd_kafka_share_ack_batches_t*).
+ *                 Elements are moved or destroyed; list is emptied.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_merge_ack_lists(rd_list_t *dst_list,
+                                           rd_list_t *src_list) {
+        rd_kafka_share_ack_batches_t *batch;
+
+        while ((batch = rd_list_pop(src_list))) {
+                rd_kafka_share_ack_batches_t *existing;
+
+                existing =
+                    rd_kafka_share_find_ack_batch(dst_list, batch->rktpar);
+                if (existing) {
+                        rd_kafka_share_ack_batch_entry_t *entry;
+                        int j;
+                        RD_LIST_FOREACH(entry, &batch->entries, j) {
+                                rd_list_add(
+                                    &existing->entries,
+                                    rd_kafka_share_ack_batch_entry_copy(entry));
+                        }
+                        rd_list_sort(&existing->entries,
+                                     rd_kafka_share_ack_entries_sort_cmp_ptr);
+                        rd_kafka_share_ack_batches_destroy(batch);
+                } else {
+                        rd_list_add(dst_list, batch);
+                }
+        }
+}
+
+/**
+ * @brief Send commit_sync response to the app thread and clear state.
+ *
+ * Creates a SHARE_COMMIT_SYNC_FANOUT reply op with the per-partition
+ * results and enqueues it on the app thread's temp queue. Clears the
+ * commit_sync request state.
+ *
+ * @param rkcg Consumer group handle.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
+        rd_kafka_op_t *rko_reply;
+
+        rko_reply = rd_kafka_op_new(RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY);
+        rko_reply->rko_u.share_commit_sync_fanout_reply.results =
+            rkcg->rkcg_commit_sync_request.results;
+
+        rd_kafka_q_enq(rkcg->rkcg_commit_sync_request.replyq, rko_reply);
+
+        rkcg->rkcg_commit_sync_request.id                       = 0;
+        rkcg->rkcg_commit_sync_request.results                  = NULL;
+        rkcg->rkcg_commit_sync_request.replyq                   = NULL;
+        rkcg->rkcg_commit_sync_request.abs_timeout              = 0;
+        rkcg->rkcg_commit_sync_request.wait_broker_result_count = 0;
+}
+
+/**
+ * @brief Check if all broker results are in and send response if done.
+ *
+ * Called after each broker reply arrives. If wait_broker_result_count
+ * reaches zero, stops the timeout timer and sends the response op
+ * to the app thread's temp queue.
+ *
+ * @param rk Client instance.
+ * @param rkcg Consumer group handle.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_commit_sync_maybe_complete(rd_kafka_t *rk,
+                                                      rd_kafka_cgrp_t *rkcg) {
+        if (rkcg->rkcg_commit_sync_request.wait_broker_result_count > 0)
+                return;
+
+        rd_kafka_timer_stop(&rk->rk_timers, &rkcg->rkcg_commit_sync_request.tmr,
+                            1);
+
+        rd_kafka_share_commit_sync_send_response(rkcg);
+}
+
+/**
+ * @brief Timeout callback for commit_sync.
+ *
+ * Fires when the commit_sync timeout expires. For each broker with
+ * pending_commit_sync, merges those acks into async_ack_details so
+ * they are sent asynchronously later. Fills all partitions still
+ * marked as IN_PROGRESS with REQUEST_TIMED_OUT. Sends the response.
+ *
+ * @locality main thread (timer thread -> main thread)
+ */
+static void rd_kafka_share_commit_sync_timeout_cb(rd_kafka_timers_t *rkts,
+                                                  void *arg) {
+        rd_kafka_t *rk        = rkts->rkts_rk;
+        rd_kafka_cgrp_t *rkcg = rd_kafka_cgrp_get(rk);
+        rd_kafka_broker_t *rkb;
+        rd_kafka_topic_partition_list_t *results;
+        int i;
+
+        rd_kafka_dbg(rk, CGRP, "SHARE",
+                     "Commit sync timeout fired, "
+                     "pending brokers: %d",
+                     rkcg->rkcg_commit_sync_request.wait_broker_result_count);
+
+        /* Move pending_commit_sync acks to async_ack_details */
+        rd_kafka_rdlock(rk);
+        TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (!rkb->rkb_pending_commit_sync.sync_ack_details)
+                        continue;
+
+                if (!rkb->rkb_share_async_ack_details)
+                        rkb->rkb_share_async_ack_details = rd_list_new(
+                            rd_list_cnt(
+                                rkb->rkb_pending_commit_sync.sync_ack_details),
+                            rd_kafka_share_ack_batches_destroy_free);
+
+                rd_kafka_share_merge_ack_lists(
+                    rkb->rkb_share_async_ack_details,
+                    rkb->rkb_pending_commit_sync.sync_ack_details);
+
+                rd_list_destroy(rkb->rkb_pending_commit_sync.sync_ack_details);
+                rkb->rkb_pending_commit_sync.sync_ack_details       = NULL;
+                rkb->rkb_pending_commit_sync.abs_timeout            = 0;
+                rkb->rkb_pending_commit_sync.commit_sync_request_id = 0;
+        }
+        rd_kafka_rdunlock(rk);
+
+        /* Fill partitions still IN_PROGRESS with REQUEST_TIMED_OUT */
+        results = rkcg->rkcg_commit_sync_request.results;
+        for (i = 0; i < results->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &results->elems[i];
+                if (rktpar->err == RD_KAFKA_RESP_ERR__IN_PROGRESS)
+                        rktpar->err = RD_KAFKA_RESP_ERR__TIMED_OUT;
+        }
+
+        rd_kafka_share_commit_sync_send_response(rkcg);
+}
+
+/**
+ * @brief Create and enqueue a sync ack-only SHARE_FETCH op on a broker.
+ *
+ * Moves ack details, abs_timeout, and commit_sync_request_id from
+ * rkb_pending_commit_sync into the op.
+ *
+ * @param rk Client instance.
+ * @param rkb Broker to enqueue on. Must have pending_commit_sync data.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_enqueue_sync_ack_op(rd_kafka_t *rk,
+                                               rd_kafka_broker_t *rkb) {
+        rd_kafka_op_t *rko_sf;
+
+        rko_sf = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
+        rko_sf->rko_u.share_fetch.should_leave = rd_false;
+        rko_sf->rko_u.share_fetch.abs_timeout =
+            rkb->rkb_pending_commit_sync.abs_timeout;
+        rko_sf->rko_u.share_fetch.should_fetch = rd_false;
+        rko_sf->rko_u.share_fetch.commit_sync_request_id =
+            rkb->rkb_pending_commit_sync.commit_sync_request_id;
+
+        /* Move ack details from pending_commit_sync to op */
+        rko_sf->rko_u.share_fetch.ack_details =
+            rkb->rkb_pending_commit_sync.sync_ack_details;
+        rkb->rkb_pending_commit_sync.sync_ack_details       = NULL;
+        rkb->rkb_pending_commit_sync.abs_timeout            = 0;
+        rkb->rkb_pending_commit_sync.commit_sync_request_id = 0;
+
+        rd_kafka_broker_keep(rkb);
+        rko_sf->rko_u.share_fetch.target_broker = rkb;
+        rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
+
+        rkb->rkb_share_fetch_enqueued = rd_true;
+
+        rd_kafka_dbg(
+            rk, CGRP, "SHARE",
+            "Enqueuing sync ack op on broker %s "
+            "(abs_timeout %" PRId64 ", commit_sync_request_id %" PRId64 ")",
+            rd_kafka_broker_name(rkb), rko_sf->rko_u.share_fetch.abs_timeout,
+            rko_sf->rko_u.share_fetch.commit_sync_request_id);
+
+        rd_kafka_q_enq(rkb->rkb_ops, rko_sf);
+}
+
+/**
+ * @brief Segregate sync ack batches by partition leader into
+ *        each broker's pending_commit_sync list.
+ *
+ * Phase 1 of sync dispatch: puts ALL acks into rkb_pending_commit_sync
+ * regardless of whether the broker is free or busy. Updates the
+ * commit_sync results for partitions with no available leader.
+ *
+ * @param rk Client instance.
+ * @param rkcg Consumer group handle.
+ * @param ack_batches List of ack batches from the SYNC_FANOUT op.
+ *                    Elements are moved to broker lists; container destroyed.
+ * @param abs_timeout Absolute timeout for the commit_sync request.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_segregate_sync_acks_by_leader(rd_kafka_t *rk,
+                                                         rd_kafka_cgrp_t *rkcg,
+                                                         rd_list_t *ack_batches,
+                                                         rd_ts_t abs_timeout) {
+        rd_kafka_share_ack_batches_t *batch;
+        int batch_cnt = rd_list_cnt(ack_batches);
+
+        while ((batch = rd_list_pop(ack_batches))) {
+                rd_kafka_toppar_t *rktp;
+                rd_kafka_broker_t *leader_rkb;
+                rd_kafka_share_ack_batches_t *existing;
+                rd_kafka_topic_partition_t *result_rktpar;
+
+                rktp = rd_kafka_topic_partition_toppar(rk, batch->rktpar);
+                if (!rktp || !rktp->rktp_leader) {
+                        result_rktpar = rd_kafka_topic_partition_list_find(
+                            rkcg->rkcg_commit_sync_request.results,
+                            batch->rktpar->topic, batch->rktpar->partition);
+                        if (result_rktpar)
+                                result_rktpar->err =
+                                    RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE;
+
+                        rd_kafka_dbg(rk, CGRP, "SHARE",
+                                     "Sync ack batch for %s [%" PRId32
+                                     "] dropped: "
+                                     "toppar or leader not available",
+                                     batch->rktpar->topic,
+                                     batch->rktpar->partition);
+                        rd_kafka_share_ack_batches_destroy(batch);
+                        continue;
+                }
+                leader_rkb = rktp->rktp_leader;
+
+                /* Put all acks into pending_commit_sync */
+                if (!leader_rkb->rkb_pending_commit_sync.sync_ack_details)
+                        leader_rkb->rkb_pending_commit_sync.sync_ack_details =
+                            rd_list_new(
+                                batch_cnt,
+                                rd_kafka_share_ack_batches_destroy_free);
+
+                existing = rd_kafka_share_find_ack_batch(
+                    leader_rkb->rkb_pending_commit_sync.sync_ack_details,
+                    batch->rktpar);
+                if (existing) {
+                        rd_kafka_share_ack_batch_entry_t *entry;
+                        int j;
+                        RD_LIST_FOREACH(entry, &batch->entries, j) {
+                                rd_list_add(
+                                    &existing->entries,
+                                    rd_kafka_share_ack_batch_entry_copy(entry));
+                        }
+                        rd_list_sort(&existing->entries,
+                                     rd_kafka_share_ack_entries_sort_cmp_ptr);
+                        rd_kafka_share_ack_batches_destroy(batch);
+                } else {
+                        rd_list_add(leader_rkb->rkb_pending_commit_sync
+                                        .sync_ack_details,
+                                    batch);
+                }
+
+                leader_rkb->rkb_pending_commit_sync.abs_timeout = abs_timeout;
+                leader_rkb->rkb_pending_commit_sync.commit_sync_request_id =
+                    rkcg->rkcg_commit_sync_request.id;
+        }
+
+        rd_list_destroy(ack_batches);
+}
+
+/**
+ * @brief Dispatch pending sync ack requests to free brokers.
+ *
+ * Phase 2 of sync dispatch: iterates all brokers. For each broker
+ * that has pending_commit_sync, increments wait_broker_result_count.
+ * If the broker is free (no inflight request), dispatches the
+ * pending sync acks immediately.
+ *
+ * @param rk Client instance.
+ * @param rkcg Consumer group handle.
+ *
+ * @locality main thread
+ */
+static void rd_kafka_share_dispatch_pending_sync_acks(rd_kafka_t *rk,
+                                                      rd_kafka_cgrp_t *rkcg) {
+        rd_kafka_broker_t *rkb;
+
+        rd_kafka_rdlock(rk);
+        TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
+                if (!rkb->rkb_pending_commit_sync.sync_ack_details)
+                        continue;
+
+                rkcg->rkcg_commit_sync_request.wait_broker_result_count++;
+
+                if (rkb->rkb_share_fetch_enqueued ||
+                    rd_kafka_broker_or_instance_terminating(rkb)) {
+                        rd_kafka_dbg(rk, CGRP, "SHARE",
+                                     "Broker %s has in-flight request, "
+                                     "sync acks stored in pending_commit_sync",
+                                     rd_kafka_broker_name(rkb));
+                        continue;
+                }
+
+                /* Broker is free — dispatch pending sync acks */
+                rd_kafka_share_enqueue_sync_ack_op(rk, rkb);
+        }
+        rd_kafka_rdunlock(rk);
+}
+
+/**
+ * @brief Main thread handler for SHARE_COMMIT_SYNC_FANOUT op.
+ *
+ * Stores the commit_sync request state, segregates acks by leader
+ * into pending_commit_sync, then dispatches to free brokers and
+ * starts the timeout timer.
+ *
+ * @locality main thread
+ */
+rd_kafka_op_res_t rd_kafka_share_commit_sync_fanout_op(rd_kafka_t *rk,
+                                                       rd_kafka_q_t *rkq,
+                                                       rd_kafka_op_t *rko) {
+        rd_kafka_cgrp_t *rkcg = rd_kafka_cgrp_get(rk);
+        rd_list_t *ack_batches =
+            rko->rko_u.share_commit_sync_fanout.ack_batches;
+        rd_ts_t abs_timeout = rko->rko_u.share_commit_sync_fanout.abs_timeout;
+        rd_kafka_topic_partition_list_t *results =
+            rko->rko_u.share_commit_sync_fanout.results;
+        int i;
+        int64_t timeout_us;
+
+        /* Take ownership from op */
+        rko->rko_u.share_commit_sync_fanout.ack_batches = NULL;
+        rko->rko_u.share_commit_sync_fanout.results     = NULL;
+
+        /* Initialize commit_sync request state */
+        rkcg->rkcg_share.commit_sync_id_counter++;
+        if (rkcg->rkcg_share.commit_sync_id_counter == INT64_MAX)
+                rkcg->rkcg_share.commit_sync_id_counter = 1;
+        rkcg->rkcg_commit_sync_request.id =
+            rkcg->rkcg_share.commit_sync_id_counter;
+        rkcg->rkcg_commit_sync_request.abs_timeout = abs_timeout;
+        rkcg->rkcg_commit_sync_request.replyq      = rko->rko_replyq.q;
+        rko->rko_replyq.q = NULL; /* Take ownership of replyq */
+        rkcg->rkcg_commit_sync_request.results                  = results;
+        rkcg->rkcg_commit_sync_request.wait_broker_result_count = 0;
+
+        /* Initialize all partition errors to IN_PROGRESS sentinel */
+        for (i = 0; i < results->cnt; i++)
+                results->elems[i].err = RD_KAFKA_RESP_ERR__IN_PROGRESS;
+
+        if (!ack_batches || rd_list_cnt(ack_batches) == 0) {
+                rd_kafka_dbg(rk, CGRP, "SHARE",
+                             "No acks to commit in "
+                             "SHARE_COMMIT_SYNC_FANOUT, "
+                             "sending immediate response");
+
+                for (i = 0; i < results->cnt; i++)
+                        results->elems[i].err = RD_KAFKA_RESP_ERR_NO_ERROR;
+
+                rd_kafka_share_commit_sync_send_response(rkcg);
+                RD_IF_FREE(ack_batches, rd_list_destroy);
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
+        /* Phase 1: Segregate all acks into rkb_pending_commit_sync */
+        rd_kafka_share_segregate_sync_acks_by_leader(rk, rkcg, ack_batches,
+                                                     abs_timeout);
+
+        /* Phase 2: Dispatch pending sync acks to free brokers */
+        rd_kafka_share_dispatch_pending_sync_acks(rk, rkcg);
+
+        if (rkcg->rkcg_commit_sync_request.wait_broker_result_count == 0) {
+                rd_kafka_dbg(rk, CGRP, "SHARE",
+                             "No brokers available for commit sync, "
+                             "sending immediate response");
+                rd_kafka_share_commit_sync_send_response(rkcg);
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
+        /* Start timeout timer */
+        timeout_us = abs_timeout - rd_clock();
+        if (timeout_us <= 0)
+                timeout_us = 1;
+
+        rd_kafka_timer_start_oneshot(
+            &rk->rk_timers, &rkcg->rkcg_commit_sync_request.tmr,
+            rd_true /*restart*/, timeout_us,
+            rd_kafka_share_commit_sync_timeout_cb, NULL);
+
+        rd_kafka_dbg(rk, CGRP, "SHARE",
+                     "Commit sync fanout: waiting for %d broker results, "
+                     "timeout in %" PRId64 " ms",
+                     rkcg->rkcg_commit_sync_request.wait_broker_result_count,
+                     timeout_us / 1000);
+
+        return RD_KAFKA_OP_RES_HANDLED;
+}
+
+/**
  * @brief Asynchronously commit all pending acknowledgements.
  *
  * Builds ack details from the inflight map and enqueues a
@@ -3742,6 +4225,8 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_op_t *rko;
         rd_list_t *ack_batches;
+
+        rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -3762,6 +4247,106 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rko->rko_u.share_commit_async_fanout.ack_batches = ack_batches;
 
         rd_kafka_q_enq(rk->rk_ops, rko);
+
+        return NULL;
+}
+
+/**
+ * @brief Synchronously commit all pending acknowledgements.
+ *
+ * Builds ack details from the inflight map and enqueues a
+ * SHARE_COMMIT_SYNC_FANOUT op on the main thread. Blocks the
+ * app thread on a temp queue until the main thread sends a
+ * response (or timeout fires).
+ *
+ * In implicit ack mode, all ACQUIRED records are first converted
+ * to ACCEPT before building the ack details.
+ *
+ * @param rkshare Share consumer instance.
+ * @param timeout_ms Timeout in milliseconds.
+ * @param partitions [out] Per-partition results. Each partition's err
+ *                   field contains the result. The caller must destroy
+ *                   the returned list with
+ *                   rd_kafka_topic_partition_list_destroy().
+ *                   Set to NULL if no acks were pending.
+ *
+ * @returns NULL on success, or an rd_kafka_error_t* on failure.
+ *          The returned error must be freed with rd_kafka_error_destroy().
+ *
+ * @locality app thread
+ */
+rd_kafka_error_t *
+rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
+                           int timeout_ms,
+                           rd_kafka_topic_partition_list_t **partitions) {
+        rd_kafka_t *rk = rkshare->rkshare_rk;
+        rd_kafka_op_t *rko;
+        rd_kafka_op_t *rko_reply;
+        rd_list_t *ack_batches;
+        rd_kafka_q_t *tmpq;
+        rd_ts_t abs_timeout;
+        rd_kafka_topic_partition_list_t *results;
+        int i;
+
+        *partitions = NULL;
+
+        rd_kafka_dbg(rk, CGRP, "SHARE",
+                     "Committing synchronously with timeout %d ms", timeout_ms);
+
+        /* Drain rk_rep for all pending callbacks (non-blocking) */
+        rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
+                         rd_kafka_poll_cb, NULL);
+
+        rd_kafka_share_acknowledge_all_if_implicit(rkshare);
+
+        ack_batches = rd_kafka_share_build_ack_details(rk->rk_rkshare);
+
+        if (!ack_batches) {
+                rd_kafka_dbg(rk, CGRP, "SHARE",
+                             "No pending acknowledgements to commit sync");
+                return NULL;
+        }
+
+        abs_timeout = rd_timeout_init(timeout_ms);
+
+        /* Build per-partition results list from ack batches */
+        results = rd_kafka_topic_partition_list_new(rd_list_cnt(ack_batches));
+        for (i = 0; i < rd_list_cnt(ack_batches); i++) {
+                rd_kafka_share_ack_batches_t *batch =
+                    rd_list_elem(ack_batches, i);
+                rd_kafka_topic_partition_list_add_copy(results, batch->rktpar);
+        }
+
+        /* Create temp queue for blocking */
+        tmpq = rd_kafka_q_new(rk);
+
+        /* Create SYNC_FANOUT op */
+        rko = rd_kafka_op_new_cb(rk, RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT,
+                                 rd_kafka_share_commit_sync_fanout_op);
+        rko->rko_u.share_commit_sync_fanout.ack_batches = ack_batches;
+        rko->rko_u.share_commit_sync_fanout.abs_timeout = abs_timeout;
+        rko->rko_u.share_commit_sync_fanout.results     = results;
+        rko->rko_replyq = RD_KAFKA_REPLYQ(tmpq, 0);
+
+        rd_kafka_q_enq(rk->rk_ops, rko);
+
+        /* Block on temp queue — main thread always sends a response
+         * (either from broker replies or timeout callback) */
+        rko_reply = rd_kafka_q_pop(tmpq, RD_POLL_INFINITE, 0);
+
+        rd_kafka_q_destroy_owner(tmpq);
+
+        /* Extract per-partition results from reply */
+        rd_dassert(rko_reply->rko_type ==
+                   RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY);
+        *partitions = rko_reply->rko_u.share_commit_sync_fanout_reply.results;
+        rko_reply->rko_u.share_commit_sync_fanout_reply.results = NULL;
+
+        rd_kafka_op_destroy(rko_reply);
+
+        /* Drain rk_rep for callbacks again before returning */
+        rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
+                         rd_kafka_poll_cb, NULL);
 
         return NULL;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3246,7 +3246,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                  * to this broker so they don't leak _IN_PROGRESS to
                  * the caller. */
 
-                rkcg->rkcg_commit_sync_request.wait_broker_result_count--;
+                rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt--;
 
                 rd_kafka_dbg(
                     rk, CGRP, "SHARE",
@@ -3254,7 +3254,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                     "remaining brokers: %d",
                     rd_kafka_broker_name(reply_rkb),
                     rd_kafka_err2str(rko_orig->rko_err),
-                    rkcg->rkcg_commit_sync_request.wait_broker_result_count);
+                    rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt);
 
                 rd_kafka_share_commit_sync_maybe_complete(rk, rkcg);
         }
@@ -3504,6 +3504,9 @@ static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
         rko_sf->rko_u.share_fetch.target_broker = rkb;
         rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
 
+        /* Set fetch guard flag to prevent multiple in-flight fetches to the
+         * same broker.*/
+        rd_assert(!rkb->rkb_share_fetch_enqueued);
         rkb->rkb_share_fetch_enqueued = rd_true;
 
         if (should_fetch)
@@ -3861,17 +3864,17 @@ static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_q_enq(rkcg->rkcg_commit_sync_request.replyq, rko_reply);
 
-        rkcg->rkcg_commit_sync_request.id                       = 0;
-        rkcg->rkcg_commit_sync_request.results                  = NULL;
-        rkcg->rkcg_commit_sync_request.replyq                   = NULL;
-        rkcg->rkcg_commit_sync_request.abs_timeout              = 0;
-        rkcg->rkcg_commit_sync_request.wait_broker_result_count = 0;
+        rkcg->rkcg_commit_sync_request.id                          = 0;
+        rkcg->rkcg_commit_sync_request.results                     = NULL;
+        rkcg->rkcg_commit_sync_request.replyq                      = NULL;
+        rkcg->rkcg_commit_sync_request.abs_timeout                 = 0;
+        rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt = 0;
 }
 
 /**
  * @brief Check if all broker results are in and send response if done.
  *
- * Called after each broker reply arrives. If wait_broker_result_count
+ * Called after each broker reply arrives. If brokers_awaiting_result_cnt
  * reaches zero, stops the timeout timer and sends the response op
  * to the app thread's temp queue.
  *
@@ -3882,7 +3885,7 @@ static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
  */
 static void rd_kafka_share_commit_sync_maybe_complete(rd_kafka_t *rk,
                                                       rd_kafka_cgrp_t *rkcg) {
-        if (rkcg->rkcg_commit_sync_request.wait_broker_result_count > 0)
+        if (rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt > 0)
                 return;
 
         rd_kafka_timer_stop(&rk->rk_timers, &rkcg->rkcg_commit_sync_request.tmr,
@@ -3909,10 +3912,11 @@ static void rd_kafka_share_commit_sync_timeout_cb(rd_kafka_timers_t *rkts,
         rd_kafka_topic_partition_list_t *results;
         int i;
 
-        rd_kafka_dbg(rk, CGRP, "SHARE",
-                     "Commit sync timeout fired, "
-                     "pending brokers: %d",
-                     rkcg->rkcg_commit_sync_request.wait_broker_result_count);
+        rd_kafka_dbg(
+            rk, CGRP, "SHARE",
+            "Commit sync timeout fired, "
+            "pending brokers: %d",
+            rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt);
 
         /* Move pending_commit_sync acks to async_ack_details */
         rd_kafka_rdlock(rk);
@@ -4033,6 +4037,13 @@ static void rd_kafka_share_segregate_sync_acks_by_leader(rd_kafka_t *rk,
                         if (result_rktpar)
                                 result_rktpar->err =
                                     RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE;
+                        else
+                                rd_kafka_dbg(rk, CGRP, "SHARE",
+                                             "Sync ack batch for %s [%" PRId32
+                                             "]: partition not found in "
+                                             "commit_sync results",
+                                             batch->rktpar->topic,
+                                             batch->rktpar->partition);
 
                         rd_kafka_dbg(rk, CGRP, "SHARE",
                                      "Sync ack batch for %s [%" PRId32
@@ -4084,7 +4095,7 @@ static void rd_kafka_share_segregate_sync_acks_by_leader(rd_kafka_t *rk,
  * @brief Dispatch pending sync ack requests to free brokers.
  *
  * Phase 2 of sync dispatch: iterates all brokers. For each broker
- * that has pending_commit_sync, increments wait_broker_result_count.
+ * that has pending_commit_sync, increments brokers_awaiting_result_cnt.
  * If the broker is free (no inflight request), dispatches the
  * pending sync acks immediately.
  *
@@ -4102,7 +4113,7 @@ static void rd_kafka_share_dispatch_pending_sync_acks(rd_kafka_t *rk,
                 if (!rkb->rkb_pending_commit_sync.sync_ack_details)
                         continue;
 
-                rkcg->rkcg_commit_sync_request.wait_broker_result_count++;
+                rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt++;
 
                 if (rkb->rkb_share_fetch_enqueued ||
                     rd_kafka_broker_or_instance_terminating(rkb)) {
@@ -4145,16 +4156,17 @@ rd_kafka_op_res_t rd_kafka_share_commit_sync_fanout_op(rd_kafka_t *rk,
         rko->rko_u.share_commit_sync_fanout.results     = NULL;
 
         /* Initialize commit_sync request state */
-        rkcg->rkcg_share.commit_sync_id_counter++;
-        if (rkcg->rkcg_share.commit_sync_id_counter == INT64_MAX)
-                rkcg->rkcg_share.commit_sync_id_counter = 1;
+        rkcg->rkcg_share.commit_sync_request_id_counter++;
+        if (rkcg->rkcg_share.commit_sync_request_id_counter == INT64_MAX)
+                rkcg->rkcg_share.commit_sync_request_id_counter = 1;
         rkcg->rkcg_commit_sync_request.id =
-            rkcg->rkcg_share.commit_sync_id_counter;
+            rkcg->rkcg_share.commit_sync_request_id_counter;
         rkcg->rkcg_commit_sync_request.abs_timeout = abs_timeout;
         rkcg->rkcg_commit_sync_request.replyq      = rko->rko_replyq.q;
-        rko->rko_replyq.q = NULL; /* Take ownership of replyq */
-        rkcg->rkcg_commit_sync_request.results                  = results;
-        rkcg->rkcg_commit_sync_request.wait_broker_result_count = 0;
+        rkcg->rkcg_commit_sync_request.results     = results;
+        rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt = 0;
+
+        rko->rko_replyq.q = NULL; /* Ownership transferred to rkcg */
 
         /* Initialize all partition errors to IN_PROGRESS sentinel */
         for (i = 0; i < results->cnt; i++)
@@ -4181,7 +4193,7 @@ rd_kafka_op_res_t rd_kafka_share_commit_sync_fanout_op(rd_kafka_t *rk,
         /* Phase 2: Dispatch pending sync acks to free brokers */
         rd_kafka_share_dispatch_pending_sync_acks(rk, rkcg);
 
-        if (rkcg->rkcg_commit_sync_request.wait_broker_result_count == 0) {
+        if (rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt == 0) {
                 rd_kafka_dbg(rk, CGRP, "SHARE",
                              "No brokers available for commit sync, "
                              "sending immediate response");
@@ -4202,7 +4214,7 @@ rd_kafka_op_res_t rd_kafka_share_commit_sync_fanout_op(rd_kafka_t *rk,
         rd_kafka_dbg(rk, CGRP, "SHARE",
                      "Commit sync fanout: waiting for %d broker results, "
                      "timeout in %" PRId64 " ms",
-                     rkcg->rkcg_commit_sync_request.wait_broker_result_count,
+                     rkcg->rkcg_commit_sync_request.brokers_awaiting_result_cnt,
                      timeout_us / 1000);
 
         return RD_KAFKA_OP_RES_HANDLED;
@@ -4305,7 +4317,7 @@ rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
 
         if (!ack_batches) {
                 rd_kafka_dbg(rk, CGRP, "SHARE",
-                             "No pending acknowledgements to commit sync");
+                             "No pending acknowledgements to commit");
                 return NULL;
         }
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3253,6 +3253,33 @@ RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare);
 
 /**
+ * @brief Synchronously commit all pending acknowledgements.
+ *
+ * Sends all pending acknowledgements (from rd_kafka_share_acknowledge*
+ * calls) to their respective brokers and blocks until all broker
+ * replies are received or the timeout expires.
+ *
+ * In implicit ack mode, all ACQUIRED records from the previous poll
+ * are first converted to ACCEPT before committing.
+ *
+ * @param rkshare Share consumer instance.
+ * @param timeout_ms Timeout in milliseconds.
+ * @param partitions [out] Per-partition results. Each partition's err
+ *                   field contains the result for that partition.
+ *                   The caller must destroy the returned list with
+ *                   rd_kafka_topic_partition_list_destroy().
+ *                   Set to NULL if no acks were pending.
+ *
+ * @returns NULL on success, or an rd_kafka_error_t* on failure.
+ *          The returned error must be freed with rd_kafka_error_destroy().
+ */
+RD_EXPORT
+rd_kafka_error_t *
+rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
+                           int timeout_ms,
+                           rd_kafka_topic_partition_list_t **partitions);
+
+/**
  * @brief Destroy Kafka handle.
  *
  * @remark This is a blocking operation.

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -455,6 +455,10 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
         /**
          * Whether a share fetch should_fetch set is enqueued on
          * this broker's op queue or not.
+         *
+         * TODO KIP-932: Check the below fields are not causing
+         * thread safety issues. If causing, check if keeping the reference
+         * to the rkb will solve the issue or not.
          */
         rd_bool_t rkb_share_fetch_enqueued;
 
@@ -469,6 +473,25 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                                            *   NULL. Freed by broker
                                            *   thread after use.
                                            *   @locality main thread */
+
+        /**
+         * Pending commit_sync ack details for this broker.
+         * Stored when a commit_sync request arrives but the broker
+         * already has an inflight request. Takes priority over
+         * rkb_share_async_ack_details when dispatching.
+         * @locality main thread
+         */
+        struct {
+                rd_list_t *sync_ack_details;    /**< Ack batches waiting to be
+                                                 *   sent. Type:
+                                                 *   rd_kafka_share_ack_batches_t*.
+                                                 */
+                rd_ts_t abs_timeout;            /**< Absolute timeout from
+                                                 *   the commit_sync request. */
+                int64_t commit_sync_request_id; /**< Request ID this
+                                                 *   pending data
+                                                 *   belongs to. */
+        } rkb_pending_commit_sync;
 };
 
 #define rd_kafka_broker_keep(rkb) rd_refcnt_add(&(rkb)->rkb_refcnt)

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -402,13 +402,13 @@ typedef struct rd_kafka_cgrp_s {
                                                            * reply.
                                                            *   @locality main
                                                            * thread */
-                int64_t commit_sync_id_counter; /**< Global counter for
-                                                 *   commit_sync request
-                                                 *   IDs. Starts at 1,
-                                                 *   wraps to 1 at
-                                                 *   INT64_MAX.
-                                                 *   @locality main
-                                                 *   thread */
+                int64_t commit_sync_request_id_counter; /**< Global counter for
+                                                         *   commit_sync request
+                                                         *   IDs. Starts at 1,
+                                                         *   wraps to 1 at
+                                                         *   INT64_MAX.
+                                                         *   @locality main
+                                                         *   thread */
         } rkcg_share;
 
         /**
@@ -420,24 +420,24 @@ typedef struct rd_kafka_cgrp_s {
          */
         struct {
                 int64_t id;          /**< Current request ID from
-                                      *   rkcg_share.commit_sync_id_counter.
+                                      *   rkcg_share.commit_sync_request_id_counter.
                                       *   Set on each new commit_sync call.
                                       *   Reset to 0 when the reply is sent.
                                       *   0 means no active request. */
                 rd_ts_t abs_timeout; /**< Absolute timeout for the
                                       *   commit_sync request. */
                 rd_kafka_topic_partition_list_t
-                    *results;                 /**< Partition-to-error mapping.
-                                               *   Populated as broker replies
-                                               *   arrive. */
-                int wait_broker_result_count; /**< Number of broker
-                                               *   results still
-                                               *   pending. */
-                rd_kafka_q_t *replyq;         /**< App thread's temp queue
-                                               *   to send response to. */
-                rd_kafka_timer_t tmr;         /**< Timeout timer. Fires at
-                                               *   abs_timeout to send
-                                               *   timeout response. */
+                    *results; /**< Partition-to-error mapping.
+                               *   Populated as broker replies
+                               *   arrive. */
+                int brokers_awaiting_result_cnt; /**< Number of broker
+                                                  *   results still
+                                                  *   pending. */
+                rd_kafka_q_t *replyq;            /**< App thread's temp queue
+                                                  *   to send response to. */
+                rd_kafka_timer_t tmr;            /**< Timeout timer. Fires at
+                                                  *   abs_timeout to send
+                                                  *   timeout response. */
         } rkcg_commit_sync_request;
 } rd_kafka_cgrp_t;
 

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -402,7 +402,43 @@ typedef struct rd_kafka_cgrp_s {
                                                            * reply.
                                                            *   @locality main
                                                            * thread */
+                int64_t commit_sync_id_counter; /**< Global counter for
+                                                 *   commit_sync request
+                                                 *   IDs. Starts at 1,
+                                                 *   wraps to 1 at
+                                                 *   INT64_MAX.
+                                                 *   @locality main
+                                                 *   thread */
         } rkcg_share;
+
+        /**
+         * Current commit_sync request state.
+         * Only one commit_sync can be active at a time since
+         * the app thread blocks until the main thread sends
+         * the response.
+         * @locality main thread
+         */
+        struct {
+                int64_t id;          /**< Current request ID from
+                                      *   rkcg_share.commit_sync_id_counter.
+                                      *   Set on each new commit_sync call.
+                                      *   Reset to 0 when the reply is sent.
+                                      *   0 means no active request. */
+                rd_ts_t abs_timeout; /**< Absolute timeout for the
+                                      *   commit_sync request. */
+                rd_kafka_topic_partition_list_t
+                    *results;                 /**< Partition-to-error mapping.
+                                               *   Populated as broker replies
+                                               *   arrive. */
+                int wait_broker_result_count; /**< Number of broker
+                                               *   results still
+                                               *   pending. */
+                rd_kafka_q_t *replyq;         /**< App thread's temp queue
+                                               *   to send response to. */
+                rd_kafka_timer_t tmr;         /**< Timeout timer. Fires at
+                                               *   abs_timeout to send
+                                               *   timeout response. */
+        } rkcg_commit_sync_request;
 } rd_kafka_cgrp_t;
 
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1804,22 +1804,35 @@ static void rd_kafka_broker_session_update(rd_kafka_broker_t *rkb) {
  * @brief Parse a ShareAcknowledge response.
  *
  * ShareAcknowledge response contains per-partition error codes for
- * acknowledgement results. Returns the top-level error code.
+ * acknowledgement results. Returns the top-level error code and
+ * populates \p ack_resultsp with per-partition error results.
  *
+ * @param rkb Broker handle.
+ * @param rkbuf Response buffer.
+ * @param request Original request buffer.
+ * @param ack_resultsp [out] Per-partition error results. Caller must
+ *                     destroy. Set to NULL on top-level error or
+ *                     parse error.
+ *
+ * @returns Top-level error code.
  * @locality broker thread
  */
-static rd_kafka_resp_err_t
-rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
-                                        rd_kafka_buf_t *rkbuf,
-                                        rd_kafka_buf_t *request) {
+static rd_kafka_resp_err_t rd_kafka_share_acknowledge_reply_handle(
+    rd_kafka_broker_t *rkb,
+    rd_kafka_buf_t *rkbuf,
+    rd_kafka_buf_t *request,
+    rd_kafka_topic_partition_list_t **ack_resultsp) {
         int32_t TopicArrayCnt;
         int i;
         const int log_decode_errors = LOG_ERR;
         int16_t ErrorCode           = RD_KAFKA_RESP_ERR_NO_ERROR;
         rd_kafkap_str_t ErrorStr    = RD_KAFKAP_STR_INITIALIZER_EMPTY;
         rd_kafkap_NodeEndpoints_t NodeEndpoints;
-        NodeEndpoints.NodeEndpoints   = NULL;
-        NodeEndpoints.NodeEndpointCnt = 0;
+        rd_kafka_topic_partition_list_t *ack_results = NULL;
+        NodeEndpoints.NodeEndpoints                  = NULL;
+        NodeEndpoints.NodeEndpointCnt                = 0;
+
+        *ack_resultsp = NULL;
 
         rd_kafka_buf_read_throttle_time(rkbuf);
 
@@ -1836,12 +1849,17 @@ rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
 
         rd_kafka_buf_read_arraycnt(rkbuf, &TopicArrayCnt, RD_KAFKAP_TOPICS_MAX);
 
+        ack_results = rd_kafka_topic_partition_list_new(TopicArrayCnt);
+
         for (i = 0; i < TopicArrayCnt; i++) {
                 rd_kafka_Uuid_t topic_id = RD_KAFKA_UUID_ZERO;
+                rd_kafka_topic_t *rkt;
                 int32_t PartitionArrayCnt;
                 int j;
 
                 rd_kafka_buf_read_uuid(rkbuf, &topic_id);
+                rkt = rd_kafka_topic_find_by_topic_id(rkb->rkb_rk, topic_id);
+
                 rd_kafka_buf_read_arraycnt(rkbuf, &PartitionArrayCnt,
                                            RD_KAFKAP_PARTITIONS_MAX);
 
@@ -1850,6 +1868,7 @@ rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
                         int16_t PartErrorCode;
                         rd_kafkap_str_t PartErrorStr;
                         rd_kafkap_CurrentLeader_t CurrentLeader;
+                        rd_kafka_topic_partition_t *rktpar;
 
                         rd_kafka_buf_read_i32(rkbuf, &Partition);
                         rd_kafka_buf_read_i16(rkbuf, &PartErrorCode);
@@ -1858,6 +1877,12 @@ rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
                         /* CurrentLeader */
                         rd_kafka_buf_read_CurrentLeader(rkbuf, &CurrentLeader);
 
+                        rktpar =
+                            rd_kafka_topic_partition_list_add_with_topic_name_and_id(
+                                ack_results, topic_id,
+                                rkt ? rkt->rkt_topic->str : NULL, Partition);
+                        rktpar->err = PartErrorCode;
+
                         if (PartErrorCode) {
                                 rd_rkb_dbg(rkb, FETCH, "SHAREACK",
                                            "ShareAcknowledge partition %" PRId32
@@ -1865,13 +1890,14 @@ rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
                                            Partition,
                                            rd_kafka_err2name(PartErrorCode),
                                            RD_KAFKAP_STR_PR(&PartErrorStr));
-                                /* TODO KIP-932: Report partition-level ack
-                                 * errors via acknowledgement callback. */
                         }
 
                         /* Partition tags */
                         rd_kafka_buf_skip_tags(rkbuf);
                 }
+
+                if (rkt)
+                        rd_kafka_topic_destroy0(rkt);
 
                 /* Topic tags */
                 rd_kafka_buf_skip_tags(rkbuf);
@@ -1883,10 +1909,12 @@ rd_kafka_share_acknowledge_reply_handle(rd_kafka_broker_t *rkb,
         rd_kafka_buf_skip_tags(rkbuf);
 
         RD_IF_FREE(NodeEndpoints.NodeEndpoints, rd_free);
+        *ack_resultsp = ack_results;
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 
 err_parse:
         RD_IF_FREE(NodeEndpoints.NodeEndpoints, rd_free);
+        RD_IF_FREE(ack_results, rd_kafka_topic_partition_list_destroy);
         rd_rkb_dbg(rkb, MSG, "BADMSG",
                    "Bad ShareAcknowledge response (v%d): parse error",
                    (int)request->rkbuf_reqhdr.ApiVersion);
@@ -1919,9 +1947,12 @@ static void rd_kafka_broker_share_acknowledge_reply(rd_kafka_t *rk,
         }
 
         /* Parse and handle the response (unless the request errored) */
-        if (!err && reply)
-                err = rd_kafka_share_acknowledge_reply_handle(rkb, reply,
-                                                              request);
+        if (!err && reply) {
+                rd_kafka_topic_partition_list_t *ack_results = NULL;
+                err = rd_kafka_share_acknowledge_reply_handle(
+                    rkb, reply, request, &ack_results);
+                rko_orig->rko_u.share_fetch.ack_results = ack_results;
+        }
 
         rd_kafka_broker_session_update(rkb);
 
@@ -2618,6 +2649,11 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
         /* Topics array with acknowledgement batches */
         of_TopicArrayCnt = rd_kafka_buf_write_arraycnt_pos(rkbuf);
 
+        rd_kafka_dbg(rkb->rkb_rk, FETCH, "SHAREACK",
+                     "Building ShareAcknowledge request with %d ack toppars "
+                     "and %d total ack entries",
+                     ack_details_cnt, total_ack_entries);
+
         if (ack_details) {
                 rd_kafka_Uuid_t *topic_id_last = NULL;
                 rd_kafka_share_ack_batches_t *batches;
@@ -2657,11 +2693,25 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
                         rd_kafka_buf_write_i32(rkbuf,
                                                batches->rktpar->partition);
 
+                        rd_kafka_dbg(rkb->rkb_rk, FETCH, "SHAREACK",
+                                     "Adding ack for topic %s [%" PRId32
+                                     "] with %d entries",
+                                     batches->rktpar->topic,
+                                     batches->rktpar->partition,
+                                     rd_list_cnt(&batches->entries));
+
                         /* Write acknowledgement batches */
                         entries_cnt = rd_list_cnt(&batches->entries);
                         rd_kafka_buf_write_arraycnt(rkbuf, entries_cnt);
 
                         RD_LIST_FOREACH(entry, &batches->entries, m) {
+                                rd_kafka_dbg(
+                                    rkb->rkb_rk, FETCH, "SHAREACK",
+                                    "Adding ack entry with start offset "
+                                    "%" PRId64 ", end offset %" PRId64
+                                    ", type %d",
+                                    entry->start_offset, entry->end_offset,
+                                    entry->types[0]);
                                 /* FirstOffset */
                                 rd_kafka_buf_write_i64(rkbuf,
                                                        entry->start_offset);
@@ -2703,7 +2753,12 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
         /* Update TopicArrayCnt */
         rd_kafka_buf_finalize_arraycnt(rkbuf, of_TopicArrayCnt, TopicArrayCnt);
 
-        /* Use configured timeout */
+        /* TODO KIP-932: Check if commit_sync requests should use
+         * rko_orig->rko_u.share_fetch.abs_timeout instead of
+         * socket.timeout.ms. Currently the transport timeout is
+         * independent of the commit_sync timeout, so the broker
+         * request may outlive a timed-out commit_sync or time out
+         * at the transport level before the commit_sync timer fires. */
         rd_kafka_buf_set_timeout(rkbuf, rkb->rkb_rk->rk_conf.socket_timeout_ms,
                                  now);
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -133,6 +133,10 @@ const char *rd_kafka_op2str(rd_kafka_op_type_t type) {
             [RD_KAFKA_OP_SHARE_FETCH_RESPONSE] = "REPLY:SHARE_FETCH_RESPONSE",
             [RD_KAFKA_OP_SHARE_COMMIT_ASYNC_FANOUT] =
                 "REPLY:SHARE_COMMIT_ASYNC_FANOUT",
+            [RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT] =
+                "REPLY:SHARE_COMMIT_SYNC_FANOUT",
+            [RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY] =
+                "REPLY:SHARE_COMMIT_SYNC_FANOUT_REPLY",
         };
 
         if (type & RD_KAFKA_OP_REPLY)
@@ -306,6 +310,10 @@ rd_kafka_op_t *rd_kafka_op_new0(const char *source, rd_kafka_op_type_t type) {
                 sizeof(rko->rko_u.share_fetch_response),
             [RD_KAFKA_OP_SHARE_COMMIT_ASYNC_FANOUT] =
                 sizeof(rko->rko_u.share_commit_async_fanout),
+            [RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT] =
+                sizeof(rko->rko_u.share_commit_sync_fanout),
+            [RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY] =
+                sizeof(rko->rko_u.share_commit_sync_fanout_reply),
         };
         size_t tsize = op2size[type & ~RD_KAFKA_OP_FLAGMASK];
 
@@ -530,6 +538,8 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
                 RD_IF_FREE(rko->rko_u.share_fetch.target_broker,
                            rd_kafka_broker_destroy);
                 RD_IF_FREE(rko->rko_u.share_fetch.ack_details, rd_list_destroy);
+                RD_IF_FREE(rko->rko_u.share_fetch.ack_results,
+                           rd_kafka_topic_partition_list_destroy);
                 break;
         }
 
@@ -541,6 +551,18 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_SHARE_COMMIT_ASYNC_FANOUT:
                 RD_IF_FREE(rko->rko_u.share_commit_async_fanout.ack_batches,
                            rd_list_destroy);
+                break;
+
+        case RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT:
+                RD_IF_FREE(rko->rko_u.share_commit_sync_fanout.ack_batches,
+                           rd_list_destroy);
+                RD_IF_FREE(rko->rko_u.share_commit_sync_fanout.results,
+                           rd_kafka_topic_partition_list_destroy);
+                break;
+
+        case RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY:
+                RD_IF_FREE(rko->rko_u.share_commit_sync_fanout_reply.results,
+                           rd_kafka_topic_partition_list_destroy);
                 break;
 
         case RD_KAFKA_OP_SHARE_FETCH_RESPONSE: {

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -192,11 +192,20 @@ typedef enum {
         RD_KAFKA_OP_SHARE_FETCH, /**< broker op: Issue share fetch request if
                                     applicable. */
         RD_KAFKA_OP_SHARE_FETCH_FANOUT, /**< fanout share fetch operation */
-        RD_KAFKA_OP_SHARE_COMMIT_ASYNC_FANOUT,   /**< fanout share commit async
-                                                  *   operation (ack-only,
-                                                  *   no fetch) */
-        RD_KAFKA_OP_SHARE_SESSION_PARTITION_ADD, /**< share session:
-                                                  * add partition */
+        RD_KAFKA_OP_SHARE_COMMIT_ASYNC_FANOUT, /**< fanout share commit async
+                                                *   operation (ack-only,
+                                                *   no fetch) */
+        RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT,  /**< fanout share commit sync
+                                                *   operation. App thread
+                                                *   blocks until main thread
+                                                *   sends response. */
+        RD_KAFKA_OP_SHARE_COMMIT_SYNC_FANOUT_REPLY, /**< Reply from main thread
+                                                     *   to app thread for
+                                                     *   commit sync. Carries
+                                                     *   per-partition results.
+                                                     */
+        RD_KAFKA_OP_SHARE_SESSION_PARTITION_ADD,    /**< share session:
+                                                     * add partition */
         RD_KAFKA_OP_SHARE_SESSION_PARTITION_REMOVE, /**< share session:
                                                      * remove partition */
         RD_KAFKA_OP_SHARE_FETCH_RESPONSE, /**< Share fetch response containing
@@ -775,6 +784,19 @@ struct rd_kafka_op_s {
                          *  TODO KIP-932: Change name.
                          */
                         rd_list_t *ack_details;
+
+                        /** Per-partition ack results from
+                         *  ShareAcknowledge response. Set by broker
+                         *  thread, read by main thread in reply
+                         *  handler. Each partition's err field
+                         *  contains the partition-level error. */
+                        rd_kafka_topic_partition_list_t *ack_results;
+
+                        /** commit_sync request ID that this op belongs
+                         *  to, or 0 if not a commit_sync op. Compared
+                         *  with rkcg_commit_sync_request.id to detect
+                         *  stale responses. */
+                        int64_t commit_sync_request_id;
                 } share_fetch;
 
                 struct {
@@ -807,6 +829,31 @@ struct rd_kafka_op_s {
                          *  to per-broker ack_details. */
                         rd_list_t *ack_batches;
                 } share_commit_async_fanout;
+
+                struct {
+                        /** List of all acknowledgement batches to commit.
+                         *  Type: rd_kafka_share_ack_batches_t*
+                         *  Built from inflight ack map, will be segregated
+                         *  by leader and sent to respective brokers.
+                         *  Set to NULL after ownership is transferred
+                         *  to per-broker ack_details. */
+                        rd_list_t *ack_batches;
+
+                        /** Absolute timeout for the commit_sync request.
+                         *  Calculated from user-provided timeout_ms. */
+                        rd_ts_t abs_timeout;
+
+                        /** Per-partition results (topic, partition, err).
+                         *  Set in response op by main thread.
+                         *  Read by app thread after unblocking. */
+                        rd_kafka_topic_partition_list_t *results;
+                } share_commit_sync_fanout;
+
+                struct {
+                        /** Per-partition results (topic, partition, err).
+                         *  Moved from commit_sync_request by main thread. */
+                        rd_kafka_topic_partition_list_t *results;
+                } share_commit_sync_fanout_reply;
 
                 /**
                  * Share fetch response - single rko containing all messages

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -372,6 +372,13 @@ rd_list_t *rd_kafka_share_build_ack_details(rd_kafka_share_t *rkshare) {
                                                         ->response_leader_epoch,
                                                     0);
                                         }
+                                        rd_kafka_dbg(
+                                            rkshare->rkshare_rk, CGRP,
+                                            "SHAREACK",
+                                            "    Adding ack detail for offsets "
+                                            "[%" PRId64 " - %" PRId64
+                                            "] with type %d",
+                                            run_start, run_end, run_type);
                                         /* Collated: 1 type for entire
                                          * range */
                                         rd_list_add(

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -38,7 +38,6 @@
  * and returns per-partition results.
  */
 
-#define MAX_MSGS      500
 #define CONSUME_ARRAY 10001
 
 /** Common producer reused across all non-mock subtests. */

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1,0 +1,1800 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#include "../src/rdkafka_proto.h"
+
+/**
+ * @brief Share consumer rd_kafka_share_commit_sync() API tests.
+ *
+ * Tests the commit_sync API in both implicit and explicit ack modes.
+ * Verifies that commit_sync synchronously commits acknowledged records
+ * and returns per-partition results.
+ */
+
+#define MAX_MSGS      500
+#define CONSUME_ARRAY 10001
+
+
+/**
+ * @brief Create share consumer with specified ack mode.
+ * @param ack_mode "implicit" or "explicit"
+ */
+static rd_kafka_share_t *create_share_consumer(const char *group_id,
+                                               const char *ack_mode) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 60);
+
+        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode, errstr,
+                          sizeof(errstr));
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
+
+        return rkshare;
+}
+
+
+/**
+ * @brief Set share.auto.offset.reset=earliest for a share group.
+ *        Uses a new admin client (not the share consumer handle).
+ */
+static void set_group_offset_earliest(const char *group_name) {
+        rd_kafka_t *admin;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
+
+        test_conf_init(&conf, NULL, 30);
+        admin = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(admin, "Failed to create admin client: %s", errstr);
+
+        test_IncrementalAlterConfigs_simple(admin, RD_KAFKA_RESOURCE_GROUP,
+                                            group_name, cfg, 1);
+
+        rd_kafka_destroy(admin);
+}
+
+
+/**
+ * @brief Subscribe a share consumer to topics.
+ */
+static void subscribe_consumer(rd_kafka_share_t *rkshare,
+                               const char **topics,
+                               int topic_cnt) {
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        int i;
+
+        subs = rd_kafka_topic_partition_list_new(topic_cnt);
+        for (i = 0; i < topic_cnt; i++)
+                rd_kafka_topic_partition_list_add(subs, topics[i],
+                                                  RD_KAFKA_PARTITION_UA);
+
+        err = rd_kafka_share_subscribe(rkshare, subs);
+        TEST_ASSERT(!err, "Subscribe failed: %s", rd_kafka_err2str(err));
+
+        rd_kafka_topic_partition_list_destroy(subs);
+}
+
+
+/* ===================================================================
+ *  Test 1: Basic implicit ack mode commit_sync.
+ *
+ *  Implicit mode auto-ACCEPTs all records from previous poll.
+ *  Consumer consumes records, calls commit_sync, verifies
+ *  per-partition results show NO_ERROR.
+ * =================================================================== */
+static void do_test_basic_implicit_commit_sync(void) {
+        const char *topic;
+        const char *group = "commit-sync-implicit-basic";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed = 0;
+        int attempts = 0;
+        int i;
+
+        topic = test_mk_topic_name("0176-cs-impl-basic", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 5);
+
+        rkshare = create_share_consumer(group, "implicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume records */
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumed %d messages\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 messages, got %d", consumed);
+
+        /* commit_sync should flush implicit acks */
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_ASSERT(partitions != NULL,
+                    "Expected per-partition results, got NULL");
+
+        TEST_SAY("commit_sync returned %d partition(s)\n", partitions->cnt);
+        TEST_ASSERT(partitions->cnt >= 1,
+                    "Expected at least 1 partition result, got %d",
+                    partitions->cnt);
+
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2str(rktpar->err));
+                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
+                            rktpar->topic, rktpar->partition,
+                            rd_kafka_err2str(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 2: Basic explicit ack mode commit_sync.
+ *
+ *  Explicit mode requires the app to ACCEPT each record via
+ *  rd_kafka_share_acknowledge(). Then commit_sync flushes acks
+ *  and returns per-partition results.
+ * =================================================================== */
+static void do_test_basic_explicit_commit_sync(void) {
+        const char *topic;
+        const char *group = "commit-sync-explicit-basic";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed = 0;
+        int attempts = 0;
+        int i;
+
+        topic = test_mk_topic_name("0176-cs-expl-basic", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 5);
+
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume records and explicitly ACCEPT each */
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumed and acknowledged %d messages\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 messages, got %d", consumed);
+
+        /* commit_sync should flush explicit acks */
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_ASSERT(partitions != NULL,
+                    "Expected per-partition results, got NULL");
+
+        TEST_SAY("commit_sync returned %d partition(s)\n", partitions->cnt);
+        TEST_ASSERT(partitions->cnt >= 1,
+                    "Expected at least 1 partition result, got %d",
+                    partitions->cnt);
+
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2str(rktpar->err));
+                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
+                            rktpar->topic, rktpar->partition,
+                            rd_kafka_err2str(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 3: No pending acks — commit_sync with nothing to commit.
+ *
+ *  Subscribe but do not consume any records. commit_sync should
+ *  return NULL error and NULL partitions.
+ * =================================================================== */
+static void do_test_no_pending_acks(void) {
+        const char *topic;
+        const char *group = "commit-sync-no-pending";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+
+        topic = test_mk_topic_name("0176-cs-no-pending", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* commit_sync with no consumed records */
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_ASSERT(partitions == NULL,
+                    "Expected NULL partitions when no acks pending, "
+                    "got %d partition(s)",
+                    partitions ? partitions->cnt : -1);
+
+        TEST_SAY(
+            "commit_sync with no pending acks returned NULL as expected\n");
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 4: commit_sync prevents redelivery.
+ *
+ *  Consumer A consumes and commit_sync's all records, then closes.
+ *  Consumer B (same group) should see 0 records since they were
+ *  all committed by A.
+ * =================================================================== */
+static void do_test_commit_sync_prevents_redelivery(void) {
+        const char *topic;
+        const char *group = "commit-sync-no-redeliver";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed = 0;
+        int attempts = 0;
+
+        topic = test_mk_topic_name("0176-cs-no-redeliver", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 5);
+
+        /* Consumer A: consume all and commit_sync */
+        rkshare = create_share_consumer(group, "implicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumer A consumed %d messages\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5, got %d", consumed);
+
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        RD_IF_FREE(partitions, rd_kafka_topic_partition_list_destroy);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Consumer B: same group, should get 0 records */
+        rkshare = create_share_consumer(group, "implicit");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 5) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumer B consumed %d messages (expected 0)\n", consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Consumer B got %d records, expected 0 after commit_sync",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 5: Mixed ack types — ACCEPT, RELEASE, REJECT.
+ *
+ *  Consumer A: ACCEPT first 5, RELEASE next 3, REJECT last 2,
+ *  then commit_sync. Consumer B should only receive the 3
+ *  RELEASE'd records with delivery_count >= 2.
+ * =================================================================== */
+static void do_test_mixed_ack_types(void) {
+        const char *topic;
+        const char *group = "commit-sync-mixed-acks";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed = 0;
+        int attempts = 0;
+        int i;
+        int64_t released_offsets[3];
+        int released_cnt = 0;
+
+        topic = test_mk_topic_name("0176-cs-mixed-acks", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 10);
+
+        /* Consumer A: consume all 10 in a single batch, apply mixed ack
+         * types */
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                /* Skip partial batches — wait for all 10 in one call */
+                if (rcvd < 10) {
+                        for (j = 0; j < rcvd; j++)
+                                rd_kafka_message_destroy(rkmessages[j]);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_resp_err_t err;
+
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+
+                        if (consumed < 5) {
+                                /* ACCEPT first 5 */
+                                err = rd_kafka_share_acknowledge_type(
+                                    rkshare, rkmessages[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                        } else if (consumed < 8) {
+                                /* RELEASE next 3 */
+                                released_offsets[released_cnt++] =
+                                    rkmessages[j]->offset;
+                                err = rd_kafka_share_acknowledge_type(
+                                    rkshare, rkmessages[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                        } else {
+                                /* REJECT last 2 */
+                                err = rd_kafka_share_acknowledge_type(
+                                    rkshare, rkmessages[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+                        }
+
+                        TEST_ASSERT(!err, "acknowledge_type failed: %s",
+                                    rd_kafka_err2str(err));
+                        consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY(
+            "Consumer A consumed %d messages "
+            "(5 ACCEPT, 3 RELEASE, 2 REJECT)\n",
+            consumed);
+        TEST_ASSERT(consumed == 10, "Expected 10, got %d", consumed);
+        TEST_ASSERT(released_cnt == 3, "Expected 3 released, got %d",
+                    released_cnt);
+
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_ASSERT(partitions != NULL,
+                    "Expected per-partition results, got NULL");
+
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2str(rktpar->err));
+                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
+                            rktpar->topic, rktpar->partition,
+                            rd_kafka_err2str(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Consumer B: should only get the 3 RELEASE'd records */
+        rkshare = create_share_consumer(group, "implicit");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 10) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                int16_t dc;
+                                int k;
+                                rd_bool_t found = rd_false;
+
+                                dc = rd_kafka_message_delivery_count(
+                                    rkmessages[j]);
+                                TEST_ASSERT(
+                                    dc >= 2,
+                                    "Consumer B got record at offset %" PRId64
+                                    " with delivery_count=%d, expected >= 2",
+                                    rkmessages[j]->offset, (int)dc);
+
+                                /* Verify it is one of the released offsets */
+                                for (k = 0; k < released_cnt; k++) {
+                                        if (rkmessages[j]->offset ==
+                                            released_offsets[k]) {
+                                                found = rd_true;
+                                                break;
+                                        }
+                                }
+                                TEST_ASSERT(found,
+                                            "Consumer B got offset %" PRId64
+                                            " which was not RELEASE'd",
+                                            rkmessages[j]->offset);
+
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumer B consumed %d messages (expected 3 RELEASE'd)\n",
+                 consumed);
+        TEST_ASSERT(consumed == 3,
+                    "Consumer B got %d records, expected 3 RELEASE'd",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 6: Multiple commit_sync calls.
+ *
+ *  Consume 50 records, ACCEPT 10 at a time and commit_sync after
+ *  each batch of 10 (5 commit_sync calls total). After each
+ *  commit_sync, immediately call commit_sync again to verify
+ *  a no-op commit (no pending acks) returns NULL/NULL cleanly.
+ *  Consumer B should get 0 records.
+ * =================================================================== */
+static void do_test_multiple_commit_sync_calls(void) {
+        const char *topic;
+        const char *group = "commit-sync-multi-calls";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed                = 0;
+        int attempts                = 0;
+        int commit_cnt              = 0;
+        int acked_since_last_commit = 0;
+        int i;
+
+        topic = test_mk_topic_name("0176-cs-multi-calls", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 50);
+
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume all 50, commit_sync every 10 records */
+        while (consumed < 50 && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                                acked_since_last_commit++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        /* commit_sync every 10 records */
+                        if (acked_since_last_commit == 10) {
+                                partitions = NULL;
+                                error      = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                commit_cnt++;
+                                TEST_ASSERT(
+                                    !error, "commit_sync #%d failed: %s",
+                                    commit_cnt,
+                                    error ? rd_kafka_error_string(error) : "");
+                                TEST_ASSERT(
+                                    partitions != NULL,
+                                    "commit_sync #%d: expected results, "
+                                    "got NULL",
+                                    commit_cnt);
+
+                                for (i = 0; i < partitions->cnt; i++) {
+                                        rd_kafka_topic_partition_t *rktpar =
+                                            &partitions->elems[i];
+                                        TEST_ASSERT(
+                                            rktpar->err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "commit_sync #%d: %s [%" PRId32
+                                            "] got %s",
+                                            commit_cnt, rktpar->topic,
+                                            rktpar->partition,
+                                            rd_kafka_err2str(rktpar->err));
+                                }
+
+                                rd_kafka_topic_partition_list_destroy(
+                                    partitions);
+                                TEST_SAY(
+                                    "commit_sync #%d OK "
+                                    "(consumed %d so far)\n",
+                                    commit_cnt, consumed);
+                                acked_since_last_commit = 0;
+
+                                /* Immediately call commit_sync again —
+                                 * no pending acks, should return
+                                 * NULL/NULL */
+                                partitions = NULL;
+                                error      = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                TEST_ASSERT(
+                                    !error,
+                                    "back-to-back commit_sync after #%d "
+                                    "failed: %s",
+                                    commit_cnt,
+                                    error ? rd_kafka_error_string(error) : "");
+                                TEST_ASSERT(
+                                    partitions == NULL,
+                                    "back-to-back commit_sync after #%d: "
+                                    "expected NULL partitions, got %d",
+                                    commit_cnt,
+                                    partitions ? partitions->cnt : -1);
+                                TEST_SAY(
+                                    "back-to-back commit_sync after "
+                                    "#%d returned NULL as expected\n",
+                                    commit_cnt);
+                        }
+                }
+        }
+
+        TEST_SAY("Consumer A consumed %d messages, %d commit_sync calls\n",
+                 consumed, commit_cnt);
+        TEST_ASSERT(consumed == 50, "Expected 50, got %d", consumed);
+        TEST_ASSERT(commit_cnt == 5, "Expected 5 commit_sync calls, got %d",
+                    commit_cnt);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Consumer B: same group, should get 0 records */
+        rkshare = create_share_consumer(group, "implicit");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 5) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumer B consumed %d messages (expected 0)\n", consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Consumer B got %d records, expected 0 after 5 "
+                    "commit_sync calls",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 7: Multi-topic multi-partition commit_sync.
+ *
+ *  10 topics with 6 partitions each, 10 messages per partition
+ *  (600 total). Consume in batches, apply mixed ack types
+ *  (ACCEPT ~50%, RELEASE ~30%, REJECT ~20%) and commit_sync
+ *  after each consume_batch call.
+ *
+ *  RELEASE'd records are redelivered. Continue consuming until
+ *  accepted + rejected == total_msgs (all records settled).
+ *  On delivery_count >= MAX_REDELIVERY_ROUNDS, force ACCEPT.
+ *  Verify commit_sync returns NO_ERROR each time and that
+ *  delivery_count stays within bounds.
+ * =================================================================== */
+#define MULTI_TP_TOPICS             10
+#define MULTI_TP_PARTITIONS         6
+#define MULTI_TP_MSGS_PER_PARTITION 10
+#define MAX_REDELIVERY_ROUNDS       4
+
+static rd_kafka_share_AcknowledgeType_t get_ack_type(int index) {
+        int r = index % 10;
+        if (r < 5)
+                return RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+        else if (r < 8)
+                return RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
+        else
+                return RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
+}
+
+static void do_test_multi_topic_partition(void) {
+        const char *group = "commit-sync-multi-tp";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        char *topics[MULTI_TP_TOPICS];
+        size_t rcvd;
+        size_t j;
+        int total_consumed = 0;
+        int accepted = 0, released = 0, rejected = 0;
+        int attempts   = 0;
+        int commit_cnt = 0;
+        int total_msgs =
+            MULTI_TP_TOPICS * MULTI_TP_PARTITIONS * MULTI_TP_MSGS_PER_PARTITION;
+        int i, p;
+        int16_t max_dc_seen = 0;
+
+        /* Create topics and produce 10 messages per partition */
+        for (i = 0; i < MULTI_TP_TOPICS; i++) {
+                topics[i] = rd_strdup(test_mk_topic_name("0176-cs-mtp", 1));
+                test_create_topic_wait_exists(
+                    NULL, topics[i], MULTI_TP_PARTITIONS, -1, 60 * 1000);
+                for (p = 0; p < MULTI_TP_PARTITIONS; p++)
+                        test_produce_msgs_easy(topics[i], p, p,
+                                               MULTI_TP_MSGS_PER_PARTITION);
+        }
+
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, (const char **)topics, MULTI_TP_TOPICS);
+
+        /* Consume until all records are settled
+         * (accepted + rejected == total_msgs) */
+        while (accepted + rejected < total_msgs && attempts++ < 200) {
+                int batch_cnt = 0;
+
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_share_AcknowledgeType_t ack_type;
+                        rd_kafka_resp_err_t err;
+                        int16_t dc;
+
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+
+                        dc = rd_kafka_message_delivery_count(rkmessages[j]);
+                        if (dc > max_dc_seen)
+                                max_dc_seen = dc;
+
+                        /* On final delivery attempt, force ACCEPT */
+                        if (dc >= MAX_REDELIVERY_ROUNDS)
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+                        else
+                                ack_type = get_ack_type(total_consumed);
+
+                        err = rd_kafka_share_acknowledge_type(
+                            rkshare, rkmessages[j], ack_type);
+                        TEST_ASSERT(!err, "acknowledge_type failed: %s",
+                                    rd_kafka_err2str(err));
+
+                        if (ack_type == RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT)
+                                accepted++;
+                        else if (ack_type ==
+                                 RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE)
+                                released++;
+                        else
+                                rejected++;
+
+                        total_consumed++;
+                        batch_cnt++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+
+                if (batch_cnt == 0)
+                        continue;
+
+                /* commit_sync after each batch */
+                partitions = NULL;
+                error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+                commit_cnt++;
+                TEST_ASSERT(!error, "commit_sync #%d failed: %s", commit_cnt,
+                            error ? rd_kafka_error_string(error) : "");
+                TEST_ASSERT(partitions != NULL,
+                            "commit_sync #%d: expected results, got NULL",
+                            commit_cnt);
+
+                for (i = 0; i < partitions->cnt; i++) {
+                        rd_kafka_topic_partition_t *rktpar =
+                            &partitions->elems[i];
+                        TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                    "commit_sync #%d: %s [%" PRId32 "] got %s",
+                                    commit_cnt, rktpar->topic,
+                                    rktpar->partition,
+                                    rd_kafka_err2str(rktpar->err));
+                }
+
+                TEST_SAY(
+                    "commit_sync #%d OK (%d in batch, %d total, "
+                    "settled=%d/%d, %d partition results)\n",
+                    commit_cnt, batch_cnt, total_consumed, accepted + rejected,
+                    total_msgs, partitions->cnt);
+
+                rd_kafka_topic_partition_list_destroy(partitions);
+        }
+
+        TEST_SAY(
+            "Total consumed=%d (original=%d), commit_sync calls=%d, "
+            "accepted=%d, released=%d, rejected=%d, "
+            "max delivery_count=%d\n",
+            total_consumed, total_msgs, commit_cnt, accepted, released,
+            rejected, (int)max_dc_seen);
+
+        TEST_ASSERT(accepted + rejected == total_msgs,
+                    "Expected accepted(%d) + rejected(%d) == %d", accepted,
+                    rejected, total_msgs);
+
+        /* Verify redelivery happened */
+        TEST_ASSERT(max_dc_seen > 1,
+                    "Expected redeliveries (max delivery_count > 1), "
+                    "got max=%d",
+                    (int)max_dc_seen);
+
+        TEST_ASSERT(max_dc_seen <= MAX_REDELIVERY_ROUNDS,
+                    "Max delivery_count=%d exceeds limit=%d", (int)max_dc_seen,
+                    MAX_REDELIVERY_ROUNDS);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        for (i = 0; i < MULTI_TP_TOPICS; i++)
+                rd_free(topics[i]);
+}
+
+
+/* ===================================================================
+ *  Mock broker infrastructure (same pattern as 0173).
+ * =================================================================== */
+typedef struct test_ctx_s {
+        rd_kafka_t *producer;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+} test_ctx_t;
+
+static test_ctx_t test_ctx_new(void) {
+        test_ctx_t ctx;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        memset(&ctx, 0, sizeof(ctx));
+
+        ctx.mcluster = test_mock_cluster_new(3, &ctx.bootstraps);
+
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        ctx.mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareGroupHeartbeat");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(ctx.mcluster,
+                                                 RD_KAFKAP_ShareFetch, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareFetch");
+
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+
+        ctx.producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(ctx.producer != NULL, "Failed to create producer: %s",
+                    errstr);
+
+        return ctx;
+}
+
+static void test_ctx_destroy(test_ctx_t *ctx) {
+        if (ctx->producer)
+                rd_kafka_destroy(ctx->producer);
+        if (ctx->mcluster)
+                test_mock_cluster_destroy(ctx->mcluster);
+        memset(ctx, 0, sizeof(*ctx));
+}
+
+static void
+mock_produce_messages(rd_kafka_t *producer, const char *topic, int msgcnt) {
+        int i;
+        for (i = 0; i < msgcnt; i++) {
+                char payload[64];
+                snprintf(payload, sizeof(payload), "%s-%d", topic, i);
+                TEST_ASSERT(rd_kafka_producev(
+                                producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
+                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Produce failed");
+        }
+        rd_kafka_flush(producer, 5000);
+}
+
+/**
+ * @brief Create share consumer for mock broker tests.
+ *
+ * Unlike create_share_consumer() which uses test_conf_init with real
+ * broker settings, this uses mock cluster bootstraps.
+ */
+static rd_kafka_share_t *create_mock_share_consumer(const char *bootstraps,
+                                                    const char *group_id,
+                                                    const char *ack_mode) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_share_t *rkshare;
+
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group_id);
+        test_conf_set(conf, "share.acknowledgement.mode", ack_mode);
+
+        rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
+        return rkshare;
+}
+
+static int count_share_ack_requests(rd_kafka_mock_cluster_t *mcluster) {
+        size_t cnt;
+        size_t i;
+        rd_kafka_mock_request_t **requests;
+        int share_ack_cnt = 0;
+
+        requests = rd_kafka_mock_get_requests(mcluster, &cnt);
+
+        for (i = 0; i < cnt; i++) {
+                int16_t api_key = rd_kafka_mock_request_api_key(requests[i]);
+                if (api_key == RD_KAFKAP_ShareAcknowledge)
+                        share_ack_cnt++;
+        }
+
+        rd_kafka_mock_request_destroy_array(requests, cnt);
+        return share_ack_cnt;
+}
+
+
+/* ===================================================================
+ *  Test 8: Mock — verify commit_sync uses ShareAcknowledge RPC.
+ *
+ *  Consume 50 records, ACCEPT 10 at a time, commit_sync after
+ *  each batch. Track ShareAcknowledge requests and verify the
+ *  count matches the number of commit_sync calls that returned
+ *  at least 1 partition result.
+ * =================================================================== */
+static void do_test_mock_uses_share_acknowledge(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        const char *topic                           = "mock-cs-share-ack";
+        const int msgcnt                            = 50;
+        int consumed                                = 0;
+        int attempts                                = 0;
+        int commit_cnt                              = 0;
+        int commit_with_partitions                  = 0;
+        int acked_since_last_commit                 = 0;
+        int share_ack_cnt;
+        int i;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        mock_produce_messages(ctx.producer, topic, msgcnt);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, "sg-mock-cs-ack",
+                                             "explicit");
+
+        {
+                const char *t = topic;
+                subscribe_consumer(rkshare, &t, 1);
+        }
+
+        /* Clear and start tracking requests */
+        rd_kafka_mock_start_request_tracking(ctx.mcluster);
+        rd_kafka_mock_clear_requests(ctx.mcluster);
+
+        /* Consume all records, ACCEPT each, commit_sync every 10 */
+        while (consumed < msgcnt && attempts++ < 30) {
+                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+                size_t rcvd = 0;
+                size_t j;
+
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                                acked_since_last_commit++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        if (acked_since_last_commit == 10) {
+                                partitions = NULL;
+                                error      = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                commit_cnt++;
+                                TEST_ASSERT(
+                                    !error, "commit_sync #%d failed: %s",
+                                    commit_cnt,
+                                    error ? rd_kafka_error_string(error) : "");
+
+                                if (partitions != NULL) {
+                                        commit_with_partitions++;
+                                        for (i = 0; i < partitions->cnt; i++) {
+                                                rd_kafka_topic_partition_t
+                                                    *rktpar =
+                                                        &partitions->elems[i];
+                                                TEST_ASSERT(
+                                                    rktpar->err ==
+                                                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                                                    "commit_sync #%d: "
+                                                    "%s [%" PRId32 "] got %s",
+                                                    commit_cnt, rktpar->topic,
+                                                    rktpar->partition,
+                                                    rd_kafka_err2str(
+                                                        rktpar->err));
+                                        }
+                                        rd_kafka_topic_partition_list_destroy(
+                                            partitions);
+                                }
+
+                                TEST_SAY(
+                                    "commit_sync #%d OK "
+                                    "(consumed %d so far)\n",
+                                    commit_cnt, consumed);
+                                acked_since_last_commit = 0;
+                        }
+                }
+        }
+
+        TEST_SAY(
+            "Mock: consumed %d/%d, %d commit_sync calls, "
+            "%d with partition results\n",
+            consumed, msgcnt, commit_cnt, commit_with_partitions);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
+                    consumed);
+
+        /* Wait for async ops to complete before counting requests */
+        rd_sleep(3);
+
+        share_ack_cnt = count_share_ack_requests(ctx.mcluster);
+        rd_kafka_mock_stop_request_tracking(ctx.mcluster);
+
+        TEST_SAY(
+            "Mock: ShareAcknowledge requests=%d, "
+            "commit_sync with partitions=%d\n",
+            share_ack_cnt, commit_with_partitions);
+        TEST_ASSERT(share_ack_cnt == commit_with_partitions,
+                    "Expected ShareAcknowledge count (%d) == commit_sync with "
+                    "partitions count (%d)",
+                    share_ack_cnt, commit_with_partitions);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test 9: Mock — commit_sync timeout and recovery.
+ *
+ *  Phase 1: Consume 10 records, ACCEPT all. Set broker RTT to
+ *  5000ms and call commit_sync with timeout_ms=2000. The call
+ *  should block ~2000ms then return _TIMED_OUT. The broker still
+ *  processes the ack when the delayed response arrives.
+ *
+ *  Phase 2: Remove RTT, wait 5s for broker to finish processing.
+ *  Second consumer should get 0 records (acks were processed).
+ *
+ *  Phase 3: Produce 10 more, consume and ACCEPT, commit_sync
+ *  with normal timeout → succeeds. Verifies recovery.
+ * =================================================================== */
+static void do_test_mock_commit_sync_timeout(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        const char *topic                           = "mock-cs-timeout";
+        const char *t                               = topic;
+        const int msgcnt                            = 10;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed;
+        int attempts;
+        int i;
+        rd_bool_t got_timed_out = rd_false;
+        rd_ts_t t_start, t_elapsed_ms;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        mock_produce_messages(ctx.producer, topic, msgcnt);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps,
+                                             "sg-mock-cs-timeout", "explicit");
+        subscribe_consumer(rkshare, &t, 1);
+
+        /* Phase 1: Consume all 10 records and ACCEPT */
+        consumed = 0;
+        attempts = 0;
+        while (consumed < msgcnt && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Phase 1: consumed and acknowledged %d messages\n", consumed);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
+                    consumed);
+
+        /* Inject 5000ms RTT on all brokers */
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, 5000);
+
+        /* commit_sync with 2000ms timeout — should block ~2000ms
+         * then time out */
+        t_start      = test_clock();
+        partitions   = NULL;
+        error        = rd_kafka_share_commit_sync(rkshare, 2000, &partitions);
+        t_elapsed_ms = (test_clock() - t_start) / 1000;
+
+        TEST_SAY("Phase 1: commit_sync returned after %" PRId64
+                 "ms, error=%s, partitions=%s\n",
+                 t_elapsed_ms, error ? rd_kafka_error_string(error) : "NULL",
+                 partitions ? "non-NULL" : "NULL");
+
+        /* Verify commit_sync blocked for ~2000ms (allow 1500-3000ms) */
+        TEST_ASSERT(t_elapsed_ms >= 1500 && t_elapsed_ms <= 3000,
+                    "Expected commit_sync to block ~2000ms, "
+                    "got %" PRId64 "ms",
+                    t_elapsed_ms);
+
+        /* May return top-level error or per-partition _TIMED_OUT */
+        if (error) {
+                TEST_SAY("Phase 1: top-level error: %s\n",
+                         rd_kafka_error_string(error));
+                rd_kafka_error_destroy(error);
+                got_timed_out = rd_true;
+        }
+
+        if (partitions) {
+                for (i = 0; i < partitions->cnt; i++) {
+                        rd_kafka_topic_partition_t *rktpar =
+                            &partitions->elems[i];
+                        TEST_SAY("Phase 1: %s [%" PRId32 "]: %s\n",
+                                 rktpar->topic, rktpar->partition,
+                                 rd_kafka_err2str(rktpar->err));
+                        if (rktpar->err == RD_KAFKA_RESP_ERR__TIMED_OUT)
+                                got_timed_out = rd_true;
+                }
+                rd_kafka_topic_partition_list_destroy(partitions);
+        }
+
+        TEST_ASSERT(got_timed_out,
+                    "Expected _TIMED_OUT error from "
+                    "commit_sync with short timeout");
+
+        /* Phase 2: Remove RTT, wait 5s for broker to finish
+         * processing the delayed response */
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, 0);
+        rd_sleep(5);
+
+        /* Close first consumer */
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Second consumer: should get 0 records because the broker
+         * processed the acks despite client-side timeout */
+        rkshare = create_mock_share_consumer(ctx.bootstraps,
+                                             "sg-mock-cs-timeout", "implicit");
+        subscribe_consumer(rkshare, &t, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 5) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Phase 2: second consumer got %d records (expected 0)\n",
+                 consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Second consumer got %d records, expected 0 "
+                    "(broker should have processed acks despite "
+                    "client-side timeout)",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Phase 3: Produce more, consume, commit_sync normally —
+         * verify recovery after timeout */
+        mock_produce_messages(ctx.producer, topic, msgcnt);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps,
+                                             "sg-mock-cs-timeout", "explicit");
+        subscribe_consumer(rkshare, &t, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (consumed < msgcnt && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Phase 3: consumed %d messages\n", consumed);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
+                    consumed);
+
+        partitions = NULL;
+        error      = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "Phase 3: commit_sync failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_ASSERT(partitions != NULL,
+                    "Phase 3: expected partition results, got NULL");
+
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                TEST_SAY("Phase 3: %s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2str(rktpar->err));
+                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Phase 3: expected NO_ERROR for %s [%" PRId32
+                            "], got %s",
+                            rktpar->topic, rktpar->partition,
+                            rd_kafka_err2str(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test 10: Mixed commit types — commit_async and commit_sync.
+ *
+ *  Produce 50 records. Consume all, ACCEPT each record
+ *  individually. For the first 10 records call commit_async,
+ *  then call commit_sync for the 11th. Repeat this pattern
+ *  (10 async + 1 sync) until all records are committed.
+ *
+ *  Verify that commit_sync after async commits completes very
+ *  quickly (acks already sent by async, so sync has little or
+ *  no work to do). Second consumer should get 0 records.
+ * =================================================================== */
+static void do_test_mixed_commit_types(void) {
+        const char *topic;
+        const char *group = "commit-sync-mixed-types";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed              = 0;
+        int attempts              = 0;
+        int async_cnt             = 0;
+        int sync_cnt              = 0;
+        int acked_since_last_sync = 0;
+        int i;
+        rd_ts_t t_start, t_elapsed_ms;
+        rd_ts_t max_sync_elapsed_ms = 0;
+
+        topic = test_mk_topic_name("0176-cs-mixed-types", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_easy(topic, 0, 0, 50);
+
+        rkshare = create_share_consumer(group, "explicit");
+        set_group_offset_earliest(group);
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume all 50 records, ACCEPT each, alternate between
+         * commit_async (10 times) and commit_sync (1 time) */
+        while (consumed < 50 && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                consumed++;
+                                acked_since_last_sync++;
+
+                                if (acked_since_last_sync <= 10) {
+                                        /* commit_async for first 10 */
+                                        error = rd_kafka_share_commit_async(
+                                            rkshare);
+                                        TEST_ASSERT(
+                                            !error,
+                                            "commit_async #%d failed: %s",
+                                            async_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        async_cnt++;
+                                }
+
+                                if (acked_since_last_sync == 11) {
+                                        /* commit_sync on the 11th —
+                                         * should be fast since most acks
+                                         * were already sent by async */
+                                        partitions = NULL;
+                                        t_start    = test_clock();
+                                        error      = rd_kafka_share_commit_sync(
+                                            rkshare, 30000, &partitions);
+                                        t_elapsed_ms =
+                                            (test_clock() - t_start) / 1000;
+                                        sync_cnt++;
+
+                                        if (t_elapsed_ms > max_sync_elapsed_ms)
+                                                max_sync_elapsed_ms =
+                                                    t_elapsed_ms;
+
+                                        TEST_ASSERT(
+                                            !error,
+                                            "commit_sync #%d failed: %s",
+                                            sync_cnt,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+
+                                        if (partitions) {
+                                                for (i = 0; i < partitions->cnt;
+                                                     i++) {
+                                                        rd_kafka_topic_partition_t
+                                                            *rktpar =
+                                                                &partitions
+                                                                     ->elems[i];
+                                                        TEST_ASSERT(
+                                                            rktpar->err ==
+                                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                                            "commit_sync #%d: "
+                                                            "%s [%" PRId32
+                                                            "] got %s",
+                                                            sync_cnt,
+                                                            rktpar->topic,
+                                                            rktpar->partition,
+                                                            rd_kafka_err2str(
+                                                                rktpar->err));
+                                                }
+                                                rd_kafka_topic_partition_list_destroy(
+                                                    partitions);
+                                        }
+
+                                        TEST_SAY(
+                                            "commit_sync #%d OK "
+                                            "in %" PRId64
+                                            "ms (consumed %d, "
+                                            "%d async calls)\n",
+                                            sync_cnt, t_elapsed_ms, consumed,
+                                            async_cnt);
+                                        acked_since_last_sync = 0;
+                                }
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        /* Final commit_sync for any remaining acks */
+        if (acked_since_last_sync > 0) {
+                partitions = NULL;
+                error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+                sync_cnt++;
+                TEST_ASSERT(!error, "final commit_sync failed: %s",
+                            error ? rd_kafka_error_string(error) : "");
+                RD_IF_FREE(partitions, rd_kafka_topic_partition_list_destroy);
+                TEST_SAY("Final commit_sync #%d OK\n", sync_cnt);
+        }
+
+        TEST_SAY(
+            "Consumed %d, async commits=%d, sync commits=%d, "
+            "max sync elapsed=%" PRId64 "ms\n",
+            consumed, async_cnt, sync_cnt, max_sync_elapsed_ms);
+        TEST_ASSERT(consumed == 50, "Expected 50, got %d", consumed);
+
+        /* Verify commit_sync completed quickly — acks were mostly
+         * already sent by commit_async, so sync should not wait long.
+         * Allow up to 1000ms to account for broker round-trip. */
+        TEST_ASSERT(max_sync_elapsed_ms < 1000,
+                    "commit_sync took too long (%" PRId64
+                    "ms), expected < 1000ms since acks were "
+                    "mostly sent by commit_async",
+                    max_sync_elapsed_ms);
+
+        /* Allow time for any in-flight async ack requests to complete
+         * before closing the consumer. The final commit_async calls
+         * may have dispatched acks that are still awaiting broker
+         * response. */
+        rd_sleep(3);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Second consumer: should get 0 records */
+        rkshare = create_share_consumer(group, "implicit");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 5) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Second consumer got %d records (expected 0)\n", consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Second consumer got %d records, expected 0 after "
+                    "mixed async+sync commits",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+
+/* ===================================================================
+ *  Test 11: Mock — broker dispatch priority (pending_commit_sync
+ *  dispatched before async_ack_details).
+ *
+ *  Produce 30 messages. Consume all 30 in one batch. Then:
+ *  - ACCEPT first 10, commit_async → inflight (push entry 1: 2s RTT)
+ *  - ACCEPT next 10, commit_async → cached in async_ack_details
+ *  - ACCEPT last 10, commit_sync(5000) → pending_commit_sync
+ *
+ *  When inflight completes at ~2s, broker dispatches next request.
+ *  If pending_commit_sync has priority (correct): sync dispatched
+ *  next (push entry 2: 2s RTT), completes at ~4s < 5s → NO_ERROR.
+ *  If async_ack_details has priority (wrong): async dispatched
+ *  next (2s RTT), then sync (2s RTT), completes at ~6s > 5s →
+ *  TIMED_OUT.
+ *
+ *  Verification:
+ *  1. commit_sync returns NO_ERROR and completes in ~4s (3500-4500ms)
+ *  2. Per-partition results show NO_ERROR
+ *  3. Second consumer gets 0 records (all acks processed)
+ * =================================================================== */
+static void do_test_mock_broker_dispatch_priority(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        const char *topic                           = "mock-cs-dispatch-prio";
+        const char *t                               = topic;
+        const int msgcnt                            = 30;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_message_t *msg_handles[30];
+        size_t rcvd;
+        size_t j;
+        int consumed;
+        int attempts;
+        int i;
+        int32_t leader_broker_id = 1;
+        rd_ts_t t_start, t_elapsed_ms;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        rd_kafka_mock_partition_set_leader(ctx.mcluster, topic, 0,
+                                           leader_broker_id);
+
+        mock_produce_messages(ctx.producer, topic, msgcnt);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, "sg-mock-cs-prio",
+                                             "explicit");
+        subscribe_consumer(rkshare, &t, 1);
+
+        /* Consume all 30 records in one batch, keep handles */
+        consumed = 0;
+        attempts = 0;
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err && consumed < msgcnt)
+                                msg_handles[consumed++] = rkmessages[j];
+                        else
+                                rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Consumed %d/%d messages\n", consumed, msgcnt);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
+                    consumed);
+
+        /* Push 3 ShareAcknowledge entries with 2000ms RTT each on
+         * the leader broker. These are consumed in order:
+         *  Entry 1: first commit_async inflight request (~2s)
+         *  Entry 2: pending_commit_sync (if priority correct) (~2s)
+         *  Entry 3: async_ack_details (dispatched last) (~2s) */
+        rd_kafka_mock_broker_push_request_error_rtts(
+            ctx.mcluster, leader_broker_id, RD_KAFKAP_ShareAcknowledge, 3,
+            RD_KAFKA_RESP_ERR_NO_ERROR, 2000, RD_KAFKA_RESP_ERR_NO_ERROR, 2000,
+            RD_KAFKA_RESP_ERR_NO_ERROR, 2000);
+
+        /* ACCEPT first 10, commit_async → sends first
+         * ShareAcknowledge (inflight, push entry 1: 2s RTT) */
+        for (i = 0; i < 10; i++)
+                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async #1 failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_SAY("commit_async #1 sent (inflight, 2s RTT)\n");
+
+        /* Small delay to ensure async request is dispatched to
+         * broker thread before next commit */
+        rd_usleep(200 * 1000, NULL);
+
+        /* ACCEPT next 10, commit_async → broker busy,
+         * cached in async_ack_details */
+        for (i = 10; i < 20; i++)
+                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async #2 failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        TEST_SAY("commit_async #2 sent (cached in async_ack_details)\n");
+
+        /* ACCEPT last 10, commit_sync(5000ms) → broker still busy,
+         * stored in pending_commit_sync.
+         *
+         * Timeline if sync has dispatch priority (correct):
+         *   t=0s:  inflight request sent
+         *   t=2s:  inflight completes, sync dispatched (entry 2)
+         *   t=4s:  sync completes → NO_ERROR (4s < 5s timeout)
+         *
+         * Timeline if async has priority (wrong):
+         *   t=0s:  inflight request sent
+         *   t=2s:  inflight completes, async dispatched (entry 2)
+         *   t=4s:  async completes, sync dispatched (entry 3)
+         *   t=5s:  sync timeout fires → TIMED_OUT (5s < 6s) */
+        for (i = 20; i < 30; i++)
+                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+
+        TEST_SAY("Calling commit_sync(5000ms)\n");
+        t_start      = test_clock();
+        partitions   = NULL;
+        error        = rd_kafka_share_commit_sync(rkshare, 5000, &partitions);
+        t_elapsed_ms = (test_clock() - t_start) / 1000;
+
+        TEST_SAY("commit_sync returned after %" PRId64 "ms, error=%s\n",
+                 t_elapsed_ms,
+                 error ? rd_kafka_error_string(error) : "NO_ERROR");
+
+        /* Verify no error */
+        if (error) {
+                TEST_ASSERT(rd_kafka_error_code(error) !=
+                                RD_KAFKA_RESP_ERR__TIMED_OUT,
+                            "commit_sync TIMED_OUT after %" PRId64
+                            "ms — pending_commit_sync was NOT dispatched "
+                            "before async_ack_details. "
+                            "Dispatch priority is broken.",
+                            t_elapsed_ms);
+                rd_kafka_error_destroy(error);
+        } else {
+                TEST_SAY(
+                    "commit_sync returned NO_ERROR — dispatch "
+                    "priority is correct\n");
+        }
+
+        /* Verify timing: should complete in ~4s (2s inflight + 2s sync),
+         * not ~6s (2s inflight + 2s async + 2s sync). */
+        TEST_ASSERT(t_elapsed_ms >= 3500 && t_elapsed_ms <= 4500,
+                    "Expected commit_sync to complete in ~4s (3500-4500ms), "
+                    "got %" PRId64 "ms. If >5s, dispatch priority is wrong.",
+                    t_elapsed_ms);
+
+        /* Verify per-partition results show NO_ERROR */
+        TEST_ASSERT(partitions != NULL,
+                    "Expected per-partition results, got NULL");
+
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2str(rktpar->err));
+                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
+                            rktpar->topic, rktpar->partition,
+                            rd_kafka_err2str(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        /* Destroy message handles */
+        for (i = 0; i < msgcnt; i++)
+                rd_kafka_message_destroy(msg_handles[i]);
+
+        /* Wait for remaining async to complete */
+        rd_sleep(3);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+
+        /* Second consumer: should get 0 records since all acks
+         * were processed successfully */
+        rkshare = create_mock_share_consumer(ctx.bootstraps, "sg-mock-cs-prio",
+                                             "implicit");
+        subscribe_consumer(rkshare, &t, 1);
+
+        consumed = 0;
+        attempts = 0;
+        while (attempts++ < 5) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Second consumer got %d records (expected 0)\n", consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Second consumer got %d records, expected 0 "
+                    "(all acks should have been processed)",
+                    consumed);
+
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+int main_0176_share_consumer_commit_sync(int argc, char **argv) {
+        /* Real broker tests */
+        do_test_basic_implicit_commit_sync();
+        do_test_basic_explicit_commit_sync();
+        do_test_no_pending_acks();
+        do_test_commit_sync_prevents_redelivery();
+        do_test_mixed_ack_types();
+        do_test_multiple_commit_sync_calls();
+        do_test_multi_topic_partition();
+        do_test_mixed_commit_types();
+
+        return 0;
+}
+
+int main_0176_share_consumer_commit_sync_local(int argc, char **argv) {
+        /* Mock broker tests only (no real broker needed) */
+        TEST_SKIP_MOCK_CLUSTER(0);
+
+        do_test_mock_uses_share_acknowledge();
+        do_test_mock_commit_sync_timeout();
+        do_test_mock_broker_dispatch_priority();
+
+        return 0;
+}

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -41,6 +41,23 @@
 #define MAX_MSGS      500
 #define CONSUME_ARRAY 10001
 
+/** Common producer reused across all non-mock subtests. */
+static rd_kafka_t *common_producer;
+
+/** Common admin client reused across all non-mock subtests. */
+static rd_kafka_t *common_admin;
+
+/**
+ * @brief Produce messages using the common producer.
+ */
+static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
+        rd_kafka_topic_t *rkt;
+        rkt = test_create_producer_topic(common_producer, topic, NULL);
+        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
+                          0);
+        rd_kafka_topic_destroy(rkt);
+}
+
 
 /**
  * @brief Create share consumer with specified ack mode.
@@ -52,7 +69,7 @@ static rd_kafka_share_t *create_share_consumer(const char *group_id,
         rd_kafka_conf_t *conf;
         char errstr[512];
 
-        test_conf_init(&conf, NULL, 60);
+        test_conf_init(&conf, NULL, 0);
 
         rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode, errstr,
@@ -67,22 +84,24 @@ static rd_kafka_share_t *create_share_consumer(const char *group_id,
 
 /**
  * @brief Set share.auto.offset.reset=earliest for a share group.
- *        Uses a new admin client (not the share consumer handle).
  */
 static void set_group_offset_earliest(const char *group_name) {
-        rd_kafka_t *admin;
-        rd_kafka_conf_t *conf;
-        char errstr[512];
         const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
 
-        test_conf_init(&conf, NULL, 30);
-        admin = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-        TEST_ASSERT(admin, "Failed to create admin client: %s", errstr);
+        test_IncrementalAlterConfigs_simple(
+            common_admin, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
+}
 
-        test_IncrementalAlterConfigs_simple(admin, RD_KAFKA_RESOURCE_GROUP,
-                                            group_name, cfg, 1);
+/**
+ * @brief Set share.record.lock.duration.ms for a share group.
+ */
+static void set_group_lock_duration(const char *group_name,
+                                    const char *duration_ms) {
+        const char *cfg[] = {"share.record.lock.duration.ms", "SET",
+                             duration_ms};
 
-        rd_kafka_destroy(admin);
+        test_IncrementalAlterConfigs_simple(
+            common_admin, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
 }
 
 
@@ -126,14 +145,14 @@ static void do_test_basic_implicit_commit_sync(void) {
         size_t j;
         int consumed = 0;
         int attempts = 0;
-        int i;
 
         topic = test_mk_topic_name("0176-cs-impl-basic", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 5);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 5);
 
         rkshare = create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
+        set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume records */
@@ -164,21 +183,62 @@ static void do_test_basic_implicit_commit_sync(void) {
                     "Expected per-partition results, got NULL");
 
         TEST_SAY("commit_sync returned %d partition(s)\n", partitions->cnt);
-        TEST_ASSERT(partitions->cnt >= 1,
-                    "Expected at least 1 partition result, got %d",
+        TEST_ASSERT(partitions->cnt == 1,
+                    "Expected exactly 1 partition result, got %d",
                     partitions->cnt);
-
-        for (i = 0; i < partitions->cnt; i++) {
-                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
-                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
-                         rktpar->partition, rd_kafka_err2str(rktpar->err));
-                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
-                            rktpar->topic, rktpar->partition,
-                            rd_kafka_err2str(rktpar->err));
-        }
+        TEST_SAY("  %s [%" PRId32 "]: %s\n", partitions->elems[0].topic,
+                 partitions->elems[0].partition,
+                 rd_kafka_err2str(partitions->elems[0].err));
+        TEST_ASSERT(!strcmp(partitions->elems[0].topic, topic),
+                    "Expected topic %s, got %s", topic,
+                    partitions->elems[0].topic);
+        TEST_ASSERT(partitions->elems[0].partition == 0,
+                    "Expected partition 0, got %" PRId32,
+                    partitions->elems[0].partition);
+        TEST_ASSERT(partitions->elems[0].err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR, got %s",
+                    rd_kafka_err2str(partitions->elems[0].err));
 
         rd_kafka_topic_partition_list_destroy(partitions);
+
+        /* Wait for acquisition lock to expire (3s + 1s buffer) */
+        rd_sleep(4);
+
+        /* Produce 5 verification records and consume with the same
+         * consumer — should get only these 5 (dc == 1), proving
+         * the first batch was committed and not redelivered. */
+        produce_to_topic(topic, 0, 5);
+
+        consumed = 0;
+        attempts = 0;
+        while (consumed < 5 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 5000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_message_delivery_count(
+                                        rkmessages[j]) == 1,
+                                    "Got redelivered record at offset %" PRId64
+                                    " (delivery_count=%d)",
+                                    rkmessages[j]->offset,
+                                    rd_kafka_message_delivery_count(
+                                        rkmessages[j]));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Verification: got %d messages (expected 5)\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
+                    consumed);
 
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
@@ -203,14 +263,14 @@ static void do_test_basic_explicit_commit_sync(void) {
         size_t j;
         int consumed = 0;
         int attempts = 0;
-        int i;
 
         topic = test_mk_topic_name("0176-cs-expl-basic", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 5);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 5);
 
         rkshare = create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
+        set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume records and explicitly ACCEPT each */
@@ -244,21 +304,62 @@ static void do_test_basic_explicit_commit_sync(void) {
                     "Expected per-partition results, got NULL");
 
         TEST_SAY("commit_sync returned %d partition(s)\n", partitions->cnt);
-        TEST_ASSERT(partitions->cnt >= 1,
-                    "Expected at least 1 partition result, got %d",
+        TEST_ASSERT(partitions->cnt == 1,
+                    "Expected exactly 1 partition result, got %d",
                     partitions->cnt);
-
-        for (i = 0; i < partitions->cnt; i++) {
-                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
-                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
-                         rktpar->partition, rd_kafka_err2str(rktpar->err));
-                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
-                            rktpar->topic, rktpar->partition,
-                            rd_kafka_err2str(rktpar->err));
-        }
+        TEST_SAY("  %s [%" PRId32 "]: %s\n", partitions->elems[0].topic,
+                 partitions->elems[0].partition,
+                 rd_kafka_err2str(partitions->elems[0].err));
+        TEST_ASSERT(!strcmp(partitions->elems[0].topic, topic),
+                    "Expected topic %s, got %s", topic,
+                    partitions->elems[0].topic);
+        TEST_ASSERT(partitions->elems[0].partition == 0,
+                    "Expected partition 0, got %" PRId32,
+                    partitions->elems[0].partition);
+        TEST_ASSERT(partitions->elems[0].err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR, got %s",
+                    rd_kafka_err2str(partitions->elems[0].err));
 
         rd_kafka_topic_partition_list_destroy(partitions);
+
+        /* Wait for acquisition lock to expire (3s + 1s buffer) */
+        rd_sleep(4);
+
+        /* Produce 5 verification records and consume with the same
+         * consumer — should get only these 5 (dc == 1), proving
+         * the first batch was committed and not redelivered. */
+        produce_to_topic(topic, 0, 5);
+
+        consumed = 0;
+        attempts = 0;
+        while (consumed < 5 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 5000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_message_delivery_count(
+                                        rkmessages[j]) == 1,
+                                    "Got redelivered record at offset %" PRId64
+                                    " (delivery_count=%d)",
+                                    rkmessages[j]->offset,
+                                    rd_kafka_message_delivery_count(
+                                        rkmessages[j]));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        TEST_SAY("Verification: got %d messages (expected 5)\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
+                    consumed);
 
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
@@ -279,7 +380,7 @@ static void do_test_no_pending_acks(void) {
         rd_kafka_topic_partition_list_t *partitions = NULL;
 
         topic = test_mk_topic_name("0176-cs-no-pending", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
 
         rkshare = create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
@@ -322,8 +423,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         int attempts = 0;
 
         topic = test_mk_topic_name("0176-cs-no-redeliver", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 5);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 5);
 
         /* Consumer A: consume all and commit_sync */
         rkshare = create_share_consumer(group, "implicit");
@@ -357,31 +458,38 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
-        /* Consumer B: same group, should get 0 records */
+        /* Produce 5 verification records */
+        produce_to_topic(topic, 0, 5);
+
+        /* Consumer B: should only get the 5 verification records.
+         * Close tears down the connection and broker releases
+         * records immediately — no lock wait needed. */
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        consumed = 0;
-        attempts = 0;
-        while (attempts++ < 5) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
+        rcvd  = 0;
+        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
+                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        if (error)
+                rd_kafka_error_destroy(error);
 
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
+        consumed = 0;
+        for (j = 0; j < rcvd; j++) {
+                if (!rkmessages[j]->err) {
+                        TEST_ASSERT(
+                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            "Consumer B got redelivered record at "
+                            "offset %" PRId64 " (delivery_count=%d)",
+                            rkmessages[j]->offset,
+                            rd_kafka_message_delivery_count(rkmessages[j]));
+                        consumed++;
                 }
+                rd_kafka_message_destroy(rkmessages[j]);
         }
 
-        TEST_SAY("Consumer B consumed %d messages (expected 0)\n", consumed);
-        TEST_ASSERT(consumed == 0,
-                    "Consumer B got %d records, expected 0 after commit_sync",
+        TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
         rd_kafka_share_consumer_close(rkshare);
@@ -407,13 +515,12 @@ static void do_test_mixed_ack_types(void) {
         size_t j;
         int consumed = 0;
         int attempts = 0;
-        int i;
         int64_t released_offsets[3];
         int released_cnt = 0;
 
         topic = test_mk_topic_name("0176-cs-mixed-acks", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 10);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 10);
 
         /* Consumer A: consume all 10 in a single batch, apply mixed ack
          * types */
@@ -484,16 +591,21 @@ static void do_test_mixed_ack_types(void) {
                     error ? rd_kafka_error_string(error) : "");
         TEST_ASSERT(partitions != NULL,
                     "Expected per-partition results, got NULL");
-
-        for (i = 0; i < partitions->cnt; i++) {
-                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
-                TEST_SAY("  %s [%" PRId32 "]: %s\n", rktpar->topic,
-                         rktpar->partition, rd_kafka_err2str(rktpar->err));
-                TEST_ASSERT(rktpar->err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Expected NO_ERROR for %s [%" PRId32 "], got %s",
-                            rktpar->topic, rktpar->partition,
-                            rd_kafka_err2str(rktpar->err));
-        }
+        TEST_ASSERT(partitions->cnt == 1,
+                    "Expected exactly 1 partition result, got %d",
+                    partitions->cnt);
+        TEST_SAY("  %s [%" PRId32 "]: %s\n", partitions->elems[0].topic,
+                 partitions->elems[0].partition,
+                 rd_kafka_err2str(partitions->elems[0].err));
+        TEST_ASSERT(!strcmp(partitions->elems[0].topic, topic),
+                    "Expected topic %s, got %s", topic,
+                    partitions->elems[0].topic);
+        TEST_ASSERT(partitions->elems[0].partition == 0,
+                    "Expected partition 0, got %" PRId32,
+                    partitions->elems[0].partition);
+        TEST_ASSERT(partitions->elems[0].err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR, got %s",
+                    rd_kafka_err2str(partitions->elems[0].err));
 
         rd_kafka_topic_partition_list_destroy(partitions);
 
@@ -506,7 +618,7 @@ static void do_test_mixed_ack_types(void) {
 
         consumed = 0;
         attempts = 0;
-        while (attempts++ < 10) {
+        while (consumed < 3 && attempts++ < 10) {
                 rcvd  = 0;
                 error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
                                                      &rcvd);
@@ -581,11 +693,10 @@ static void do_test_multiple_commit_sync_calls(void) {
         int attempts                = 0;
         int commit_cnt              = 0;
         int acked_since_last_commit = 0;
-        int i;
 
         topic = test_mk_topic_name("0176-cs-multi-calls", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 50);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 50);
 
         rkshare = create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
@@ -625,19 +736,28 @@ static void do_test_multiple_commit_sync_calls(void) {
                                     "commit_sync #%d: expected results, "
                                     "got NULL",
                                     commit_cnt);
-
-                                for (i = 0; i < partitions->cnt; i++) {
-                                        rd_kafka_topic_partition_t *rktpar =
-                                            &partitions->elems[i];
-                                        TEST_ASSERT(
-                                            rktpar->err ==
-                                                RD_KAFKA_RESP_ERR_NO_ERROR,
-                                            "commit_sync #%d: %s [%" PRId32
-                                            "] got %s",
-                                            commit_cnt, rktpar->topic,
-                                            rktpar->partition,
-                                            rd_kafka_err2str(rktpar->err));
-                                }
+                                TEST_ASSERT(partitions->cnt == 1,
+                                            "commit_sync #%d: expected 1 "
+                                            "partition, got %d",
+                                            commit_cnt, partitions->cnt);
+                                TEST_ASSERT(
+                                    !strcmp(partitions->elems[0].topic, topic),
+                                    "commit_sync #%d: expected topic "
+                                    "%s, got %s",
+                                    commit_cnt, topic,
+                                    partitions->elems[0].topic);
+                                TEST_ASSERT(partitions->elems[0].partition == 0,
+                                            "commit_sync #%d: expected "
+                                            "partition 0, got %" PRId32,
+                                            commit_cnt,
+                                            partitions->elems[0].partition);
+                                TEST_ASSERT(
+                                    partitions->elems[0].err ==
+                                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                                    "commit_sync #%d: %s [%" PRId32 "] got %s",
+                                    commit_cnt, partitions->elems[0].topic,
+                                    partitions->elems[0].partition,
+                                    rd_kafka_err2str(partitions->elems[0].err));
 
                                 rd_kafka_topic_partition_list_destroy(
                                     partitions);
@@ -682,32 +802,36 @@ static void do_test_multiple_commit_sync_calls(void) {
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
-        /* Consumer B: same group, should get 0 records */
+        /* Produce 5 verification records */
+        produce_to_topic(topic, 0, 5);
+
+        /* Consumer B: should only get the 5 verification records */
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        consumed = 0;
-        attempts = 0;
-        while (attempts++ < 5) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
+        rcvd  = 0;
+        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
+                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        if (error)
+                rd_kafka_error_destroy(error);
 
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
+        consumed = 0;
+        for (j = 0; j < rcvd; j++) {
+                if (!rkmessages[j]->err) {
+                        TEST_ASSERT(
+                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            "Consumer B got redelivered record at "
+                            "offset %" PRId64 " (delivery_count=%d)",
+                            rkmessages[j]->offset,
+                            rd_kafka_message_delivery_count(rkmessages[j]));
+                        consumed++;
                 }
+                rd_kafka_message_destroy(rkmessages[j]);
         }
 
-        TEST_SAY("Consumer B consumed %d messages (expected 0)\n", consumed);
-        TEST_ASSERT(consumed == 0,
-                    "Consumer B got %d records, expected 0 after 5 "
-                    "commit_sync calls",
+        TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
         rd_kafka_share_consumer_close(rkshare);
@@ -765,11 +889,12 @@ static void do_test_multi_topic_partition(void) {
         /* Create topics and produce 10 messages per partition */
         for (i = 0; i < MULTI_TP_TOPICS; i++) {
                 topics[i] = rd_strdup(test_mk_topic_name("0176-cs-mtp", 1));
-                test_create_topic_wait_exists(
-                    NULL, topics[i], MULTI_TP_PARTITIONS, -1, 60 * 1000);
+                test_create_topic_wait_exists(common_admin, topics[i],
+                                              MULTI_TP_PARTITIONS, -1,
+                                              60 * 1000);
                 for (p = 0; p < MULTI_TP_PARTITIONS; p++)
-                        test_produce_msgs_easy(topics[i], p, p,
-                                               MULTI_TP_MSGS_PER_PARTITION);
+                        produce_to_topic(topics[i], p,
+                                         MULTI_TP_MSGS_PER_PARTITION);
         }
 
         rkshare = create_share_consumer(group, "explicit");
@@ -779,6 +904,7 @@ static void do_test_multi_topic_partition(void) {
         /* Consume until all records are settled
          * (accepted + rejected == total_msgs) */
         while (accepted + rejected < total_msgs && attempts++ < 200) {
+                rd_kafka_topic_partition_list_t *batch_tps;
                 int batch_cnt = 0;
 
                 rcvd  = 0;
@@ -789,15 +915,29 @@ static void do_test_multi_topic_partition(void) {
                         continue;
                 }
 
+                /* Track unique topic-partitions in this batch */
+                batch_tps = rd_kafka_topic_partition_list_new(
+                    MULTI_TP_TOPICS * MULTI_TP_PARTITIONS);
+
                 for (j = 0; j < rcvd; j++) {
                         rd_kafka_share_AcknowledgeType_t ack_type;
                         rd_kafka_resp_err_t err;
                         int16_t dc;
+                        const char *msg_topic;
 
                         if (rkmessages[j]->err) {
                                 rd_kafka_message_destroy(rkmessages[j]);
                                 continue;
                         }
+
+                        msg_topic = rd_kafka_topic_name(rkmessages[j]->rkt);
+
+                        /* Add to batch TPs if not already present */
+                        if (!rd_kafka_topic_partition_list_find(
+                                batch_tps, msg_topic, rkmessages[j]->partition))
+                                rd_kafka_topic_partition_list_add(
+                                    batch_tps, msg_topic,
+                                    rkmessages[j]->partition);
 
                         dc = rd_kafka_message_delivery_count(rkmessages[j]);
                         if (dc > max_dc_seen)
@@ -828,8 +968,10 @@ static void do_test_multi_topic_partition(void) {
                         rd_kafka_message_destroy(rkmessages[j]);
                 }
 
-                if (batch_cnt == 0)
+                if (batch_cnt == 0) {
+                        rd_kafka_topic_partition_list_destroy(batch_tps);
                         continue;
+                }
 
                 /* commit_sync after each batch */
                 partitions = NULL;
@@ -841,6 +983,12 @@ static void do_test_multi_topic_partition(void) {
                             "commit_sync #%d: expected results, got NULL",
                             commit_cnt);
 
+                /* Verify commit_sync returned exactly the TPs we
+                 * consumed from in this batch */
+                TEST_ASSERT(partitions->cnt == batch_tps->cnt,
+                            "commit_sync #%d: expected %d partition(s), got %d",
+                            commit_cnt, batch_tps->cnt, partitions->cnt);
+
                 for (i = 0; i < partitions->cnt; i++) {
                         rd_kafka_topic_partition_t *rktpar =
                             &partitions->elems[i];
@@ -849,6 +997,13 @@ static void do_test_multi_topic_partition(void) {
                                     commit_cnt, rktpar->topic,
                                     rktpar->partition,
                                     rd_kafka_err2str(rktpar->err));
+                        TEST_ASSERT(rd_kafka_topic_partition_list_find(
+                                        batch_tps, rktpar->topic,
+                                        rktpar->partition) != NULL,
+                                    "commit_sync #%d: unexpected partition "
+                                    "%s [%" PRId32 "] in results",
+                                    commit_cnt, rktpar->topic,
+                                    rktpar->partition);
                 }
 
                 TEST_SAY(
@@ -858,6 +1013,7 @@ static void do_test_multi_topic_partition(void) {
                     total_msgs, partitions->cnt);
 
                 rd_kafka_topic_partition_list_destroy(partitions);
+                rd_kafka_topic_partition_list_destroy(batch_tps);
         }
 
         TEST_SAY(
@@ -1381,8 +1537,8 @@ static void do_test_mixed_commit_types(void) {
         rd_ts_t max_sync_elapsed_ms = 0;
 
         topic = test_mk_topic_name("0176-cs-mixed-types", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 50);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        produce_to_topic(topic, 0, 50);
 
         rkshare = create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
@@ -1514,32 +1670,36 @@ static void do_test_mixed_commit_types(void) {
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
-        /* Second consumer: should get 0 records */
+        /* Produce 5 verification records */
+        produce_to_topic(topic, 0, 5);
+
+        /* Second consumer: should only get the 5 verification records */
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        consumed = 0;
-        attempts = 0;
-        while (attempts++ < 5) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
+        rcvd  = 0;
+        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
+                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        if (error)
+                rd_kafka_error_destroy(error);
 
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
+        consumed = 0;
+        for (j = 0; j < rcvd; j++) {
+                if (!rkmessages[j]->err) {
+                        TEST_ASSERT(
+                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            "Consumer B got redelivered record at "
+                            "offset %" PRId64 " (delivery_count=%d)",
+                            rkmessages[j]->offset,
+                            rd_kafka_message_delivery_count(rkmessages[j]));
+                        consumed++;
                 }
+                rd_kafka_message_destroy(rkmessages[j]);
         }
 
-        TEST_SAY("Second consumer got %d records (expected 0)\n", consumed);
-        TEST_ASSERT(consumed == 0,
-                    "Second consumer got %d records, expected 0 after "
-                    "mixed async+sync commits",
+        TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
+        TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
         rd_kafka_share_consumer_close(rkshare);
@@ -1775,6 +1935,10 @@ static void do_test_mock_broker_dispatch_priority(void) {
 
 
 int main_0176_share_consumer_commit_sync(int argc, char **argv) {
+        test_timeout_set(120);
+        common_producer = test_create_producer();
+        common_admin    = test_create_producer();
+
         /* Real broker tests */
         do_test_basic_implicit_commit_sync();
         do_test_basic_explicit_commit_sync();
@@ -1784,6 +1948,9 @@ int main_0176_share_consumer_commit_sync(int argc, char **argv) {
         do_test_multiple_commit_sync_calls();
         do_test_multi_topic_partition();
         do_test_mixed_commit_types();
+
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_producer);
 
         return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ set(
     0171-share_consumer_consume.c
     0172-share_consumer_acknowledge.c
     0173-share_consumer_commit_async.c
+    0176-share_consumer_commit_sync.c
     0177-share_consumer_transactions.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -294,6 +294,8 @@ _TEST_DECL(0171_share_consumer_consume);
 _TEST_DECL(0172_share_consumer_acknowledge);
 _TEST_DECL(0173_share_consumer_commit_async_local);
 _TEST_DECL(0173_share_consumer_commit_async);
+_TEST_DECL(0176_share_consumer_commit_sync);
+_TEST_DECL(0176_share_consumer_commit_sync_local);
 _TEST_DECL(0177_share_consumer_transactions);
 
 /* Manual tests */
@@ -571,10 +573,10 @@ struct test tests[] = {
     _TEST(0170_share_consumer_subscription, 0, TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0171_share_consumer_consume, 0, TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0172_share_consumer_acknowledge, 0, TEST_BRKVER(0, 4, 0, 0)),
-    _TEST(0173_share_consumer_commit_async_local,
-          TEST_F_LOCAL,
-          TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0173_share_consumer_commit_async_local, TEST_F_LOCAL),
     _TEST(0173_share_consumer_commit_async, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0176_share_consumer_commit_sync, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0176_share_consumer_commit_sync_local, TEST_F_LOCAL),
     _TEST(0177_share_consumer_transactions, 0, TEST_BRKVER(0, 4, 0, 0)),
 
     /* Manual tests */

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="..\..\tests\0171-share_consumer_consume.c" />
     <ClCompile Include="..\..\tests\0172-share_consumer_acknowledge.c" />
     <ClCompile Include="..\..\tests\0173-share_consumer_commit_async.c" />
+    <ClCompile Include="..\..\tests\0176-share_consumer_commit_sync.c" />
     <ClCompile Include="..\..\tests\0177-share_consumer_transactions.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />


### PR DESCRIPTION
1. Core implementation:
   - SHARE_COMMIT_SYNC_FANOUT op type and handler in main thread
   - Segregate acks by partition leader into per-broker pending_commit_sync
   - Dispatch sync ack ops with priority over async_ack_details
   - Timeout timer fills remaining partitions with _TIMED_OUT
   - App thread blocks on temp queue until all broker replies or timeout

2. Data structures:
   - commit_sync_request in rkcg (abs_timeout, results, wait count, replyq, timer)
   - pending_commit_sync in broker (sync_ack_details, abs_timeout, request_id)
   - SHARE_COMMIT_SYNC_FANOUT and FANOUT_REPLY op types with union members

3. Broker thread changes:
   - ShareAcknowledge reply handler populates ack_results in reply op
   - Main thread reply handler copies per-partition errors to sync results
   - Pending sync acks dispatched before async when broker becomes free

4. Tests (0176-share_consumer_commit_sync.c):
   - Basic implicit/explicit ack mode commit_sync
   - No pending acks returns NULL/NULL
   - Commit prevents redelivery (Consumer B gets 0 records)
   - Mixed ack types (ACCEPT/RELEASE/REJECT) with delivery count verification
   - Multiple commit_sync calls with back-to-back no-op commits
   - Multi-topic multi-partition (10 topics x 6 partitions x 10 msgs)
   - Mock: verifies ShareAcknowledge RPC count matches commit_sync calls
   - Mock: timeout handling with 5s RTT / 2s timeout and recovery
   - Mixed commit types (10 async + 1 sync pattern)
   - Mock: broker dispatch priority (sync before async)

5. Example program and build integration