### PR TITLE
[KIP-932] Update trivup to 0.15.0 in Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -173,11 +173,11 @@ blocks:
             - brew install openjdk@21
             - sudo ln -sfn $(brew --prefix openjdk@21)/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-21.jdk
             - export JAVA_HOME=$(/usr/libexec/java_home -v 21)
-            - python3 -m pip install tests/trivup/trivup-0.14.0.tar.gz jsoncomment
-            - cache restore trivup-kafka-osx-${KAFKA_VERSION}-${CACHE_TAG}
+            - cd tests && python3 -m pip install -r requirements.txt && cd ..
+            - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - ./packaging/tools/run-share-consumer-tests.sh
               ${KAFKA_VERSION} ${CP_VERSION}
-            - cache store trivup-kafka-osx-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
 
   - name: 'Linux Ubuntu aarch64: share consumer tests'
     dependencies: []


### PR DESCRIPTION
1. Use tests/requirements.txt instead of hardcoding trivup version
2. Unify macOS cache key with Linux (Kafka binaries are platform-independent JVM artifacts)