### PR TITLE
Wrote tests for checking transactions and control records filtering h…

### DIFF
--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -1,0 +1,1139 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2025, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+/**
+ * @brief Share consumer transaction tests.
+ *
+ * Tests that share consumers correctly handle transactional messages
+ * based on the isolation.level configuration:
+ *
+ * - read_committed: Only see committed messages, aborted filtered out
+ * - read_uncommitted: See ALL messages including aborted ones
+ *
+ * Both modes are tested to verify correct behavior.
+ */
+
+#define BATCH_SIZE 1000
+
+
+/**
+ * @brief Create a transactional producer.
+ */
+static rd_kafka_t *create_txn_producer(const char *txn_id) {
+        rd_kafka_t *rk;
+        rd_kafka_conf_t *conf;
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "transactional.id", txn_id);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+
+        rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, 30000));
+
+        return rk;
+}
+
+
+/**
+ * @brief Create a share consumer with specified group.
+ *
+ * Note: For share consumers, isolation.level is configured on the
+ * BROKER-SIDE via share group configuration (share.isolation.level),
+ * not on the client. See configure_share_group().
+ */
+static rd_kafka_share_t *create_share_consumer(const char *group) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 60);
+        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer: %s",
+                    errstr);
+
+        return rkshare;
+}
+
+
+/**
+ * @brief Configure share group settings.
+ *
+ * Sets share.auto.offset.reset=earliest and share.isolation.level
+ * based on the isolation_level parameter.
+ *
+ * Note: share.isolation.level is a BROKER-SIDE share group configuration.
+ * Transaction filtering happens on the broker, not the client.
+ */
+static void configure_share_group(rd_kafka_t *rk,
+                                  const char *group,
+                                  const char *isolation_level) {
+        const char *offset_cfg[] = {"share.auto.offset.reset", "SET",
+                                    "earliest"};
+        const char *isolation_cfg[] = {"share.isolation.level", "SET",
+                                       isolation_level};
+
+        test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP, group,
+                                            offset_cfg, 1);
+        test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP, group,
+                                            isolation_cfg, 1);
+}
+
+
+/**
+ * @brief Subscribe share consumer to a topic.
+ */
+static void subscribe_share_consumer(rd_kafka_share_t *rkshare,
+                                     const char *topic) {
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+
+        err = rd_kafka_share_subscribe(rkshare, subs);
+        TEST_ASSERT(!err, "Share subscribe failed: %s", rd_kafka_err2str(err));
+
+        rd_kafka_topic_partition_list_destroy(subs);
+}
+
+
+/**
+ * @brief Consume messages from share consumer.
+ *
+ * @returns Number of non-error messages consumed.
+ */
+static int consume_share_messages(rd_kafka_share_t *rkshare,
+                                  int expected_cnt,
+                                  int max_attempts,
+                                  int poll_timeout_ms) {
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        int consumed = 0;
+        int attempts = max_attempts;
+
+        while (consumed < expected_cnt && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t i;
+                rd_kafka_error_t *err;
+
+                err = rd_kafka_share_consume_batch(rkshare, poll_timeout_ms,
+                                                   batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (i = 0; i < rcvd; i++) {
+                        if (!batch[i]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        return consumed;
+}
+
+
+/**
+ * @brief Poll share consumer expecting no messages (for abort verification).
+ *
+ * @returns Number of messages received (should be 0 for aborted txns
+ *          with read_committed).
+ */
+static int consume_share_no_msgs(rd_kafka_share_t *rkshare,
+                                 int poll_attempts,
+                                 int poll_timeout_ms) {
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        int consumed = 0;
+        int attempts = poll_attempts;
+
+        while (attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t i;
+                rd_kafka_error_t *err;
+
+                err = rd_kafka_share_consume_batch(rkshare, poll_timeout_ms,
+                                                   batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (i = 0; i < rcvd; i++) {
+                        if (!batch[i]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        return consumed;
+}
+
+
+/* ===================================================================
+ *  Test: Committed transaction visibility.
+ *
+ *  Both read_committed and read_uncommitted should see committed
+ *  messages.
+ * =================================================================== */
+static void do_test_committed_transaction(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-commit-test";
+        const int msg_cnt = 100;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-commit-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-commit-%s",
+                    isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Begin transaction */
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+
+        /* Produce messages */
+        TEST_SAY("Producing %d messages in transaction\n", msg_cnt);
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+
+        /* Commit transaction */
+        TEST_SAY("Committing transaction\n");
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        /* Consume messages - both modes should receive committed messages */
+        TEST_SAY("Consuming messages via share consumer (%s)\n",
+                 isolation_level);
+        consumed = consume_share_messages(consumer, msg_cnt, 50, 3000);
+
+        TEST_ASSERT(consumed == msg_cnt,
+                    "[%s] Expected %d messages from committed transaction, "
+                    "got %d",
+                    isolation_level, msg_cnt, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d committed "
+                 "messages\n",
+                 isolation_level, consumed);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Aborted transaction visibility.
+ *
+ *  - read_committed: Should NOT see aborted messages (expect 0)
+ *  - read_uncommitted: Should see ALL messages (expect msg_cnt)
+ * =================================================================== */
+static void do_test_aborted_transaction(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-abort-test";
+        const int msg_cnt = 100;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-abort-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-abort-%s", isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Expected messages depend on isolation level:
+         * - read_committed: 0 (aborted messages filtered)
+         * - read_uncommitted: msg_cnt (all messages visible) */
+        expected_msgs = is_read_committed ? 0 : msg_cnt;
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Begin transaction */
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+
+        /* Produce messages */
+        TEST_SAY("Producing %d messages in transaction\n", msg_cnt);
+        test_curr->ignore_dr_err = rd_true; /* Aborted messages may fail */
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+
+        /* Abort transaction */
+        TEST_SAY("Aborting transaction\n");
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* Consume messages */
+        TEST_SAY("Consuming messages via share consumer (%s), expecting %d\n",
+                 isolation_level, expected_msgs);
+
+        if (is_read_committed) {
+                consumed = consume_share_no_msgs(consumer, 10, 2000);
+        } else {
+                consumed =
+                    consume_share_messages(consumer, expected_msgs, 50, 3000);
+        }
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages from aborted transaction, "
+                    "got %d",
+                    isolation_level, expected_msgs, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages "
+                 "(expected %d)\n",
+                 isolation_level, consumed, expected_msgs);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Mixed transactions (some committed, some aborted).
+ *
+ *  - read_committed: Only see committed messages
+ *  - read_uncommitted: See ALL messages
+ * =================================================================== */
+static void do_test_mixed_transactions(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-mixed-test";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int i;
+        int expected_committed = 0;
+        int expected_total     = 0;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        /* Define transaction scenarios */
+        struct {
+                const char *desc;
+                rd_bool_t commit;
+                int msg_cnt;
+        } txns[] = {
+            {"Commit 50 msgs", rd_true, 50},
+            {"Abort 50 msgs", rd_false, 50},
+            {"Commit 30 msgs", rd_true, 30},
+            {"Abort 20 msgs", rd_false, 20},
+            {"Commit 40 msgs", rd_true, 40},
+        };
+        const int txn_cnt = sizeof(txns) / sizeof(txns[0]);
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-mixed-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-mixed-%s", isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Execute transactions */
+        for (i = 0; i < txn_cnt; i++) {
+                TEST_SAY("Transaction %d: %s\n", i + 1, txns[i].desc);
+
+                TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+
+                test_curr->ignore_dr_err = !txns[i].commit;
+                test_produce_msgs2(producer, topic, test_id_generate(),
+                                   RD_KAFKA_PARTITION_UA, 0, txns[i].msg_cnt,
+                                   NULL, 0);
+
+                if (txns[i].commit) {
+                        TEST_CALL_ERROR__(
+                            rd_kafka_commit_transaction(producer, 30000));
+                        expected_committed += txns[i].msg_cnt;
+                } else {
+                        TEST_CALL_ERROR__(
+                            rd_kafka_abort_transaction(producer, 30000));
+                }
+                expected_total += txns[i].msg_cnt;
+                test_curr->ignore_dr_err = rd_false;
+        }
+
+        /* Expected depends on isolation level */
+        expected_msgs = is_read_committed ? expected_committed : expected_total;
+
+        TEST_SAY("Expected messages [%s]: %d (committed=%d, total=%d)\n",
+                 isolation_level, expected_msgs, expected_committed,
+                 expected_total);
+
+        /* Consume messages */
+        consumed = consume_share_messages(consumer, expected_msgs, 100, 3000);
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msgs, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages\n",
+                 isolation_level, consumed);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Control records filtering.
+ *
+ *  Control records (abort/commit markers) should never be visible
+ *  to the application, regardless of isolation level.
+ * =================================================================== */
+static void do_test_control_records_filtered(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-ctrl-test";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-ctrl-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-ctrl-%s", isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Transaction 1: Produce and ABORT (1 msg + 1 abort marker) */
+        TEST_SAY("Transaction 1: Produce 1 message, then ABORT\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, 1, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* Transaction 2: Produce and COMMIT (5 msgs + 1 commit marker) */
+        TEST_SAY("Transaction 2: Produce 5 messages, then COMMIT\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, 5, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        /*
+         * Topic now contains:
+         * - Offset 0: aborted message
+         * - Offset 1: abort control record
+         * - Offset 2-6: committed messages
+         * - Offset 7: commit control record
+         *
+         * read_committed: should see offsets 2,3,4,5,6 (committed only)
+         * read_uncommitted: should see offsets 0,2,3,4,5,6 (aborted + committed)
+         * Control records (offsets 1 and 7) should NEVER be visible.
+         */
+        expected_msgs = is_read_committed ? 5 : 6;
+
+        /* Consume and verify exact offsets */
+        {
+                rd_kafka_message_t *batch[BATCH_SIZE];
+                int attempts = 50;
+                int64_t received_offsets[10];
+                int64_t expected_offsets_committed[] = {2, 3, 4, 5, 6};
+                int64_t expected_offsets_uncommitted[] = {0, 2, 3, 4, 5, 6};
+                int64_t *expected_offsets;
+                int j;
+
+                consumed = 0;
+
+                TEST_SAY("[%s] Consuming messages and verifying offsets:\n",
+                         isolation_level);
+
+                while (consumed < expected_msgs && attempts-- > 0) {
+                        size_t rcvd = 0;
+                        size_t i;
+                        rd_kafka_error_t *err;
+
+                        err = rd_kafka_share_consume_batch(
+                            consumer, 3000, batch, &rcvd);
+                        if (err) {
+                                rd_kafka_error_destroy(err);
+                                continue;
+                        }
+
+                        for (i = 0; i < rcvd; i++) {
+                                if (!batch[i]->err && consumed < 10) {
+                                        received_offsets[consumed] =
+                                            batch[i]->offset;
+                                        TEST_SAY(
+                                            "  Message %d: offset=%" PRId64
+                                            "\n",
+                                            consumed, batch[i]->offset);
+                                        consumed++;
+                                }
+                                rd_kafka_message_destroy(batch[i]);
+                        }
+                }
+
+                /* Verify no control records (offsets 1 and 7) were received */
+                for (j = 0; j < consumed; j++) {
+                        TEST_ASSERT(
+                            received_offsets[j] != 1 &&
+                                received_offsets[j] != 7,
+                            "[%s] Received control record at offset %" PRId64
+                            " - should be filtered!",
+                            isolation_level, received_offsets[j]);
+                }
+
+                /* Verify expected offsets based on isolation level */
+                expected_offsets = is_read_committed ? expected_offsets_committed
+                                                     : expected_offsets_uncommitted;
+
+                TEST_ASSERT(consumed == expected_msgs,
+                            "[%s] Expected %d messages, got %d", isolation_level,
+                            expected_msgs, consumed);
+
+                for (j = 0; j < consumed; j++) {
+                        TEST_ASSERT(
+                            received_offsets[j] == expected_offsets[j],
+                            "[%s] Message %d: expected offset %" PRId64
+                            ", got %" PRId64,
+                            isolation_level, j, expected_offsets[j],
+                            received_offsets[j]);
+                }
+
+                TEST_SAY("SUCCESS [%s]: All %d offsets verified correctly, "
+                         "control records filtered\n",
+                         isolation_level, consumed);
+        }
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Multiple partitions with transactions.
+ * =================================================================== */
+static void do_test_multi_partition_transactions(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-multipart-test";
+        const int partition_cnt = 3;
+        const int msgs_per_partition = 30;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int expected_committed;
+        int expected_total;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-multipart-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-multipart-%s",
+                    isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic with multiple partitions */
+        test_create_topic(NULL, topic, partition_cnt, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Transaction 1: Produce to all partitions and COMMIT */
+        TEST_SAY("Transaction 1: Produce to all partitions, COMMIT\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0,
+                           msgs_per_partition * partition_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        /* Transaction 2: Produce to all partitions and ABORT */
+        TEST_SAY("Transaction 2: Produce to all partitions, ABORT\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0,
+                           msgs_per_partition * partition_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* Transaction 3: Produce to all partitions and COMMIT */
+        TEST_SAY("Transaction 3: Produce to all partitions, COMMIT\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0,
+                           msgs_per_partition * partition_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        /* Calculate expected messages */
+        expected_committed = 2 * msgs_per_partition * partition_cnt;
+        expected_total     = 3 * msgs_per_partition * partition_cnt;
+        expected_msgs = is_read_committed ? expected_committed : expected_total;
+
+        TEST_SAY("Expected messages [%s]: %d\n", isolation_level, expected_msgs);
+
+        consumed = consume_share_messages(consumer, expected_msgs, 100, 3000);
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msgs, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages\n",
+                 isolation_level, consumed);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Interleaved transactions from multiple producers.
+ * =================================================================== */
+static void do_test_interleaved_producers(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const int msg_cnt = 50;
+        rd_kafka_t *producer1, *producer2;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix),
+                    "0177-txn-interleave-%s", isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-interleave-%s",
+                    isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create two transactional producers */
+        producer1 = create_txn_producer("txn-producer-1");
+        producer2 = create_txn_producer("txn-producer-2");
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Producer 1: Begin transaction */
+        TEST_SAY("Producer 1: Begin transaction\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer1));
+
+        /* Producer 2: Begin transaction */
+        TEST_SAY("Producer 2: Begin transaction\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer2));
+
+        /* Producer 1: Produce messages */
+        TEST_SAY("Producer 1: Produce %d messages\n", msg_cnt);
+        test_produce_msgs2(producer1, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+
+        /* Producer 2: Produce messages */
+        TEST_SAY("Producer 2: Produce %d messages\n", msg_cnt);
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer2, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+
+        /* Producer 1: COMMIT */
+        TEST_SAY("Producer 1: COMMIT\n");
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer1, 30000));
+
+        /* Producer 2: ABORT */
+        TEST_SAY("Producer 2: ABORT\n");
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer2, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* Expected: read_committed sees only producer1's msgs,
+         * read_uncommitted sees both */
+        expected_msgs = is_read_committed ? msg_cnt : (2 * msg_cnt);
+
+        consumed = consume_share_messages(consumer, expected_msgs, 50, 3000);
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msgs, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages\n",
+                 isolation_level, consumed);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer1);
+        rd_kafka_destroy(producer2);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Non-transactional and transactional messages mixed.
+ * =================================================================== */
+static void do_test_mixed_txn_non_txn(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-mixed-type-test";
+        const int non_txn_msgs = 50;
+        const int txn_commit_msgs = 30;
+        const int txn_abort_msgs = 20;
+        rd_kafka_t *txn_producer, *regular_producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix),
+                    "0177-txn-mixed-type-%s", isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-txn-mixed-type-%s",
+                    isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        txn_producer = create_txn_producer(txn_id);
+
+        /* Create regular (non-transactional) producer */
+        regular_producer = test_create_producer();
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Produce non-transactional messages */
+        TEST_SAY("Producing %d non-transactional messages\n", non_txn_msgs);
+        test_produce_msgs2(regular_producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, non_txn_msgs, NULL, 0);
+
+        /* Transactional: Commit */
+        TEST_SAY("Producing %d transactional messages (will commit)\n",
+                 txn_commit_msgs);
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(txn_producer));
+        test_produce_msgs2(txn_producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, txn_commit_msgs, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(txn_producer, 30000));
+
+        /* Transactional: Abort */
+        TEST_SAY("Producing %d transactional messages (will abort)\n",
+                 txn_abort_msgs);
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(txn_producer));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(txn_producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, txn_abort_msgs, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(txn_producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* Expected:
+         * read_committed: non-txn + committed = 50 + 30 = 80
+         * read_uncommitted: all = 50 + 30 + 20 = 100 */
+        expected_msgs = is_read_committed
+                            ? (non_txn_msgs + txn_commit_msgs)
+                            : (non_txn_msgs + txn_commit_msgs + txn_abort_msgs);
+
+        TEST_SAY("Expected messages [%s]: %d\n", isolation_level, expected_msgs);
+
+        consumed = consume_share_messages(consumer, expected_msgs, 100, 3000);
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msgs, consumed);
+
+        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages\n",
+                 isolation_level, consumed);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(txn_producer);
+        rd_kafka_destroy(regular_producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Dynamic isolation level change (READ_UNCOMMITTED -> READ_COMMITTED)
+ *
+ *  1. Start with READ_UNCOMMITTED
+ *  2. Produce committed txn, consume and acknowledge
+ *  3. Produce aborted txn, consume and release
+ *  4. Change to READ_COMMITTED
+ *  5. Produce more committed/aborted txns
+ *  6. Verify only committed txns are now returned
+ * =================================================================== */
+static void do_test_dynamic_uncommitted_to_committed(void) {
+        const char *topic;
+        const char *group = "share-dynamic-uc-to-c";
+        const char *txn_id = "txn-dynamic-uc-c";
+        const int msg_cnt = 10;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0177-dynamic-uc-to-c", 1);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer with READ_UNCOMMITTED */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              "read_uncommitted");
+        subscribe_share_consumer(consumer, topic);
+
+        /* Phase 1: Produce and consume committed transaction */
+        TEST_SAY("Phase 1: Committed transaction with READ_UNCOMMITTED\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        consumed = consume_share_messages(consumer, msg_cnt, 50, 3000);
+        TEST_ASSERT(consumed == msg_cnt,
+                    "Phase 1: Expected %d committed msgs, got %d", msg_cnt,
+                    consumed);
+
+        /* Phase 2: Produce aborted transaction - should be visible in
+         * READ_UNCOMMITTED */
+        TEST_SAY("Phase 2: Aborted transaction with READ_UNCOMMITTED\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        consumed = consume_share_messages(consumer, msg_cnt, 50, 3000);
+        TEST_ASSERT(consumed == msg_cnt,
+                    "Phase 2: Expected %d aborted msgs (uncommitted mode), "
+                    "got %d",
+                    msg_cnt, consumed);
+
+        /* Phase 3: Change isolation level to READ_COMMITTED */
+        TEST_SAY("Phase 3: Changing isolation level to READ_COMMITTED\n");
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              "read_committed");
+
+        /* Phase 4: Produce aborted transaction - should NOT be visible now */
+        TEST_SAY("Phase 4: Aborted transaction with READ_COMMITTED\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        consumed = consume_share_no_msgs(consumer, 10, 2000);
+        TEST_ASSERT(consumed == 0,
+                    "Phase 4: Expected 0 aborted msgs (committed mode), got %d",
+                    consumed);
+
+        /* Phase 5: Produce committed transaction - should be visible */
+        TEST_SAY("Phase 5: Committed transaction with READ_COMMITTED\n");
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+        test_produce_msgs2(producer, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+
+        consumed = consume_share_messages(consumer, msg_cnt, 50, 3000);
+        TEST_ASSERT(consumed == msg_cnt,
+                    "Phase 5: Expected %d committed msgs, got %d", msg_cnt,
+                    consumed);
+
+        TEST_SAY("SUCCESS: Dynamic isolation change READ_UNCOMMITTED -> "
+                 "READ_COMMITTED works correctly\n");
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Test: Interval-based abort pattern.
+ *
+ *  Produce N transactions where every Kth one is aborted.
+ *  Verify READ_COMMITTED skips exactly the aborted ones.
+ *  Verify READ_UNCOMMITTED sees all.
+ * =================================================================== */
+static void do_test_interval_abort_pattern(const char *isolation_level) {
+        char topic_suffix[64];
+        const char *topic;
+        char group[128];
+        const char *txn_id = "txn-interval-abort";
+        const int total_txns = 20;
+        const int abort_interval = 5; /* Every 5th transaction is aborted */
+        const int msgs_per_txn = 5;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        int consumed;
+        int i;
+        int committed_txns = 0;
+        int aborted_txns   = 0;
+        int expected_msgs;
+        rd_bool_t is_read_committed =
+            !strcmp(isolation_level, "read_committed");
+
+        rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-interval-%s",
+                    isolation_level);
+        topic = test_mk_topic_name(topic_suffix, 1);
+        rd_snprintf(group, sizeof(group), "share-interval-%s", isolation_level);
+
+        SUB_TEST("isolation.level=%s", isolation_level);
+
+        /* Create topic */
+        test_create_topic(NULL, topic, 1, 1);
+
+        /* Create transactional producer */
+        producer = create_txn_producer(txn_id);
+
+        /* Create share consumer and set group config */
+        consumer = create_share_consumer(group);
+        configure_share_group(test_share_consumer_get_rk(consumer), group,
+                              isolation_level);
+        subscribe_share_consumer(consumer, topic);
+
+        /* Produce transactions with interval-based abort pattern */
+        TEST_SAY("Producing %d transactions (every %dth is aborted)\n",
+                 total_txns, abort_interval);
+
+        for (i = 1; i <= total_txns; i++) {
+                rd_bool_t should_abort = (i % abort_interval == 0);
+
+                TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+
+                if (should_abort)
+                        test_curr->ignore_dr_err = rd_true;
+
+                test_produce_msgs2(producer, topic, test_id_generate(),
+                                   RD_KAFKA_PARTITION_UA, 0, msgs_per_txn, NULL,
+                                   0);
+
+                if (should_abort) {
+                        TEST_CALL_ERROR__(
+                            rd_kafka_abort_transaction(producer, 30000));
+                        test_curr->ignore_dr_err = rd_false;
+                        aborted_txns++;
+                        TEST_SAY("  Transaction %d: ABORTED\n", i);
+                } else {
+                        TEST_CALL_ERROR__(
+                            rd_kafka_commit_transaction(producer, 30000));
+                        committed_txns++;
+                }
+        }
+
+        TEST_SAY("Produced: %d committed txns, %d aborted txns\n",
+                 committed_txns, aborted_txns);
+
+        /* Calculate expected messages */
+        if (is_read_committed) {
+                expected_msgs = committed_txns * msgs_per_txn;
+        } else {
+                expected_msgs = total_txns * msgs_per_txn;
+        }
+
+        TEST_SAY("[%s] Expected %d messages\n", isolation_level, expected_msgs);
+
+        /* Consume and verify */
+        consumed = consume_share_messages(consumer, expected_msgs, 200, 3000);
+
+        TEST_ASSERT(consumed == expected_msgs,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msgs, consumed);
+
+        /* Verify no extra messages */
+        {
+                int extra = consume_share_no_msgs(consumer, 5, 2000);
+                TEST_ASSERT(extra == 0,
+                            "[%s] Unexpected extra messages: %d",
+                            isolation_level, extra);
+        }
+
+        TEST_SAY("SUCCESS [%s]: Interval abort pattern - received exactly %d "
+                 "messages (committed=%d, aborted=%d txns)\n",
+                 isolation_level, consumed, committed_txns, aborted_txns);
+
+        /* Cleanup */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+int main_0177_share_consumer_transactions(int argc, char **argv) {
+
+        /* Test both isolation levels */
+        const char *isolation_levels[] = {"read_committed", "read_uncommitted"};
+        int i;
+
+        for (i = 0; i < 2; i++) {
+                const char *level = isolation_levels[i];
+
+                TEST_SAY("\n");
+                TEST_SAY("========================================\n");
+                TEST_SAY("Testing with isolation.level=%s\n", level);
+                TEST_SAY("========================================\n");
+
+                /* Basic transaction tests */
+                do_test_committed_transaction(level);
+                do_test_aborted_transaction(level);
+                do_test_mixed_transactions(level);
+
+                /* Control records filtering */
+                do_test_control_records_filtered(level);
+
+                /* Multi-partition and multi-producer scenarios */
+                do_test_multi_partition_transactions(level);
+                do_test_interleaved_producers(level);
+
+                /* Mixed workloads */
+                do_test_mixed_txn_non_txn(level);
+
+                /* Interval-based abort pattern */
+                do_test_interval_abort_pattern(level);
+        }
+
+        /* Dynamic isolation level change tests (run once, not per-level) */
+        TEST_SAY("\n");
+        TEST_SAY("========================================\n");
+        TEST_SAY("Testing dynamic isolation level changes\n");
+        TEST_SAY("========================================\n");
+
+        do_test_dynamic_uncommitted_to_committed();
+
+        return 0;
+}

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -96,8 +96,8 @@ static rd_kafka_share_t *create_share_consumer(const char *group) {
 static void configure_share_group(rd_kafka_t *rk,
                                   const char *group,
                                   const char *isolation_level) {
-        const char *offset_cfg[] = {"share.auto.offset.reset", "SET",
-                                    "earliest"};
+        const char *offset_cfg[]    = {"share.auto.offset.reset", "SET",
+                                       "earliest"};
         const char *isolation_cfg[] = {"share.isolation.level", "SET",
                                        isolation_level};
 
@@ -209,7 +209,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         const char *topic;
         char group[128];
         const char *txn_id = "txn-commit-test";
-        const int msg_cnt = 100;
+        const int msg_cnt  = 100;
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         int consumed;
@@ -256,9 +256,10 @@ static void do_test_committed_transaction(const char *isolation_level) {
                     "got %d",
                     isolation_level, msg_cnt, consumed);
 
-        TEST_SAY("SUCCESS [%s]: Share consumer received %d committed "
-                 "messages\n",
-                 isolation_level, consumed);
+        TEST_SAY(
+            "SUCCESS [%s]: Share consumer received %d committed "
+            "messages\n",
+            isolation_level, consumed);
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);
@@ -280,7 +281,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         const char *topic;
         char group[128];
         const char *txn_id = "txn-abort-test";
-        const int msg_cnt = 100;
+        const int msg_cnt  = 100;
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         int consumed;
@@ -291,7 +292,8 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-abort-%s",
                     isolation_level);
         topic = test_mk_topic_name(topic_suffix, 1);
-        rd_snprintf(group, sizeof(group), "share-txn-abort-%s", isolation_level);
+        rd_snprintf(group, sizeof(group), "share-txn-abort-%s",
+                    isolation_level);
 
         SUB_TEST("isolation.level=%s", isolation_level);
 
@@ -342,9 +344,10 @@ static void do_test_aborted_transaction(const char *isolation_level) {
                     "got %d",
                     isolation_level, expected_msgs, consumed);
 
-        TEST_SAY("SUCCESS [%s]: Share consumer received %d messages "
-                 "(expected %d)\n",
-                 isolation_level, consumed, expected_msgs);
+        TEST_SAY(
+            "SUCCESS [%s]: Share consumer received %d messages "
+            "(expected %d)\n",
+            isolation_level, consumed, expected_msgs);
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);
@@ -382,10 +385,8 @@ static void do_test_mixed_transactions(const char *isolation_level) {
                 rd_bool_t commit;
                 int msg_cnt;
         } txns[] = {
-            {"Commit 50 msgs", rd_true, 50},
-            {"Abort 50 msgs", rd_false, 50},
-            {"Commit 30 msgs", rd_true, 30},
-            {"Abort 20 msgs", rd_false, 20},
+            {"Commit 50 msgs", rd_true, 50}, {"Abort 50 msgs", rd_false, 50},
+            {"Commit 30 msgs", rd_true, 30}, {"Abort 20 msgs", rd_false, 20},
             {"Commit 40 msgs", rd_true, 40},
         };
         const int txn_cnt = sizeof(txns) / sizeof(txns[0]);
@@ -393,7 +394,8 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         rd_snprintf(topic_suffix, sizeof(topic_suffix), "0177-txn-mixed-%s",
                     isolation_level);
         topic = test_mk_topic_name(topic_suffix, 1);
-        rd_snprintf(group, sizeof(group), "share-txn-mixed-%s", isolation_level);
+        rd_snprintf(group, sizeof(group), "share-txn-mixed-%s",
+                    isolation_level);
 
         SUB_TEST("isolation.level=%s", isolation_level);
 
@@ -519,8 +521,8 @@ static void do_test_control_records_filtered(const char *isolation_level) {
          * - Offset 7: commit control record
          *
          * read_committed: should see offsets 2,3,4,5,6 (committed only)
-         * read_uncommitted: should see offsets 0,2,3,4,5,6 (aborted + committed)
-         * Control records (offsets 1 and 7) should NEVER be visible.
+         * read_uncommitted: should see offsets 0,2,3,4,5,6 (aborted +
+         * committed) Control records (offsets 1 and 7) should NEVER be visible.
          */
         expected_msgs = is_read_committed ? 5 : 6;
 
@@ -529,7 +531,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
                 rd_kafka_message_t *batch[BATCH_SIZE];
                 int attempts = 50;
                 int64_t received_offsets[10];
-                int64_t expected_offsets_committed[] = {2, 3, 4, 5, 6};
+                int64_t expected_offsets_committed[]   = {2, 3, 4, 5, 6};
                 int64_t expected_offsets_uncommitted[] = {0, 2, 3, 4, 5, 6};
                 int64_t *expected_offsets;
                 int j;
@@ -544,8 +546,8 @@ static void do_test_control_records_filtered(const char *isolation_level) {
                         size_t i;
                         rd_kafka_error_t *err;
 
-                        err = rd_kafka_share_consume_batch(
-                            consumer, 3000, batch, &rcvd);
+                        err = rd_kafka_share_consume_batch(consumer, 3000,
+                                                           batch, &rcvd);
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
@@ -555,10 +557,9 @@ static void do_test_control_records_filtered(const char *isolation_level) {
                                 if (!batch[i]->err && consumed < 10) {
                                         received_offsets[consumed] =
                                             batch[i]->offset;
-                                        TEST_SAY(
-                                            "  Message %d: offset=%" PRId64
-                                            "\n",
-                                            consumed, batch[i]->offset);
+                                        TEST_SAY("  Message %d: offset=%" PRId64
+                                                 "\n",
+                                                 consumed, batch[i]->offset);
                                         consumed++;
                                 }
                                 rd_kafka_message_destroy(batch[i]);
@@ -576,25 +577,26 @@ static void do_test_control_records_filtered(const char *isolation_level) {
                 }
 
                 /* Verify expected offsets based on isolation level */
-                expected_offsets = is_read_committed ? expected_offsets_committed
-                                                     : expected_offsets_uncommitted;
+                expected_offsets = is_read_committed
+                                       ? expected_offsets_committed
+                                       : expected_offsets_uncommitted;
 
                 TEST_ASSERT(consumed == expected_msgs,
-                            "[%s] Expected %d messages, got %d", isolation_level,
-                            expected_msgs, consumed);
+                            "[%s] Expected %d messages, got %d",
+                            isolation_level, expected_msgs, consumed);
 
                 for (j = 0; j < consumed; j++) {
-                        TEST_ASSERT(
-                            received_offsets[j] == expected_offsets[j],
-                            "[%s] Message %d: expected offset %" PRId64
-                            ", got %" PRId64,
-                            isolation_level, j, expected_offsets[j],
-                            received_offsets[j]);
+                        TEST_ASSERT(received_offsets[j] == expected_offsets[j],
+                                    "[%s] Message %d: expected offset %" PRId64
+                                    ", got %" PRId64,
+                                    isolation_level, j, expected_offsets[j],
+                                    received_offsets[j]);
                 }
 
-                TEST_SAY("SUCCESS [%s]: All %d offsets verified correctly, "
-                         "control records filtered\n",
-                         isolation_level, consumed);
+                TEST_SAY(
+                    "SUCCESS [%s]: All %d offsets verified correctly, "
+                    "control records filtered\n",
+                    isolation_level, consumed);
         }
 
         /* Cleanup */
@@ -613,8 +615,8 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
         char group[128];
-        const char *txn_id = "txn-multipart-test";
-        const int partition_cnt = 3;
+        const char *txn_id           = "txn-multipart-test";
+        const int partition_cnt      = 3;
         const int msgs_per_partition = 30;
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
@@ -676,7 +678,8 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         expected_total     = 3 * msgs_per_partition * partition_cnt;
         expected_msgs = is_read_committed ? expected_committed : expected_total;
 
-        TEST_SAY("Expected messages [%s]: %d\n", isolation_level, expected_msgs);
+        TEST_SAY("Expected messages [%s]: %d\n", isolation_level,
+                 expected_msgs);
 
         consumed = consume_share_messages(consumer, expected_msgs, 100, 3000);
 
@@ -790,10 +793,10 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
         char group[128];
-        const char *txn_id = "txn-mixed-type-test";
-        const int non_txn_msgs = 50;
+        const char *txn_id        = "txn-mixed-type-test";
+        const int non_txn_msgs    = 50;
         const int txn_commit_msgs = 30;
-        const int txn_abort_msgs = 20;
+        const int txn_abort_msgs  = 20;
         rd_kafka_t *txn_producer, *regular_producer;
         rd_kafka_share_t *consumer;
         int consumed;
@@ -854,7 +857,8 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
                             ? (non_txn_msgs + txn_commit_msgs)
                             : (non_txn_msgs + txn_commit_msgs + txn_abort_msgs);
 
-        TEST_SAY("Expected messages [%s]: %d\n", isolation_level, expected_msgs);
+        TEST_SAY("Expected messages [%s]: %d\n", isolation_level,
+                 expected_msgs);
 
         consumed = consume_share_messages(consumer, expected_msgs, 100, 3000);
 
@@ -887,9 +891,9 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
  * =================================================================== */
 static void do_test_dynamic_uncommitted_to_committed(void) {
         const char *topic;
-        const char *group = "share-dynamic-uc-to-c";
+        const char *group  = "share-dynamic-uc-to-c";
         const char *txn_id = "txn-dynamic-uc-c";
-        const int msg_cnt = 10;
+        const int msg_cnt  = 10;
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         int consumed;
@@ -969,8 +973,9 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
                     "Phase 5: Expected %d committed msgs, got %d", msg_cnt,
                     consumed);
 
-        TEST_SAY("SUCCESS: Dynamic isolation change READ_UNCOMMITTED -> "
-                 "READ_COMMITTED works correctly\n");
+        TEST_SAY(
+            "SUCCESS: Dynamic isolation change READ_UNCOMMITTED -> "
+            "READ_COMMITTED works correctly\n");
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);
@@ -992,10 +997,10 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
         char group[128];
-        const char *txn_id = "txn-interval-abort";
-        const int total_txns = 20;
+        const char *txn_id       = "txn-interval-abort";
+        const int total_txns     = 20;
         const int abort_interval = 5; /* Every 5th transaction is aborted */
-        const int msgs_per_txn = 5;
+        const int msgs_per_txn   = 5;
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         int consumed;
@@ -1076,14 +1081,14 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         /* Verify no extra messages */
         {
                 int extra = consume_share_no_msgs(consumer, 5, 2000);
-                TEST_ASSERT(extra == 0,
-                            "[%s] Unexpected extra messages: %d",
+                TEST_ASSERT(extra == 0, "[%s] Unexpected extra messages: %d",
                             isolation_level, extra);
         }
 
-        TEST_SAY("SUCCESS [%s]: Interval abort pattern - received exactly %d "
-                 "messages (committed=%d, aborted=%d txns)\n",
-                 isolation_level, consumed, committed_txns, aborted_txns);
+        TEST_SAY(
+            "SUCCESS [%s]: Interval abort pattern - received exactly %d "
+            "messages (committed=%d, aborted=%d txns)\n",
+            isolation_level, consumed, committed_txns, aborted_txns);
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -85,6 +85,19 @@ static rd_kafka_share_t *create_share_consumer(const char *group) {
 
 
 /**
+ * @brief Create an admin client (producer) for admin API calls.
+ *
+ * Admin APIs should use a separate handle from the share consumer.
+ */
+static rd_kafka_t *create_admin_client(void) {
+        rd_kafka_conf_t *conf;
+
+        test_conf_init(&conf, NULL, 60);
+        return test_create_handle(RD_KAFKA_PRODUCER, conf);
+}
+
+
+/**
  * @brief Configure share group settings.
  *
  * Sets share.auto.offset.reset=earliest and share.isolation.level
@@ -92,8 +105,10 @@ static rd_kafka_share_t *create_share_consumer(const char *group) {
  *
  * Note: share.isolation.level is a BROKER-SIDE share group configuration.
  * Transaction filtering happens on the broker, not the client.
+ *
+ * @param admin_rk Admin client handle (producer) for admin API calls.
  */
-static void configure_share_group(rd_kafka_t *rk,
+static void configure_share_group(rd_kafka_t *admin_rk,
                                   const char *group,
                                   const char *isolation_level) {
         const char *offset_cfg[]    = {"share.auto.offset.reset", "SET",
@@ -101,10 +116,10 @@ static void configure_share_group(rd_kafka_t *rk,
         const char *isolation_cfg[] = {"share.isolation.level", "SET",
                                        isolation_level};
 
-        test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP, group,
-                                            offset_cfg, 1);
-        test_IncrementalAlterConfigs_simple(rk, RD_KAFKA_RESOURCE_GROUP, group,
-                                            isolation_cfg, 1);
+        test_IncrementalAlterConfigs_simple(admin_rk, RD_KAFKA_RESOURCE_GROUP,
+                                            group, offset_cfg, 1);
+        test_IncrementalAlterConfigs_simple(admin_rk, RD_KAFKA_RESOURCE_GROUP,
+                                            group, isolation_cfg, 1);
 }
 
 
@@ -211,6 +226,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         const char *txn_id = "txn-commit-test";
         const int msg_cnt  = 100;
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
 
@@ -228,10 +244,12 @@ static void do_test_committed_transaction(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Begin transaction */
@@ -265,6 +283,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -283,6 +302,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         const char *txn_id = "txn-abort-test";
         const int msg_cnt  = 100;
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -308,10 +328,12 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Begin transaction */
@@ -353,6 +375,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -370,6 +393,7 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         char group[128];
         const char *txn_id = "txn-mixed-test";
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int i;
@@ -405,10 +429,12 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Execute transactions */
@@ -455,6 +481,7 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -472,6 +499,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         char group[128];
         const char *txn_id = "txn-ctrl-test";
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -491,10 +519,12 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Transaction 1: Produce and ABORT (1 msg + 1 abort marker) */
@@ -603,6 +633,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -619,6 +650,7 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         const int partition_cnt      = 3;
         const int msgs_per_partition = 30;
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_committed;
@@ -641,10 +673,12 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Transaction 1: Produce to all partitions and COMMIT */
@@ -694,6 +728,7 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -708,6 +743,7 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         char group[128];
         const int msg_cnt = 50;
         rd_kafka_t *producer1, *producer2;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -729,10 +765,12 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         producer1 = create_txn_producer("txn-producer-1");
         producer2 = create_txn_producer("txn-producer-2");
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Producer 1: Begin transaction */
@@ -781,6 +819,7 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer1);
         rd_kafka_destroy(producer2);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -798,6 +837,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         const int txn_commit_msgs = 30;
         const int txn_abort_msgs  = 20;
         rd_kafka_t *txn_producer, *regular_producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -821,10 +861,12 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         /* Create regular (non-transactional) producer */
         regular_producer = test_create_producer();
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Produce non-transactional messages */
@@ -874,6 +916,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(txn_producer);
         rd_kafka_destroy(regular_producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -895,6 +938,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         const char *txn_id = "txn-dynamic-uc-c";
         const int msg_cnt  = 10;
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
 
@@ -908,10 +952,12 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer with READ_UNCOMMITTED */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              "read_uncommitted");
+        configure_share_group(admin_client, group, "read_uncommitted");
         subscribe_share_consumer(consumer, topic);
 
         /* Phase 1: Produce and consume committed transaction */
@@ -944,8 +990,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
 
         /* Phase 3: Change isolation level to READ_COMMITTED */
         TEST_SAY("Phase 3: Changing isolation level to READ_COMMITTED\n");
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              "read_committed");
+        configure_share_group(admin_client, group, "read_committed");
 
         /* Phase 4: Produce aborted transaction - should NOT be visible now */
         TEST_SAY("Phase 4: Aborted transaction with READ_COMMITTED\n");
@@ -981,6 +1026,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -1002,6 +1048,7 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         const int abort_interval = 5; /* Every 5th transaction is aborted */
         const int msgs_per_txn   = 5;
         rd_kafka_t *producer;
+        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int i;
@@ -1024,10 +1071,12 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
+        /* Create admin client for group configuration */
+        admin_client = create_admin_client();
+
         /* Create share consumer and set group config */
         consumer = create_share_consumer(group);
-        configure_share_group(test_share_consumer_get_rk(consumer), group,
-                              isolation_level);
+        configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Produce transactions with interval-based abort pattern */
@@ -1094,6 +1143,7 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
+        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -62,29 +62,6 @@ static rd_kafka_t *create_txn_producer(const char *txn_id) {
 
 
 /**
- * @brief Create a share consumer with specified group.
- *
- * Note: For share consumers, isolation.level is configured on the
- * BROKER-SIDE via share group configuration (share.isolation.level),
- * not on the client. See configure_share_group().
- */
-static rd_kafka_share_t *create_share_consumer(const char *group) {
-        rd_kafka_share_t *rkshare;
-        rd_kafka_conf_t *conf;
-        char errstr[512];
-
-        test_conf_init(&conf, NULL, 60);
-        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
-
-        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer: %s",
-                    errstr);
-
-        return rkshare;
-}
-
-
-/**
  * @brief Create an admin client (producer) for admin API calls.
  *
  * Admin APIs should use a separate handle from the share consumer.
@@ -111,15 +88,12 @@ static rd_kafka_t *create_admin_client(void) {
 static void configure_share_group(rd_kafka_t *admin_rk,
                                   const char *group,
                                   const char *isolation_level) {
-        const char *offset_cfg[]    = {"share.auto.offset.reset", "SET",
-                                       "earliest"};
-        const char *isolation_cfg[] = {"share.isolation.level", "SET",
-                                       isolation_level};
+        const char *configs[] = {
+            "share.auto.offset.reset", "SET", "earliest",
+            "share.isolation.level",   "SET", isolation_level};
 
         test_IncrementalAlterConfigs_simple(admin_rk, RD_KAFKA_RESOURCE_GROUP,
-                                            group, offset_cfg, 1);
-        test_IncrementalAlterConfigs_simple(admin_rk, RD_KAFKA_RESOURCE_GROUP,
-                                            group, isolation_cfg, 1);
+                                            group, configs, 2);
 }
 
 
@@ -213,12 +187,98 @@ static int consume_share_no_msgs(rd_kafka_share_t *rkshare,
 }
 
 
-/* ===================================================================
- *  Test: Committed transaction visibility.
+/**
+ * @brief Consume messages and verify exact offsets.
  *
- *  Both read_committed and read_uncommitted should see committed
- *  messages.
- * =================================================================== */
+ * Consumes messages from the share consumer and verifies that:
+ * 1. The number of messages matches expected_msg_cnt
+ * 2. The offsets match the expected_offsets array
+ * 3. None of the forbidden_offsets appear (e.g., control records)
+ *
+ * @param rkshare Share consumer instance
+ * @param expected_msg_cnt Expected number of messages to consume
+ * @param expected_offsets Array of expected offsets in order
+ * @param forbidden_offsets Array of offsets that should never appear
+ * @param forbidden_cnt Number of forbidden offsets
+ * @param isolation_level Isolation level string (for logging)
+ *
+ * @returns Number of messages consumed
+ */
+static int consume_and_verify_offsets(rd_kafka_share_t *rkshare,
+                                      int expected_msg_cnt,
+                                      const int64_t *expected_offsets,
+                                      const int64_t *forbidden_offsets,
+                                      int forbidden_cnt,
+                                      const char *isolation_level) {
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        int attempts = 50;
+        int64_t received_offsets[10];
+        int consumed = 0;
+        int i, j;
+
+        TEST_SAY("[%s] Consuming messages and verifying offsets:\n",
+                 isolation_level);
+
+        /* Consume messages and collect offsets */
+        while (consumed < expected_msg_cnt && attempts-- > 0) {
+                size_t rcvd = 0;
+                rd_kafka_error_t *err;
+
+                err = rd_kafka_share_consume_batch(rkshare, 3000, batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (i = 0; i < (int)rcvd; i++) {
+                        if (!batch[i]->err && consumed < 10) {
+                                received_offsets[consumed] = batch[i]->offset;
+                                TEST_SAY("  Message %d: offset=%" PRId64 "\n",
+                                         consumed, batch[i]->offset);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        /* Verify no forbidden offsets were received */
+        for (i = 0; i < consumed; i++) {
+                for (j = 0; j < forbidden_cnt; j++) {
+                        TEST_ASSERT(received_offsets[i] != forbidden_offsets[j],
+                                    "[%s] Received forbidden offset %" PRId64
+                                    " at position %d - should be filtered!",
+                                    isolation_level, forbidden_offsets[j], i);
+                }
+        }
+
+        /* Verify message count */
+        TEST_ASSERT(consumed == expected_msg_cnt,
+                    "[%s] Expected %d messages, got %d", isolation_level,
+                    expected_msg_cnt, consumed);
+
+        /* Verify exact offsets */
+        for (i = 0; i < consumed; i++) {
+                TEST_ASSERT(received_offsets[i] == expected_offsets[i],
+                            "[%s] Message %d: expected offset %" PRId64
+                            ", got %" PRId64,
+                            isolation_level, i, expected_offsets[i],
+                            received_offsets[i]);
+        }
+
+        TEST_SAY(
+            "SUCCESS [%s]: All %d offsets verified correctly, "
+            "forbidden offsets filtered\n",
+            isolation_level, consumed);
+
+        return consumed;
+}
+
+
+/**
+ * @brief Test committed transaction visibility.
+ *
+ * Both read_committed and read_uncommitted should see committed messages.
+ */
 static void do_test_committed_transaction(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -248,7 +308,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -289,12 +349,12 @@ static void do_test_committed_transaction(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Aborted transaction visibility.
+/**
+ * @brief Test aborted transaction visibility.
  *
- *  - read_committed: Should NOT see aborted messages (expect 0)
- *  - read_uncommitted: Should see ALL messages (expect msg_cnt)
- * =================================================================== */
+ * - read_committed: Should NOT see aborted messages (expect 0)
+ * - read_uncommitted: Should see ALL messages (expect msg_cnt)
+ */
 static void do_test_aborted_transaction(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -332,7 +392,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -381,12 +441,12 @@ static void do_test_aborted_transaction(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Mixed transactions (some committed, some aborted).
+/**
+ * @brief Test mixed transactions (some committed, some aborted).
  *
- *  - read_committed: Only see committed messages
- *  - read_uncommitted: See ALL messages
- * =================================================================== */
+ * - read_committed: Only see committed messages
+ * - read_uncommitted: See ALL messages
+ */
 static void do_test_mixed_transactions(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -433,7 +493,7 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -487,12 +547,12 @@ static void do_test_mixed_transactions(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Control records filtering.
+/**
+ * @brief Test control records filtering.
  *
- *  Control records (abort/commit markers) should never be visible
- *  to the application, regardless of isolation level.
- * =================================================================== */
+ * Control records (abort/commit markers) should never be visible to the
+ * application, regardless of isolation level.
+ */
 static void do_test_control_records_filtered(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -523,7 +583,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -557,77 +617,17 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         expected_msgs = is_read_committed ? 5 : 6;
 
         /* Consume and verify exact offsets */
-        {
-                rd_kafka_message_t *batch[BATCH_SIZE];
-                int attempts = 50;
-                int64_t received_offsets[10];
-                int64_t expected_offsets_committed[]   = {2, 3, 4, 5, 6};
-                int64_t expected_offsets_uncommitted[] = {0, 2, 3, 4, 5, 6};
-                int64_t *expected_offsets;
-                int j;
+        int64_t expected_offsets_committed[]   = {2, 3, 4, 5, 6};
+        int64_t expected_offsets_uncommitted[] = {0, 2, 3, 4, 5, 6};
+        int64_t control_record_offsets[]       = {1, 7};
+        const int64_t *expected_offsets;
 
-                consumed = 0;
+        expected_offsets = is_read_committed ? expected_offsets_committed
+                                             : expected_offsets_uncommitted;
 
-                TEST_SAY("[%s] Consuming messages and verifying offsets:\n",
-                         isolation_level);
-
-                while (consumed < expected_msgs && attempts-- > 0) {
-                        size_t rcvd = 0;
-                        size_t i;
-                        rd_kafka_error_t *err;
-
-                        err = rd_kafka_share_consume_batch(consumer, 3000,
-                                                           batch, &rcvd);
-                        if (err) {
-                                rd_kafka_error_destroy(err);
-                                continue;
-                        }
-
-                        for (i = 0; i < rcvd; i++) {
-                                if (!batch[i]->err && consumed < 10) {
-                                        received_offsets[consumed] =
-                                            batch[i]->offset;
-                                        TEST_SAY("  Message %d: offset=%" PRId64
-                                                 "\n",
-                                                 consumed, batch[i]->offset);
-                                        consumed++;
-                                }
-                                rd_kafka_message_destroy(batch[i]);
-                        }
-                }
-
-                /* Verify no control records (offsets 1 and 7) were received */
-                for (j = 0; j < consumed; j++) {
-                        TEST_ASSERT(
-                            received_offsets[j] != 1 &&
-                                received_offsets[j] != 7,
-                            "[%s] Received control record at offset %" PRId64
-                            " - should be filtered!",
-                            isolation_level, received_offsets[j]);
-                }
-
-                /* Verify expected offsets based on isolation level */
-                expected_offsets = is_read_committed
-                                       ? expected_offsets_committed
-                                       : expected_offsets_uncommitted;
-
-                TEST_ASSERT(consumed == expected_msgs,
-                            "[%s] Expected %d messages, got %d",
-                            isolation_level, expected_msgs, consumed);
-
-                for (j = 0; j < consumed; j++) {
-                        TEST_ASSERT(received_offsets[j] == expected_offsets[j],
-                                    "[%s] Message %d: expected offset %" PRId64
-                                    ", got %" PRId64,
-                                    isolation_level, j, expected_offsets[j],
-                                    received_offsets[j]);
-                }
-
-                TEST_SAY(
-                    "SUCCESS [%s]: All %d offsets verified correctly, "
-                    "control records filtered\n",
-                    isolation_level, consumed);
-        }
+        consumed = consume_and_verify_offsets(
+            consumer, expected_msgs, expected_offsets, control_record_offsets,
+            2, isolation_level);
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);
@@ -639,9 +639,9 @@ static void do_test_control_records_filtered(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Multiple partitions with transactions.
- * =================================================================== */
+/**
+ * @brief Test multiple partitions with transactions.
+ */
 static void do_test_multi_partition_transactions(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -677,7 +677,7 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -734,9 +734,9 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Interleaved transactions from multiple producers.
- * =================================================================== */
+/**
+ * @brief Test interleaved transactions from multiple producers.
+ */
 static void do_test_interleaved_producers(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -769,7 +769,7 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -825,9 +825,9 @@ static void do_test_interleaved_producers(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Non-transactional and transactional messages mixed.
- * =================================================================== */
+/**
+ * @brief Test non-transactional and transactional messages mixed.
+ */
 static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -865,7 +865,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -922,16 +922,17 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
 }
 
 
-/* ===================================================================
- *  Test: Dynamic isolation level change (READ_UNCOMMITTED -> READ_COMMITTED)
+/**
+ * @brief Test dynamic isolation level change (READ_UNCOMMITTED ->
+ * READ_COMMITTED).
  *
- *  1. Start with READ_UNCOMMITTED
- *  2. Produce committed txn, consume and acknowledge
- *  3. Produce aborted txn, consume and release
- *  4. Change to READ_COMMITTED
- *  5. Produce more committed/aborted txns
- *  6. Verify only committed txns are now returned
- * =================================================================== */
+ * 1. Start with READ_UNCOMMITTED
+ * 2. Produce committed txn, consume and acknowledge
+ * 3. Produce aborted txn, consume and release
+ * 4. Change to READ_COMMITTED
+ * 5. Produce more committed/aborted txns
+ * 6. Verify only committed txns are now returned
+ */
 static void do_test_dynamic_uncommitted_to_committed(void) {
         const char *topic;
         const char *group  = "share-dynamic-uc-to-c";
@@ -956,7 +957,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         admin_client = create_admin_client();
 
         /* Create share consumer with READ_UNCOMMITTED */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, "read_uncommitted");
         subscribe_share_consumer(consumer, topic);
 
@@ -1032,13 +1033,13 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
 }
 
 
-/* ===================================================================
- *  Test: Interval-based abort pattern.
+/**
+ * @brief Test interval-based abort pattern.
  *
- *  Produce N transactions where every Kth one is aborted.
- *  Verify READ_COMMITTED skips exactly the aborted ones.
- *  Verify READ_UNCOMMITTED sees all.
- * =================================================================== */
+ * Produce N transactions where every Kth one is aborted.
+ * Verify READ_COMMITTED skips exactly the aborted ones.
+ * Verify READ_UNCOMMITTED sees all.
+ */
 static void do_test_interval_abort_pattern(const char *isolation_level) {
         char topic_suffix[64];
         const char *topic;
@@ -1075,7 +1076,7 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         admin_client = create_admin_client();
 
         /* Create share consumer and set group config */
-        consumer = create_share_consumer(group);
+        consumer = test_create_share_consumer(group);
         configure_share_group(admin_client, group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -42,6 +42,10 @@
 
 #define BATCH_SIZE 1000
 
+/* Common handles shared across all tests */
+static rd_kafka_t *common_admin;
+static rd_kafka_t *common_regular_producer;
+
 
 /**
  * @brief Create a transactional producer.
@@ -62,19 +66,6 @@ static rd_kafka_t *create_txn_producer(const char *txn_id) {
 
 
 /**
- * @brief Create an admin client (producer) for admin API calls.
- *
- * Admin APIs should use a separate handle from the share consumer.
- */
-static rd_kafka_t *create_admin_client(void) {
-        rd_kafka_conf_t *conf;
-
-        test_conf_init(&conf, NULL, 60);
-        return test_create_handle(RD_KAFKA_PRODUCER, conf);
-}
-
-
-/**
  * @brief Configure share group settings.
  *
  * Sets share.auto.offset.reset=earliest and share.isolation.level
@@ -82,18 +73,15 @@ static rd_kafka_t *create_admin_client(void) {
  *
  * Note: share.isolation.level is a BROKER-SIDE share group configuration.
  * Transaction filtering happens on the broker, not the client.
- *
- * @param admin_rk Admin client handle (producer) for admin API calls.
  */
-static void configure_share_group(rd_kafka_t *admin_rk,
-                                  const char *group,
+static void configure_share_group(const char *group,
                                   const char *isolation_level) {
         const char *configs[] = {
             "share.auto.offset.reset", "SET", "earliest",
             "share.isolation.level",   "SET", isolation_level};
 
-        test_IncrementalAlterConfigs_simple(admin_rk, RD_KAFKA_RESOURCE_GROUP,
-                                            group, configs, 2);
+        test_IncrementalAlterConfigs_simple(
+            common_admin, RD_KAFKA_RESOURCE_GROUP, group, configs, 2);
 }
 
 
@@ -282,7 +270,6 @@ static void do_test_committed_transaction(const char *isolation_level) {
         const char *txn_id = "txn-commit-test";
         const int msg_cnt  = 100;
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
 
@@ -300,12 +287,9 @@ static void do_test_committed_transaction(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Begin transaction */
@@ -339,7 +323,6 @@ static void do_test_committed_transaction(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -358,7 +341,6 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         const char *txn_id = "txn-abort-test";
         const int msg_cnt  = 100;
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -384,12 +366,9 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Begin transaction */
@@ -431,7 +410,6 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -449,7 +427,6 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         char group[128];
         const char *txn_id = "txn-mixed-test";
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int i;
@@ -485,12 +462,9 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Execute transactions */
@@ -537,7 +511,6 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -555,7 +528,6 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         char group[128];
         const char *txn_id = "txn-ctrl-test";
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int expected_msgs;
         rd_bool_t is_read_committed =
@@ -574,12 +546,9 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Transaction 1: Produce and ABORT (1 msg + 1 abort marker) */
@@ -627,7 +596,6 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -644,7 +612,6 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         const int partition_cnt      = 3;
         const int msgs_per_partition = 30;
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_committed;
@@ -667,12 +634,9 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Transaction 1: Produce to all partitions and COMMIT */
@@ -722,7 +686,6 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -737,7 +700,6 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         char group[128];
         const int msg_cnt = 50;
         rd_kafka_t *producer1, *producer2;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -759,12 +721,9 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         producer1 = create_txn_producer("txn-producer-1");
         producer2 = create_txn_producer("txn-producer-2");
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Producer 1: Begin transaction */
@@ -813,7 +772,6 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer1);
         rd_kafka_destroy(producer2);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -830,8 +788,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         const int non_txn_msgs    = 50;
         const int txn_commit_msgs = 30;
         const int txn_abort_msgs  = 20;
-        rd_kafka_t *txn_producer, *regular_producer;
-        rd_kafka_t *admin_client;
+        rd_kafka_t *txn_producer;
         rd_kafka_share_t *consumer;
         int consumed;
         int expected_msgs;
@@ -852,20 +809,14 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         /* Create transactional producer */
         txn_producer = create_txn_producer(txn_id);
 
-        /* Create regular (non-transactional) producer */
-        regular_producer = test_create_producer();
-
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Produce non-transactional messages */
         TEST_SAY("Producing %d non-transactional messages\n", non_txn_msgs);
-        test_produce_msgs2(regular_producer, topic, test_id_generate(),
+        test_produce_msgs2(common_regular_producer, topic, test_id_generate(),
                            RD_KAFKA_PARTITION_UA, 0, non_txn_msgs, NULL, 0);
 
         /* Transactional: Commit */
@@ -909,8 +860,6 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(txn_producer);
-        rd_kafka_destroy(regular_producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -933,7 +882,6 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         const char *txn_id = "txn-dynamic-uc-c";
         const int msg_cnt  = 10;
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
 
@@ -947,12 +895,9 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer with READ_UNCOMMITTED */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, "read_uncommitted");
+        configure_share_group(group, "read_uncommitted");
         subscribe_share_consumer(consumer, topic);
 
         /* Phase 1: Produce and consume committed transaction */
@@ -985,7 +930,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
 
         /* Phase 3: Change isolation level to READ_COMMITTED */
         TEST_SAY("Phase 3: Changing isolation level to READ_COMMITTED\n");
-        configure_share_group(admin_client, group, "read_committed");
+        configure_share_group(group, "read_committed");
 
         /* Phase 4: Produce aborted transaction - should NOT be visible now */
         TEST_SAY("Phase 4: Aborted transaction with READ_COMMITTED\n");
@@ -1021,7 +966,6 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
@@ -1043,7 +987,6 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         const int abort_interval = 5; /* Every 5th transaction is aborted */
         const int msgs_per_txn   = 5;
         rd_kafka_t *producer;
-        rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
         int consumed;
         int i;
@@ -1066,12 +1009,9 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
 
-        /* Create admin client for group configuration */
-        admin_client = create_admin_client();
-
         /* Create share consumer and set group config */
         consumer = test_create_share_consumer(group);
-        configure_share_group(admin_client, group, isolation_level);
+        configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
         /* Produce transactions with interval-based abort pattern */
@@ -1138,17 +1078,19 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
-        rd_kafka_destroy(admin_client);
 
         SUB_TEST_PASS();
 }
 
 
 int main_0177_share_consumer_transactions(int argc, char **argv) {
-
         /* Test both isolation levels */
         const char *isolation_levels[] = {"read_committed", "read_uncommitted"};
         int i;
+
+        /* Create common handles for all tests */
+        common_admin            = test_create_producer();
+        common_regular_producer = test_create_producer();
 
         for (i = 0; i < 2; i++) {
                 const char *level = isolation_levels[i];
@@ -1184,6 +1126,10 @@ int main_0177_share_consumer_transactions(int argc, char **argv) {
         TEST_SAY("========================================\n");
 
         do_test_dynamic_uncommitted_to_committed();
+
+        /* Cleanup common handles */
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_regular_producer);
 
         return 0;
 }

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -201,15 +201,13 @@ static int consume_share_no_msgs(rd_kafka_share_t *rkshare,
  * @param forbidden_offsets Array of offsets that should never appear
  * @param forbidden_cnt Number of forbidden offsets
  * @param isolation_level Isolation level string (for logging)
- *
- * @returns Number of messages consumed
  */
-static int consume_and_verify_offsets(rd_kafka_share_t *rkshare,
-                                      int expected_msg_cnt,
-                                      const int64_t *expected_offsets,
-                                      const int64_t *forbidden_offsets,
-                                      int forbidden_cnt,
-                                      const char *isolation_level) {
+static void consume_and_verify_offsets(rd_kafka_share_t *rkshare,
+                                       int expected_msg_cnt,
+                                       const int64_t *expected_offsets,
+                                       const int64_t *forbidden_offsets,
+                                       int forbidden_cnt,
+                                       const char *isolation_level) {
         rd_kafka_message_t *batch[BATCH_SIZE];
         int attempts = 50;
         int64_t received_offsets[10];
@@ -269,8 +267,6 @@ static int consume_and_verify_offsets(rd_kafka_share_t *rkshare,
             "SUCCESS [%s]: All %d offsets verified correctly, "
             "forbidden offsets filtered\n",
             isolation_level, consumed);
-
-        return consumed;
 }
 
 
@@ -561,7 +557,6 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         rd_kafka_t *producer;
         rd_kafka_t *admin_client;
         rd_kafka_share_t *consumer;
-        int consumed;
         int expected_msgs;
         rd_bool_t is_read_committed =
             !strcmp(isolation_level, "read_committed");
@@ -625,9 +620,8 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         expected_offsets = is_read_committed ? expected_offsets_committed
                                              : expected_offsets_uncommitted;
 
-        consumed = consume_and_verify_offsets(
-            consumer, expected_msgs, expected_offsets, control_record_offsets,
-            2, isolation_level);
+        consume_and_verify_offsets(consumer, expected_msgs, expected_offsets,
+                                   control_record_offsets, 2, isolation_level);
 
         /* Cleanup */
         rd_kafka_share_consumer_close(consumer);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,6 +152,7 @@ set(
     0171-share_consumer_consume.c
     0172-share_consumer_acknowledge.c
     0173-share_consumer_commit_async.c
+    0177-share_consumer_transactions.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -294,6 +294,7 @@ _TEST_DECL(0171_share_consumer_consume);
 _TEST_DECL(0172_share_consumer_acknowledge);
 _TEST_DECL(0173_share_consumer_commit_async_local);
 _TEST_DECL(0173_share_consumer_commit_async);
+_TEST_DECL(0177_share_consumer_transactions);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -574,6 +575,7 @@ struct test tests[] = {
           TEST_F_LOCAL,
           TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0173_share_consumer_commit_async, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0177_share_consumer_transactions, 0, TEST_BRKVER(0, 4, 0, 0)),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/tests/test.c
+++ b/tests/test.c
@@ -2803,7 +2803,7 @@ rd_kafka_share_t *test_create_share_consumer(const char *group_id) {
         rd_kafka_conf_t *conf;
         char errstr[512];
 
-        test_conf_init(&conf, NULL, 60);
+        test_conf_init(&conf, NULL, 0);
 
         rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,

--- a/tests/test.c
+++ b/tests/test.c
@@ -2803,7 +2803,7 @@ rd_kafka_share_t *test_create_share_consumer(const char *group_id) {
         rd_kafka_conf_t *conf;
         char errstr[512];
 
-        test_conf_init(&conf, NULL, 0);
+        test_conf_init(&conf, NULL, 60);
 
         rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="..\..\tests\0171-share_consumer_consume.c" />
     <ClCompile Include="..\..\tests\0172-share_consumer_acknowledge.c" />
     <ClCompile Include="..\..\tests\0173-share_consumer_commit_async.c" />
+    <ClCompile Include="..\..\tests\0177-share_consumer_transactions.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
Share Consumer Transaction Tests

Tests share consumer behavior with transactional messages using the broker-side share.isolation.level configuration (KIP-932). Unlike regular consumers where isolation level is a client config, share consumers rely on broker-side filtering configured via share group settings.

**Isolation Level Behavior**
Each test runs twice - once with read_committed and once with read_uncommitted

1. Committed transactions - Produces 100 messages in a committed transaction; verifies both isolation levels receive all messages (baseline sanity check)

2. Aborted transactions - Produces 100 messages then aborts the transaction; read_committed should receive 0 messages while read_uncommitted receives all 100
 
3. Mixed commit/abort transactions - Executes 5 transactions with varying message counts (50 commit, 50 abort, 30 commit, 20 abort, 40 commit); validates read_committed sees only 120 committed messages while read_uncommitted sees all 190

4. Control record filtering - Produces 1 aborted + 5 committed messages, creating control records at specific offsets; verifies commit/abort markers (offsets 1 and 7) are never delivered to applications regardless of isolation level; validates exact offset sequences

5. Multi-partition transactions - Creates topic with 3 partitions; runs 3 transactions (commit, abort, commit) each writing to all partitions; verifies correct aggregate counts across partitions

6. Interleaved producers - Two transactional producers begin transactions simultaneously, interleave their writes, then one commits while the other aborts; tests broker's ability to track independent transaction states

7. Mixed transactional and non-transactional - Combines 50 non-transactional messages with 30 committed + 20 aborted transactional messages; verifies non-transactional messages are always visible and transaction filtering only applies to transactional batches
 
8. Interval-based abort pattern - Produces 20 transactions (5 messages each) where every 5th transaction is aborted; read_committed should see exactly 80 messages (16 committed × 5), read_uncommitted sees all 100

**Dynamic Isolation Level Change**

Runtime isolation level switch (read_uncommitted → read_committed) - Starts consumer with read_uncommitted, consumes committed and aborted transactions, then changes group config to read_committed via IncrementalAlterConfigs; produces new aborted transaction and verifies it's now filtered; produces committed transaction and verifies it's still visible. Demonstrates isolation level changes take effect on next poll without requiring consumer restart.