### PR TITLE
[KIP-932] Implement close APIs

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -5160,6 +5160,8 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
                      NULL))
                 return error;
 
+        /* TODO KIP-932: Check fatal error handling
+         * while implementing destroy */
         rk                                = rkshare->rkshare_rk;
         rkshare->rkshare_consumer_closing = rd_true;
         error                             = rd_kafka_consumer_close0(rk);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1192,7 +1192,10 @@ static void rd_kafka_destroy_app(rd_kafka_t *rk, int flags) {
         if (rk->rk_cgrp) {
                 rd_kafka_dbg(rk, GENERIC, "TERMINATE",
                              "Terminating consumer group handler");
-                rd_kafka_consumer_close(rk);
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                        rd_kafka_share_consumer_close(rk->rk_rkshare);
+                else
+                        rd_kafka_consumer_close(rk);
         }
 
         /* Await telemetry termination. This method blocks until the last
@@ -2293,9 +2296,6 @@ static int rd_kafka_init_wait(rd_kafka_t *rk, int timeout_ms) {
 /* Forward declarations: defined after reply/fanout handlers */
 static rd_kafka_broker_t *rd_kafka_share_select_broker(rd_kafka_t *rk,
                                                        rd_kafka_cgrp_t *rkcg);
-static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
-                                            rd_kafka_broker_t *rkb,
-                                            rd_bool_t should_fetch);
 
 /**
  * Main loop for Kafka handler thread.
@@ -2376,8 +2376,8 @@ static int rd_kafka_thread_main(void *arg) {
                                              "Re-triggering fetch for "
                                              "share_fetch_more_records=true "
                                              "and no fetch in-flight");
-                                rd_kafka_share_enqueue_fetch_op(rk, rkb_sel,
-                                                                rd_true);
+                                rd_kafka_share_enqueue_fetch_op(
+                                    rk, rkb_sel, rd_true, rd_false);
                                 rd_kafka_broker_destroy(rkb_sel);
                         }
                 }
@@ -3232,7 +3232,8 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
          * enqueue a session leave op on the replying broker thread and return
          */
         if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
-                rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk, reply_rkb);
+                rd_kafka_share_enqueue_fetch_op(rkcg->rkcg_rk, reply_rkb,
+                                                rd_false, rd_true);
                 return RD_KAFKA_OP_RES_HANDLED;
         }
 
@@ -3319,7 +3320,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                                      rd_kafka_broker_name(reply_rkb));
 
                         rd_kafka_share_enqueue_fetch_op(rk, selected_rkb,
-                                                        rd_true);
+                                                        rd_true, rd_false);
                         rd_kafka_broker_destroy(selected_rkb);
                 } else {
                         rd_kafka_dbg(rk, CGRP, "SHARE",
@@ -3339,7 +3340,8 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                              "Enqueuing ack-only SHARE_FETCH to broker %s "
                              "to flush pending acks",
                              rd_kafka_broker_name(reply_rkb));
-                rd_kafka_share_enqueue_fetch_op(rk, reply_rkb, rd_false);
+                rd_kafka_share_enqueue_fetch_op(rk, reply_rkb, rd_false,
+                                                rd_false);
         }
 
         return RD_KAFKA_OP_RES_HANDLED;
@@ -3395,16 +3397,19 @@ rd_kafka_share_fetch_fanout_reply_op(rd_kafka_t *rk, rd_kafka_op_t *rko_orig) {
  * @param rk Client instance
  * @param rkb Broker to enqueue on. Must not have rkb_share_fetch_enqueued set.
  * @param should_fetch Whether the broker should fetch records.
+ * @param should_leave Whether the broker should close the session.
  *
  * @locality main thread
  */
-static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
-                                            rd_kafka_broker_t *rkb,
-                                            rd_bool_t should_fetch) {
+void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
+                                     rd_kafka_broker_t *rkb,
+                                     rd_bool_t should_fetch,
+                                     rd_bool_t should_leave) {
         rd_kafka_op_t *rko_sf;
 
+        rd_assert(!(should_fetch && should_leave));
         rko_sf = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
-        rko_sf->rko_u.share_fetch.should_leave = rd_false;
+        rko_sf->rko_u.share_fetch.should_leave = should_leave;
         rko_sf->rko_u.share_fetch.abs_timeout =
             rd_timeout_init(rk->rk_conf.socket_timeout_ms);
         rko_sf->rko_u.share_fetch.should_fetch = should_fetch;
@@ -3429,8 +3434,9 @@ static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
 
         rd_kafka_dbg(rk, CGRP, "SHAREFETCH",
                      "Enqueuing share fetch op on broker %s "
-                     "(%s fetch, %s acks)",
+                     "(%s fetch, %s leave, %s acks)",
                      rd_kafka_broker_name(rkb), should_fetch ? "with" : "no",
+                     should_leave ? "with" : "no",
                      rko_sf->rko_u.share_fetch.ack_details ? "with" : "no");
 
         // /* TODO KIP-932: Remove this debug printing */
@@ -3553,7 +3559,8 @@ rd_kafka_share_segregate_and_dispatch_acks(rd_kafka_t *rk,
                         continue;
                 }
 
-                rd_kafka_share_enqueue_fetch_op(rk, rkb, is_fetch_broker);
+                rd_kafka_share_enqueue_fetch_op(rk, rkb, is_fetch_broker,
+                                                rd_false);
         }
         rd_kafka_rdunlock(rk);
 }
@@ -3567,14 +3574,6 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
                                                  rd_kafka_op_t *rko) {
         rd_kafka_broker_t *selected_rkb = NULL;
         rd_kafka_cgrp_t *rkcg           = rd_kafka_cgrp_get(rk);
-
-        if (rkcg && rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
-                rd_kafka_dbg(
-                    rk, CGRP, "SHARE",
-                    "Ignoring SHARE_FETCH_FANOUT op received after close");
-                return RD_KAFKA_OP_RES_HANDLED;
-        }
-
         rd_bool_t fetch_more_records =
             rko->rko_u.share_fetch_fanout.fetch_more_records;
         rd_bool_t has_fanout_acks =
@@ -3636,6 +3635,31 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
         return RD_KAFKA_OP_RES_HANDLED;
 }
 
+/**
+ * @brief Return an error if the share consumer is closed or closing.
+ *
+ * @param rkshare Share consumer instance.
+ * @returns error if closed/closing, NULL otherwise. Caller owns the error.
+ */
+rd_kafka_error_t *
+rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Share consumer is closed");
+        if (unlikely(rkshare->rkshare_consumer_closing))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Share consumer is closing");
+        return NULL;
+}
+
+rd_kafka_resp_err_t
+rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare) {
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare) ||
+                     rkshare->rkshare_consumer_closing))
+                return RD_KAFKA_RESP_ERR__STATE;
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
 rd_kafka_error_t *rd_kafka_share_consume_batch(
     rd_kafka_share_t *rkshare,
     int timeout_ms,
@@ -3656,10 +3680,9 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                                           "rd_kafka_share_consume_batch(): "
                                           "Consumer group not initialized");
 
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "rd_kafka_share_consume_batch(): "
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -4166,10 +4189,11 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_op_t *rko;
         rd_list_t *ack_batches;
+        rd_kafka_error_t *error;
 
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
         rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
 
@@ -4987,13 +5011,7 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
 
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
          * on the rkq when done. */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rd_kafka_share_cgrp_terminate(
-                    rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
-        else
-                rd_kafka_cgrp_terminate(rkcg,
-                                        RD_KAFKA_REPLYQ(rkq, 0)); /* async */
-
+        rd_kafka_cgrp_terminate(rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
         return error;
 }
 
@@ -5013,13 +5031,21 @@ rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
  */
 rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
                                                       rd_kafka_queue_t *rkqu) {
+        rd_kafka_error_t *error = NULL;
+
         /* TODO KIP-932: Guard this with checks for rkshare
          * and rkshare->rkshare_rk */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
-        return rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
+        rkshare->rkshare_consumer_closing = rd_true;
+        error = rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
+        if (error) {
+                rkshare->rkshare_consumer_closing = rd_false;
+                return error;
+        }
+        return NULL;
 }
 
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
@@ -5088,36 +5114,32 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
 }
 
 rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
-        rd_kafka_error_t *error, *default_error;
+        rd_kafka_error_t *error;
         rd_kafka_t *rk;
         rd_kafka_q_t *rkq;
 
         /* TODO KIP-932: Guard this with checks for rkshare and
          * rkshare->rkshare_rk */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
+        rk                                = rkshare->rkshare_rk;
         rkshare->rkshare_consumer_closing = rd_true;
 
         /*
          * TODO KIP-932: Need to check if this behaviour is correct
          */
-        rd_kafka_q_fwd_set(rkshare->rkshare_rk->rk_rep,
-                           rkshare->rkshare_rk->rk_cgrp->rkcg_q);
+        rd_kafka_q_fwd_set(rk->rk_rep, rk->rk_cgrp->rkcg_q);
 
         /* Create a temporary reply queue to handle the TERMINATE reply op. */
-        rk  = rkshare->rkshare_rk;
         rkq = rd_kafka_q_new(rk);
-
-        error = default_error = rd_kafka_error_new(
-            RD_KAFKA_RESP_ERR__TIMED_OUT,
-            "Timed out waiting for TERMINATE reply to arrive");
 
         /* Initiate the close (async) */
         error = rd_kafka_consumer_close_q(rk, rkq);
         if (error) {
-                return error;
+                rd_kafka_q_destroy_owner(rkq);
+                goto done;
         }
 
         /* Disable the queue if termination is immediate or the user
@@ -5129,43 +5151,47 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
                 rd_kafka_dbg(rk, CONSUMER, "CLOSE",
                              "Disabling and purging temporary queue to quench "
                              "close events");
-                error = NULL;
                 rd_kafka_q_disable(rkq);
                 /* Purge ops already enqueued */
                 rd_kafka_q_purge(rkq);
         } else {
                 rd_kafka_op_t *rko;
+                rd_bool_t got_terminate = rd_false;
+
                 rd_kafka_dbg(rk, CONSUMER, "CLOSE", "Waiting for close events");
                 while ((rko = rd_kafka_q_pop(rkq, RD_POLL_INFINITE, 0))) {
-                        rd_kafka_op_res_t res;
                         if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
                             RD_KAFKA_OP_TERMINATE) {
-                                error = rko->rko_error;
-                                rd_kafka_op_destroy(rko);
+                                /* Transfer ownership of rko_error out
+                                 * before op_destroy frees it. */
+                                error         = rd_kafka_op_error_destroy(rko);
+                                got_terminate = rd_true;
                                 break;
                         }
                         /* Handle callbacks */
-                        res = rd_kafka_poll_cb(rk, rkq, rko,
-                                               RD_KAFKA_Q_CB_RETURN, NULL);
-                        if (res == RD_KAFKA_OP_RES_PASS)
+                        if (rd_kafka_poll_cb(rk, rkq, rko, RD_KAFKA_Q_CB_RETURN,
+                                             NULL) == RD_KAFKA_OP_RES_PASS)
                                 rd_kafka_op_destroy(rko);
                         /* Ignore YIELD, we need to finish */
                 }
+
+                if (!got_terminate)
+                        error = rd_kafka_error_new(
+                            RD_KAFKA_RESP_ERR__TIMED_OUT,
+                            "Timed out waiting for TERMINATE reply to arrive");
         }
 
         rd_kafka_q_destroy_owner(rkq);
 
+done:
         if (error)
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed with error: %s",
-                             rd_kafka_error_name(error));
+                             rd_kafka_error_string(error));
         else
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed");
-
-        if (error != default_error)
-                rd_kafka_error_destroy(default_error);
-
+        rkshare->rkshare_consumer_closing = rd_false;
         return error;
 }
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2362,6 +2362,7 @@ static int rd_kafka_thread_main(void *arg) {
                  * rkcg->rkcg_rk->rk_consumer.assignment.all should
                  * be used instead. */
                 if (RD_KAFKA_IS_SHARE_CONSUMER(rk) && rk->rk_cgrp &&
+                    !(rk->rk_cgrp->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) &&
                     rk->rk_cgrp->rkcg_share.share_fetch_more_records &&
                     rk->rk_cgrp->rkcg_share
                             .share_should_fetch_ops_in_flight_cnt == 0 &&
@@ -3192,19 +3193,25 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         rd_kafka_cgrp_t *rkcg     = rd_kafka_cgrp_get(rk);
         rd_bool_t should_fetch    = rko_orig->rko_u.share_fetch.should_fetch;
         rd_bool_t records_fetched = rko_orig->rko_u.share_fetch.records_fetched;
+        rd_bool_t should_leave    = rko_orig->rko_u.share_fetch.should_leave;
 
         rd_kafka_assert(rk, thrd_is_current(rk->rk_thread));
         rd_kafka_dbg(rk, CGRP, "SHAREFETCH",
                      "Share fetch reply: %s, should_fetch=%d, "
-                     "records_fetched=%d, broker=%s",
+                     "records_fetched=%d, should_leave=%d, broker=%s",
                      rd_kafka_err2str(rko_orig->rko_err), should_fetch,
-                     records_fetched,
+                     records_fetched, should_leave,
                      reply_rkb ? rd_kafka_broker_name(reply_rkb) : "none");
 
         reply_rkb->rkb_share_fetch_enqueued = rd_false;
 
         if (should_fetch)
                 rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt--;
+
+        if (should_leave) {
+                rkcg->rkcg_share.share_session_leave_remaining_cnt--;
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
 
         /*
          * Step 1: If records were fetched and broker is not terminating,
@@ -3215,7 +3222,16 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                 rkcg->rkcg_share.share_fetch_more_records = rd_false;
 
         /*
-         * Step 2: Handle commit_sync reply if this op belongs to
+         * Step 2: If the consumer has been marked for termination,
+         * enqueue a session leave op on the replying broker thread and return
+         */
+        if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
+                rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk, reply_rkb);
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
+        /*
+         * Step 3: Handle commit_sync reply if this op belongs to
          * the current commit_sync request.
          */
         if (rko_orig->rko_u.share_fetch.commit_sync_request_id != 0 &&
@@ -3260,7 +3276,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 3: Dispatch pending commit_sync to the replying broker
+         * Step 4: Dispatch pending commit_sync to the replying broker
          * (highest priority). Acks must always be sent.
          */
         if (!reply_rkb->rkb_share_fetch_enqueued &&
@@ -3273,7 +3289,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 4: If this was the fetch broker but no records were received,
+         * Step 5: If this was the fetch broker but no records were received,
          * try to select another broker to fetch from.
          *
          * TODO: KIP-932: Handle the case where all assignments are removed
@@ -3307,7 +3323,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 5: If the replying broker has cached async ack details,
+         * Step 6: If the replying broker has cached async ack details,
          * send an ack-only SHARE_FETCH op to it.
          */
         if (reply_rkb->rkb_share_async_ack_details &&
@@ -3362,114 +3378,6 @@ rd_kafka_share_fetch_fanout_reply_op(rd_kafka_t *rk, rd_kafka_op_t *rko_orig) {
         }
         return RD_KAFKA_OP_RES_HANDLED;
 }
-
-/**
- * @brief Find an existing ack batch for the same topic-partition in a list.
- *
- * @param ack_list List of rd_kafka_share_ack_batches_t*
- * @param rktpar Topic-partition to match (by topic id and partition)
- *
- * @returns Matching batch, or NULL if not found.
- * @locality main thread
- */
-static rd_kafka_share_ack_batches_t *
-rd_kafka_share_find_ack_batch(rd_list_t *ack_list,
-                              const rd_kafka_topic_partition_t *rktpar) {
-        rd_kafka_share_ack_batches_t *existing;
-        int i;
-
-        RD_LIST_FOREACH(existing, ack_list, i) {
-                /* TODO KIP-932: We might need to use leader id and epoch
-                 * as well to understand about the stale topic partition
-                 * information */
-                if (rd_kafka_topic_partition_by_id_cmp(existing->rktpar,
-                                                       rktpar) == 0)
-                        return existing;
-        }
-        return NULL;
-}
-
-/**
- * @brief Segregate ack batches from a FANOUT op by partition leader.
- *
- * For each ack batch, looks up the current leader broker via the
- * toppar reference in batch->rktpar, and merges the batch into that
- * broker's rkb_share_async_ack_details list. If the broker already
- * has cached acks for the same topic-partition, the entries are
- * appended to the existing batch.
- *
- * @param rk Client instance
- * @param ack_batches List of rd_kafka_share_ack_batches_t* from FANOUT op.
- *                    Elements whose leader is found are moved to broker
- *                    ack_details; remaining elements are not freed.
- *
- * @locality main thread
- */
-static void rd_kafka_share_segregate_acks_by_leader(rd_kafka_t *rk,
-                                                    rd_list_t *ack_batches) {
-        rd_kafka_share_ack_batches_t *batch;
-        int batch_cnt = rd_list_cnt(ack_batches);
-
-        while ((batch = rd_list_pop(ack_batches))) {
-                rd_kafka_toppar_t *rktp;
-                rd_kafka_broker_t *leader_rkb;
-                rd_kafka_share_ack_batches_t *existing;
-
-                rktp = rd_kafka_topic_partition_toppar(rk, batch->rktpar);
-                if (!rktp || !rktp->rktp_leader) {
-                        rd_kafka_dbg(rk, CGRP, "SHARE",
-                                     "Ack batch for leader %" PRId32
-                                     " dropped: toppar or leader not available",
-                                     batch->response_leader_id);
-                        rd_kafka_share_ack_batches_destroy(batch);
-                        continue;
-                }
-                leader_rkb = rktp->rktp_leader;
-
-                /* Allocate list on first use with incoming batch count
-                 * as initial capacity hint */
-                if (!leader_rkb->rkb_share_async_ack_details)
-                        leader_rkb->rkb_share_async_ack_details = rd_list_new(
-                            batch_cnt, rd_kafka_share_ack_batches_destroy_free);
-
-                /* Check if there's already a batch for this topic-partition.
-                 * If so, merge entries; otherwise add as new. */
-                existing = rd_kafka_share_find_ack_batch(
-                    leader_rkb->rkb_share_async_ack_details, batch->rktpar);
-
-                if (existing) {
-                        /* Merge: deep-copy entries from new batch into
-                         * existing, preserving order. The source batch
-                         * is then fully destroyed (freeing its entries). */
-                        rd_kafka_share_ack_batch_entry_t *entry;
-                        int j;
-                        /*
-                         * TODO KIP-932: Merge with overlapping offsets into
-                         * single entry with single type. For example, if
-                         * existing has an ACCEPT for offsets 0-50 and new
-                         * batch has ACCEPT for offsets 51-100, they can be
-                         * merged into a single ACCEPT for offsets 0-100.
-                         * Currently, we are blindly adding entries from the
-                         * new batch into the existing batch, which means we
-                         * may end up with multiple adjacent or overlapping
-                         * entries of the same type that could have been
-                         * merged. This is not incorrect, but it is less
-                         * efficient in terms of the network bandwidth in the
-                         * RPC call.
-                         */
-                        RD_LIST_FOREACH(entry, &batch->entries, j) {
-                                rd_list_add(
-                                    &existing->entries,
-                                    rd_kafka_share_ack_batch_entry_copy(entry));
-                        }
-                        rd_kafka_share_ack_batches_destroy(batch);
-                } else {
-                        rd_list_add(leader_rkb->rkb_share_async_ack_details,
-                                    batch);
-                }
-        }
-}
-
 
 /**
  * @brief Create and enqueue a SHARE_FETCH op on a broker.
@@ -3653,6 +3561,14 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
                                                  rd_kafka_op_t *rko) {
         rd_kafka_broker_t *selected_rkb = NULL;
         rd_kafka_cgrp_t *rkcg           = rd_kafka_cgrp_get(rk);
+
+        if (rkcg && rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
+                rd_kafka_dbg(
+                    rk, CGRP, "SHARE",
+                    "Ignoring SHARE_FETCH_FANOUT op received after close");
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
         rd_bool_t fetch_more_records =
             rko->rko_u.share_fetch_fanout.fetch_more_records;
         rd_bool_t has_fanout_acks =
@@ -3733,6 +3649,11 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
                                           "rd_kafka_share_consume_batch(): "
                                           "Consumer group not initialized");
+
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "rd_kafka_share_consume_batch(): "
+                                          "Consumer already closed");
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -4239,6 +4160,10 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_op_t *rko;
         rd_list_t *ack_batches;
+
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
 
         rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
 
@@ -5049,11 +4974,6 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
         rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                      "Closing consumer");
 
-
-        /*
-         * TODO KIP-932: Need to check what to do for rk_rep queue as we are
-         * not forwarding rk_rep to the rkcg_q in Share Consumer.
-         */
         /* Redirect cgrp queue to the rebalance queue to make sure all posted
          * ops (e.g., rebalance callbacks) are served by
          * the application/caller. */
@@ -5061,7 +4981,12 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
 
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
          * on the rkq when done. */
-        rd_kafka_cgrp_terminate(rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                rd_kafka_share_cgrp_terminate(
+                    rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
+        else
+                rd_kafka_cgrp_terminate(rkcg,
+                                        RD_KAFKA_REPLYQ(rkq, 0)); /* async */
 
         return error;
 }
@@ -5072,6 +4997,23 @@ rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__INVALID_ARG,
                                           "Queue must be specified");
         return rd_kafka_consumer_close_q(rk, rkqu->rkqu_q);
+}
+
+/**
+ * @brief Asynchronously close the share consumer.
+ * @param rkshare Share consumer instance.
+ * @param rkqu Queue for forwarding events/callbacks during close.
+ * @returns `rd_kafka_error_t *` - NULL on success, error object on failure
+ */
+rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
+                                                      rd_kafka_queue_t *rkqu) {
+        /* TODO KIP-932: Guard this with checks for rkshare
+         * and rkshare->rkshare_rk */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
+
+        return rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
 }
 
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
@@ -5139,13 +5081,86 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
         return err;
 }
 
-rd_kafka_resp_err_t rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
+rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
+        rd_kafka_error_t *error, *default_error;
+        rd_kafka_t *rk;
+        rd_kafka_q_t *rkq;
+
+        /* TODO KIP-932: Guard this with checks for rkshare and
+         * rkshare->rkshare_rk */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
+
         rkshare->rkshare_consumer_closing = rd_true;
-        /* TODO KIP-932: Need to check this behavior is correct while closing.
+
+        /*
+         * TODO KIP-932: Need to check if this behaviour is correct
          */
         rd_kafka_q_fwd_set(rkshare->rkshare_rk->rk_rep,
                            rkshare->rkshare_rk->rk_cgrp->rkcg_q);
-        return rd_kafka_consumer_close(rkshare->rkshare_rk);
+
+        /* Create a temporary reply queue to handle the TERMINATE reply op. */
+        rk  = rkshare->rkshare_rk;
+        rkq = rd_kafka_q_new(rk);
+
+        error = default_error = rd_kafka_error_new(
+            RD_KAFKA_RESP_ERR__TIMED_OUT,
+            "Timed out waiting for TERMINATE reply to arrive");
+
+        /* Initiate the close (async) */
+        error = rd_kafka_consumer_close_q(rk, rkq);
+        if (error) {
+                return error;
+        }
+
+        /* Disable the queue if termination is immediate or the user
+         * does not want the blocking consumer_close() behaviour, this will
+         * cause any ops posted for this queue (such as rebalance) to
+         * be destroyed.
+         */
+        if (rd_kafka_destroy_flags_no_consumer_close(rk)) {
+                rd_kafka_dbg(rk, CONSUMER, "CLOSE",
+                             "Disabling and purging temporary queue to quench "
+                             "close events");
+                error = NULL;
+                rd_kafka_q_disable(rkq);
+                /* Purge ops already enqueued */
+                rd_kafka_q_purge(rkq);
+        } else {
+                rd_kafka_op_t *rko;
+                rd_kafka_dbg(rk, CONSUMER, "CLOSE", "Waiting for close events");
+                while ((rko = rd_kafka_q_pop(rkq, RD_POLL_INFINITE, 0))) {
+                        rd_kafka_op_res_t res;
+                        if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
+                            RD_KAFKA_OP_TERMINATE) {
+                                error = rko->rko_error;
+                                rd_kafka_op_destroy(rko);
+                                break;
+                        }
+                        /* Handle callbacks */
+                        res = rd_kafka_poll_cb(rk, rkq, rko,
+                                               RD_KAFKA_Q_CB_RETURN, NULL);
+                        if (res == RD_KAFKA_OP_RES_PASS)
+                                rd_kafka_op_destroy(rko);
+                        /* Ignore YIELD, we need to finish */
+                }
+        }
+
+        rd_kafka_q_destroy_owner(rkq);
+
+        if (error)
+                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
+                             "Consumer closed with error: %s",
+                             rd_kafka_error_name(error));
+        else
+                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
+                             "Consumer closed");
+
+        if (error != default_error)
+                rd_kafka_error_destroy(default_error);
+
+        return error;
 }
 
 
@@ -5154,6 +5169,15 @@ int rd_kafka_consumer_closed(rd_kafka_t *rk) {
                 return 0;
 
         return rd_atomic32_get(&rk->rk_cgrp->rkcg_terminated);
+}
+
+/**
+ * @brief Check if the share consumer is closed.
+ * @param rkshare Share consumer instance.
+ * @returns 1 if the consumer is closed, else 0.
+ */
+int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare) {
+        return rd_kafka_consumer_closed(rkshare->rkshare_rk);
 }
 
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3639,7 +3639,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
  * @returns error if closed/closing, NULL otherwise. Caller owns the error.
  */
 rd_kafka_error_t *
-rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
+rd_kafka_share_consumer_closed_error(rd_kafka_share_t *rkshare) {
         if (unlikely(rd_kafka_share_consumer_closed(rkshare) ||
                      rkshare->rkshare_consumer_closing))
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
@@ -3648,11 +3648,11 @@ rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
 }
 
 rd_kafka_resp_err_t
-rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare) {
+rd_kafka_share_consumer_closed_err(rd_kafka_share_t *rkshare) {
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
 
-        error = rd_kafka_share_consumer_closed_or_closing_error(rkshare);
+        error = rd_kafka_share_consumer_closed_error(rkshare);
         if (!error)
                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
@@ -3681,8 +3681,8 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                                           "rd_kafka_share_consume_batch(): "
                                           "Consumer group not initialized");
 
-        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
-                          rkshare)) != NULL))
+        if (unlikely((error = rd_kafka_share_consumer_closed_error(rkshare)) !=
+                     NULL))
                 return error;
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
@@ -4193,8 +4193,8 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_list_t *ack_batches;
         rd_kafka_error_t *error;
 
-        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
-                          rkshare)) != NULL))
+        if (unlikely((error = rd_kafka_share_consumer_closed_error(rkshare)) !=
+                     NULL))
                 return error;
 
         rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
@@ -4262,8 +4262,8 @@ rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
 
         *partitions = NULL;
 
-        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
-                          rkshare)) != NULL))
+        if (unlikely((error = rd_kafka_share_consumer_closed_error(rkshare)) !=
+                     NULL))
                 return error;
 
         rd_kafka_dbg(rk, CGRP, "SHARE",
@@ -5052,8 +5052,8 @@ rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
 
         /* TODO KIP-932: Guard this with checks for rkshare
          * and rkshare->rkshare_rk */
-        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
-                          rkshare)) != NULL))
+        if (unlikely((error = rd_kafka_share_consumer_closed_error(rkshare)) !=
+                     NULL))
                 return error;
 
         rkshare->rkshare_consumer_closing = rd_true;
@@ -5156,8 +5156,8 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
          * rkshare->rkshare_rk. Check if this is needed for other APIs
          * as well.
          */
-        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
-                          rkshare)) != NULL))
+        if (unlikely((error = rd_kafka_share_consumer_closed_error(rkshare)) !=
+                     NULL))
                 return error;
 
         rk                                = rkshare->rkshare_rk;

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1192,7 +1192,10 @@ static void rd_kafka_destroy_app(rd_kafka_t *rk, int flags) {
         if (rk->rk_cgrp) {
                 rd_kafka_dbg(rk, GENERIC, "TERMINATE",
                              "Terminating consumer group handler");
-                rd_kafka_consumer_close(rk);
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                        rd_kafka_share_consumer_close(rk->rk_rkshare);
+                else
+                        rd_kafka_consumer_close(rk);
         }
 
         /* Await telemetry termination. This method blocks until the last
@@ -2293,9 +2296,6 @@ static int rd_kafka_init_wait(rd_kafka_t *rk, int timeout_ms) {
 /* Forward declarations: defined after reply/fanout handlers */
 static rd_kafka_broker_t *rd_kafka_share_select_broker(rd_kafka_t *rk,
                                                        rd_kafka_cgrp_t *rkcg);
-static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
-                                            rd_kafka_broker_t *rkb,
-                                            rd_bool_t should_fetch);
 
 /**
  * Main loop for Kafka handler thread.
@@ -2376,8 +2376,8 @@ static int rd_kafka_thread_main(void *arg) {
                                              "Re-triggering fetch for "
                                              "share_fetch_more_records=true "
                                              "and no fetch in-flight");
-                                rd_kafka_share_enqueue_fetch_op(rk, rkb_sel,
-                                                                rd_true);
+                                rd_kafka_share_enqueue_fetch_op(
+                                    rk, rkb_sel, rd_true, rd_false);
                                 rd_kafka_broker_destroy(rkb_sel);
                         }
                 }
@@ -3226,7 +3226,8 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
          * enqueue a session leave op on the replying broker thread and return
          */
         if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
-                rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk, reply_rkb);
+                rd_kafka_share_enqueue_fetch_op(rkcg->rkcg_rk, reply_rkb,
+                                                rd_false, rd_true);
                 return RD_KAFKA_OP_RES_HANDLED;
         }
 
@@ -3313,7 +3314,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                                      rd_kafka_broker_name(reply_rkb));
 
                         rd_kafka_share_enqueue_fetch_op(rk, selected_rkb,
-                                                        rd_true);
+                                                        rd_true, rd_false);
                         rd_kafka_broker_destroy(selected_rkb);
                 } else {
                         rd_kafka_dbg(rk, CGRP, "SHARE",
@@ -3333,7 +3334,8 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                              "Enqueuing ack-only SHARE_FETCH to broker %s "
                              "to flush pending acks",
                              rd_kafka_broker_name(reply_rkb));
-                rd_kafka_share_enqueue_fetch_op(rk, reply_rkb, rd_false);
+                rd_kafka_share_enqueue_fetch_op(rk, reply_rkb, rd_false,
+                                                rd_false);
         }
 
         return RD_KAFKA_OP_RES_HANDLED;
@@ -3389,16 +3391,19 @@ rd_kafka_share_fetch_fanout_reply_op(rd_kafka_t *rk, rd_kafka_op_t *rko_orig) {
  * @param rk Client instance
  * @param rkb Broker to enqueue on. Must not have rkb_share_fetch_enqueued set.
  * @param should_fetch Whether the broker should fetch records.
+ * @param should_leave Whether the broker should close the session.
  *
  * @locality main thread
  */
-static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
-                                            rd_kafka_broker_t *rkb,
-                                            rd_bool_t should_fetch) {
+void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
+                                     rd_kafka_broker_t *rkb,
+                                     rd_bool_t should_fetch,
+                                     rd_bool_t should_leave) {
         rd_kafka_op_t *rko_sf;
 
+        rd_assert(!(should_fetch && should_leave));
         rko_sf = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
-        rko_sf->rko_u.share_fetch.should_leave = rd_false;
+        rko_sf->rko_u.share_fetch.should_leave = should_leave;
         rko_sf->rko_u.share_fetch.abs_timeout =
             rd_timeout_init(rk->rk_conf.socket_timeout_ms);
         rko_sf->rko_u.share_fetch.should_fetch = should_fetch;
@@ -3423,8 +3428,9 @@ static void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
 
         rd_kafka_dbg(rk, CGRP, "SHAREFETCH",
                      "Enqueuing share fetch op on broker %s "
-                     "(%s fetch, %s acks)",
+                     "(%s fetch, %s leave, %s acks)",
                      rd_kafka_broker_name(rkb), should_fetch ? "with" : "no",
+                     should_leave ? "with" : "no",
                      rko_sf->rko_u.share_fetch.ack_details ? "with" : "no");
 
         // /* TODO KIP-932: Remove this debug printing */
@@ -3547,7 +3553,8 @@ rd_kafka_share_segregate_and_dispatch_acks(rd_kafka_t *rk,
                         continue;
                 }
 
-                rd_kafka_share_enqueue_fetch_op(rk, rkb, is_fetch_broker);
+                rd_kafka_share_enqueue_fetch_op(rk, rkb, is_fetch_broker,
+                                                rd_false);
         }
         rd_kafka_rdunlock(rk);
 }
@@ -3561,14 +3568,6 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
                                                  rd_kafka_op_t *rko) {
         rd_kafka_broker_t *selected_rkb = NULL;
         rd_kafka_cgrp_t *rkcg           = rd_kafka_cgrp_get(rk);
-
-        if (rkcg && rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
-                rd_kafka_dbg(
-                    rk, CGRP, "SHARE",
-                    "Ignoring SHARE_FETCH_FANOUT op received after close");
-                return RD_KAFKA_OP_RES_HANDLED;
-        }
-
         rd_bool_t fetch_more_records =
             rko->rko_u.share_fetch_fanout.fetch_more_records;
         rd_bool_t has_fanout_acks =
@@ -3630,6 +3629,31 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
         return RD_KAFKA_OP_RES_HANDLED;
 }
 
+/**
+ * @brief Return an error if the share consumer is closed or closing.
+ *
+ * @param rkshare Share consumer instance.
+ * @returns error if closed/closing, NULL otherwise. Caller owns the error.
+ */
+rd_kafka_error_t *
+rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Share consumer is closed");
+        if (unlikely(rkshare->rkshare_consumer_closing))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Share consumer is closing");
+        return NULL;
+}
+
+rd_kafka_resp_err_t
+rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare) {
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare) ||
+                     rkshare->rkshare_consumer_closing))
+                return RD_KAFKA_RESP_ERR__STATE;
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
+
 rd_kafka_error_t *rd_kafka_share_consume_batch(
     rd_kafka_share_t *rkshare,
     int timeout_ms,
@@ -3650,10 +3674,9 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                                           "rd_kafka_share_consume_batch(): "
                                           "Consumer group not initialized");
 
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "rd_kafka_share_consume_batch(): "
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -4160,10 +4183,11 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_op_t *rko;
         rd_list_t *ack_batches;
+        rd_kafka_error_t *error;
 
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
         rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
 
@@ -4981,13 +5005,7 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
 
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
          * on the rkq when done. */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rd_kafka_share_cgrp_terminate(
-                    rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
-        else
-                rd_kafka_cgrp_terminate(rkcg,
-                                        RD_KAFKA_REPLYQ(rkq, 0)); /* async */
-
+        rd_kafka_cgrp_terminate(rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
         return error;
 }
 
@@ -5007,13 +5025,21 @@ rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
  */
 rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
                                                       rd_kafka_queue_t *rkqu) {
+        rd_kafka_error_t *error = NULL;
+
         /* TODO KIP-932: Guard this with checks for rkshare
          * and rkshare->rkshare_rk */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
-        return rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
+        rkshare->rkshare_consumer_closing = rd_true;
+        error = rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
+        if (error) {
+                rkshare->rkshare_consumer_closing = rd_false;
+                return error;
+        }
+        return NULL;
 }
 
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
@@ -5082,36 +5108,32 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
 }
 
 rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
-        rd_kafka_error_t *error, *default_error;
+        rd_kafka_error_t *error;
         rd_kafka_t *rk;
         rd_kafka_q_t *rkq;
 
         /* TODO KIP-932: Guard this with checks for rkshare and
          * rkshare->rkshare_rk */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Consumer already closed");
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
+        rk                                = rkshare->rkshare_rk;
         rkshare->rkshare_consumer_closing = rd_true;
 
         /*
          * TODO KIP-932: Need to check if this behaviour is correct
          */
-        rd_kafka_q_fwd_set(rkshare->rkshare_rk->rk_rep,
-                           rkshare->rkshare_rk->rk_cgrp->rkcg_q);
+        rd_kafka_q_fwd_set(rk->rk_rep, rk->rk_cgrp->rkcg_q);
 
         /* Create a temporary reply queue to handle the TERMINATE reply op. */
-        rk  = rkshare->rkshare_rk;
         rkq = rd_kafka_q_new(rk);
-
-        error = default_error = rd_kafka_error_new(
-            RD_KAFKA_RESP_ERR__TIMED_OUT,
-            "Timed out waiting for TERMINATE reply to arrive");
 
         /* Initiate the close (async) */
         error = rd_kafka_consumer_close_q(rk, rkq);
         if (error) {
-                return error;
+                rd_kafka_q_destroy_owner(rkq);
+                goto done;
         }
 
         /* Disable the queue if termination is immediate or the user
@@ -5123,43 +5145,47 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
                 rd_kafka_dbg(rk, CONSUMER, "CLOSE",
                              "Disabling and purging temporary queue to quench "
                              "close events");
-                error = NULL;
                 rd_kafka_q_disable(rkq);
                 /* Purge ops already enqueued */
                 rd_kafka_q_purge(rkq);
         } else {
                 rd_kafka_op_t *rko;
+                rd_bool_t got_terminate = rd_false;
+
                 rd_kafka_dbg(rk, CONSUMER, "CLOSE", "Waiting for close events");
                 while ((rko = rd_kafka_q_pop(rkq, RD_POLL_INFINITE, 0))) {
-                        rd_kafka_op_res_t res;
                         if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
                             RD_KAFKA_OP_TERMINATE) {
-                                error = rko->rko_error;
-                                rd_kafka_op_destroy(rko);
+                                /* Transfer ownership of rko_error out
+                                 * before op_destroy frees it. */
+                                error         = rd_kafka_op_error_destroy(rko);
+                                got_terminate = rd_true;
                                 break;
                         }
                         /* Handle callbacks */
-                        res = rd_kafka_poll_cb(rk, rkq, rko,
-                                               RD_KAFKA_Q_CB_RETURN, NULL);
-                        if (res == RD_KAFKA_OP_RES_PASS)
+                        if (rd_kafka_poll_cb(rk, rkq, rko, RD_KAFKA_Q_CB_RETURN,
+                                             NULL) == RD_KAFKA_OP_RES_PASS)
                                 rd_kafka_op_destroy(rko);
                         /* Ignore YIELD, we need to finish */
                 }
+
+                if (!got_terminate)
+                        error = rd_kafka_error_new(
+                            RD_KAFKA_RESP_ERR__TIMED_OUT,
+                            "Timed out waiting for TERMINATE reply to arrive");
         }
 
         rd_kafka_q_destroy_owner(rkq);
 
+done:
         if (error)
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed with error: %s",
-                             rd_kafka_error_name(error));
+                             rd_kafka_error_string(error));
         else
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed");
-
-        if (error != default_error)
-                rd_kafka_error_destroy(default_error);
-
+        rkshare->rkshare_consumer_closing = rd_false;
         return error;
 }
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3640,12 +3640,10 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
  */
 rd_kafka_error_t *
 rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare) ||
+                     rkshare->rkshare_consumer_closing))
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
                                           "Share consumer is closed");
-        if (unlikely(rkshare->rkshare_consumer_closing))
-                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                          "Share consumer is closing");
         return NULL;
 }
 
@@ -3817,6 +3815,7 @@ static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_q_enq(rkcg->rkcg_commit_sync_request.replyq, rko_reply);
         rd_kafka_q_destroy(rkcg->rkcg_commit_sync_request.replyq);
+
         rkcg->rkcg_commit_sync_request.id                          = 0;
         rkcg->rkcg_commit_sync_request.results                     = NULL;
         rkcg->rkcg_commit_sync_request.replyq                      = NULL;
@@ -5012,9 +5011,18 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
         rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                      "Closing consumer");
 
-        /* Redirect cgrp queue to the rebalance queue to make sure all posted
-         * ops (e.g., rebalance callbacks) are served by
-         * the application/caller. */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
+                /* Unlike regular consumer, the rk_rep queue is not forwarded to
+                 * rkcg_q by default, so we need this additional step to ensure
+                 * callbacks from rk_rep queue can be served by the
+                 * application/caller */
+                rd_kafka_q_fwd_set(rk->rk_rep, rkq);
+        }
+
+        /* For regular consumers, this redirects cgrp queue to the rebalance
+         * queue to make sure all posted ops (e.g., rebalance callbacks) are
+         * served by the application/caller. For share consumers, this will take
+         * care of forwarding only the cgrp ops */
         rd_kafka_q_fwd_set(rkcg->rkcg_q, rkq);
 
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
@@ -5153,14 +5161,7 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
 
         rk                                = rkshare->rkshare_rk;
         rkshare->rkshare_consumer_closing = rd_true;
-
-        /*
-         * TODO KIP-932: Need to check if this behaviour is correct
-         */
-        rd_kafka_q_fwd_set(rk->rk_rep, rk->rk_cgrp->rkcg_q);
-
-        error = rd_kafka_consumer_close0(rk);
-
+        error                             = rd_kafka_consumer_close0(rk);
         rkshare->rkshare_consumer_closing = rd_false;
         return error;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2362,6 +2362,7 @@ static int rd_kafka_thread_main(void *arg) {
                  * rkcg->rkcg_rk->rk_consumer.assignment.all should
                  * be used instead. */
                 if (RD_KAFKA_IS_SHARE_CONSUMER(rk) && rk->rk_cgrp &&
+                    !(rk->rk_cgrp->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) &&
                     rk->rk_cgrp->rkcg_share.share_fetch_more_records &&
                     rk->rk_cgrp->rkcg_share
                             .share_should_fetch_ops_in_flight_cnt == 0 &&
@@ -3198,19 +3199,25 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         rd_kafka_cgrp_t *rkcg     = rd_kafka_cgrp_get(rk);
         rd_bool_t should_fetch    = rko_orig->rko_u.share_fetch.should_fetch;
         rd_bool_t records_fetched = rko_orig->rko_u.share_fetch.records_fetched;
+        rd_bool_t should_leave    = rko_orig->rko_u.share_fetch.should_leave;
 
         rd_kafka_assert(rk, thrd_is_current(rk->rk_thread));
         rd_kafka_dbg(rk, CGRP, "SHAREFETCH",
                      "Share fetch reply: %s, should_fetch=%d, "
-                     "records_fetched=%d, broker=%s",
+                     "records_fetched=%d, should_leave=%d, broker=%s",
                      rd_kafka_err2str(rko_orig->rko_err), should_fetch,
-                     records_fetched,
+                     records_fetched, should_leave,
                      reply_rkb ? rd_kafka_broker_name(reply_rkb) : "none");
 
         reply_rkb->rkb_share_fetch_enqueued = rd_false;
 
         if (should_fetch)
                 rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt--;
+
+        if (should_leave) {
+                rkcg->rkcg_share.share_session_leave_remaining_cnt--;
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
 
         /*
          * Step 1: If records were fetched and broker is not terminating,
@@ -3221,7 +3228,16 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
                 rkcg->rkcg_share.share_fetch_more_records = rd_false;
 
         /*
-         * Step 2: Handle commit_sync reply if this op belongs to
+         * Step 2: If the consumer has been marked for termination,
+         * enqueue a session leave op on the replying broker thread and return
+         */
+        if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
+                rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk, reply_rkb);
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
+        /*
+         * Step 3: Handle commit_sync reply if this op belongs to
          * the current commit_sync request.
          */
         if (rko_orig->rko_u.share_fetch.commit_sync_request_id != 0 &&
@@ -3266,7 +3282,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 3: Dispatch pending commit_sync to the replying broker
+         * Step 4: Dispatch pending commit_sync to the replying broker
          * (highest priority). Acks must always be sent.
          */
         if (!reply_rkb->rkb_share_fetch_enqueued &&
@@ -3279,7 +3295,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 4: If this was the fetch broker but no records were received,
+         * Step 5: If this was the fetch broker but no records were received,
          * try to select another broker to fetch from.
          *
          * TODO: KIP-932: Handle the case where all assignments are removed
@@ -3313,7 +3329,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
         }
 
         /*
-         * Step 5: If the replying broker has cached async ack details,
+         * Step 6: If the replying broker has cached async ack details,
          * send an ack-only SHARE_FETCH op to it.
          */
         if (reply_rkb->rkb_share_async_ack_details &&
@@ -3368,114 +3384,6 @@ rd_kafka_share_fetch_fanout_reply_op(rd_kafka_t *rk, rd_kafka_op_t *rko_orig) {
         }
         return RD_KAFKA_OP_RES_HANDLED;
 }
-
-/**
- * @brief Find an existing ack batch for the same topic-partition in a list.
- *
- * @param ack_list List of rd_kafka_share_ack_batches_t*
- * @param rktpar Topic-partition to match (by topic id and partition)
- *
- * @returns Matching batch, or NULL if not found.
- * @locality main thread
- */
-static rd_kafka_share_ack_batches_t *
-rd_kafka_share_find_ack_batch(rd_list_t *ack_list,
-                              const rd_kafka_topic_partition_t *rktpar) {
-        rd_kafka_share_ack_batches_t *existing;
-        int i;
-
-        RD_LIST_FOREACH(existing, ack_list, i) {
-                /* TODO KIP-932: We might need to use leader id and epoch
-                 * as well to understand about the stale topic partition
-                 * information */
-                if (rd_kafka_topic_partition_by_id_cmp(existing->rktpar,
-                                                       rktpar) == 0)
-                        return existing;
-        }
-        return NULL;
-}
-
-/**
- * @brief Segregate ack batches from a FANOUT op by partition leader.
- *
- * For each ack batch, looks up the current leader broker via the
- * toppar reference in batch->rktpar, and merges the batch into that
- * broker's rkb_share_async_ack_details list. If the broker already
- * has cached acks for the same topic-partition, the entries are
- * appended to the existing batch.
- *
- * @param rk Client instance
- * @param ack_batches List of rd_kafka_share_ack_batches_t* from FANOUT op.
- *                    Elements whose leader is found are moved to broker
- *                    ack_details; remaining elements are not freed.
- *
- * @locality main thread
- */
-static void rd_kafka_share_segregate_acks_by_leader(rd_kafka_t *rk,
-                                                    rd_list_t *ack_batches) {
-        rd_kafka_share_ack_batches_t *batch;
-        int batch_cnt = rd_list_cnt(ack_batches);
-
-        while ((batch = rd_list_pop(ack_batches))) {
-                rd_kafka_toppar_t *rktp;
-                rd_kafka_broker_t *leader_rkb;
-                rd_kafka_share_ack_batches_t *existing;
-
-                rktp = rd_kafka_topic_partition_toppar(rk, batch->rktpar);
-                if (!rktp || !rktp->rktp_leader) {
-                        rd_kafka_dbg(rk, CGRP, "SHARE",
-                                     "Ack batch for leader %" PRId32
-                                     " dropped: toppar or leader not available",
-                                     batch->response_leader_id);
-                        rd_kafka_share_ack_batches_destroy(batch);
-                        continue;
-                }
-                leader_rkb = rktp->rktp_leader;
-
-                /* Allocate list on first use with incoming batch count
-                 * as initial capacity hint */
-                if (!leader_rkb->rkb_share_async_ack_details)
-                        leader_rkb->rkb_share_async_ack_details = rd_list_new(
-                            batch_cnt, rd_kafka_share_ack_batches_destroy_free);
-
-                /* Check if there's already a batch for this topic-partition.
-                 * If so, merge entries; otherwise add as new. */
-                existing = rd_kafka_share_find_ack_batch(
-                    leader_rkb->rkb_share_async_ack_details, batch->rktpar);
-
-                if (existing) {
-                        /* Merge: deep-copy entries from new batch into
-                         * existing, preserving order. The source batch
-                         * is then fully destroyed (freeing its entries). */
-                        rd_kafka_share_ack_batch_entry_t *entry;
-                        int j;
-                        /*
-                         * TODO KIP-932: Merge with overlapping offsets into
-                         * single entry with single type. For example, if
-                         * existing has an ACCEPT for offsets 0-50 and new
-                         * batch has ACCEPT for offsets 51-100, they can be
-                         * merged into a single ACCEPT for offsets 0-100.
-                         * Currently, we are blindly adding entries from the
-                         * new batch into the existing batch, which means we
-                         * may end up with multiple adjacent or overlapping
-                         * entries of the same type that could have been
-                         * merged. This is not incorrect, but it is less
-                         * efficient in terms of the network bandwidth in the
-                         * RPC call.
-                         */
-                        RD_LIST_FOREACH(entry, &batch->entries, j) {
-                                rd_list_add(
-                                    &existing->entries,
-                                    rd_kafka_share_ack_batch_entry_copy(entry));
-                        }
-                        rd_kafka_share_ack_batches_destroy(batch);
-                } else {
-                        rd_list_add(leader_rkb->rkb_share_async_ack_details,
-                                    batch);
-                }
-        }
-}
-
 
 /**
  * @brief Create and enqueue a SHARE_FETCH op on a broker.
@@ -3659,6 +3567,14 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
                                                  rd_kafka_op_t *rko) {
         rd_kafka_broker_t *selected_rkb = NULL;
         rd_kafka_cgrp_t *rkcg           = rd_kafka_cgrp_get(rk);
+
+        if (rkcg && rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) {
+                rd_kafka_dbg(
+                    rk, CGRP, "SHARE",
+                    "Ignoring SHARE_FETCH_FANOUT op received after close");
+                return RD_KAFKA_OP_RES_HANDLED;
+        }
+
         rd_bool_t fetch_more_records =
             rko->rko_u.share_fetch_fanout.fetch_more_records;
         rd_bool_t has_fanout_acks =
@@ -3739,6 +3655,11 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
                                           "rd_kafka_share_consume_batch(): "
                                           "Consumer group not initialized");
+
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "rd_kafka_share_consume_batch(): "
+                                          "Consumer already closed");
 
         /* Drain rk_rep for all pending callbacks (non-blocking) */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -4245,6 +4166,10 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_op_t *rko;
         rd_list_t *ack_batches;
+
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
 
         rd_kafka_dbg(rk, CGRP, "SHARE", "Committing asynchronously");
 
@@ -5055,11 +4980,6 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
         rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                      "Closing consumer");
 
-
-        /*
-         * TODO KIP-932: Need to check what to do for rk_rep queue as we are
-         * not forwarding rk_rep to the rkcg_q in Share Consumer.
-         */
         /* Redirect cgrp queue to the rebalance queue to make sure all posted
          * ops (e.g., rebalance callbacks) are served by
          * the application/caller. */
@@ -5067,7 +4987,12 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
 
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
          * on the rkq when done. */
-        rd_kafka_cgrp_terminate(rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                rd_kafka_share_cgrp_terminate(
+                    rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
+        else
+                rd_kafka_cgrp_terminate(rkcg,
+                                        RD_KAFKA_REPLYQ(rkq, 0)); /* async */
 
         return error;
 }
@@ -5078,6 +5003,23 @@ rd_kafka_error_t *rd_kafka_consumer_close_queue(rd_kafka_t *rk,
                 return rd_kafka_error_new(RD_KAFKA_RESP_ERR__INVALID_ARG,
                                           "Queue must be specified");
         return rd_kafka_consumer_close_q(rk, rkqu->rkqu_q);
+}
+
+/**
+ * @brief Asynchronously close the share consumer.
+ * @param rkshare Share consumer instance.
+ * @param rkqu Queue for forwarding events/callbacks during close.
+ * @returns `rd_kafka_error_t *` - NULL on success, error object on failure
+ */
+rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
+                                                      rd_kafka_queue_t *rkqu) {
+        /* TODO KIP-932: Guard this with checks for rkshare
+         * and rkshare->rkshare_rk */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
+
+        return rd_kafka_consumer_close_queue(rkshare->rkshare_rk, rkqu);
 }
 
 rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
@@ -5145,13 +5087,86 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
         return err;
 }
 
-rd_kafka_resp_err_t rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
+rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
+        rd_kafka_error_t *error, *default_error;
+        rd_kafka_t *rk;
+        rd_kafka_q_t *rkq;
+
+        /* TODO KIP-932: Guard this with checks for rkshare and
+         * rkshare->rkshare_rk */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
+                                          "Consumer already closed");
+
         rkshare->rkshare_consumer_closing = rd_true;
-        /* TODO KIP-932: Need to check this behavior is correct while closing.
+
+        /*
+         * TODO KIP-932: Need to check if this behaviour is correct
          */
         rd_kafka_q_fwd_set(rkshare->rkshare_rk->rk_rep,
                            rkshare->rkshare_rk->rk_cgrp->rkcg_q);
-        return rd_kafka_consumer_close(rkshare->rkshare_rk);
+
+        /* Create a temporary reply queue to handle the TERMINATE reply op. */
+        rk  = rkshare->rkshare_rk;
+        rkq = rd_kafka_q_new(rk);
+
+        error = default_error = rd_kafka_error_new(
+            RD_KAFKA_RESP_ERR__TIMED_OUT,
+            "Timed out waiting for TERMINATE reply to arrive");
+
+        /* Initiate the close (async) */
+        error = rd_kafka_consumer_close_q(rk, rkq);
+        if (error) {
+                return error;
+        }
+
+        /* Disable the queue if termination is immediate or the user
+         * does not want the blocking consumer_close() behaviour, this will
+         * cause any ops posted for this queue (such as rebalance) to
+         * be destroyed.
+         */
+        if (rd_kafka_destroy_flags_no_consumer_close(rk)) {
+                rd_kafka_dbg(rk, CONSUMER, "CLOSE",
+                             "Disabling and purging temporary queue to quench "
+                             "close events");
+                error = NULL;
+                rd_kafka_q_disable(rkq);
+                /* Purge ops already enqueued */
+                rd_kafka_q_purge(rkq);
+        } else {
+                rd_kafka_op_t *rko;
+                rd_kafka_dbg(rk, CONSUMER, "CLOSE", "Waiting for close events");
+                while ((rko = rd_kafka_q_pop(rkq, RD_POLL_INFINITE, 0))) {
+                        rd_kafka_op_res_t res;
+                        if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
+                            RD_KAFKA_OP_TERMINATE) {
+                                error = rko->rko_error;
+                                rd_kafka_op_destroy(rko);
+                                break;
+                        }
+                        /* Handle callbacks */
+                        res = rd_kafka_poll_cb(rk, rkq, rko,
+                                               RD_KAFKA_Q_CB_RETURN, NULL);
+                        if (res == RD_KAFKA_OP_RES_PASS)
+                                rd_kafka_op_destroy(rko);
+                        /* Ignore YIELD, we need to finish */
+                }
+        }
+
+        rd_kafka_q_destroy_owner(rkq);
+
+        if (error)
+                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
+                             "Consumer closed with error: %s",
+                             rd_kafka_error_name(error));
+        else
+                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
+                             "Consumer closed");
+
+        if (error != default_error)
+                rd_kafka_error_destroy(default_error);
+
+        return error;
 }
 
 
@@ -5160,6 +5175,15 @@ int rd_kafka_consumer_closed(rd_kafka_t *rk) {
                 return 0;
 
         return rd_atomic32_get(&rk->rk_cgrp->rkcg_terminated);
+}
+
+/**
+ * @brief Check if the share consumer is closed.
+ * @param rkshare Share consumer instance.
+ * @returns 1 if the consumer is closed, else 0.
+ */
+int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare) {
+        return rd_kafka_consumer_closed(rkshare->rkshare_rk);
 }
 
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -5028,6 +5028,7 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
         /* Tell cgrp subsystem to terminate. A TERMINATE op will be posted
          * on the rkq when done. */
         rd_kafka_cgrp_terminate(rkcg, RD_KAFKA_REPLYQ(rkq, 0)); /* async */
+
         return error;
 }
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1192,9 +1192,12 @@ static void rd_kafka_destroy_app(rd_kafka_t *rk, int flags) {
         if (rk->rk_cgrp) {
                 rd_kafka_dbg(rk, GENERIC, "TERMINATE",
                              "Terminating consumer group handler");
-                if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                        rd_kafka_share_consumer_close(rk->rk_rkshare);
-                else
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
+                        rd_kafka_error_t *error =
+                            rd_kafka_share_consumer_close(rk->rk_rkshare);
+                        if (error)
+                                rd_kafka_error_destroy(error);
+                } else
                         rd_kafka_consumer_close(rk);
         }
 
@@ -3807,7 +3810,6 @@ static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
             rkcg->rkcg_commit_sync_request.results;
 
         rd_kafka_q_enq(rkcg->rkcg_commit_sync_request.replyq, rko_reply);
-
         rkcg->rkcg_commit_sync_request.id                          = 0;
         rkcg->rkcg_commit_sync_request.results                     = NULL;
         rkcg->rkcg_commit_sync_request.replyq                      = NULL;
@@ -4249,9 +4251,14 @@ rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
         rd_kafka_q_t *tmpq;
         rd_ts_t abs_timeout;
         rd_kafka_topic_partition_list_t *results;
+        rd_kafka_error_t *error;
         int i;
 
         *partitions = NULL;
+
+        if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
+                          rkshare)) != NULL))
+                return error;
 
         rd_kafka_dbg(rk, CGRP, "SHARE",
                      "Committing synchronously with timeout %d ms", timeout_ms);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3651,10 +3651,16 @@ rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare) {
 
 rd_kafka_resp_err_t
 rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare) {
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare) ||
-                     rkshare->rkshare_consumer_closing))
-                return RD_KAFKA_RESP_ERR__STATE;
-        return RD_KAFKA_RESP_ERR_NO_ERROR;
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t err;
+
+        error = rd_kafka_share_consumer_closed_or_closing_error(rkshare);
+        if (!error)
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+        err = rd_kafka_error_code(error);
+        rd_kafka_error_destroy(error);
+        return err;
 }
 
 rd_kafka_error_t *rd_kafka_share_consume_batch(
@@ -3810,6 +3816,7 @@ static void rd_kafka_share_commit_sync_send_response(rd_kafka_cgrp_t *rkcg) {
             rkcg->rkcg_commit_sync_request.results;
 
         rd_kafka_q_enq(rkcg->rkcg_commit_sync_request.replyq, rko_reply);
+        rd_kafka_q_destroy(rkcg->rkcg_commit_sync_request.replyq);
         rkcg->rkcg_commit_sync_request.id                          = 0;
         rkcg->rkcg_commit_sync_request.results                     = NULL;
         rkcg->rkcg_commit_sync_request.replyq                      = NULL;
@@ -5049,10 +5056,11 @@ rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
         return NULL;
 }
 
-rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
+
+rd_kafka_error_t *rd_kafka_consumer_close0(rd_kafka_t *rk) {
         rd_kafka_error_t *error;
-        rd_kafka_resp_err_t err = RD_KAFKA_RESP_ERR__TIMED_OUT;
         rd_kafka_q_t *rkq;
+        rd_bool_t got_terminate = rd_false;
 
         /* Create a temporary reply queue to handle the TERMINATE reply op. */
         rkq = rd_kafka_q_new(rk);
@@ -5060,12 +5068,8 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
         /* Initiate the close (async) */
         error = rd_kafka_consumer_close_q(rk, rkq);
         if (error) {
-                err = rd_kafka_error_is_fatal(error)
-                          ? RD_KAFKA_RESP_ERR__FATAL
-                          : rd_kafka_error_code(error);
-                rd_kafka_error_destroy(error);
                 rd_kafka_q_destroy_owner(rkq);
-                return err;
+                return error;
         }
 
         /* Disable the queue if termination is immediate or the user
@@ -5077,7 +5081,7 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
                 rd_kafka_dbg(rk, CONSUMER, "CLOSE",
                              "Disabling and purging temporary queue to quench "
                              "close events");
-                err = RD_KAFKA_RESP_ERR_NO_ERROR;
+                got_terminate = rd_true;
                 rd_kafka_q_disable(rkq);
                 /* Purge ops already enqueued */
                 rd_kafka_q_purge(rkq);
@@ -5088,7 +5092,9 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
                         rd_kafka_op_res_t res;
                         if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
                             RD_KAFKA_OP_TERMINATE) {
-                                err = rko->rko_err;
+                                error          = rko->rko_error;
+                                rko->rko_error = NULL;
+                                got_terminate  = rd_true;
                                 rd_kafka_op_destroy(rko);
                                 break;
                         }
@@ -5103,24 +5109,44 @@ rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
 
         rd_kafka_q_destroy_owner(rkq);
 
-        if (err)
+        if (!got_terminate)
+                error = rd_kafka_error_new(
+                    RD_KAFKA_RESP_ERR__TIMED_OUT, "%s",
+                    "Timed out waiting for a TERMINATE reply to arrive");
+
+        if (error)
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed with error: %s",
-                             rd_kafka_err2str(err));
+                             rd_kafka_error_string(error));
         else
                 rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
                              "Consumer closed");
 
+        return error;
+}
+
+rd_kafka_resp_err_t rd_kafka_consumer_close(rd_kafka_t *rk) {
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t err;
+
+        error = rd_kafka_consumer_close0(rk);
+        if (!error)
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+        err = rd_kafka_error_is_fatal(error) ? RD_KAFKA_RESP_ERR__FATAL
+                                             : rd_kafka_error_code(error);
+        rd_kafka_error_destroy(error);
         return err;
 }
 
 rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
         rd_kafka_error_t *error;
         rd_kafka_t *rk;
-        rd_kafka_q_t *rkq;
 
         /* TODO KIP-932: Guard this with checks for rkshare and
-         * rkshare->rkshare_rk */
+         * rkshare->rkshare_rk. Check if this is needed for other APIs
+         * as well.
+         */
         if (unlikely((error = rd_kafka_share_consumer_closed_or_closing_error(
                           rkshare)) != NULL))
                 return error;
@@ -5133,65 +5159,8 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
          */
         rd_kafka_q_fwd_set(rk->rk_rep, rk->rk_cgrp->rkcg_q);
 
-        /* Create a temporary reply queue to handle the TERMINATE reply op. */
-        rkq = rd_kafka_q_new(rk);
+        error = rd_kafka_consumer_close0(rk);
 
-        /* Initiate the close (async) */
-        error = rd_kafka_consumer_close_q(rk, rkq);
-        if (error) {
-                rd_kafka_q_destroy_owner(rkq);
-                goto done;
-        }
-
-        /* Disable the queue if termination is immediate or the user
-         * does not want the blocking consumer_close() behaviour, this will
-         * cause any ops posted for this queue (such as rebalance) to
-         * be destroyed.
-         */
-        if (rd_kafka_destroy_flags_no_consumer_close(rk)) {
-                rd_kafka_dbg(rk, CONSUMER, "CLOSE",
-                             "Disabling and purging temporary queue to quench "
-                             "close events");
-                rd_kafka_q_disable(rkq);
-                /* Purge ops already enqueued */
-                rd_kafka_q_purge(rkq);
-        } else {
-                rd_kafka_op_t *rko;
-                rd_bool_t got_terminate = rd_false;
-
-                rd_kafka_dbg(rk, CONSUMER, "CLOSE", "Waiting for close events");
-                while ((rko = rd_kafka_q_pop(rkq, RD_POLL_INFINITE, 0))) {
-                        if ((rko->rko_type & ~RD_KAFKA_OP_FLAGMASK) ==
-                            RD_KAFKA_OP_TERMINATE) {
-                                /* Transfer ownership of rko_error out
-                                 * before op_destroy frees it. */
-                                error         = rd_kafka_op_error_destroy(rko);
-                                got_terminate = rd_true;
-                                break;
-                        }
-                        /* Handle callbacks */
-                        if (rd_kafka_poll_cb(rk, rkq, rko, RD_KAFKA_Q_CB_RETURN,
-                                             NULL) == RD_KAFKA_OP_RES_PASS)
-                                rd_kafka_op_destroy(rko);
-                        /* Ignore YIELD, we need to finish */
-                }
-
-                if (!got_terminate)
-                        error = rd_kafka_error_new(
-                            RD_KAFKA_RESP_ERR__TIMED_OUT,
-                            "Timed out waiting for TERMINATE reply to arrive");
-        }
-
-        rd_kafka_q_destroy_owner(rkq);
-
-done:
-        if (error)
-                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
-                             "Consumer closed with error: %s",
-                             rd_kafka_error_string(error));
-        else
-                rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_CGRP, "CLOSE",
-                             "Consumer closed");
         rkshare->rkshare_consumer_closing = rd_false;
         return error;
 }

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5059,19 +5059,18 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
 
 
 /**
- * @brief Close the consumer.
+ * @brief Close the share consumer.
  *
- * This call will block until the consumer has revoked its assignment,
- * calling the \c rebalance_cb if it is configured, committed offsets
- * to broker, and left the consumer group (if applicable).
- * The maximum blocking time is roughly limited to session.timeout.ms.
+ * This call will block until the consumer has committed all the pending
+ * acknowledgments and left the consumer group. The maximum blocking time is
+ * roughly limited to socket.timeout.ms.
  *
- * @returns An error code indicating if the consumer close was succesful
+ * @returns An error code indicating if the consumer close was successful
  *          or not.
  *          RD_KAFKA_RESP_ERR__FATAL is returned if the consumer has raised
  *          a fatal error.
  *
- * @remark The application still needs to call rd_kafka_destroy() after
+ * @remark The application still needs to call rd_kafka_share_destroy() after
  *         this call finishes to clean up the underlying handle resources.
  *
  */
@@ -5079,21 +5078,19 @@ RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
 
 /**
- * @brief Asynchronously close the consumer.
+ * @brief Asynchronously close the share consumer.
  *
- * Performs the same actions as rd_kafka_consumer_close() but in a
+ * Performs the same actions as rd_kafka_share_consumer_close() but in a
  * background thread.
  *
- * Rebalance events/callbacks (etc) will be forwarded to the
+ * Callbacks (etc) will be forwarded to the
  * application-provided \p rkqu. The application must poll/serve this queue
- * until rd_kafka_consumer_closed() returns true.
+ * until rd_kafka_share_consumer_closed() returns true.
  *
- * @remark Depending on consumer group join state there may or may not be
- *         rebalance events emitted on \p rkqu.
  *
  * @returns an error object if the consumer close failed, else NULL.
  *
- * @sa rd_kafka_consumer_closed()
+ * @sa rd_kafka_share_consumer_closed()
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
@@ -5103,10 +5100,10 @@ rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
 /**
  * @returns 1 if the consumer is closed, else 0.
  *
- * Should be used in conjunction with rd_kafka_consumer_close_queue() to know
- * when the consumer has been closed.
+ * Should be used in conjunction with rd_kafka_share_consumer_close_queue() to
+ * know when the consumer has been closed.
  *
- * @sa rd_kafka_consumer_close_queue()
+ * @sa rd_kafka_consumer_share_close_queue()
  */
 RD_EXPORT
 int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5076,7 +5076,41 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
  *
  */
 RD_EXPORT
-rd_kafka_resp_err_t rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
+rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
+
+/**
+ * @brief Asynchronously close the consumer.
+ *
+ * Performs the same actions as rd_kafka_consumer_close() but in a
+ * background thread.
+ *
+ * Rebalance events/callbacks (etc) will be forwarded to the
+ * application-provided \p rkqu. The application must poll/serve this queue
+ * until rd_kafka_consumer_closed() returns true.
+ *
+ * @remark Depending on consumer group join state there may or may not be
+ *         rebalance events emitted on \p rkqu.
+ *
+ * @returns an error object if the consumer close failed, else NULL.
+ *
+ * @sa rd_kafka_consumer_closed()
+ */
+RD_EXPORT
+rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
+                                                      rd_kafka_queue_t *rkqu);
+
+
+/**
+ * @returns 1 if the consumer is closed, else 0.
+ *
+ * Should be used in conjunction with rd_kafka_consumer_close_queue() to know
+ * when the consumer has been closed.
+ *
+ * @sa rd_kafka_consumer_close_queue()
+ */
+RD_EXPORT
+int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);
+
 
 /**@}*/
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5103,7 +5103,7 @@ rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
  * Should be used in conjunction with rd_kafka_share_consumer_close_queue() to
  * know when the consumer has been closed.
  *
- * @sa rd_kafka_consumer_share_close_queue()
+ * @sa rd_kafka_share_consumer_close_queue()
  */
 RD_EXPORT
 int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5070,7 +5070,41 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
  *
  */
 RD_EXPORT
-rd_kafka_resp_err_t rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
+rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
+
+/**
+ * @brief Asynchronously close the consumer.
+ *
+ * Performs the same actions as rd_kafka_consumer_close() but in a
+ * background thread.
+ *
+ * Rebalance events/callbacks (etc) will be forwarded to the
+ * application-provided \p rkqu. The application must poll/serve this queue
+ * until rd_kafka_consumer_closed() returns true.
+ *
+ * @remark Depending on consumer group join state there may or may not be
+ *         rebalance events emitted on \p rkqu.
+ *
+ * @returns an error object if the consumer close failed, else NULL.
+ *
+ * @sa rd_kafka_consumer_closed()
+ */
+RD_EXPORT
+rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
+                                                      rd_kafka_queue_t *rkqu);
+
+
+/**
+ * @returns 1 if the consumer is closed, else 0.
+ *
+ * Should be used in conjunction with rd_kafka_consumer_close_queue() to know
+ * when the consumer has been closed.
+ *
+ * @sa rd_kafka_consumer_close_queue()
+ */
+RD_EXPORT
+int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);
+
 
 /**@}*/
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5053,19 +5053,18 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
 
 
 /**
- * @brief Close the consumer.
+ * @brief Close the share consumer.
  *
- * This call will block until the consumer has revoked its assignment,
- * calling the \c rebalance_cb if it is configured, committed offsets
- * to broker, and left the consumer group (if applicable).
- * The maximum blocking time is roughly limited to session.timeout.ms.
+ * This call will block until the consumer has committed all the pending
+ * acknowledgments and left the consumer group. The maximum blocking time is
+ * roughly limited to socket.timeout.ms.
  *
- * @returns An error code indicating if the consumer close was succesful
+ * @returns An error code indicating if the consumer close was successful
  *          or not.
  *          RD_KAFKA_RESP_ERR__FATAL is returned if the consumer has raised
  *          a fatal error.
  *
- * @remark The application still needs to call rd_kafka_destroy() after
+ * @remark The application still needs to call rd_kafka_share_destroy() after
  *         this call finishes to clean up the underlying handle resources.
  *
  */
@@ -5073,21 +5072,19 @@ RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
 
 /**
- * @brief Asynchronously close the consumer.
+ * @brief Asynchronously close the share consumer.
  *
- * Performs the same actions as rd_kafka_consumer_close() but in a
+ * Performs the same actions as rd_kafka_share_consumer_close() but in a
  * background thread.
  *
- * Rebalance events/callbacks (etc) will be forwarded to the
+ * Callbacks (etc) will be forwarded to the
  * application-provided \p rkqu. The application must poll/serve this queue
- * until rd_kafka_consumer_closed() returns true.
+ * until rd_kafka_share_consumer_closed() returns true.
  *
- * @remark Depending on consumer group join state there may or may not be
- *         rebalance events emitted on \p rkqu.
  *
  * @returns an error object if the consumer close failed, else NULL.
  *
- * @sa rd_kafka_consumer_closed()
+ * @sa rd_kafka_share_consumer_closed()
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
@@ -5097,10 +5094,10 @@ rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
 /**
  * @returns 1 if the consumer is closed, else 0.
  *
- * Should be used in conjunction with rd_kafka_consumer_close_queue() to know
- * when the consumer has been closed.
+ * Should be used in conjunction with rd_kafka_share_consumer_close_queue() to
+ * know when the consumer has been closed.
  *
- * @sa rd_kafka_consumer_close_queue()
+ * @sa rd_kafka_consumer_share_close_queue()
  */
 RD_EXPORT
 int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3257,7 +3257,8 @@ rd_kafka_broker_share_session_toppar_remove(rd_kafka_broker_t *rkb,
          * need to add if it is not present?
          *  * Check if rktp is already present in toppars_to_forget?
          */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk) &&
+            rkb->rkb_share_fetch_session.epoch > 0) {
                 rd_kafka_broker_share_session_add_remove_toppar(
                     &rkb->rkb_share_fetch_session.toppars_to_forget,
                     &rkb->rkb_share_fetch_session.toppars_to_add, rktp);
@@ -3580,10 +3581,41 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 // }
 
                 if (rko->rko_u.share_fetch.should_leave) {
-                        rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                     "Processing SHARE_FETCH op: "
-                                     "should_leave is true");
-                        rd_kafka_broker_share_fetch_leave(rkb, rko, rd_clock());
+                        if (rkb->rkb_share_fetch_session.epoch > 0) {
+                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                                             "Processing SHARE_FETCH op: "
+                                             "should_leave is true");
+                                rd_kafka_broker_share_fetch_leave(rkb, rko,
+                                                                  rd_clock());
+                        } else {
+                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                                             "Ignoring SHARE_FETCH op with "
+                                             "should_leave = 1: "
+                                             "no active session");
+
+                                /* TODO KIP-932: Session vars should be cleared
+                                 * during destroy() instead of close() */
+                                if (rkb->rkb_share_fetch_session
+                                        .toppars_to_add) {
+                                        rd_rkb_dbg(
+                                            rkb, BROKER, "SHAREFETCH",
+                                            "Clearing %d toppars to add from "
+                                            "ShareFetch session on "
+                                            "clear",
+                                            rd_list_cnt(
+                                                rkb->rkb_share_fetch_session
+                                                    .toppars_to_add));
+                                        rd_list_destroy(
+                                            rkb->rkb_share_fetch_session
+                                                .toppars_to_add);
+                                        rkb->rkb_share_fetch_session
+                                            .toppars_to_add = NULL;
+                                }
+                                rd_kafka_op_reply(
+                                    rko,
+                                    RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND);
+                        }
+
                         rko = NULL; /* the rko is reused for the reply */
                         break;
                 }
@@ -6522,8 +6554,6 @@ void rd_kafka_broker_decommission(rd_kafka_t *rk,
 
         if (RD_KAFKA_IS_SHARE_CONSUMER(rk) &&
             rkb->rkb_source == RD_KAFKA_LEARNED) {
-                rd_kafka_op_t *rko_sf;
-
                 /* Clear pending ack details cached on this broker.
                  * TODO KIP-932: Maybe move ack_details cleanup to clear
                  *               through DESTROY err flow when main thread
@@ -6538,26 +6568,6 @@ void rd_kafka_broker_decommission(rd_kafka_t *rk,
                         rd_list_destroy(rkb->rkb_share_async_ack_details);
                         rkb->rkb_share_async_ack_details = NULL;
                 }
-
-                /**
-                 * TODO KIP-932: Not leaving properly. Need to fix this.
-                 *               It will be moved to consumer close
-                 *               instead of decommissioning.
-                 */
-                rko_sf = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
-                rko_sf->rko_u.share_fetch.should_leave = rd_true;
-                rko_sf->rko_u.share_fetch.abs_timeout =
-                    0;  // TODO KIP-932: Check timeout part.
-                rko_sf->rko_u.share_fetch.should_fetch = rd_false;
-                rd_kafka_broker_keep(rkb);
-                rko_sf->rko_u.share_fetch.target_broker = rkb;
-                rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
-
-                rd_kafka_dbg(rk, BROKER, "SHAREFETCH",
-                             "Enqueuing leave share fetch op on broker %s: "
-                             "decommissioning broker.",
-                             rd_kafka_broker_name(rkb));
-                rd_kafka_q_enq(rkb->rkb_ops, rko_sf);
         }
 
         rd_atomic32_add(&rkb->termination_in_progress, 1);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3234,10 +3234,9 @@ static void rd_kafka_broker_share_session_toppar_add(rd_kafka_broker_t *rkb,
                         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
                                    "Not adding %.*s [%" PRId32
                                    "] to share fetch session "
-                                   "as session epoch is %" PRId32,
+                                   "as share session is closed",
                                    RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
-                                   rktp->rktp_partition,
-                                   rkb->rkb_share_fetch_session.epoch);
+                                   rktp->rktp_partition);
 
                         return;
                 }
@@ -3627,27 +3626,8 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                         rd_kafka_op_reply(rko,
                                           RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS);
                 } else if (rko->rko_u.share_fetch.should_leave) {
-                        if (rkb->rkb_share_fetch_session.epoch > 0) {
-                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                             "Processing SHARE_FETCH op: "
-                                             "should_leave is true");
-                                /* Session vars will be cleared in callback */
-                                rd_kafka_broker_share_fetch_leave(rkb, rko,
+                        rd_kafka_broker_share_fetch_session_leave(rkb, rko,
                                                                   rd_clock());
-                        } else {
-                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                             "Ignoring SHARE_FETCH op with "
-                                             "should_leave = 1: "
-                                             "no active session");
-
-                                /* Required as it is possible that we were about
-                                 * to establish a session */
-                                rd_kafka_broker_share_fetch_session_clear(rkb);
-                                rd_kafka_op_reply(
-                                    rko,
-                                    RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND);
-                        }
-
                         rko = NULL; /* the rko is reused for the reply */
                         break;
                 } else {

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3230,6 +3230,18 @@ static void rd_kafka_broker_share_session_toppar_add(rd_kafka_broker_t *rkb,
          *  * Check if rktp is already present in toppars_to_add?
          */
         if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                if (rkb->rkb_share_fetch_session.epoch < 0) {
+                        rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
+                                   "Not adding %.*s [%" PRId32
+                                   "] to share fetch session "
+                                   "as session epoch is %" PRId32,
+                                   RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+                                   rktp->rktp_partition,
+                                   rkb->rkb_share_fetch_session.epoch);
+
+                        return;
+                }
+
                 rd_kafka_broker_share_session_add_remove_toppar(
                     &rkb->rkb_share_fetch_session.toppars_to_add,
                     &rkb->rkb_share_fetch_session.toppars_to_forget, rktp);
@@ -3257,8 +3269,19 @@ rd_kafka_broker_share_session_toppar_remove(rd_kafka_broker_t *rkb,
          * need to add if it is not present?
          *  * Check if rktp is already present in toppars_to_forget?
          */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk) &&
-            rkb->rkb_share_fetch_session.epoch > 0) {
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                if (rkb->rkb_share_fetch_session.epoch <= 0) {
+                        rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
+                                   "Not removing %.*s [%" PRId32
+                                   "] from share fetch session "
+                                   "as session epoch is %" PRId32,
+                                   RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+                                   rktp->rktp_partition,
+                                   rkb->rkb_share_fetch_session.epoch);
+
+                        return;
+                }
+
                 rd_kafka_broker_share_session_add_remove_toppar(
                     &rkb->rkb_share_fetch_session.toppars_to_forget,
                     &rkb->rkb_share_fetch_session.toppars_to_add, rktp);
@@ -3579,47 +3602,7 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 //         rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__STATE);
                 //         rko = NULL;
                 // }
-
-                if (rko->rko_u.share_fetch.should_leave) {
-                        if (rkb->rkb_share_fetch_session.epoch > 0) {
-                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                             "Processing SHARE_FETCH op: "
-                                             "should_leave is true");
-                                rd_kafka_broker_share_fetch_leave(rkb, rko,
-                                                                  rd_clock());
-                        } else {
-                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                             "Ignoring SHARE_FETCH op with "
-                                             "should_leave = 1: "
-                                             "no active session");
-
-                                /* TODO KIP-932: Session vars should be cleared
-                                 * during destroy() instead of close() */
-                                if (rkb->rkb_share_fetch_session
-                                        .toppars_to_add) {
-                                        rd_rkb_dbg(
-                                            rkb, BROKER, "SHAREFETCH",
-                                            "Clearing %d toppars to add from "
-                                            "ShareFetch session on "
-                                            "clear",
-                                            rd_list_cnt(
-                                                rkb->rkb_share_fetch_session
-                                                    .toppars_to_add));
-                                        rd_list_destroy(
-                                            rkb->rkb_share_fetch_session
-                                                .toppars_to_add);
-                                        rkb->rkb_share_fetch_session
-                                            .toppars_to_add = NULL;
-                                }
-                                rd_kafka_op_reply(
-                                    rko,
-                                    RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND);
-                        }
-
-                        rko = NULL; /* the rko is reused for the reply */
-                        break;
-                }
-
+                /* TODO KIP-932: Verify handling of this op */
                 if (rd_kafka_broker_or_instance_terminating(rkb)) {
                         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
                                      "Ignoring SHARE_FETCH op: "
@@ -3643,10 +3626,36 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                                      "already fetching");
                         rd_kafka_op_reply(rko,
                                           RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS);
+                } else if (rko->rko_u.share_fetch.should_leave) {
+                        if (rkb->rkb_share_fetch_session.epoch > 0) {
+                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                                             "Processing SHARE_FETCH op: "
+                                             "should_leave is true");
+                                /* Session vars will be cleared in callback */
+                                rd_kafka_broker_share_fetch_leave(rkb, rko,
+                                                                  rd_clock());
+                        } else {
+                                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                                             "Ignoring SHARE_FETCH op with "
+                                             "should_leave = 1: "
+                                             "no active session");
+
+                                /* Required as it is possible that we were about
+                                 * to establish a session */
+                                rd_kafka_broker_share_fetch_session_clear(rkb);
+                                rd_kafka_op_reply(
+                                    rko,
+                                    RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND);
+                        }
+
+                        rko = NULL; /* the rko is reused for the reply */
+                        break;
                 } else {
                         rd_kafka_broker_share_rpc(rkb, rko, rd_clock());
                 }
 
+                /* TODO KIP-932: Add handling for commit sync partition level
+                 * and ack callback errors */
                 // if (!rko->rko_u.share_fetch.should_fetch) {
                 //         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
                 //                    "Ignoring SHARE_FETCH op: "

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3234,7 +3234,7 @@ static void rd_kafka_broker_share_session_toppar_add(rd_kafka_broker_t *rkb,
                         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
                                    "Not adding %.*s [%" PRId32
                                    "] to share fetch session "
-                                   "as share session is closed",
+                                   "as share session is already closed",
                                    RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
                                    rktp->rktp_partition);
 
@@ -3273,10 +3273,9 @@ rd_kafka_broker_share_session_toppar_remove(rd_kafka_broker_t *rkb,
                         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
                                    "Not removing %.*s [%" PRId32
                                    "] from share fetch session "
-                                   "as session epoch is %" PRId32,
+                                   "as share session is already closed",
                                    RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
-                                   rktp->rktp_partition,
-                                   rkb->rkb_share_fetch_session.epoch);
+                                   rktp->rktp_partition);
 
                         return;
                 }

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3269,7 +3269,7 @@ rd_kafka_broker_share_session_toppar_remove(rd_kafka_broker_t *rkb,
          *  * Check if rktp is already present in toppars_to_forget?
          */
         if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
-                if (rkb->rkb_share_fetch_session.epoch <= 0) {
+                if (rkb->rkb_share_fetch_session.epoch < 0) {
                         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
                                    "Not removing %.*s [%" PRId32
                                    "] from share fetch session "
@@ -3627,8 +3627,6 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 } else if (rko->rko_u.share_fetch.should_leave) {
                         rd_kafka_broker_share_fetch_session_leave(rkb, rko,
                                                                   rd_clock());
-                        rko = NULL; /* the rko is reused for the reply */
-                        break;
                 } else {
                         rd_kafka_broker_share_rpc(rkb, rko, rd_clock());
                 }

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -37,6 +37,7 @@
 #include "rdkafka_metadata.h"
 #include "rdkafka_cgrp.h"
 #include "rdkafka_interceptor.h"
+#include "rdkafka_share_acknowledgement.h"
 #include "rdmap.h"
 
 #include "rdunittest.h"
@@ -554,6 +555,11 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
                     &rk->rk_timers, &rkcg->rkcg_offset_commit_tmr,
                     rk->rk_conf.auto_commit_interval_ms * 1000ll,
                     rd_kafka_cgrp_offset_commit_tmr_cb, rkcg);
+
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                /* Only applicable when consumer is closing */
+                rkcg->rkcg_share.share_session_leave_remaining_cnt = -1;
+
 
         return rkcg;
 }
@@ -3911,10 +3917,21 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_cgrp_group_assignment_set(rkcg, NULL);
 
-        rd_kafka_assert(NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
-        rd_kafka_assert(NULL, !rkcg->rkcg_group_assignment);
-        rd_kafka_assert(NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
         rd_kafka_assert(NULL, rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM);
+        rd_kafka_assert(NULL, !rkcg->rkcg_group_assignment);
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                rd_kafka_assert(
+                    NULL,
+                    rkcg->rkcg_share.share_session_leave_remaining_cnt == 0);
+                rd_kafka_assert(
+                    NULL,
+                    rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt == 0);
+        } else {
+                rd_kafka_assert(
+                    NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
+                rd_kafka_assert(
+                    NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
+        }
 
         rd_kafka_timer_stop(&rkcg->rkcg_rk->rk_timers,
                             &rkcg->rkcg_offset_commit_tmr, 1 /*lock*/);
@@ -3969,6 +3986,10 @@ static RD_INLINE int rd_kafka_cgrp_try_terminate(rd_kafka_cgrp_t *rkcg) {
                 return 1;
 
         if (likely(!(rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE)))
+                return 0;
+
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk) &&
+            rkcg->rkcg_share.share_session_leave_remaining_cnt)
                 return 0;
 
         /* Check if wait-coord queue has timed out.
@@ -6092,7 +6113,41 @@ rd_kafka_cgrp_subscribe(rd_kafka_cgrp_t *rkcg,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+/**
+ * @brief Create and enqueue a leave SHARE_FETCH op on a broker.
+ *
+ * Moves any cached ack details from rkb_share_async_ack_details
+ * into the op, sets rkb_share_fetch_enqueued, and enqueues the op
+ * on the broker's ops queue.
+ *
+ * @param rk Client instance
+ * @param rkb Broker to enqueue on. Must not have rkb_share_fetch_enqueued set.
+ * @param should_fetch Whether the broker should fetch records.
+ *
+ * @locality main thread
+ */
+void rd_kafka_share_enqueue_fetch_leave_op(rd_kafka_t *rk,
+                                           rd_kafka_broker_t *rkb) {
+        rd_kafka_op_t *rko_sf = NULL;
+        rko_sf                = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
+        rko_sf->rko_u.share_fetch.should_leave = rd_true;
+        rko_sf->rko_u.share_fetch.abs_timeout =
+            rd_timeout_init(rk->rk_conf.socket_timeout_ms);
+        rko_sf->rko_u.share_fetch.should_fetch = rd_false;
 
+        rko_sf->rko_u.share_fetch.ack_details =
+            rkb->rkb_share_async_ack_details;
+        rkb->rkb_share_async_ack_details = NULL;
+
+        rd_kafka_broker_keep(rkb);
+        rko_sf->rko_u.share_fetch.target_broker = rkb;
+        rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
+        rd_kafka_dbg(rk, BROKER, "SHAREFETCH",
+                     "Enqueuing leave share fetch op on broker %s",
+                     rd_kafka_broker_name(rkb));
+        rkb->rkb_share_fetch_enqueued = rd_true;
+        rd_kafka_q_enq(rkb->rkb_ops, rko_sf);
+}
 
 /**
  * Same as cgrp_terminate() but called from the cgrp/main thread upon receiving
@@ -6141,6 +6196,45 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
                     ~RD_KAFKA_CGRP_CONSUMER_F_WAIT_REJOIN &
                     ~RD_KAFKA_CGRP_CONSUMER_F_WAIT_REJOIN_TO_COMPLETE;
         }
+
+        /* For share groups, we have to additionally close
+         * sessions with all the brokers */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                rd_kafka_broker_t *rkb                             = NULL;
+                rkcg->rkcg_share.share_session_leave_remaining_cnt = 0;
+                rd_list_t *ack_batches =
+                    rko->rko_u.share_fetch_fanout.ack_batches;
+                if (ack_batches) {
+                        rd_kafka_share_segregate_acks_by_leader(rkcg->rkcg_rk,
+                                                                ack_batches);
+                        /* Ownership of elements transferred to broker
+                         * ack_details. Destroy the container. */
+                        rd_list_destroy(ack_batches);
+                }
+                rd_kafka_rdlock(rkcg->rkcg_rk);
+                TAILQ_FOREACH(rkb, &rkcg->rkcg_rk->rk_brokers, rkb_link) {
+                        if (rd_kafka_broker_or_instance_terminating(rkb) ||
+                            RD_KAFKA_BROKER_IS_LOGICAL(rkb))
+                                continue;
+
+                        rkcg->rkcg_share.share_session_leave_remaining_cnt++;
+                        /* For brokers that are currently processing share fetch
+                         * requests we will enqueue the leave op when they reply
+                         * back to the main thread */
+                        if (rkb->rkb_share_fetch_enqueued) {
+                                rd_kafka_dbg(
+                                    rkcg->rkcg_rk, CGRP, "CLOSE",
+                                    "Broker %s has in-flight request, ",
+                                    rd_kafka_broker_name(rkb));
+                                continue;
+                        }
+
+                        rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk,
+                                                              rkb);
+                }
+                rd_kafka_rdunlock(rkcg->rkcg_rk);
+        }
+
         rkcg->rkcg_ts_terminate = rd_clock();
         rkcg->rkcg_reply_rko    = rko;
 
@@ -6182,6 +6276,25 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
 void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq) {
         rd_kafka_assert(NULL, !thrd_is_current(rkcg->rkcg_rk->rk_thread));
         rd_kafka_cgrp_op(rkcg, NULL, replyq, RD_KAFKA_OP_TERMINATE, 0);
+}
+
+/**
+ * Terminate and decommission a share cgrp asynchronously.
+ * Passes the acknowledgement batches in the rko to be sent
+ * in the session close requests.
+ *
+ * Locality: any thread
+ */
+void rd_kafka_share_cgrp_terminate(rd_kafka_cgrp_t *rkcg,
+                                   rd_kafka_replyq_t replyq) {
+        rd_kafka_assert(NULL, !thrd_is_current(rkcg->rkcg_rk->rk_thread));
+        rd_list_t *ack_batches =
+            rd_kafka_share_build_ack_details(rkcg->rkcg_rk->rk_rkshare);
+
+        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_TERMINATE);
+        rko->rko_replyq    = replyq;
+        rko->rko_u.share_fetch_fanout.ack_batches = ack_batches;
+        rd_kafka_q_enq(rkcg->rkcg_ops, rko);
 }
 
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -556,11 +556,6 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
                     rk->rk_conf.auto_commit_interval_ms * 1000ll,
                     rd_kafka_cgrp_offset_commit_tmr_cb, rkcg);
 
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                /* Only applicable when consumer is closing */
-                rkcg->rkcg_share.share_session_leave_remaining_cnt = -1;
-
-
         return rkcg;
 }
 
@@ -3919,19 +3914,12 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_assert(NULL, rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM);
         rd_kafka_assert(NULL, !rkcg->rkcg_group_assignment);
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
-                rd_kafka_assert(
-                    NULL,
-                    rkcg->rkcg_share.share_session_leave_remaining_cnt == 0);
-                rd_kafka_assert(
-                    NULL,
-                    rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt == 0);
-        } else {
-                rd_kafka_assert(
-                    NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
-                rd_kafka_assert(
-                    NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
-        }
+        rd_kafka_assert(
+            NULL, rkcg->rkcg_share.share_session_leave_remaining_cnt == 0);
+        rd_kafka_assert(
+            NULL, rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt == 0);
+        rd_kafka_assert(NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
+        rd_kafka_assert(NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
 
         rd_kafka_timer_stop(&rkcg->rkcg_rk->rk_timers,
                             &rkcg->rkcg_offset_commit_tmr, 1 /*lock*/);
@@ -3988,10 +3976,6 @@ static RD_INLINE int rd_kafka_cgrp_try_terminate(rd_kafka_cgrp_t *rkcg) {
         if (likely(!(rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE)))
                 return 0;
 
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk) &&
-            rkcg->rkcg_share.share_session_leave_remaining_cnt)
-                return 0;
-
         /* Check if wait-coord queue has timed out.
 
            FIXME: Remove usage of `group_session_timeout_ms` for the new
@@ -4018,6 +4002,7 @@ static RD_INLINE int rd_kafka_cgrp_try_terminate(rd_kafka_cgrp_t *rkcg) {
             rd_list_empty(&rkcg->rkcg_toppars) &&
             !rd_kafka_assignment_in_progress(rkcg->rkcg_rk) &&
             rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0 &&
+            rkcg->rkcg_share.share_session_leave_remaining_cnt == 0 &&
             !(rkcg->rkcg_flags & RD_KAFKA_CGRP_F_WAIT_LEAVE)) {
                 /* Since we might be deep down in a 'rko' handler
                  * called from cgrp_op_serve() we cant call terminated()
@@ -4034,7 +4019,9 @@ static RD_INLINE int rd_kafka_cgrp_try_terminate(rd_kafka_cgrp_t *rkcg) {
                     "Group \"%s\": "
                     "waiting for %s%d toppar(s), "
                     "%s"
-                    "%d commit(s)%s%s%s (state %s, join-state %s) "
+                    "%d commit(s), "
+                    "%d share session leave(s) remaining"
+                    "%s%s%s (state %s, join-state %s) "
                     "before terminating",
                     rkcg->rkcg_group_id->str,
                     RD_KAFKA_CGRP_WAIT_ASSIGN_CALL(rkcg) ? "assign call, " : "",
@@ -4043,6 +4030,7 @@ static RD_INLINE int rd_kafka_cgrp_try_terminate(rd_kafka_cgrp_t *rkcg) {
                         ? "assignment in progress, "
                         : "",
                     rkcg->rkcg_rk->rk_consumer.wait_commit_cnt,
+                    rkcg->rkcg_share.share_session_leave_remaining_cnt,
                     (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_WAIT_LEAVE)
                         ? ", wait-leave,"
                         : "",
@@ -6114,42 +6102,6 @@ rd_kafka_cgrp_subscribe(rd_kafka_cgrp_t *rkcg,
 }
 
 /**
- * @brief Create and enqueue a leave SHARE_FETCH op on a broker.
- *
- * Moves any cached ack details from rkb_share_async_ack_details
- * into the op, sets rkb_share_fetch_enqueued, and enqueues the op
- * on the broker's ops queue.
- *
- * @param rk Client instance
- * @param rkb Broker to enqueue on. Must not have rkb_share_fetch_enqueued set.
- * @param should_fetch Whether the broker should fetch records.
- *
- * @locality main thread
- */
-void rd_kafka_share_enqueue_fetch_leave_op(rd_kafka_t *rk,
-                                           rd_kafka_broker_t *rkb) {
-        rd_kafka_op_t *rko_sf = NULL;
-        rko_sf                = rd_kafka_op_new(RD_KAFKA_OP_SHARE_FETCH);
-        rko_sf->rko_u.share_fetch.should_leave = rd_true;
-        rko_sf->rko_u.share_fetch.abs_timeout =
-            rd_timeout_init(rk->rk_conf.socket_timeout_ms);
-        rko_sf->rko_u.share_fetch.should_fetch = rd_false;
-
-        rko_sf->rko_u.share_fetch.ack_details =
-            rkb->rkb_share_async_ack_details;
-        rkb->rkb_share_async_ack_details = NULL;
-
-        rd_kafka_broker_keep(rkb);
-        rko_sf->rko_u.share_fetch.target_broker = rkb;
-        rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
-        rd_kafka_dbg(rk, BROKER, "SHAREFETCH",
-                     "Enqueuing leave share fetch op on broker %s",
-                     rd_kafka_broker_name(rkb));
-        rkb->rkb_share_fetch_enqueued = rd_true;
-        rd_kafka_q_enq(rkb->rkb_ops, rko_sf);
-}
-
-/**
  * Same as cgrp_terminate() but called from the cgrp/main thread upon receiving
  * the op 'rko' from cgrp_terminate().
  *
@@ -6218,19 +6170,21 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
                                 continue;
 
                         rkcg->rkcg_share.share_session_leave_remaining_cnt++;
+                        rd_assert(
+                            !rkb->rkb_pending_commit_sync.sync_ack_details);
                         /* For brokers that are currently processing share fetch
                          * requests we will enqueue the leave op when they reply
                          * back to the main thread */
                         if (rkb->rkb_share_fetch_enqueued) {
-                                rd_kafka_dbg(
-                                    rkcg->rkcg_rk, CGRP, "CLOSE",
-                                    "Broker %s has in-flight request, ",
-                                    rd_kafka_broker_name(rkb));
+                                rd_kafka_dbg(rkcg->rkcg_rk, CGRP, "CLOSE",
+                                             "Deferring close request as "
+                                             "broker %s has in-flight request",
+                                             rd_kafka_broker_name(rkb));
                                 continue;
                         }
 
-                        rd_kafka_share_enqueue_fetch_leave_op(rkcg->rkcg_rk,
-                                                              rkb);
+                        rd_kafka_share_enqueue_fetch_op(rkcg->rkcg_rk, rkb,
+                                                        rd_false, rd_true);
                 }
                 rd_kafka_rdunlock(rkcg->rkcg_rk);
         }
@@ -6275,28 +6229,17 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
  */
 void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq) {
         rd_kafka_assert(NULL, !thrd_is_current(rkcg->rkcg_rk->rk_thread));
-        rd_kafka_cgrp_op(rkcg, NULL, replyq, RD_KAFKA_OP_TERMINATE, 0);
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                rd_list_t *ack_batches =
+                    rd_kafka_share_build_ack_details(rkcg->rkcg_rk->rk_rkshare);
+
+                rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_TERMINATE);
+                rko->rko_replyq    = replyq;
+                rko->rko_u.share_fetch_fanout.ack_batches = ack_batches;
+                rd_kafka_q_enq(rkcg->rkcg_ops, rko);
+        } else
+                rd_kafka_cgrp_op(rkcg, NULL, replyq, RD_KAFKA_OP_TERMINATE, 0);
 }
-
-/**
- * Terminate and decommission a share cgrp asynchronously.
- * Passes the acknowledgement batches in the rko to be sent
- * in the session close requests.
- *
- * Locality: any thread
- */
-void rd_kafka_share_cgrp_terminate(rd_kafka_cgrp_t *rkcg,
-                                   rd_kafka_replyq_t replyq) {
-        rd_kafka_assert(NULL, !thrd_is_current(rkcg->rkcg_rk->rk_thread));
-        rd_list_t *ack_batches =
-            rd_kafka_share_build_ack_details(rkcg->rkcg_rk->rk_rkshare);
-
-        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_TERMINATE);
-        rko->rko_replyq    = replyq;
-        rko->rko_u.share_fetch_fanout.ack_batches = ack_batches;
-        rd_kafka_q_enq(rkcg->rkcg_ops, rko);
-}
-
 
 struct _op_timeout_offset_commit {
         rd_ts_t now;

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3957,6 +3957,9 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
 
         /* Remove cgrp application queue forwarding, if any. */
         rd_kafka_q_fwd_set(rkcg->rkcg_q, NULL);
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                rd_kafka_q_fwd_set(rkcg->rkcg_rk->rk_ops, NULL);
+        }
 
         /* Destroy KIP-848 consumer group structures */
         rd_kafka_cgrp_consumer_reset(rkcg);
@@ -6152,6 +6155,9 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
         /* For share groups, we have to additionally close
          * sessions with all the brokers */
         if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                /* TODO KIP-932: the below code is similar to
+                 * rd_kafka_share_segregate_and_dispatch_acks()
+                 * Check if we can reduce code duplication */
                 rd_kafka_broker_t *rkb                             = NULL;
                 rkcg->rkcg_share.share_session_leave_remaining_cnt = 0;
                 rd_list_t *ack_batches =
@@ -6170,7 +6176,7 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
                                 continue;
 
                         rkcg->rkcg_share.share_session_leave_remaining_cnt++;
-                        rd_assert(
+                        rd_dassert(
                             !rkb->rkb_pending_commit_sync.sync_ack_details);
                         /* For brokers that are currently processing share fetch
                          * requests we will enqueue the leave op when they reply

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3912,14 +3912,14 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_cgrp_group_assignment_set(rkcg, NULL);
 
-        rd_kafka_assert(NULL, rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM);
+        rd_kafka_assert(NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
         rd_kafka_assert(NULL, !rkcg->rkcg_group_assignment);
+        rd_kafka_assert(NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
+        rd_kafka_assert(NULL, rkcg->rkcg_state == RD_KAFKA_CGRP_STATE_TERM);
         rd_kafka_assert(
             NULL, rkcg->rkcg_share.share_session_leave_remaining_cnt == 0);
         rd_kafka_assert(
             NULL, rkcg->rkcg_share.share_should_fetch_ops_in_flight_cnt == 0);
-        rd_kafka_assert(NULL, !rd_kafka_assignment_in_progress(rkcg->rkcg_rk));
-        rd_kafka_assert(NULL, rkcg->rkcg_rk->rk_consumer.wait_commit_cnt == 0);
 
         rd_kafka_timer_stop(&rkcg->rkcg_rk->rk_timers,
                             &rkcg->rkcg_offset_commit_tmr, 1 /*lock*/);

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -6104,6 +6104,8 @@ rd_kafka_cgrp_subscribe(rd_kafka_cgrp_t *rkcg,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+
+
 /**
  * Same as cgrp_terminate() but called from the cgrp/main thread upon receiving
  * the op 'rko' from cgrp_terminate().

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -6171,6 +6171,7 @@ void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko) {
                          * ack_details. Destroy the container. */
                         rd_list_destroy(ack_batches);
                 }
+                /* TODO KIP-932: See how we can avoid locking the handle */
                 rd_kafka_rdlock(rkcg->rkcg_rk);
                 TAILQ_FOREACH(rkb, &rkcg->rkcg_rk->rk_brokers, rkb_link) {
                         if (rd_kafka_broker_or_instance_terminating(rkb) ||

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3958,7 +3958,7 @@ static void rd_kafka_cgrp_terminated(rd_kafka_cgrp_t *rkcg) {
         /* Remove cgrp application queue forwarding, if any. */
         rd_kafka_q_fwd_set(rkcg->rkcg_q, NULL);
         if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
-                rd_kafka_q_fwd_set(rkcg->rkcg_rk->rk_ops, NULL);
+                rd_kafka_q_fwd_set(rkcg->rkcg_rk->rk_rep, NULL);
         }
 
         /* Destroy KIP-848 consumer group structures */
@@ -6240,6 +6240,7 @@ void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq) {
         if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
                 rd_list_t *ack_batches =
                     rd_kafka_share_build_ack_details(rkcg->rkcg_rk->rk_rkshare);
+                RD_MAP_CLEAR(&rkcg->rkcg_rk->rk_rkshare->rkshare_inflight_acks);
 
                 rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_TERMINATE);
                 rko->rko_replyq    = replyq;

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -402,6 +402,19 @@ typedef struct rd_kafka_cgrp_s {
                                                            * reply.
                                                            *   @locality main
                                                            * thread */
+                int share_session_leave_remaining_cnt;    /**< Number of
+                                                           * session leave requests
+                                                           * which are either
+                                                           * pending to be sent or
+                                                           * are in-flight.
+                                                           * Populated when cgrp
+                                                           * termination op    is
+                                                           * received and
+                                                           * decremented    whenever
+                                                           * we receive a reply    to
+                                                           * a leave request
+                                                           *    @locality main
+                                                           * thread */
                 int64_t commit_sync_request_id_counter; /**< Global counter for
                                                          *   commit_sync request
                                                          *   IDs. Starts at 1,
@@ -471,6 +484,10 @@ void rd_kafka_cgrp_op(rd_kafka_cgrp_t *rkcg,
                       rd_kafka_resp_err_t err);
 void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko);
 void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq);
+void rd_kafka_share_cgrp_terminate(rd_kafka_cgrp_t *rkcg,
+                                   rd_kafka_replyq_t replyq);
+void rd_kafka_share_enqueue_fetch_leave_op(rd_kafka_t *rk,
+                                           rd_kafka_broker_t *rkb);
 
 
 rd_kafka_resp_err_t rd_kafka_cgrp_topic_pattern_del(rd_kafka_cgrp_t *rkcg,

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -485,6 +485,7 @@ void rd_kafka_cgrp_op(rd_kafka_cgrp_t *rkcg,
 void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko);
 void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq);
 
+
 rd_kafka_resp_err_t rd_kafka_cgrp_topic_pattern_del(rd_kafka_cgrp_t *rkcg,
                                                     const char *pattern);
 rd_kafka_resp_err_t rd_kafka_cgrp_topic_pattern_add(rd_kafka_cgrp_t *rkcg,

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -484,11 +484,6 @@ void rd_kafka_cgrp_op(rd_kafka_cgrp_t *rkcg,
                       rd_kafka_resp_err_t err);
 void rd_kafka_cgrp_terminate0(rd_kafka_cgrp_t *rkcg, rd_kafka_op_t *rko);
 void rd_kafka_cgrp_terminate(rd_kafka_cgrp_t *rkcg, rd_kafka_replyq_t replyq);
-void rd_kafka_share_cgrp_terminate(rd_kafka_cgrp_t *rkcg,
-                                   rd_kafka_replyq_t replyq);
-void rd_kafka_share_enqueue_fetch_leave_op(rd_kafka_t *rk,
-                                           rd_kafka_broker_t *rkb);
-
 
 rd_kafka_resp_err_t rd_kafka_cgrp_topic_pattern_del(rd_kafka_cgrp_t *rkcg,
                                                     const char *pattern);

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -2773,6 +2773,7 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
             rkb, rkbuf, rd_kafka_broker_share_acknowledge_reply, rko_orig);
 }
 
+
 void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
         rd_kafka_toppar_t *rktp, *tmp_rktp;
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1800,6 +1800,71 @@ static void rd_kafka_broker_session_update(rd_kafka_broker_t *rkb) {
         rd_kafka_broker_session_update_partitions(rkb);
 }
 
+static void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
+        rd_kafka_toppar_t *rktp, *tmp_rktp;
+
+        /* Clear toppars in session */
+        TAILQ_FOREACH_SAFE(rktp,
+                           &rkb->rkb_share_fetch_session.toppars_in_session,
+                           rktp_rkb_session_link, tmp_rktp) {
+                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
+                             rktp, rktp_rkb_session_link);
+                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
+                           "%s [%" PRId32
+                           "]: removed from ShareFetch session on clear",
+                           rktp->rktp_rkt->rkt_topic->str,
+                           rktp->rktp_partition);
+                rd_kafka_toppar_destroy(rktp);  // from session list
+        }
+        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
+
+        /* Clear toppars to add */
+        if (rkb->rkb_share_fetch_session.toppars_to_add) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d toppars to add from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(rkb->rkb_share_fetch_session.toppars_to_add));
+                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_add);
+                rkb->rkb_share_fetch_session.toppars_to_add = NULL;
+        }
+
+        /* Clear toppars to forget */
+        if (rkb->rkb_share_fetch_session.toppars_to_forget) {
+                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
+                           "Clearing %d toppars to forget from ShareFetch "
+                           "session on clear",
+                           rd_list_cnt(
+                               rkb->rkb_share_fetch_session.toppars_to_forget));
+                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_forget);
+                rkb->rkb_share_fetch_session.toppars_to_forget = NULL;
+        }
+
+        /* Clear adding toppars */
+        if (rkb->rkb_share_fetch_session.adding_toppars) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d adding toppars from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(rkb->rkb_share_fetch_session.adding_toppars));
+                rd_list_destroy(rkb->rkb_share_fetch_session.adding_toppars);
+                rkb->rkb_share_fetch_session.adding_toppars = NULL;
+        }
+
+        /* Clear forgetting toppars */
+        if (rkb->rkb_share_fetch_session.forgetting_toppars) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d forgetting toppars from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(
+                        rkb->rkb_share_fetch_session.forgetting_toppars));
+                rd_list_destroy(
+                    rkb->rkb_share_fetch_session.forgetting_toppars);
+                rkb->rkb_share_fetch_session.forgetting_toppars = NULL;
+        }
+}
+
 /**
  * @brief Parse a ShareAcknowledge response.
  *
@@ -1988,6 +2053,11 @@ static void rd_kafka_broker_share_acknowledge_reply(rd_kafka_t *rk,
                         break;
                 }
         }
+
+        /* TODO KIP-932: Session should be cleared during destroy()
+         * instead of close() */
+        if (rko_orig->rko_u.share_fetch.should_leave)
+                rd_kafka_broker_share_fetch_session_clear(rkb);
 
         /* Destroy ack_details — on success the acks have been sent,
          * on error they are unprocessable. */
@@ -2770,85 +2840,18 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
             rkb, rkbuf, rd_kafka_broker_share_acknowledge_reply, rko_orig);
 }
 
-
-void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
-        rd_kafka_toppar_t *rktp, *tmp_rktp;
-
-        rkb->rkb_share_fetch_session.epoch = -1;
-
-        /* Clear toppars in session */
-        TAILQ_FOREACH_SAFE(rktp,
-                           &rkb->rkb_share_fetch_session.toppars_in_session,
-                           rktp_rkb_session_link, tmp_rktp) {
-                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
-                             rktp, rktp_rkb_session_link);
-                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
-                           "%s [%" PRId32
-                           "]: removed from ShareFetch session on clear",
-                           rktp->rktp_rkt->rkt_topic->str,
-                           rktp->rktp_partition);
-                rd_kafka_toppar_destroy(rktp);  // from session list
-        }
-        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
-
-        /* Clear toppars to add */
-        if (rkb->rkb_share_fetch_session.toppars_to_add) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d toppars to add from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(rkb->rkb_share_fetch_session.toppars_to_add));
-                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_add);
-                rkb->rkb_share_fetch_session.toppars_to_add = NULL;
-        }
-
-        /* Clear toppars to forget */
-        if (rkb->rkb_share_fetch_session.toppars_to_forget) {
-                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
-                           "Clearing %d toppars to forget from ShareFetch "
-                           "session on clear",
-                           rd_list_cnt(
-                               rkb->rkb_share_fetch_session.toppars_to_forget));
-                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_forget);
-                rkb->rkb_share_fetch_session.toppars_to_forget = NULL;
-        }
-
-        /* Clear adding toppars */
-        if (rkb->rkb_share_fetch_session.adding_toppars) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d adding toppars from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(rkb->rkb_share_fetch_session.adding_toppars));
-                rd_list_destroy(rkb->rkb_share_fetch_session.adding_toppars);
-                rkb->rkb_share_fetch_session.adding_toppars = NULL;
-        }
-
-        /* Clear forgetting toppars */
-        if (rkb->rkb_share_fetch_session.forgetting_toppars) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d forgetting toppars from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(
-                        rkb->rkb_share_fetch_session.forgetting_toppars));
-                rd_list_destroy(
-                    rkb->rkb_share_fetch_session.forgetting_toppars);
-                rkb->rkb_share_fetch_session.forgetting_toppars = NULL;
-        }
-}
-
 void rd_kafka_broker_share_fetch_leave(rd_kafka_broker_t *rkb,
                                        rd_kafka_op_t *rko_orig,
                                        rd_ts_t now) {
         rd_kafka_cgrp_t *rkcg = rkb->rkb_rk->rk_cgrp;
-        /* Use ShareAcknowledge with epoch=-1 to close the session,
-         * sending any final acknowledgements. */
+
+        /* Set epoch to -1 to signal session close before sending request.
+         * This ensures session_update_epoch() skips incrementing on reply. */
+        rkb->rkb_share_fetch_session.epoch = -1;
         rd_kafka_ShareAcknowledgeRequest(
             rkb, rkcg->rkcg_group_id, rkcg->rkcg_member_id,
             -1, /* epoch=-1 signals session close */
             rko_orig, now);
-        rd_kafka_broker_share_fetch_session_clear(rkb);
 }
 
 void rd_kafka_broker_share_rpc(rd_kafka_broker_t *rkb,

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -2837,6 +2837,7 @@ void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
                     rkb->rkb_share_fetch_session.forgetting_toppars);
                 rkb->rkb_share_fetch_session.forgetting_toppars = NULL;
         }
+        rkb->rkb_share_fetch_session.epoch = -1;
 }
 
 void rd_kafka_broker_share_fetch_session_leave(rd_kafka_broker_t *rkb,

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1800,71 +1800,6 @@ static void rd_kafka_broker_session_update(rd_kafka_broker_t *rkb) {
         rd_kafka_broker_session_update_partitions(rkb);
 }
 
-static void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
-        rd_kafka_toppar_t *rktp, *tmp_rktp;
-
-        /* Clear toppars in session */
-        TAILQ_FOREACH_SAFE(rktp,
-                           &rkb->rkb_share_fetch_session.toppars_in_session,
-                           rktp_rkb_session_link, tmp_rktp) {
-                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
-                             rktp, rktp_rkb_session_link);
-                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
-                           "%s [%" PRId32
-                           "]: removed from ShareFetch session on clear",
-                           rktp->rktp_rkt->rkt_topic->str,
-                           rktp->rktp_partition);
-                rd_kafka_toppar_destroy(rktp);  // from session list
-        }
-        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
-
-        /* Clear toppars to add */
-        if (rkb->rkb_share_fetch_session.toppars_to_add) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d toppars to add from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(rkb->rkb_share_fetch_session.toppars_to_add));
-                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_add);
-                rkb->rkb_share_fetch_session.toppars_to_add = NULL;
-        }
-
-        /* Clear toppars to forget */
-        if (rkb->rkb_share_fetch_session.toppars_to_forget) {
-                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
-                           "Clearing %d toppars to forget from ShareFetch "
-                           "session on clear",
-                           rd_list_cnt(
-                               rkb->rkb_share_fetch_session.toppars_to_forget));
-                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_forget);
-                rkb->rkb_share_fetch_session.toppars_to_forget = NULL;
-        }
-
-        /* Clear adding toppars */
-        if (rkb->rkb_share_fetch_session.adding_toppars) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d adding toppars from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(rkb->rkb_share_fetch_session.adding_toppars));
-                rd_list_destroy(rkb->rkb_share_fetch_session.adding_toppars);
-                rkb->rkb_share_fetch_session.adding_toppars = NULL;
-        }
-
-        /* Clear forgetting toppars */
-        if (rkb->rkb_share_fetch_session.forgetting_toppars) {
-                rd_rkb_dbg(
-                    rkb, BROKER, "SHAREFETCH",
-                    "Clearing %d forgetting toppars from ShareFetch session on "
-                    "clear",
-                    rd_list_cnt(
-                        rkb->rkb_share_fetch_session.forgetting_toppars));
-                rd_list_destroy(
-                    rkb->rkb_share_fetch_session.forgetting_toppars);
-                rkb->rkb_share_fetch_session.forgetting_toppars = NULL;
-        }
-}
-
 /**
  * @brief Parse a ShareAcknowledge response.
  *
@@ -2054,8 +1989,6 @@ static void rd_kafka_broker_share_acknowledge_reply(rd_kafka_t *rk,
                 }
         }
 
-        /* TODO KIP-932: Session should be cleared during destroy()
-         * instead of close() */
         if (rko_orig->rko_u.share_fetch.should_leave)
                 rd_kafka_broker_share_fetch_session_clear(rkb);
 
@@ -2838,6 +2771,71 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
                      cnt, rkb->rkb_name, rkb->rkb_nodeid);
         rd_kafka_broker_buf_enq1(
             rkb, rkbuf, rd_kafka_broker_share_acknowledge_reply, rko_orig);
+}
+
+void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
+        rd_kafka_toppar_t *rktp, *tmp_rktp;
+
+        /* Clear toppars in session */
+        TAILQ_FOREACH_SAFE(rktp,
+                           &rkb->rkb_share_fetch_session.toppars_in_session,
+                           rktp_rkb_session_link, tmp_rktp) {
+                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
+                             rktp, rktp_rkb_session_link);
+                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
+                           "%s [%" PRId32
+                           "]: removed from ShareFetch session on clear",
+                           rktp->rktp_rkt->rkt_topic->str,
+                           rktp->rktp_partition);
+                rd_kafka_toppar_destroy(rktp);  // from session list
+        }
+        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
+
+        /* Clear toppars to add */
+        if (rkb->rkb_share_fetch_session.toppars_to_add) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d toppars to add from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(rkb->rkb_share_fetch_session.toppars_to_add));
+                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_add);
+                rkb->rkb_share_fetch_session.toppars_to_add = NULL;
+        }
+
+        /* Clear toppars to forget */
+        if (rkb->rkb_share_fetch_session.toppars_to_forget) {
+                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
+                           "Clearing %d toppars to forget from ShareFetch "
+                           "session on clear",
+                           rd_list_cnt(
+                               rkb->rkb_share_fetch_session.toppars_to_forget));
+                rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_forget);
+                rkb->rkb_share_fetch_session.toppars_to_forget = NULL;
+        }
+
+        /* Clear adding toppars */
+        if (rkb->rkb_share_fetch_session.adding_toppars) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d adding toppars from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(rkb->rkb_share_fetch_session.adding_toppars));
+                rd_list_destroy(rkb->rkb_share_fetch_session.adding_toppars);
+                rkb->rkb_share_fetch_session.adding_toppars = NULL;
+        }
+
+        /* Clear forgetting toppars */
+        if (rkb->rkb_share_fetch_session.forgetting_toppars) {
+                rd_rkb_dbg(
+                    rkb, BROKER, "SHAREFETCH",
+                    "Clearing %d forgetting toppars from ShareFetch session on "
+                    "clear",
+                    rd_list_cnt(
+                        rkb->rkb_share_fetch_session.forgetting_toppars));
+                rd_list_destroy(
+                    rkb->rkb_share_fetch_session.forgetting_toppars);
+                rkb->rkb_share_fetch_session.forgetting_toppars = NULL;
+        }
 }
 
 void rd_kafka_broker_share_fetch_leave(rd_kafka_broker_t *rkb,

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -2838,18 +2838,37 @@ void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
         }
 }
 
-void rd_kafka_broker_share_fetch_leave(rd_kafka_broker_t *rkb,
-                                       rd_kafka_op_t *rko_orig,
-                                       rd_ts_t now) {
+void rd_kafka_broker_share_fetch_session_leave(rd_kafka_broker_t *rkb,
+                                               rd_kafka_op_t *rko_orig,
+                                               rd_ts_t now) {
         rd_kafka_cgrp_t *rkcg = rkb->rkb_rk->rk_cgrp;
 
-        /* Set epoch to -1 to signal session close before sending request.
-         * This ensures session_update_epoch() skips incrementing on reply. */
-        rkb->rkb_share_fetch_session.epoch = -1;
-        rd_kafka_ShareAcknowledgeRequest(
-            rkb, rkcg->rkcg_group_id, rkcg->rkcg_member_id,
-            -1, /* epoch=-1 signals session close */
-            rko_orig, now);
+        if (rkb->rkb_share_fetch_session.epoch > 0) {
+                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                             "Processing SHARE_FETCH op: "
+                             "should_leave = true");
+
+                /* Set epoch to -1 to signal session close before sending
+                 * request. This ensures session_update_epoch() skips
+                 * incrementing on reply. */
+                rkb->rkb_share_fetch_session.epoch = -1;
+                rd_kafka_ShareAcknowledgeRequest(
+                    rkb, rkcg->rkcg_group_id, rkcg->rkcg_member_id,
+                    -1, /* epoch=-1 signals session close */
+                    rko_orig, now);
+        } else {
+                rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
+                             "Ignoring SHARE_FETCH op with "
+                             "should_leave = true: "
+                             "no active session");
+
+                if (rkb->rkb_share_fetch_session.epoch == 0)
+                        /* Required as it is possible that we were about
+                         * to establish a session */
+                        rd_kafka_broker_share_fetch_session_clear(rkb);
+                rd_kafka_op_reply(rko_orig,
+                                  RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND);
+        }
 }
 
 void rd_kafka_broker_share_rpc(rd_kafka_broker_t *rkb,

--- a/src/rdkafka_fetcher.h
+++ b/src/rdkafka_fetcher.h
@@ -40,9 +40,9 @@ rd_ts_t rd_kafka_toppar_fetch_decide(rd_kafka_toppar_t *rktp,
                                      rd_kafka_broker_t *rkb,
                                      int force_remove);
 
-void rd_kafka_broker_share_fetch_leave(rd_kafka_broker_t *rkb,
-                                       rd_kafka_op_t *rko_orig,
-                                       rd_ts_t now);
+void rd_kafka_broker_share_fetch_session_leave(rd_kafka_broker_t *rkb,
+                                               rd_kafka_op_t *rko_orig,
+                                               rd_ts_t now);
 void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb);
 void rd_kafka_broker_share_rpc(rd_kafka_broker_t *rkb,
                                rd_kafka_op_t *rko_orig,

--- a/src/rdkafka_fetcher.h
+++ b/src/rdkafka_fetcher.h
@@ -43,6 +43,7 @@ rd_ts_t rd_kafka_toppar_fetch_decide(rd_kafka_toppar_t *rktp,
 void rd_kafka_broker_share_fetch_leave(rd_kafka_broker_t *rkb,
                                        rd_kafka_op_t *rko_orig,
                                        rd_ts_t now);
+void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb);
 void rd_kafka_broker_share_rpc(rd_kafka_broker_t *rkb,
                                rd_kafka_op_t *rko_orig,
                                rd_ts_t now);

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -815,8 +815,9 @@ struct rd_kafka_share_s {
         rd_bool_t rkshare_fetch_more_records_requested;
 
         /**
-         * Set to true when the consumer is closing. Will be used to
-         * check if SHARE_FETCH_RESPONSE is received to poll_cb only
+         * Set to true when the consumer is closing. Will be used to:
+         * * prevent any new API call from the app.
+         * * check if SHARE_FETCH_RESPONSE is received to poll_cb only
          * while closing
          */
         rd_bool_t rkshare_consumer_closing;
@@ -1314,5 +1315,26 @@ void rd_kafka_reset_any_broker_down_reported(rd_kafka_t *rk);
 rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
                                                  rd_kafka_q_t *rkq,
                                                  rd_kafka_op_t *rko);
+
+/**
+ * @brief Return an error object if the share consumer is closed or closing.
+ * @returns a newly-allocated error (owned by caller) or NULL if usable.
+ */
+rd_kafka_error_t *
+rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare);
+
+/**
+ * @brief Return a response-error code if the share consumer is closed or
+ *        closing.
+ * @returns RD_KAFKA_RESP_ERR__STATE if closed/closing, else
+ *          RD_KAFKA_RESP_ERR_NO_ERROR.
+ */
+rd_kafka_resp_err_t
+rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare);
+
+void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
+                                     rd_kafka_broker_t *rkb,
+                                     rd_bool_t should_fetch,
+                                     rd_bool_t should_leave);
 
 #endif /* _RDKAFKA_INT_H_ */

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -1321,7 +1321,7 @@ rd_kafka_op_res_t rd_kafka_share_fetch_fanout_op(rd_kafka_t *rk,
  * @returns a newly-allocated error (owned by caller) or NULL if usable.
  */
 rd_kafka_error_t *
-rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare);
+rd_kafka_share_consumer_closed_error(rd_kafka_share_t *rkshare);
 
 /**
  * @brief Return a response-error code if the share consumer is closed or
@@ -1330,7 +1330,7 @@ rd_kafka_share_consumer_closed_or_closing_error(rd_kafka_share_t *rkshare);
  *          RD_KAFKA_RESP_ERR_NO_ERROR.
  */
 rd_kafka_resp_err_t
-rd_kafka_share_consumer_closed_or_closing_err(rd_kafka_share_t *rkshare);
+rd_kafka_share_consumer_closed_err(rd_kafka_share_t *rkshare);
 
 void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
                                      rd_kafka_broker_t *rkb,

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -815,10 +815,9 @@ struct rd_kafka_share_s {
         rd_bool_t rkshare_fetch_more_records_requested;
 
         /**
-         * Set to true when the consumer is closing. Will be used to:
-         * * prevent any new API call from the app.
-         * * check if SHARE_FETCH_RESPONSE is received to poll_cb only
-         *   while closing
+         * Set to true when the consumer is closing. Will be used to
+         * check if SHARE_FETCH_RESPONSE is received to poll_cb only
+         * while closing
          */
         rd_bool_t rkshare_consumer_closing;
 };

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -285,6 +285,99 @@ static void rd_kafka_share_ack_details_batch_destroy(void *ptr) {
 }
 
 /**
+ * @brief Find an existing ack batch for the same topic-partition in a list.
+ *
+ * @param ack_list List of rd_kafka_share_ack_batches_t*
+ * @param rktpar Topic-partition to match (by topic id and partition)
+ *
+ * @returns Matching batch, or NULL if not found.
+ * @locality main thread
+ */
+rd_kafka_share_ack_batches_t *
+rd_kafka_share_find_ack_batch(rd_list_t *ack_list,
+                              const rd_kafka_topic_partition_t *rktpar) {
+        rd_kafka_share_ack_batches_t *existing;
+        int i;
+
+        RD_LIST_FOREACH(existing, ack_list, i) {
+                /* TODO KIP-932: We might need to use leader id and epoch
+                 * as well to understand about the stale topic partition
+                 * information */
+                if (rd_kafka_topic_partition_by_id_cmp(existing->rktpar,
+                                                       rktpar) == 0)
+                        return existing;
+        }
+        return NULL;
+}
+
+/**
+ * @brief Segregate ack batches from a FANOUT op by partition leader.
+ *
+ * For each ack batch, looks up the current leader broker via the
+ * toppar reference in batch->rktpar, and merges the batch into that
+ * broker's rkb_share_async_ack_details list. If the broker already
+ * has cached acks for the same topic-partition, the entries are
+ * appended to the existing batch.
+ *
+ * @param rk Client instance
+ * @param ack_batches List of rd_kafka_share_ack_batches_t* from FANOUT op.
+ *                    Elements whose leader is found are moved to broker
+ *                    ack_details; remaining elements are not freed.
+ *
+ * @locality main thread
+ */
+void rd_kafka_share_segregate_acks_by_leader(rd_kafka_t *rk,
+                                             rd_list_t *ack_batches) {
+        rd_kafka_share_ack_batches_t *batch;
+        int batch_cnt = rd_list_cnt(ack_batches);
+
+        while ((batch = rd_list_pop(ack_batches))) {
+                rd_kafka_toppar_t *rktp;
+                rd_kafka_broker_t *leader_rkb;
+                rd_kafka_share_ack_batches_t *existing;
+
+                rktp = rd_kafka_topic_partition_toppar(rk, batch->rktpar);
+                if (!rktp || !rktp->rktp_leader) {
+                        rd_kafka_dbg(rk, CGRP, "SHARE",
+                                     "Ack batch for leader %" PRId32
+                                     " dropped: toppar or leader not available",
+                                     batch->response_leader_id);
+                        rd_kafka_share_ack_batches_destroy(batch);
+                        continue;
+                }
+                leader_rkb = rktp->rktp_leader;
+
+                /* Allocate list on first use with incoming batch count
+                 * as initial capacity hint */
+                if (!leader_rkb->rkb_share_async_ack_details)
+                        leader_rkb->rkb_share_async_ack_details = rd_list_new(
+                            batch_cnt, rd_kafka_share_ack_batches_destroy_free);
+
+                /* Check if there's already a batch for this topic-partition.
+                 * If so, merge entries; otherwise add as new. */
+                existing = rd_kafka_share_find_ack_batch(
+                    leader_rkb->rkb_share_async_ack_details, batch->rktpar);
+
+                if (existing) {
+                        /* Merge: deep-copy entries from new batch into
+                         * existing, preserving order. The source batch
+                         * is then fully destroyed (freeing its entries). */
+                        rd_kafka_share_ack_batch_entry_t *entry;
+                        int j;
+                        RD_LIST_FOREACH(entry, &batch->entries, j) {
+                                rd_list_add(
+                                    &existing->entries,
+                                    rd_kafka_share_ack_batch_entry_copy(entry));
+                        }
+                        rd_kafka_share_ack_batches_destroy(batch);
+                } else {
+                        rd_list_add(leader_rkb->rkb_share_async_ack_details,
+                                    batch);
+                }
+        }
+}
+
+/**
  * @brief Extract acknowledged (non-ACQUIRED) records from inflight map.
  *
  * Iterates through the inflight acknowledgement map and separates each
@@ -596,6 +689,9 @@ rd_kafka_share_acknowledge_offset(rd_kafka_share_t *rkshare,
         if (type < RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT ||
             type > RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT)
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
+
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return RD_KAFKA_RESP_ERR__STATE;
 
         /* Find partition and entry containing the offset */
         err = rd_kafka_share_find_ack_entry(rkshare, topic, partition, offset,

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -690,8 +690,9 @@ rd_kafka_share_acknowledge_offset(rd_kafka_share_t *rkshare,
             type > RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT)
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
 
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return RD_KAFKA_RESP_ERR__STATE;
+        if (unlikely(
+                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+                return err;
 
         /* Find partition and entry containing the offset */
         err = rd_kafka_share_find_ack_entry(rkshare, topic, partition, offset,

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -690,8 +690,7 @@ rd_kafka_share_acknowledge_offset(rd_kafka_share_t *rkshare,
             type > RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT)
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
 
-        if (unlikely(
-                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
                 return err;
 
         /* Find partition and entry containing the offset */

--- a/src/rdkafka_share_acknowledgement.h
+++ b/src/rdkafka_share_acknowledgement.h
@@ -154,6 +154,13 @@ void rd_kafka_share_build_inflight_acks_map(rd_kafka_share_t *rkshare,
  */
 void rd_kafka_share_ack_all(rd_kafka_share_t *rkshare);
 
+rd_kafka_share_ack_batches_t *
+rd_kafka_share_find_ack_batch(rd_list_t *ack_list,
+                              const rd_kafka_topic_partition_t *rktpar);
+
+void rd_kafka_share_segregate_acks_by_leader(rd_kafka_t *rk,
+                                             rd_list_t *ack_batches);
+
 /**
  * @brief Extract acknowledged (non-ACQUIRED) records from inflight map.
  *

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -51,6 +51,8 @@ rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare) {
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return RD_KAFKA_RESP_ERR__STATE;
         return rd_kafka_unsubscribe(rkshare->rkshare_rk);
 }
 
@@ -113,6 +115,8 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return RD_KAFKA_RESP_ERR__STATE;
         return rd_kafka_subscribe(rkshare->rkshare_rk, topics);
 }
 
@@ -284,6 +288,8 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
+        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
+                return RD_KAFKA_RESP_ERR__STATE;
         return rd_kafka_subscription(rkshare->rkshare_rk, topics);
 }
 

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -47,12 +47,15 @@ rd_kafka_resp_err_t rd_kafka_unsubscribe(rd_kafka_t *rk) {
 }
 
 rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare) {
+        rd_kafka_resp_err_t err;
+
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return RD_KAFKA_RESP_ERR__STATE;
+        if (unlikely(
+                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+                return err;
         return rd_kafka_unsubscribe(rkshare->rkshare_rk);
 }
 
@@ -111,12 +114,15 @@ rd_kafka_subscribe(rd_kafka_t *rk,
 rd_kafka_resp_err_t
 rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
                          const rd_kafka_topic_partition_list_t *topics) {
+        rd_kafka_resp_err_t err;
+
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return RD_KAFKA_RESP_ERR__STATE;
+        if (unlikely(
+                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+                return err;
         return rd_kafka_subscribe(rkshare->rkshare_rk, topics);
 }
 
@@ -284,12 +290,15 @@ rd_kafka_subscription(rd_kafka_t *rk,
 rd_kafka_resp_err_t
 rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
                             rd_kafka_topic_partition_list_t **topics) {
+        rd_kafka_resp_err_t err;
+
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(rd_kafka_share_consumer_closed(rkshare)))
-                return RD_KAFKA_RESP_ERR__STATE;
+        if (unlikely(
+                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+                return err;
         return rd_kafka_subscription(rkshare->rkshare_rk, topics);
 }
 

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -53,8 +53,7 @@ rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare) {
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(
-                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
                 return err;
         return rd_kafka_unsubscribe(rkshare->rkshare_rk);
 }
@@ -120,8 +119,7 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(
-                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
                 return err;
         return rd_kafka_subscribe(rkshare->rkshare_rk, topics);
 }
@@ -296,8 +294,7 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely(
-                (err = rd_kafka_share_consumer_closed_or_closing_err(rkshare))))
+        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
                 return err;
         return rd_kafka_subscription(rkshare->rkshare_rk, topics);
 }

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -1696,6 +1696,7 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
+        rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-success";
 
@@ -1723,7 +1724,9 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         /* Leave group - should send leave heartbeat and complete.
          * Note: After close(), we cannot call rd_kafka_assignment() anymore
          * as the broker handle is destroyed. */
-        test_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Cleanup */
         test_share_destroy(share_c);
@@ -1745,6 +1748,7 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
+        rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-error";
 
@@ -1777,7 +1781,12 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         /* Leave group - should still complete despite error (best effort).
          * The key behavior: close() must not hang even when the leave
          * heartbeat gets an error response. */
-        test_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        /* Close completed (didn't hang) - this is the primary assertion.
+         * The return code may vary depending on whether the error was
+         * processed during leave. */
+        TEST_SAY("Leave completed with: %s (didn't hang - correct)\n",
+                 rd_kafka_error_name(error));
 
         /* Cleanup */
         test_share_destroy(share_c);
@@ -1893,6 +1902,7 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
         rd_kafka_resp_err_t fatal_err;
+        rd_kafka_error_t *error;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-id-not-found-unsub";
@@ -1942,7 +1952,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
                     rd_kafka_err2str(fatal_err), errstr);
 
         /* Close consumer */
-        test_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_SAY("Close returned: %s\n", rd_kafka_error_name(error));
 
         /* Cleanup */
         test_share_destroy(share_c);
@@ -2220,6 +2231,7 @@ static void do_test_graceful_shutdown_stable_state(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
         rd_kafka_share_t *share_c;
+        rd_kafka_error_t *error;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-graceful-shutdown";
@@ -2257,7 +2269,9 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* Close consumer gracefully - should send leave heartbeat */
-        test_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Verify leave heartbeat was sent */
         found_heartbeats = wait_share_heartbeats(mcluster, 1, 1000);
@@ -2454,6 +2468,7 @@ static void do_test_double_close(void) {
         const char *group_id = topic;
         rd_kafka_share_t *share_c;
         rd_kafka_topic_partition_list_t *subscription;
+        rd_kafka_error_t *error;
 
         SUB_TEST_QUICK();
 
@@ -2471,12 +2486,16 @@ static void do_test_double_close(void) {
         wait_share_heartbeats(mcluster, 3, 1000);
 
         /* First close - should succeed */
-        test_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected first close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Second close - should handle gracefully without crashing.
          * The Java equivalent tests verify the CompletableFuture
          * completes immediately on double-leave. */
-        rd_kafka_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_SAY("Second close returned: %s (no crash - correct)\n",
+                 rd_kafka_error_name(error));
 
         rd_kafka_topic_partition_list_destroy(subscription);
         test_share_destroy(share_c);

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -1715,7 +1715,7 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
+        rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-success";
 
@@ -1743,9 +1743,9 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         /* Leave group - should send leave heartbeat and complete.
          * Note: After close(), we cannot call rd_kafka_assignment() anymore
          * as the broker handle is destroyed. */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Cleanup */
         rd_kafka_share_destroy(share_c);
@@ -1767,7 +1767,7 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
+        rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-error";
 
@@ -1800,12 +1800,12 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         /* Leave group - should still complete despite error (best effort).
          * The key behavior: close() must not hang even when the leave
          * heartbeat gets an error response. */
-        err = rd_kafka_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
         /* Close completed (didn't hang) - this is the primary assertion.
          * The return code may vary depending on whether the error was
          * processed during leave. */
         TEST_SAY("Leave completed with: %s (didn't hang - correct)\n",
-                 rd_kafka_err2str(err));
+                 rd_kafka_error_name(error));
 
         /* Cleanup */
         rd_kafka_share_destroy(share_c);
@@ -1920,7 +1920,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err, fatal_err;
+        rd_kafka_resp_err_t fatal_err;
+        rd_kafka_error_t *error;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-id-not-found-unsub";
@@ -1970,8 +1971,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
                     rd_kafka_err2str(fatal_err), errstr);
 
         /* Close consumer */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_SAY("Close returned: %s\n", rd_kafka_err2str(err));
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_SAY("Close returned: %s\n", rd_kafka_error_name(error));
 
         /* Cleanup */
         rd_kafka_share_destroy(share_c);
@@ -2249,7 +2250,7 @@ static void do_test_graceful_shutdown_stable_state(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
+        rd_kafka_error_t *error;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-graceful-shutdown";
@@ -2287,9 +2288,9 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* Close consumer gracefully - should send leave heartbeat */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Verify leave heartbeat was sent */
         found_heartbeats = wait_share_heartbeats(mcluster, 1, 1000);
@@ -2488,7 +2489,7 @@ static void do_test_double_close(void) {
         const char *group_id = topic;
         rd_kafka_share_t *share_c;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_resp_err_t err;
+        rd_kafka_error_t *error;
 
         SUB_TEST_QUICK();
 
@@ -2506,16 +2507,16 @@ static void do_test_double_close(void) {
         wait_share_heartbeats(mcluster, 3, 1000);
 
         /* First close - should succeed */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected first close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        error = rd_kafka_share_consumer_close(share_c);
+        TEST_ASSERT(!error, "Expected first close to succeed, got %s",
+                    rd_kafka_error_name(error));
 
         /* Second close - should handle gracefully without crashing.
          * The Java equivalent tests verify the CompletableFuture
          * completes immediately on double-leave. */
-        err = rd_kafka_share_consumer_close(share_c);
+        error = rd_kafka_share_consumer_close(share_c);
         TEST_SAY("Second close returned: %s (no crash - correct)\n",
-                 rd_kafka_err2str(err));
+                 rd_kafka_error_name(error));
 
         rd_kafka_topic_partition_list_destroy(subscription);
         rd_kafka_share_destroy(share_c);

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -578,6 +578,10 @@ static void test_close_with_acknowledge(void) {
                 /* Cleanup */
                 free_tracked_messages(tracked_msgs, tracked_cnt);
 
+                for (int t = 0; t < ctx.topic_cnt; t++) {
+                        rd_free(ctx.topic_names[t]);
+                }
+
                 TEST_SAY("Test %s completed successfully\n\n",
                          config->test_name);
         }
@@ -1111,8 +1115,8 @@ static void test_close_respects_socket_timeout(void) {
         const char *group = "sg-close-timeout";
         const int msgcnt  = 10;
         const int rtt_delay_ms =
-            80000; /* 80 seconds - exceeds socket timeout */
-        const int socket_timeout_ms = 60000; /* 60 seconds */
+            40000; /* 40 seconds - exceeds socket timeout */
+        const int socket_timeout_ms = 20000; /* 60 seconds */
         rd_kafka_message_t *batch[BATCH_SIZE];
         rd_kafka_error_t *error;
         size_t rcvd;
@@ -1399,14 +1403,321 @@ static void test_close_with_broker_error_response(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Helper: assert the given rd_kafka_error_t* signals closed/closing.
+ *
+ * Expects non-NULL error with err code RD_KAFKA_RESP_ERR__STATE and a
+ * string containing \p expect_substr ("closed" or "closing").
+ * Destroys the error.
+ */
+static void assert_state_error(rd_kafka_error_t *error,
+                               const char *api_name,
+                               const char *expect_substr) {
+        TEST_ASSERT(error != NULL, "%s: expected error, got NULL", api_name);
+        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
+                    "%s: expected __STATE, got %s", api_name,
+                    rd_kafka_err2name(rd_kafka_error_code(error)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(error), expect_substr) != NULL,
+                    "%s: expected error string to contain '%s', got '%s'",
+                    api_name, expect_substr, rd_kafka_error_string(error));
+        rd_kafka_error_destroy(error);
+}
+
+/**
+ * @brief Invoke every share-consumer API and assert each returns a
+ *        closed/closing state error.
+ *
+ * @param consumer    Share consumer (already closed or closing).
+ * @param topic       Topic name (for subscribe/acknowledge_offset).
+ * @param expect_substr "closed" or "closing" (matched in error string).
+ */
+static void verify_all_apis_return_state_error(rd_kafka_share_t *consumer,
+                                               const char *topic,
+                                               const char *expect_substr) {
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t err;
+        rd_kafka_message_t *batch[4];
+        size_t rcvd = 0;
+        rd_kafka_topic_partition_list_t *subs, *sub_result = NULL;
+        rd_kafka_topic_partition_list_t *commit_results = NULL;
+        rd_kafka_queue_t *queue                         = NULL;
+
+        /* 1. consume_batch */
+        error = rd_kafka_share_consume_batch(consumer, 100, batch, &rcvd);
+        assert_state_error(error, "consume_batch", expect_substr);
+
+        /* 2. commit_async */
+        error = rd_kafka_share_commit_async(consumer);
+        assert_state_error(error, "commit_async", expect_substr);
+
+        /* 3. commit_sync */
+        error = rd_kafka_share_commit_sync(consumer, 1000, &commit_results);
+        assert_state_error(error, "commit_sync", expect_substr);
+        TEST_ASSERT(commit_results == NULL,
+                    "commit_sync: expected no partitions on error");
+
+        /* 4. acknowledge_offset */
+        err = rd_kafka_share_acknowledge_offset(
+            consumer, topic, 0, 0, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "acknowledge_offset: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+
+        /* 5. subscribe */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "subscribe: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* 6. unsubscribe */
+        err = rd_kafka_share_unsubscribe(consumer);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "unsubscribe: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+
+        /* 7. subscription */
+        err = rd_kafka_share_subscription(consumer, &sub_result);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "subscription: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+        TEST_ASSERT(sub_result == NULL, "subscription: expected NULL result");
+
+        /* 8. close */
+        error = rd_kafka_share_consumer_close(consumer);
+        assert_state_error(error, "close", expect_substr);
+
+        /* 9. async close */
+        queue = rd_kafka_queue_new(consumer->rkshare_rk);
+        error = rd_kafka_share_consumer_close_queue(consumer, queue);
+        rd_kafka_queue_destroy(queue);
+        assert_state_error(error, "close", expect_substr);
+}
+
+/**
+ * @brief Test: calling share-consumer APIs after close() completes.
+ *
+ * Verifies every guarded API returns RD_KAFKA_RESP_ERR__STATE with
+ * "closed" in the error string.
+ */
+static void test_api_calls_on_closed_consumer(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        const char *topic = "0178-api-after-close";
+        const char *group = "grp-0178-api-after-close";
+        char errstr[512];
+        rd_kafka_error_t *close_error;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "ShareGroupHeartbeat apiversion");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
+                                                 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "ShareFetch apiversion");
+        TEST_ASSERT(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
+                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+            "ShareAcknowledge apiversion");
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Create mock topic");
+
+        /* Producer */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(producer, "producer: %s", errstr);
+        TEST_ASSERT(rd_kafka_producev(producer, RD_KAFKA_V_TOPIC(topic),
+                                      RD_KAFKA_V_VALUE("msg", 3),
+                                      RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                      RD_KAFKA_V_END) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "produce");
+        rd_kafka_flush(producer, 5000);
+
+        /* Consumer */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "consumer: %s", errstr);
+
+        rd_kafka_topic_partition_list_t *subs =
+            rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs), "subscribe");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Close (blocking), then verify all APIs reject further calls. */
+        TEST_SAY("Calling close() and waiting for completion\n");
+        close_error = rd_kafka_share_consumer_close(consumer);
+        TEST_ASSERT(close_error == NULL, "initial close: %s",
+                    close_error ? rd_kafka_error_string(close_error) : "");
+        TEST_ASSERT(rd_kafka_share_consumer_closed(consumer),
+                    "consumer should report closed");
+
+        TEST_SAY("Exercising APIs on closed consumer\n");
+        verify_all_apis_return_state_error(consumer, topic, "closed");
+
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test: once close_queue() returns successfully, all subsequent API
+ *        calls must be rejected with RD_KAFKA_RESP_ERR__STATE.
+ *
+ * A 5s RTT delay is injected on ShareAcknowledge so the consumer remains
+ * in the "closing" state (close_queue returns immediately, actual close
+ * completes later), giving us a deterministic window to exercise every
+ * guarded API.
+ */
+static void test_api_calls_during_closing(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        const char *topic = "0178-api-during-closing";
+        const char *group = "grp-0178-api-during-closing";
+        char errstr[512];
+        rd_kafka_queue_t *queue;
+        rd_kafka_error_t *close_error;
+        const int rtt_delay_ms = 5000;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "ShareGroupHeartbeat apiversion");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
+                                                 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "ShareFetch apiversion");
+        TEST_ASSERT(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
+                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+            "ShareAcknowledge apiversion");
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Create mock topic");
+
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(producer, "producer: %s", errstr);
+        TEST_ASSERT(rd_kafka_producev(producer, RD_KAFKA_V_TOPIC(topic),
+                                      RD_KAFKA_V_VALUE("msg", 3),
+                                      RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                      RD_KAFKA_V_END) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "produce");
+        rd_kafka_flush(producer, 5000);
+
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "debug", "all");
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "consumer: %s", errstr);
+
+        rd_kafka_topic_partition_list_t *subs =
+            rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs), "subscribe");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consume one batch so there's state to flush on close. */
+        {
+                rd_kafka_message_t *batch[4];
+                size_t rcvd            = 0;
+                int attempts           = 0;
+                rd_kafka_error_t *cerr = NULL;
+                while (attempts++ < 20 && rcvd == 0) {
+                        cerr = rd_kafka_share_consume_batch(consumer, 500,
+                                                            batch, &rcvd);
+                        if (cerr)
+                                rd_kafka_error_destroy(cerr);
+                }
+                for (size_t i = 0; i < rcvd; i++)
+                        rd_kafka_message_destroy(batch[i]);
+        }
+
+        /* Inject 5s delay on ShareAcknowledge so close() stays in flight. */
+        TEST_SAY("Injecting %dms RTT delay on broker\n", rtt_delay_ms);
+        rd_kafka_mock_broker_set_rtt(mcluster, 1, rtt_delay_ms);
+
+        queue = rd_kafka_queue_new(consumer->rkshare_rk);
+
+        TEST_SAY("Calling close_queue() to initiate async close\n");
+        close_error = rd_kafka_share_consumer_close_queue(consumer, queue);
+        TEST_ASSERT(close_error == NULL, "close_queue: %s",
+                    close_error ? rd_kafka_error_string(close_error) : "");
+
+        /* close_queue has returned. Consumer must now be in closing state
+         * (not fully closed yet, since ShareAcknowledge response is still
+         * delayed). Every subsequent API call must be rejected. */
+        TEST_ASSERT(!rd_kafka_share_consumer_closed(consumer),
+                    "consumer should still be closing, not closed");
+
+        TEST_SAY("Exercising APIs on closing consumer\n");
+        verify_all_apis_return_state_error(consumer, topic, "closing");
+
+        /* Wait for async close to complete before destroying. */
+        TEST_SAY("Waiting for consumer to finish closing\n");
+        while (!rd_kafka_share_consumer_closed(consumer)) {
+                rd_usleep(500 * 1000, NULL); /* 500ms */
+        }
+
+        rd_kafka_queue_destroy(queue);
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
 int main_0178_share_consumer_close(int argc, char **argv) {
         /* Set overall timeout for all tests */
         test_timeout_set(600); /* 10 minutes */
+
+        /* Real broker tests */
         test_close_with_acknowledge();
         test_close_without_acknowledge();
+
+        return 0;
+}
+
+int main_0178_share_consumer_close_local(int argc, char **argv) {
+        /* Mock broker tests only (no real broker needed) */
+        TEST_SKIP_MOCK_CLUSTER(0);
+
         test_close_with_slow_broker_response();
         test_close_respects_socket_timeout();
         test_close_with_broker_error_response();
+        test_api_calls_on_closed_consumer();
+        test_api_calls_during_closing();
 
         return 0;
 }

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -595,7 +595,7 @@ static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
         assert_state_error(error, "close");
 
         /* 9. async close */
-        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
+        queue = rd_kafka_queue_new(test_share_consumer_get_rk(consumer));
         error = rd_kafka_share_consumer_close_queue(consumer, queue);
         rd_kafka_queue_destroy(queue);
         assert_state_error(error, "close_queue");
@@ -1681,7 +1681,7 @@ static void test_api_calls_during_closing(void) {
         TEST_SAY("Injecting %dms RTT delay on broker\n", rtt_delay_ms);
         rd_kafka_mock_broker_set_rtt(mcluster, 1, rtt_delay_ms);
 
-        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
+        queue = rd_kafka_queue_new(test_share_consumer_get_rk(consumer));
 
         TEST_SAY("Calling close_queue() to initiate async close\n");
         close_error = rd_kafka_share_consumer_close_queue(consumer, queue);

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -30,9 +30,10 @@
 #include "rdkafka.h"
 #include "rdkafka_protocol.h"
 
-#define MAX_TOPICS     16
-#define MAX_PARTITIONS 32
-#define BATCH_SIZE     10000
+#define MAX_TOPICS           16
+#define MAX_PARTITIONS       32
+#define BATCH_SIZE           10000
+#define MAX_CONSUME_ATTEMPTS 30
 
 /** Common producer reused across all real-broker tests. */
 static rd_kafka_t *common_producer;
@@ -163,36 +164,41 @@ static void subscribe_consumer(rd_kafka_share_t *rkshare,
 }
 
 /**
- * @brief Consume and optionally acknowledge messages (modular helper)
+ * @brief Consume messages, track them, and optionally ACCEPT-acknowledge.
+ *
+ * In ack mode (do_acknowledge=true), messages are acknowledged with ACCEPT;
+ * any remaining messages in a batch beyond target_count are RELEASE'd so they
+ * can be redelivered. In no-ack mode (do_acknowledge=false), messages are
+ * tracked and destroyed without acknowledging — close() should release them.
  *
  * @param rkshare Consumer handle
  * @param consumer_name Name for logging (e.g., "C1", "C2")
- * @param max_attempts Maximum consume attempts
- * @param ack_count Number of messages to acknowledge and track (0 = consume
- * only)
- * @param tracked_msgs If non-NULL, track acknowledged messages here
+ * @param target_count Number of messages to track (and ACCEPT in ack mode)
+ * @param do_acknowledge If true, ACCEPT each tracked message and RELEASE the
+ *                      rest of the batch; if false, track-and-destroy only.
+ * @param tracked_msgs If non-NULL, track messages here
  * @param tracked_cnt If non-NULL, store count of tracked messages here
  *
- * @returns Number of messages acknowledged
+ * @returns Number of messages tracked
  */
-static int consume_and_acknowledge(rd_kafka_share_t *rkshare,
-                                   const char *consumer_name,
-                                   int max_attempts,
-                                   int ack_count,
-                                   tracked_msg_t *tracked_msgs,
-                                   int *tracked_cnt) {
+static int consume_and_track(rd_kafka_share_t *rkshare,
+                             const char *consumer_name,
+                             int target_count,
+                             rd_bool_t do_acknowledge,
+                             tracked_msg_t *tracked_msgs,
+                             int *tracked_cnt) {
         rd_kafka_message_t *batch[BATCH_SIZE];
         int attempt;
         rd_kafka_error_t *error;
-        int acked = 0;
+        int tracked = 0;
 
-        TEST_SAY(
-            "%s: Consuming and acknowledging %d messages (max %d "
-            "attempts)...\n",
-            consumer_name, ack_count, max_attempts);
+        TEST_SAY("%s: Consuming and %s %d messages (max %d attempts)...\n",
+                 consumer_name,
+                 do_acknowledge ? "acknowledging" : "tracking (no ack)",
+                 target_count, MAX_CONSUME_ATTEMPTS);
 
-        /* Consume and acknowledge messages until we have ack_count acked */
-        for (attempt = 0; attempt < max_attempts && acked < ack_count;
+        for (attempt = 0;
+             attempt < MAX_CONSUME_ATTEMPTS && tracked < target_count;
              attempt++) {
                 size_t rcvd_msgs = 0;
                 int i;
@@ -202,7 +208,8 @@ static int consume_and_acknowledge(rd_kafka_share_t *rkshare,
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
-                                 consumer_name, attempt + 1, max_attempts,
+                                 consumer_name, attempt + 1,
+                                 MAX_CONSUME_ATTEMPTS,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         continue;
@@ -212,74 +219,65 @@ static int consume_and_acknowledge(rd_kafka_share_t *rkshare,
                         continue;
 
                 TEST_SAY("%s: Attempt %d/%d: Received %d messages\n",
-                         consumer_name, attempt + 1, max_attempts,
+                         consumer_name, attempt + 1, MAX_CONSUME_ATTEMPTS,
                          (int)rcvd_msgs);
 
-                /* Process each message in this batch */
-                for (i = 0; i < (int)rcvd_msgs && acked < ack_count; i++) {
+                for (i = 0; i < (int)rcvd_msgs && tracked < target_count; i++) {
                         rd_kafka_message_t *rkm = batch[i];
 
                         if (rkm->err) {
                                 TEST_SAY(
-                                    "%s: Skipping message %d with error:"
-                                    "%s\n",
+                                    "%s: Skipping message %d with error: %s\n",
                                     consumer_name, i,
                                     rd_kafka_message_errstr(rkm));
                                 rd_kafka_message_destroy(rkm);
                                 continue;
                         }
 
-                        /* Track this message if tracking enabled */
-                        if (tracked_msgs && acked < BATCH_SIZE) {
-                                tracked_msgs[acked].topic =
+                        if (tracked_msgs && tracked < BATCH_SIZE) {
+                                tracked_msgs[tracked].topic =
                                     rd_strdup(rd_kafka_topic_name(rkm->rkt));
-                                tracked_msgs[acked].partition = rkm->partition;
-                                tracked_msgs[acked].offset    = rkm->offset;
+                                tracked_msgs[tracked].partition =
+                                    rkm->partition;
+                                tracked_msgs[tracked].offset = rkm->offset;
                         }
 
-                        TEST_SAY(
-                            "%s: Acking message %d: %s [%d] @ offset "
-                            "%" PRId64 "\n",
-                            consumer_name, acked, rd_kafka_topic_name(rkm->rkt),
-                            rkm->partition, rkm->offset);
+                        TEST_SAY("%s: %s message %d: %s [%d] @ offset %" PRId64
+                                 "\n",
+                                 consumer_name,
+                                 do_acknowledge ? "Acking" : "Tracking",
+                                 tracked, rd_kafka_topic_name(rkm->rkt),
+                                 rkm->partition, rkm->offset);
 
-                        rd_kafka_share_acknowledge(rkshare, rkm);
+                        if (do_acknowledge)
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         rd_kafka_message_destroy(rkm);
-                        acked++;
+                        tracked++;
                 }
 
-                /* Release any remaining messages from this batch that we
-                 * didn't process - they will be redelivered to other consumers
-                 */
                 for (; i < (int)rcvd_msgs; i++) {
-                        rd_kafka_share_acknowledge_type(
-                            rkshare, batch[i],
-                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                         rd_kafka_message_destroy(batch[i]);
                 }
 
-                /* Exit early if we've acknowledged enough */
-                if (acked >= ack_count) {
-                        TEST_SAY(
-                            "%s: Reached target of %d acknowledged "
-                            "messages\n",
-                            consumer_name, ack_count);
+                if (tracked >= target_count) {
+                        TEST_SAY("%s: Reached target of %d tracked messages\n",
+                                 consumer_name, target_count);
                         break;
                 }
         }
 
-        TEST_SAY("%s: Finished - acknowledged %d messages\n", consumer_name,
-                 acked);
+        TEST_SAY("%s: Finished - tracked %d messages\n", consumer_name,
+                 tracked);
 
-        if (acked < ack_count) {
-                TEST_FAIL("%s: Expected to acknowledge %d messages, got %d",
-                          consumer_name, ack_count, acked);
+        if (tracked < target_count) {
+                TEST_FAIL("%s: Expected to track %d messages, got %d",
+                          consumer_name, target_count, tracked);
         }
 
         if (tracked_cnt)
-                *tracked_cnt = acked;
+                *tracked_cnt = tracked;
 
-        return acked;
+        return tracked;
 }
 
 /**
@@ -335,112 +333,173 @@ static void perform_commit(rd_kafka_share_t *rkshare,
 }
 
 /**
- * @brief Verify no redelivery of tracked messages (modular helper)
+ * @brief Verify whether tracked messages are (or are not) redelivered.
+ *
+ * Consumes up to @p max_total_msgs messages and compares each against the
+ * @p tracked_msgs list. Behavior depends on @p expect_redelivery:
+ *  - false: fails if any tracked message is received (post-ack scenario);
+ *           also asserts the total received count equals @p max_total_msgs.
+ *  - true:  fails unless every tracked message is received (post-release
+ *           scenario); stops early once all tracked messages have been
+ *           matched.
  *
  * @param rkshare Consumer handle to check
  * @param consumer_name Name for logging
- * @param max_attempts Maximum consume attempts
- * @param expected_msgs Expected number of messages to receive (total -
- tracked)
+ * @param max_total_msgs Number of messages to consume (also the exact-count
+ *                      assertion in the not-redelivered case)
  * @param tracked_msgs Array of tracked messages to check against
  * @param tracked_cnt Number of tracked messages
- * @param commit_mode Commit mode used (for error messages)
+ * @param expect_redelivery true = expect all tracked redelivered; false =
+ *                          expect none redelivered
+ * @param context_label Free-form label included in failure messages
+ *                     (e.g., commit mode name)
  */
-static void verify_no_redelivery(rd_kafka_share_t *rkshare,
-                                 const char *consumer_name,
-                                 int max_attempts,
-                                 int expected_msgs,
-                                 const tracked_msg_t *tracked_msgs,
-                                 int tracked_cnt,
-                                 commit_mode_t commit_mode) {
+static void verify_tracked_messages(rd_kafka_share_t *rkshare,
+                                    const char *consumer_name,
+                                    int max_total_msgs,
+                                    const tracked_msg_t *tracked_msgs,
+                                    int tracked_cnt,
+                                    rd_bool_t expect_redelivery,
+                                    const char *context_label) {
         rd_kafka_message_t *batch[BATCH_SIZE];
         size_t total_rcvd = 0;
         int attempt;
         rd_kafka_error_t *error;
-        int redelivered_count = 0;
+        int matched_count = 0;
+        rd_bool_t *tracked_seen =
+            tracked_cnt > 0 ? rd_calloc(tracked_cnt, sizeof(*tracked_seen))
+                            : NULL;
 
         TEST_SAY(
-            "%s: Consuming messages for verification (expecting %d "
-            "messages, max %d attempts)...\n",
-            consumer_name, expected_msgs, max_attempts);
+            "%s: Consuming for verification (up to %d messages, max %d "
+            "attempts, expect_redelivery=%s)...\n",
+            consumer_name, max_total_msgs, MAX_CONSUME_ATTEMPTS,
+            expect_redelivery ? "true" : "false");
 
-        /* Consume messages until we get expected count or max attempts */
-        for (attempt = 0;
-             attempt < max_attempts && (int)total_rcvd < expected_msgs;
+        for (attempt = 0; attempt < MAX_CONSUME_ATTEMPTS &&
+                          (int)total_rcvd < max_total_msgs &&
+                          (!expect_redelivery || matched_count < tracked_cnt);
              attempt++) {
                 size_t rcvd_msgs = 0;
+                size_t i;
 
                 error = rd_kafka_share_consume_batch(
                     rkshare, 3000, batch + total_rcvd, &rcvd_msgs);
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
-                                 consumer_name, attempt + 1, max_attempts,
+                                 consumer_name, attempt + 1,
+                                 MAX_CONSUME_ATTEMPTS,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
-                if (rcvd_msgs > 0) {
-                        TEST_SAY(
-                            "%s: Attempt %d/%d: Received %d messages "
-                            "(total: %d)\n",
-                            consumer_name, attempt + 1, max_attempts,
-                            (int)rcvd_msgs, (int)(total_rcvd + rcvd_msgs));
-                        total_rcvd += rcvd_msgs;
-                }
-        }
-
-        TEST_SAY("%s: Received %d messages\n", consumer_name, (int)total_rcvd);
-
-        /* Verify we received the expected number of messages */
-        if ((int)total_rcvd != expected_msgs) {
-                TEST_FAIL("%s: Expected to receive %d messages, got %d",
-                          consumer_name, expected_msgs, (int)total_rcvd);
-        }
-
-        /* Check if any received message was in tracked list */
-        for (size_t i = 0; i < total_rcvd; i++) {
-                rd_kafka_message_t *rkm = batch[i];
-
-                if (rkm->err) {
-                        rd_kafka_message_destroy(rkm);
+                if (rcvd_msgs == 0)
                         continue;
-                }
 
-                const char *topic = rd_kafka_topic_name(rkm->rkt);
-                int partition     = rkm->partition;
-                int64_t offset    = rkm->offset;
+                TEST_SAY(
+                    "%s: Attempt %d/%d: Received %d messages (total: %d)\n",
+                    consumer_name, attempt + 1, MAX_CONSUME_ATTEMPTS,
+                    (int)rcvd_msgs, (int)(total_rcvd + rcvd_msgs));
 
-                /* Check if this message was in tracked list */
-                for (int j = 0; j < tracked_cnt; j++) {
-                        if (strcmp(topic, tracked_msgs[j].topic) == 0 &&
-                            partition == tracked_msgs[j].partition &&
-                            offset == tracked_msgs[j].offset) {
-                                TEST_WARN(
-                                    "%s: Received previously acknowledged "
-                                    "message: %s [%d] @ offset %ld\n",
-                                    consumer_name, topic, partition, offset);
-                                redelivered_count++;
-                                break;
+                /* Match each new message against the tracked list */
+                for (i = total_rcvd; i < total_rcvd + rcvd_msgs; i++) {
+                        rd_kafka_message_t *rkm = batch[i];
+                        const char *topic;
+                        int32_t partition;
+                        int64_t offset;
+                        int j;
+
+                        if (rkm->err)
+                                continue;
+
+                        topic     = rd_kafka_topic_name(rkm->rkt);
+                        partition = rkm->partition;
+                        offset    = rkm->offset;
+
+                        for (j = 0; j < tracked_cnt; j++) {
+                                if (tracked_seen && tracked_seen[j])
+                                        continue;
+                                if (strcmp(topic, tracked_msgs[j].topic) == 0 &&
+                                    partition == tracked_msgs[j].partition &&
+                                    offset == tracked_msgs[j].offset) {
+                                        if (tracked_seen)
+                                                tracked_seen[j] = rd_true;
+                                        matched_count++;
+                                        if (expect_redelivery) {
+                                                TEST_SAY(
+                                                    "%s: Matched tracked "
+                                                    "message %d/%d: %s [%d] "
+                                                    "@ offset %" PRId64 "\n",
+                                                    consumer_name,
+                                                    matched_count, tracked_cnt,
+                                                    topic, partition, offset);
+                                        } else {
+                                                TEST_WARN(
+                                                    "%s: Received previously "
+                                                    "acknowledged message: "
+                                                    "%s [%d] @ offset %" PRId64
+                                                    "\n",
+                                                    consumer_name, topic,
+                                                    partition, offset);
+                                        }
+                                        break;
+                                }
                         }
                 }
 
-                rd_kafka_message_destroy(rkm);
+                total_rcvd += rcvd_msgs;
         }
 
-        if (redelivered_count > 0) {
-                TEST_FAIL(
-                    "%s received %d messages that were acknowledged "
-                    "(commit mode: %s)",
-                    consumer_name, redelivered_count,
-                    commit_mode_str(commit_mode));
+        TEST_SAY("%s: Received %d messages, matched %d/%d tracked\n",
+                 consumer_name, (int)total_rcvd, matched_count, tracked_cnt);
+
+        if (expect_redelivery) {
+                int j;
+                if (matched_count != tracked_cnt) {
+                        for (j = 0; j < tracked_cnt; j++) {
+                                if (!tracked_seen[j]) {
+                                        TEST_FAIL(
+                                            "%s: Did not receive tracked "
+                                            "message: %s [%d] @ offset "
+                                            "%" PRId64 " (context: %s)",
+                                            consumer_name,
+                                            tracked_msgs[j].topic,
+                                            tracked_msgs[j].partition,
+                                            tracked_msgs[j].offset,
+                                            context_label);
+                                }
+                        }
+                }
+                TEST_SAY(
+                    "%s: Verification passed - all %d tracked messages "
+                    "redelivered\n",
+                    consumer_name, matched_count);
+        } else {
+                if ((int)total_rcvd != max_total_msgs) {
+                        TEST_FAIL("%s: Expected to receive %d messages, got %d",
+                                  consumer_name, max_total_msgs,
+                                  (int)total_rcvd);
+                }
+                if (matched_count > 0) {
+                        TEST_FAIL(
+                            "%s received %d messages that were acknowledged "
+                            "(context: %s)",
+                            consumer_name, matched_count, context_label);
+                }
+                TEST_SAY(
+                    "%s: Verification passed - no acknowledged messages "
+                    "were redelivered\n",
+                    consumer_name);
         }
 
-        TEST_SAY(
-            "%s: Verification passed - no acknowledged messages were "
-            "redelivered\n",
-            consumer_name);
+        /* Destroy all consumed messages */
+        for (size_t i = 0; i < total_rcvd; i++)
+                rd_kafka_message_destroy(batch[i]);
+
+        if (tracked_seen)
+                rd_free(tracked_seen);
 }
 
 /**
@@ -539,8 +598,139 @@ static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
         queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
         error = rd_kafka_share_consumer_close_queue(consumer, queue);
         rd_kafka_queue_destroy(queue);
-        assert_state_error(error, "close");
+        assert_state_error(error, "close_queue");
 }
+
+/**
+ * @brief Enable the three Share APIs (Heartbeat, Fetch, Acknowledge) on the
+ *        given mock cluster. Every share-consumer mock test in this file
+ *        needs all three.
+ */
+static void enable_share_apis(rd_kafka_mock_cluster_t *mcluster) {
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareGroupHeartbeat");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
+                                                 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareFetch");
+        TEST_ASSERT(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
+                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Failed to enable ShareAck");
+}
+
+/**
+ * @brief Common setup for 3-broker mock close-tests.
+ *
+ * Creates a 3-broker mock cluster, a topic with one partition per broker,
+ * produces 10 messages to each partition, then creates a share consumer
+ * (with optional socket.timeout.ms), subscribes, and consumes all
+ * @p partition_cnt * @p msgs_per_partition messages so the share session
+ * is established with every partition leader.
+ *
+ * @param test_name Used to derive unique topic and group names.
+ * @param socket_timeout_ms Pass 0 to leave socket.timeout.ms at default,
+ *                          or a positive value to override it.
+ * @param out_mcluster Output: created cluster (caller destroys).
+ * @param out_consumer Output: subscribed share consumer (caller destroys).
+ */
+static void setup_3broker_share_consumer(const char *test_name,
+                                         int socket_timeout_ms,
+                                         rd_kafka_mock_cluster_t **out_mcluster,
+                                         rd_kafka_share_t **out_consumer) {
+        const int partition_cnt      = 3;
+        const int msgs_per_partition = 10;
+        const int total_msgs         = partition_cnt * msgs_per_partition;
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *error;
+        char topic[64], group[64], errstr[512];
+        int p, consumed = 0, attempts = 0;
+        size_t i, rcvd;
+
+        rd_snprintf(topic, sizeof(topic), "mock-%s", test_name);
+        rd_snprintf(group, sizeof(group), "sg-%s", test_name);
+
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        enable_share_apis(mcluster);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, partition_cnt,
+                                               1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        /* Produce msgs_per_partition msgs to each partition via test helper. */
+        for (p = 0; p < partition_cnt; p++) {
+                test_produce_msgs_easy_v(topic, 0, p, 0, msgs_per_partition, 16,
+                                         "bootstrap.servers", bootstraps, NULL);
+        }
+
+        /* Consumer */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+        if (socket_timeout_ms > 0) {
+                rd_snprintf(errstr, sizeof(errstr), "%d", socket_timeout_ms);
+                test_conf_set(conf, "socket.timeout.ms", errstr);
+        }
+
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
+                    "Subscribe failed");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consume all messages so share session is established with every
+         * partition leader (i.e. all 3 brokers). */
+        TEST_SAY("Consuming %d messages across %d partitions...\n", total_msgs,
+                 partition_cnt);
+        while (consumed < total_msgs && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (i = 0; i < rcvd; i++) {
+                        if (!batch[i]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        TEST_ASSERT(consumed == total_msgs, "Expected %d messages, got %d",
+                    total_msgs, consumed);
+        TEST_SAY("Consumed all %d messages\n", consumed);
+
+        *out_mcluster = mcluster;
+        *out_consumer = consumer;
+}
+
+/** is_fatal_cb hook scoped to test_close_with_broker_down: ignores
+ *  the transport error and cascading ALL_BROKERS_DOWN that result from
+ *  taking the mock broker down mid-close. */
+// static int test_close_with_broker_down_is_fatal_cb(rd_kafka_t *rk,
+//                                                    rd_kafka_resp_err_t err,
+//                                                    const char *reason) {
+//         if (err == RD_KAFKA_RESP_ERR__TRANSPORT ||
+//             err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN) {
+//                 TEST_SAY("Ignoring expected error: %s: %s\n",
+//                          rd_kafka_err2name(err), reason);
+//                 return 0;
+//             }
+//         return 1;
+// }
+
+/*#################################################################################*/
 
 /**
  * @brief Close with acknowledge test scenarios
@@ -626,17 +816,20 @@ static void test_close_with_acknowledge(void) {
                 subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
 
                 /* C1: Consume and acknowledge */
-                consume_and_acknowledge(c1, "C1", 30, config->ack_count,
-                                        tracked_msgs, &tracked_cnt);
+                consume_and_track(c1, "C1", config->ack_count, rd_true,
+                                  tracked_msgs, &tracked_cnt);
 
                 /* Execute commit */
                 perform_commit(c1, "C1", config->commit_mode);
 
                 /* Close C1 */
                 TEST_SAY("C1: Closing consumer\n");
-                rd_kafka_share_consumer_close(c1);
+                rd_kafka_error_t *c1_close_err =
+                    rd_kafka_share_consumer_close(c1);
+                TEST_ASSERT(c1_close_err == NULL,
+                            "C1: close returned error: %s",
+                            rd_kafka_error_string(c1_close_err));
                 TEST_SAY("C1: Closed successfully\n");
-                rd_kafka_share_destroy(c1);
 
                 /* Create C2 with implicit ack mode after C1 is fully destroyed
                  */
@@ -645,9 +838,10 @@ static void test_close_with_acknowledge(void) {
                 subscribe_consumer(c2, ctx.topic_names, ctx.topic_cnt);
 
                 /* C2: Consume and verify no redelivery */
-                verify_no_redelivery(
-                    c2, "C2", 30, ctx.total_msgs_produced - tracked_cnt,
-                    tracked_msgs, tracked_cnt, config->commit_mode);
+                verify_tracked_messages(c2, "C2",
+                                        ctx.total_msgs_produced - tracked_cnt,
+                                        tracked_msgs, tracked_cnt, rd_false,
+                                        commit_mode_str(config->commit_mode));
 
                 /* Close C2 */
                 TEST_SAY("C2: Closing consumer\n");
@@ -665,6 +859,7 @@ static void test_close_with_acknowledge(void) {
 
                 TEST_SAY("Test %s completed successfully\n\n",
                          config->test_name);
+                rd_kafka_share_destroy(c1);
         }
 }
 
@@ -682,7 +877,7 @@ static void test_close_with_acknowledge(void) {
  *
  * Tests multiple topologies: 1t1p, 1t3p, 3t1p, 2t2p
  */
-static void test_close_without_acknowledge(void) {
+static void test_close_without_acknowledge() {
         /**
          * @brief Test configuration for close without acknowledge scenarios
          */
@@ -691,36 +886,33 @@ static void test_close_without_acknowledge(void) {
                 int topic_cnt;
                 int partitions[MAX_TOPICS];
                 int msgs_per_partition;
+                int track_count;
         } close_no_ack_test_config_t;
 
         /* Test matrix: various topologies */
         close_no_ack_test_config_t tests[] = {
             /* 1 topic, 1 partition */
-            {"close-no-ack-1t1p", 1, {1}, 20},
+            {"close-no-ack-1t1p", 1, {1}, 20, 5},
 
             /* 1 topic, multiple partitions */
-            {"close-no-ack-1t3p", 1, {3}, 10},
+            {"close-no-ack-1t3p", 1, {3}, 10, 5},
 
             /* Multiple topics, 1 partition each */
-            {"close-no-ack-3t1p", 3, {1, 1, 1}, 10},
+            {"close-no-ack-3t1p", 3, {1, 1, 1}, 10, 5},
 
             /* Multiple topics, multiple partitions */
-            {"close-no-ack-2t2p", 2, {2, 2}, 10},
+            {"close-no-ack-2t2p", 2, {2, 2}, 10, 5},
         };
 
         for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
                 close_no_ack_test_config_t *config = &tests[i];
                 test_context_t ctx                 = {0};
                 rd_kafka_share_t *c1, *c2;
-                rd_kafka_message_t *batch[BATCH_SIZE];
-                rd_kafka_error_t *error;
-                size_t c1_rcvd_msgs = 0;
-                int attempt;
-                tracked_msg_t c1_tracked_msgs[BATCH_SIZE];
-                int c1_tracked_cnt = 0;
+                tracked_msg_t tracked_msgs[BATCH_SIZE];
+                int tracked_cnt = 0;
+                char group_id[64];
 
                 TEST_SAY("\n========================================\n");
-                TEST_SAY("Test: %s\n", config->test_name);
                 TEST_SAY("Topology: %d topic(s), partitions: [",
                          config->topic_cnt);
                 for (int j = 0; j < config->topic_cnt; j++) {
@@ -730,257 +922,54 @@ static void test_close_without_acknowledge(void) {
                 TEST_SAY("]\n");
                 TEST_SAY("========================================\n\n");
 
-                ctx.group_id = "0178-group-no-ack";
+                rd_snprintf(group_id, sizeof(group_id),
+                            "0178-group-no-ack-%" PRIu64, test_id_generate());
+                ctx.group_id = group_id;
                 setup_topics_and_produce(&ctx, config->topic_cnt,
                                          config->partitions,
                                          config->msgs_per_partition);
 
-                /* Set group offset to earliest */
                 test_share_set_auto_offset_reset(ctx.group_id, "earliest");
 
-                /* Create C1 with implicit ack mode */
-                TEST_SAY("C1: Creating consumer\n");
                 c1 = test_create_share_consumer(ctx.group_id, "implicit");
-
-                /* Subscribe C1 */
                 subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
 
-                /* C1: Consume messages WITHOUT acknowledging */
-                TEST_SAY("C1: Consuming messages WITHOUT acknowledging...\n");
+                /* C1: Consume and track without acknowledging. */
+                consume_and_track(c1, "C1", config->track_count, rd_false,
+                                  tracked_msgs, &tracked_cnt);
 
-                for (attempt = 0; attempt < 30 && c1_rcvd_msgs == 0;
-                     attempt++) {
-                        error = rd_kafka_share_consume_batch(c1, 3000, batch,
-                                                             &c1_rcvd_msgs);
+                /* Close C1 - unacked records must be released back to the
+                 * share group. */
+                TEST_SAY("C1: Closing without acknowledging\n");
+                rd_kafka_error_t *c1_close_err =
+                    rd_kafka_share_consumer_close(c1);
+                TEST_ASSERT(c1_close_err == NULL,
+                            "C1: close returned error: %s",
+                            rd_kafka_error_string(c1_close_err));
 
-                        if (error) {
-                                TEST_SAY("C1: Attempt %d: error: %s\n",
-                                         attempt + 1,
-                                         rd_kafka_error_string(error));
-                                rd_kafka_error_destroy(error);
-                                continue;
-                        }
-
-                        if (c1_rcvd_msgs > 0) {
-                                TEST_SAY(
-                                    "C1: Received %d messages (NOT "
-                                    "acknowledging)\n",
-                                    (int)c1_rcvd_msgs);
-
-                                /* Track and destroy messages without
-                                 * acknowledging them */
-                                for (size_t i = 0; i < c1_rcvd_msgs; i++) {
-                                        if (!batch[i]->err) {
-                                                /* Track this message */
-                                                c1_tracked_msgs[c1_tracked_cnt]
-                                                    .topic = rd_strdup(
-                                                    rd_kafka_topic_name(
-                                                        batch[i]->rkt));
-                                                c1_tracked_msgs[c1_tracked_cnt]
-                                                    .partition =
-                                                    batch[i]->partition;
-                                                c1_tracked_msgs[c1_tracked_cnt]
-                                                    .offset = batch[i]->offset;
-                                                c1_tracked_cnt++;
-
-                                                TEST_SAY(
-                                                    "C1: Consumed (no ack): %s "
-                                                    "[%d] @ "
-                                                    "offset %" PRId64 "\n",
-                                                    rd_kafka_topic_name(
-                                                        batch[i]->rkt),
-                                                    batch[i]->partition,
-                                                    batch[i]->offset);
-                                        }
-                                        rd_kafka_message_destroy(batch[i]);
-                                }
-                                break;
-                        }
-                }
-
-                TEST_ASSERT(
-                    c1_rcvd_msgs > 0,
-                    "C1: Expected to receive at least 1 message, got %d",
-                    (int)c1_rcvd_msgs);
-
-                TEST_ASSERT(c1_tracked_cnt == (int)c1_rcvd_msgs,
-                            "C1: Tracked %d messages but received %d",
-                            c1_tracked_cnt, (int)c1_rcvd_msgs);
-
-                TEST_SAY(
-                    "C1: Consumed and tracked %d messages that will be "
-                    "released "
-                    "on close\n",
-                    c1_tracked_cnt);
-
-                /* Close C1 without acknowledging - records should be released
-                 */
-                TEST_SAY(
-                    "C1: Closing consumer WITHOUT acknowledging consumed "
-                    "records\n");
-                rd_kafka_share_consumer_close(c1);
-                TEST_SAY("C1: Closed successfully\n");
-                rd_kafka_share_destroy(c1);
-
-                /* Create C2 after C1 is destroyed */
-                TEST_SAY("C2: Creating consumer after C1 close\n");
                 c2 = test_create_share_consumer(ctx.group_id, "implicit");
                 subscribe_consumer(c2, ctx.topic_names, ctx.topic_cnt);
 
-                /* C2: Should be able to consume all records that C1 released
-                 * (C2 may receive additional messages beyond C1's released set)
-                 */
-                TEST_SAY(
-                    "C2: Attempting to consume records released by C1 "
-                    "(expecting at least %d messages)...\n",
-                    c1_tracked_cnt);
+                /* C2: Verify every tracked message is redelivered. Cap the
+                 * scan at total produced so we don't loop forever if redelivery
+                 * is broken. */
+                verify_tracked_messages(c2, "C2", ctx.total_msgs_produced,
+                                        tracked_msgs, tracked_cnt, rd_true,
+                                        "no-ack-close");
 
-                int c2_matched_cnt = 0;
-                int c2_total_msgs  = 0;
-                rd_bool_t *c1_msg_matched =
-                    rd_calloc(c1_tracked_cnt, sizeof(*c1_msg_matched));
-
-                for (attempt = 0;
-                     attempt < 30 && c2_matched_cnt < c1_tracked_cnt;
-                     attempt++) {
-                        size_t batch_rcvd = 0;
-                        size_t i;
-
-                        error = rd_kafka_share_consume_batch(c2, 3000, batch,
-                                                             &batch_rcvd);
-
-                        if (error) {
-                                TEST_SAY("C2: Attempt %d: error: %s\n",
-                                         attempt + 1,
-                                         rd_kafka_error_string(error));
-                                rd_kafka_error_destroy(error);
-                                continue;
-                        }
-
-                        if (batch_rcvd == 0)
-                                continue;
-
-                        TEST_SAY("C2: Attempt %d: Received %d messages\n",
-                                 attempt + 1, (int)batch_rcvd);
-
-                        /* Check each received message against C1's tracked
-                         * messages */
-                        for (i = 0; i < batch_rcvd; i++) {
-                                rd_kafka_message_t *rkm = batch[i];
-                                int j;
-                                rd_bool_t found = rd_false;
-
-                                if (rkm->err) {
-                                        rd_kafka_message_destroy(rkm);
-                                        continue;
-                                }
-
-                                c2_total_msgs++;
-
-                                const char *topic =
-                                    rd_kafka_topic_name(rkm->rkt);
-                                int32_t partition = rkm->partition;
-                                int64_t offset    = rkm->offset;
-
-                                /* Check if this message matches any from C1's
-                                 * tracked list */
-                                for (j = 0; j < c1_tracked_cnt; j++) {
-                                        if (!c1_msg_matched[j] &&
-                                            strcmp(topic,
-                                                   c1_tracked_msgs[j].topic) ==
-                                                0 &&
-                                            partition ==
-                                                c1_tracked_msgs[j].partition &&
-                                            offset ==
-                                                c1_tracked_msgs[j].offset) {
-                                                found             = rd_true;
-                                                c1_msg_matched[j] = rd_true;
-                                                c2_matched_cnt++;
-
-                                                TEST_SAY(
-                                                    "C2: Matched C1 message "
-                                                    "%d/%d: "
-                                                    "%s [%d] @ offset %" PRId64
-                                                    "\n",
-                                                    c2_matched_cnt,
-                                                    c1_tracked_cnt, topic,
-                                                    partition, offset);
-                                                break;
-                                        }
-                                }
-
-                                if (!found) {
-                                        /* C2 received a message not in C1's
-                                         * list - this is OK, just log it */
-                                        TEST_SAY(
-                                            "C2: Received additional message "
-                                            "(not from C1): %s [%d] @ offset "
-                                            "%" PRId64 "\n",
-                                            topic, partition, offset);
-                                }
-
-                                rd_kafka_message_destroy(rkm);
-                        }
-
-                        /* Break early if we've matched all C1 messages */
-                        if (c2_matched_cnt >= c1_tracked_cnt) {
-                                TEST_SAY(
-                                    "C2: All %d messages from C1 have been "
-                                    "matched, "
-                                    "breaking early (total received: %d)\n",
-                                    c1_tracked_cnt, c2_total_msgs);
-                                break;
-                        }
-                }
-
-                TEST_SAY(
-                    "C2: Total received %d messages, matched %d/%d from "
-                    "C1\n",
-                    c2_total_msgs, c2_matched_cnt, c1_tracked_cnt);
-
-                /* Verify C2 received all the messages C1 released */
-                TEST_ASSERT(
-                    c2_matched_cnt == c1_tracked_cnt,
-                    "C2: Expected to receive all %d messages released by C1, "
-                    "matched only %d",
-                    c1_tracked_cnt, c2_matched_cnt);
-
-                /* Check if any C1 messages were not matched */
-                for (int j = 0; j < c1_tracked_cnt; j++) {
-                        if (!c1_msg_matched[j]) {
-                                TEST_FAIL(
-                                    "C2: Did not receive C1 message: "
-                                    "%s [%d] @ offset %" PRId64,
-                                    c1_tracked_msgs[j].topic,
-                                    c1_tracked_msgs[j].partition,
-                                    c1_tracked_msgs[j].offset);
-                        }
-                }
-
-                TEST_SAY(
-                    "C2: Successfully received all %d messages released "
-                    "by C1 "
-                    "(total messages received: %d)\n",
-                    c2_matched_cnt, c2_total_msgs);
-
-                rd_free(c1_msg_matched);
-
-                /* Close C2 */
                 TEST_SAY("C2: Closing consumer\n");
                 rd_kafka_share_consumer_close(c2);
-                TEST_SAY("C2: Closed successfully\n");
                 rd_kafka_share_destroy(c2);
 
-                /* Cleanup tracked messages */
-                free_tracked_messages(c1_tracked_msgs, c1_tracked_cnt);
+                free_tracked_messages(tracked_msgs, tracked_cnt);
 
-                /* Cleanup */
                 for (int t = 0; t < ctx.topic_cnt; t++) {
                         rd_free(ctx.topic_names[t]);
                 }
 
                 TEST_SAY("Test %s completed successfully\n\n",
                          config->test_name);
+                rd_kafka_share_destroy(c1);
         }
 }
 
@@ -1016,25 +1005,10 @@ static void test_close_with_slow_broker_response(void) {
              test_idx++) {
                 delay_test_config_t *config = &tests[test_idx];
                 rd_kafka_mock_cluster_t *mcluster;
-                const char *bootstraps;
-                rd_kafka_t *producer;
                 rd_kafka_share_t *consumer;
-                rd_kafka_conf_t *conf;
-                const char *topic = "mock-close-delay";
-                char group[64];
-                const int msgcnt       = 10;
                 const int rtt_delay_ms = 10000; /* 10 seconds */
-                rd_kafka_message_t *batch[BATCH_SIZE];
-                rd_kafka_error_t *error;
-                size_t rcvd;
-                int consumed = 0;
-                int attempts = 0;
-                size_t i;
                 rd_ts_t t_start, t_elapsed_ms;
-                char errstr[512];
-
-                rd_snprintf(group, sizeof(group), "sg-close-delay-%s",
-                            config->test_name);
+                int i;
 
                 TEST_SAY("\n========================================\n");
                 TEST_SAY("Test: %s\n", config->test_name);
@@ -1043,101 +1017,18 @@ static void test_close_with_slow_broker_response(void) {
 
                 SUB_TEST("%s", config->test_name);
 
-                /* Create mock cluster with 3 brokers */
-                mcluster = test_mock_cluster_new(3, &bootstraps);
+                setup_3broker_share_consumer(config->test_name, 0, &mcluster,
+                                             &consumer);
 
-                TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                                mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1,
-                                1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Failed to enable ShareGroupHeartbeat");
-                TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                                mcluster, RD_KAFKAP_ShareFetch, 1, 1) ==
-                                RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Failed to enable ShareFetch");
-                TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                                mcluster, RD_KAFKAP_ShareAcknowledge, 1, 1) ==
-                                RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Failed to enable ShareAck");
-
-                /* Create topic */
-                TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
-                                RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Failed to create mock topic");
-
-                /* Create producer and produce messages */
-                test_conf_init(&conf, NULL, 0);
-                test_conf_set(conf, "bootstrap.servers", bootstraps);
-                producer = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr,
-                                        sizeof(errstr));
-                TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
-
-                for (i = 0; i < (size_t)msgcnt; i++) {
-                        char payload[64];
-                        rd_snprintf(payload, sizeof(payload), "%s-%d", topic,
-                                    (int)i);
-                        TEST_ASSERT(
-                            rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-                }
-                rd_kafka_flush(producer, 5000);
-
-                /* Create consumer */
-                test_conf_init(&conf, NULL, 0);
-                test_conf_set(conf, "bootstrap.servers", bootstraps);
-                test_conf_set(conf, "group.id", group);
-
-                consumer =
-                    rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-                TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
-
-                /* Subscribe */
-                rd_kafka_topic_partition_list_t *subs;
-                subs = rd_kafka_topic_partition_list_new(1);
-                rd_kafka_topic_partition_list_add(subs, topic,
-                                                  RD_KAFKA_PARTITION_UA);
-                TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
-                            "Subscribe failed");
-                rd_kafka_topic_partition_list_destroy(subs);
-
-                /* Consume some messages */
-                TEST_SAY("Consuming messages...\n");
-                while (consumed < msgcnt && attempts++ < 30) {
-                        rcvd  = 0;
-                        error = rd_kafka_share_consume_batch(consumer, 3000,
-                                                             batch, &rcvd);
-                        if (error) {
-                                rd_kafka_error_destroy(error);
-                                continue;
-                        }
-
-                        for (i = 0; i < rcvd; i++) {
-                                if (!batch[i]->err)
-                                        consumed++;
-                                rd_kafka_message_destroy(batch[i]);
-                        }
-                }
-
-                TEST_SAY("Consumed %d messages\n", consumed);
-                TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d",
-                            msgcnt, consumed);
-
-                /* Inject RTT delay on specified brokers
-                 * This will delay responses from partition leaders including
-                 * the session close request sent during close() */
-                for (i = 0; i < (size_t)config->delayed_broker_cnt; i++) {
+                /* Inject RTT delay on the specified brokers; this delays
+                 * responses (including the session-close request). */
+                for (i = 0; i < config->delayed_broker_cnt; i++) {
                         TEST_SAY("Injecting %dms RTT delay on broker %d\n",
                                  rtt_delay_ms, config->delayed_brokers[i]);
                         rd_kafka_mock_broker_set_rtt(
                             mcluster, config->delayed_brokers[i], rtt_delay_ms);
                 }
 
-                /* Call close and measure time
-                 * close() should send session close request to partition
-                 * leader and wait for the response */
                 TEST_SAY(
                     "Calling close() with delayed broker response(s)...\n");
                 t_start = test_clock();
@@ -1147,10 +1038,8 @@ static void test_close_with_slow_broker_response(void) {
                 TEST_SAY("Close completed after %" PRId64 " ms\n",
                          t_elapsed_ms);
 
-                /* Verify close waited for the delayed response
-                 * Should take approximately rtt_delay_ms
-                 * Allow range: (rtt_delay_ms - 1000ms) to (rtt_delay_ms +
-                 * 2000ms) */
+                /* close() should wait ~rtt_delay_ms for the slowest delayed
+                 * broker. Allow (rtt - 1s) to (rtt + 2s). */
                 int64_t min_expected_ms = rtt_delay_ms - 1000;
                 int64_t max_expected_ms = rtt_delay_ms + 2000;
 
@@ -1168,7 +1057,6 @@ static void test_close_with_slow_broker_response(void) {
                     rtt_delay_ms);
 
                 rd_kafka_share_destroy(consumer);
-                rd_kafka_destroy(producer);
                 test_mock_cluster_destroy(mcluster);
 
                 SUB_TEST_PASS();
@@ -1176,313 +1064,496 @@ static void test_close_with_slow_broker_response(void) {
 }
 
 /**
- * @brief Test close respects socket timeout with very slow broker
+ * @brief Test close respects socket timeout with very slow broker(s).
  *
- * Verifies that when broker takes longer than socket.timeout.ms (60s)
- * to respond to the session close request, close() should timeout and
- * not wait indefinitely.
+ * Verifies that when broker(s) take longer than socket.timeout.ms to
+ * respond to the session close request, close() times out at
+ * socket.timeout.ms and does not wait for the full broker delay.
  *
- * Setup:
- * - Single broker with 80s RTT delay (exceeds 60s socket timeout)
- * - close() should timeout around 60s, not wait for full 80s
+ * Tests 3 scenarios with a 3-broker setup:
+ * 1. Only broker 1 has delayed response (40s, exceeds 20s socket timeout)
+ * 2. Brokers 1 and 2 have delayed responses
+ * 3. All 3 brokers have delayed responses
  */
 static void test_close_respects_socket_timeout(void) {
+        typedef struct {
+                const char *test_name;
+                int delayed_broker_cnt;
+                int32_t delayed_brokers[3];
+        } delay_test_config_t;
+
+        delay_test_config_t tests[] = {
+            {"close-timeout-1-broker", 1, {1, 0, 0}},
+            {"close-timeout-2-brokers", 2, {1, 2, 0}},
+            {"close-timeout-3-brokers", 3, {1, 2, 3}},
+        };
+
+        const int rtt_delay_ms = 40000; /* 40s — exceeds socket.timeout */
+        const int socket_timeout_ms = 20000; /* 20s */
+
+        for (size_t test_idx = 0; test_idx < sizeof(tests) / sizeof(tests[0]);
+             test_idx++) {
+                delay_test_config_t *config = &tests[test_idx];
+                rd_kafka_mock_cluster_t *mcluster;
+                rd_kafka_share_t *consumer;
+                rd_ts_t t_start, t_elapsed_ms;
+                int i;
+
+                TEST_SAY("\n========================================\n");
+                TEST_SAY("Test: %s\n", config->test_name);
+                TEST_SAY(
+                    "Delayed brokers: %d, RTT: %dms, Socket timeout: %dms\n",
+                    config->delayed_broker_cnt, rtt_delay_ms,
+                    socket_timeout_ms);
+                TEST_SAY("========================================\n\n");
+
+                SUB_TEST("%s", config->test_name);
+
+                setup_3broker_share_consumer(
+                    config->test_name, socket_timeout_ms, &mcluster, &consumer);
+
+                for (i = 0; i < config->delayed_broker_cnt; i++) {
+                        TEST_SAY(
+                            "Injecting %dms RTT delay on broker %d "
+                            "(exceeds socket timeout %dms)\n",
+                            rtt_delay_ms, config->delayed_brokers[i],
+                            socket_timeout_ms);
+                        rd_kafka_mock_broker_set_rtt(
+                            mcluster, config->delayed_brokers[i], rtt_delay_ms);
+                }
+
+                TEST_SAY("Calling close() - should timeout around %dms...\n",
+                         socket_timeout_ms);
+                t_start = test_clock();
+                rd_kafka_share_consumer_close(consumer);
+                t_elapsed_ms = (test_clock() - t_start) / 1000;
+
+                TEST_SAY("Close completed after %" PRId64 " ms\n",
+                         t_elapsed_ms);
+
+                /* close() should timeout around socket.timeout.ms.
+                 * Allow ±5s margin. */
+                int64_t min_expected_ms = socket_timeout_ms - 5000;
+                int64_t max_expected_ms = socket_timeout_ms + 5000;
+
+                TEST_ASSERT(t_elapsed_ms >= min_expected_ms &&
+                                t_elapsed_ms <= max_expected_ms,
+                            "Close took %" PRId64
+                            " ms, expected ~%dms (between %" PRId64
+                            " and %" PRId64
+                            " ms). Should NOT wait for full broker delay "
+                            "of %dms",
+                            t_elapsed_ms, socket_timeout_ms, min_expected_ms,
+                            max_expected_ms, rtt_delay_ms);
+
+                /* Defensively verify it did not wait the full broker delay. */
+                TEST_ASSERT(t_elapsed_ms < (rtt_delay_ms - 10000),
+                            "Close took %" PRId64
+                            " ms — too close to broker delay %dms. "
+                            "Should have timed out at socket.timeout.ms=%dms",
+                            t_elapsed_ms, rtt_delay_ms, socket_timeout_ms);
+
+                TEST_SAY(
+                    "SUCCESS: Close respected socket timeout (%dms) with "
+                    "%d delayed broker(s)\n",
+                    socket_timeout_ms, config->delayed_broker_cnt);
+
+                rd_kafka_share_destroy(consumer);
+                test_mock_cluster_destroy(mcluster);
+
+                SUB_TEST_PASS();
+        }
+}
+
+/**
+ * @brief Test close with broker error response.
+ *
+ * Verifies that close() handles error responses from the broker
+ * gracefully. When the broker(s) respond with an error to the
+ * ShareAcknowledge request (session close request), close() should
+ * complete without retrying.
+ *
+ * Tests 3 scenarios with a 3-broker setup:
+ * 1. Only broker 1 returns LEADER_NOT_AVAILABLE
+ * 2. Brokers 1 and 2 return the error
+ * 3. All 3 brokers return the error
+ */
+static void test_close_with_broker_error_response(void) {
+        typedef struct {
+                const char *test_name;
+                int erroring_broker_cnt;
+                int32_t erroring_brokers[3];
+        } error_test_config_t;
+
+        error_test_config_t tests[] = {
+            {"close-error-1-broker", 1, {1, 0, 0}},
+            {"close-error-2-brokers", 2, {1, 2, 0}},
+            {"close-error-3-brokers", 3, {1, 2, 3}},
+        };
+
+        const rd_kafka_resp_err_t error_code =
+            RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE;
+
+        for (size_t test_idx = 0; test_idx < sizeof(tests) / sizeof(tests[0]);
+             test_idx++) {
+                error_test_config_t *config = &tests[test_idx];
+                rd_kafka_mock_cluster_t *mcluster;
+                rd_kafka_share_t *consumer;
+                int i;
+
+                TEST_SAY("\n========================================\n");
+                TEST_SAY("Test: %s\n", config->test_name);
+                TEST_SAY("Erroring brokers: %d, error code: %s\n",
+                         config->erroring_broker_cnt,
+                         rd_kafka_err2str(error_code));
+                TEST_SAY("========================================\n\n");
+
+                SUB_TEST("%s", config->test_name);
+
+                setup_3broker_share_consumer(config->test_name, 0, &mcluster,
+                                             &consumer);
+
+                /* Push the error onto the specified brokers' next
+                 * ShareAcknowledge request. */
+                for (i = 0; i < config->erroring_broker_cnt; i++) {
+                        TEST_SAY("Injecting %s error on broker %d\n",
+                                 rd_kafka_err2str(error_code),
+                                 config->erroring_brokers[i]);
+                        rd_kafka_mock_broker_push_request_error_rtts(
+                            mcluster, config->erroring_brokers[i],
+                            RD_KAFKAP_ShareAcknowledge, 1, error_code, 0);
+                }
+
+                TEST_SAY(
+                    "Calling close() - should complete despite error(s)...\n");
+                rd_kafka_share_consumer_close(consumer);
+                TEST_SAY("Close completed\n");
+
+                TEST_SAY(
+                    "SUCCESS: Close handled error %s gracefully on %d "
+                    "broker(s) (no retry)\n",
+                    rd_kafka_err2str(error_code), config->erroring_broker_cnt);
+
+                rd_kafka_share_destroy(consumer);
+                test_mock_cluster_destroy(mcluster);
+
+                SUB_TEST_PASS();
+        }
+}
+
+
+/**
+ * @brief Test close() when brokers have pending acks queued.
+ *
+ * Setup:
+ *  - 3-broker mock cluster, topic with 3 partitions (one leader per broker).
+ *  - Inject 5s RTT delay on ShareAcknowledge for all brokers — this makes
+ *    every ack the consumer sends take 5s broker-side.
+ *  - Produce 30 msgs (10/partition), consume them all with an implicit-ack
+ *    consumer. Implicit-ack piggybacks acks on the next ShareFetch, so by
+ *    the end of the first round there are still acks in flight or queued.
+ *  - Repeat: produce another 30, consume them all (same consumer).
+ *  - Call close(). close() should drain the in-flight ShareAcknowledges
+ *    and send the session-leave; with the 5s delay this should take
+ *    roughly 5s (remaining ack RTT) + 5s (leave RTT) = ~10s.
+ *  - Remove the RTT delay, start a second consumer (also implicit ack)
+ *    and verify it receives 0 messages over up to 5 fetch attempts. If
+ *    any message is delivered, close() failed to send the acks.
+ */
+static void test_close_with_broker_busy(void) {
+        const char *test_name        = "close-broker-busy";
+        const int partition_cnt      = 3;
+        const int msgs_per_partition = 10;
+        const int total_msgs         = partition_cnt * msgs_per_partition;
+        const int rtt_delay_ms       = 5000;
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
-        rd_kafka_t *producer;
-        rd_kafka_share_t *consumer;
+        rd_kafka_share_t *consumer, *c2;
         rd_kafka_conf_t *conf;
-        const char *topic = "mock-close-timeout";
-        const char *group = "sg-close-timeout";
-        const int msgcnt  = 10;
-        const int rtt_delay_ms =
-            40000; /* 40 seconds - exceeds socket timeout */
-        const int socket_timeout_ms = 20000; /* 60 seconds */
+        rd_kafka_topic_partition_list_t *subs;
         rd_kafka_message_t *batch[BATCH_SIZE];
-        rd_kafka_error_t *error;
+        rd_kafka_error_t *error, *close_err;
+        char topic[64], group[64], errstr[512];
+        int iter, p, i;
         size_t rcvd;
-        int consumed = 0;
-        int attempts = 0;
-        size_t i;
         rd_ts_t t_start, t_elapsed_ms;
-        char errstr[512];
 
-        SUB_TEST("close-respects-socket-timeout");
+        SUB_TEST("%s", test_name);
+
+        rd_snprintf(topic, sizeof(topic), "mock-%s", test_name);
+        rd_snprintf(group, sizeof(group), "sg-%s", test_name);
 
         TEST_SAY("\n========================================\n");
-        TEST_SAY("Test: close respects socket timeout\n");
-        TEST_SAY("Broker delay: %dms, Socket timeout: %dms\n", rtt_delay_ms,
-                 socket_timeout_ms);
+        TEST_SAY("Test: %s\n", test_name);
+        TEST_SAY("ShareAck RTT: %dms on all brokers\n", rtt_delay_ms);
         TEST_SAY("========================================\n\n");
 
-        /* Create mock cluster with single broker */
-        mcluster = test_mock_cluster_new(1, &bootstraps);
+        /* Cluster + APIs + topic */
+        mcluster = test_mock_cluster_new(3, &bootstraps);
+        enable_share_apis(mcluster);
 
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to enable ShareGroupHeartbeat");
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
-                                                 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to enable ShareFetch");
-        TEST_ASSERT(
-            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
-                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-            "Failed to enable ShareAck");
-
-        /* Create topic */
-        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, partition_cnt,
+                                               1) == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
 
-        /* Create producer and produce messages */
-        test_conf_init(&conf, NULL, 0);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        producer =
-            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-        TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
-
-        for (i = 0; i < (size_t)msgcnt; i++) {
-                char payload[64];
-                rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
-
-        /* Create consumer with explicit socket timeout */
+        /* Producer */
+        /* Implicit-ack consumer */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", bootstraps);
         test_conf_set(conf, "group.id", group);
-        /* Set socket.timeout.ms to 60 seconds */
-        rd_snprintf(errstr, sizeof(errstr), "%d", socket_timeout_ms);
-        test_conf_set(conf, "socket.timeout.ms", errstr);
-
+        test_conf_set(conf, "share.acknowledgement.mode", "implicit");
         consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
 
-        /* Subscribe */
-        rd_kafka_topic_partition_list_t *subs;
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
                     "Subscribe failed");
         rd_kafka_topic_partition_list_destroy(subs);
 
-        /* Consume some messages */
-        TEST_SAY("Consuming messages...\n");
-        while (consumed < msgcnt && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
-                if (error) {
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-
-                for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
-                                consumed++;
-                        rd_kafka_message_destroy(batch[i]);
+        /* Inject 5s RTT delay on the next 20 ShareAcknowledge responses on
+         * each broker (no error, just delay) */
+        TEST_SAY(
+            "Injecting %dms RTT delay on ShareAcknowledge "
+            "(20 entries/broker)\n",
+            rtt_delay_ms);
+        for (i = 1; i <= 3; i++) {
+                int j;
+                for (j = 0; j < 20; j++) {
+                        TEST_ASSERT(
+                            rd_kafka_mock_broker_push_request_error_rtts(
+                                mcluster, i, RD_KAFKAP_ShareAcknowledge, 1,
+                                (rd_kafka_resp_err_t)0,
+                                rtt_delay_ms) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Failed to push RTT delay on broker %d", i);
                 }
         }
 
-        TEST_SAY("Consumed %d messages\n", consumed);
-        TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d", msgcnt,
-                    consumed);
+        /* Two rounds of produce+consume so that by the end there are acks
+         * queued/in-flight on every broker. */
+        for (iter = 1; iter <= 2; iter++) {
+                int consumed = 0, attempts = 0;
+                TEST_SAY(
+                    "Iteration %d: producing %d msgs across %d "
+                    "partitions\n",
+                    iter, total_msgs, partition_cnt);
+                for (p = 0; p < partition_cnt; p++) {
+                        test_produce_msgs_easy_v(
+                            topic, 0, p, iter * msgs_per_partition,
+                            msgs_per_partition, 16, "bootstrap.servers",
+                            bootstraps, NULL);
+                }
 
-        /* Inject 80s RTT delay on broker (exceeds 60s socket timeout)
-         * This will cause the session close request to timeout */
-        TEST_SAY(
-            "Injecting %dms RTT delay on broker 1 (exceeds socket "
-            "timeout)\n",
-            rtt_delay_ms);
-        rd_kafka_mock_broker_set_rtt(mcluster, 1, rtt_delay_ms);
+                TEST_SAY("Iteration %d: consuming %d msgs\n", iter, total_msgs);
+                while (consumed < total_msgs && attempts++ < 30) {
+                        rcvd  = 0;
+                        error = rd_kafka_share_consume_batch(consumer, 3000,
+                                                             batch, &rcvd);
+                        if (error) {
+                                rd_kafka_error_destroy(error);
+                                continue;
+                        }
+                        for (i = 0; i < (int)rcvd; i++) {
+                                if (!batch[i]->err)
+                                        consumed++;
+                                rd_kafka_message_destroy(batch[i]);
+                        }
+                        TEST_ASSERT(rd_kafka_share_commit_async(consumer) ==
+                                        NULL,
+                                    "fail to call commit async");
+                }
+                TEST_ASSERT(consumed == total_msgs,
+                            "Iteration %d: expected %d msgs, got %d", iter,
+                            total_msgs, consumed);
+                TEST_SAY("Iteration %d: consumed all %d msgs\n", iter,
+                         consumed);
+        }
 
-        /* Call close and measure time
-         * close() should timeout around socket.timeout.ms (60s)
-         * and NOT wait for the full 80s broker delay */
-        TEST_SAY("Calling close() - should timeout around %dms...\n",
-                 socket_timeout_ms);
-        t_start = test_clock();
-        rd_kafka_share_consumer_close(consumer);
+        /* Call close. Expect ~10s: ~5s for in-flight ack to drain, then
+         * ~5s for the session-leave ShareAcknowledge to come back. */
+        TEST_SAY("Calling close() - expecting ~10s\n");
+        t_start      = test_clock();
+        close_err    = rd_kafka_share_consumer_close(consumer);
         t_elapsed_ms = (test_clock() - t_start) / 1000;
 
         TEST_SAY("Close completed after %" PRId64 " ms\n", t_elapsed_ms);
-
-        /* Verify close did NOT wait for full 80s delay
-         * Should timeout around socket.timeout.ms (60s)
-         * Allow range: 55s to 65s (socket timeout ± 5s margin) */
-        int64_t min_expected_ms = socket_timeout_ms - 5000;
-        int64_t max_expected_ms = socket_timeout_ms + 5000;
-
-        TEST_ASSERT(t_elapsed_ms >= min_expected_ms &&
-                        t_elapsed_ms <= max_expected_ms,
-                    "Close took %" PRId64
-                    " ms, expected timeout around %dms "
-                    "(between %" PRId64 " and %" PRId64
-                    " ms). "
-                    "Should NOT wait for full broker delay of %dms",
-                    t_elapsed_ms, socket_timeout_ms, min_expected_ms,
-                    max_expected_ms, rtt_delay_ms);
-
-        /* Also verify it definitely did NOT wait for the full 80s */
-        TEST_ASSERT(t_elapsed_ms < 70000,
-                    "Close took %" PRId64
-                    " ms, which is too close to broker delay "
-                    "of %dms. Should have timed out at socket.timeout.ms=%dms",
-                    t_elapsed_ms, rtt_delay_ms, socket_timeout_ms);
-
-        TEST_SAY(
-            "SUCCESS: Close respected socket timeout (%dms) and did not "
-            "wait for full broker delay (%dms)\n",
-            socket_timeout_ms, rtt_delay_ms);
+        TEST_ASSERT(close_err == NULL, "Close returned error: %s",
+                    rd_kafka_error_string(close_err));
+        TEST_ASSERT(t_elapsed_ms >= 8000 && t_elapsed_ms <= 12000,
+                    "Close took %" PRId64 " ms, expected 8000-12000 ms",
+                    t_elapsed_ms);
 
         rd_kafka_share_destroy(consumer);
-        rd_kafka_destroy(producer);
+
+        /* Verify nothing was redelivered: c2 should consume 0 messages
+         * because c1's close() flushed all acks. */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "implicit");
+        c2 = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(c2, "Failed to create c2: %s", errstr);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(c2, subs), "c2 subscribe failed");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        TEST_SAY("c2: verifying no msgs redelivered (5 fetch attempts)\n");
+        for (i = 0; i < 5; i++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(c2, 2000, batch, &rcvd);
+                if (error) {
+                        TEST_SAY("c2 attempt %d: error: %s\n", i + 1,
+                                 rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                TEST_ASSERT(
+                    rcvd == 0,
+                    "c2 attempt %d: received %d msgs (expected 0 — close "
+                    "did not flush acks)",
+                    i + 1, (int)rcvd);
+        }
+
+        TEST_SAY("SUCCESS: close() flushed acks; c2 received no msgs\n");
+
+        rd_kafka_share_destroy(c2);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
 }
 
 /**
- * @brief Test close with broker error response
+ * @brief Test close() when the broker is down.
  *
- * Verifies that close() handles error responses from the broker gracefully.
- * When the broker responds with an error to the ShareAcknowledge request
- * (session close request), close() should handle it.
+ * Verifies that close() returns immediately without an error
+ * when the broker is down
  *
- * This test injects a COORDINATOR_NOT_AVAILABLE error response and verifies
- * that close() completes (errors during close are not retriable).
+ * Setup:
+ * - Consumer subscribes, consumes at least one batch, then we set the
+ *   broker down and call close().
+ * - close() should return immediately and return NULL (no error).
  */
-static void test_close_with_broker_error_response(void) {
-        rd_kafka_mock_cluster_t *mcluster;
-        const char *bootstraps;
-        rd_kafka_t *producer;
-        rd_kafka_share_t *consumer;
-        rd_kafka_conf_t *conf;
-        const char *topic              = "mock-close-error";
-        const char *group              = "sg-close-error";
-        const int msgcnt               = 10;
-        rd_kafka_resp_err_t error_code = RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        rd_kafka_error_t *error;
-        size_t rcvd;
-        int consumed = 0;
-        int attempts = 0;
-        size_t i;
-        char errstr[512];
-
-        SUB_TEST("close-with-broker-error");
-
-        TEST_SAY("\n========================================\n");
-        TEST_SAY("Test: Close with broker error response\n");
-        TEST_SAY("Error code: %s\n", rd_kafka_err2str(error_code));
-        TEST_SAY("========================================\n\n");
-
-        /* Create mock cluster with single broker */
-        mcluster = test_mock_cluster_new(1, &bootstraps);
-
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to enable ShareGroupHeartbeat");
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
-                                                 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to enable ShareFetch");
-        TEST_ASSERT(
-            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
-                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-            "Failed to enable ShareAck");
-
-        /* Create topic */
-        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to create mock topic");
-
-        /* Create producer and produce messages */
-        test_conf_init(&conf, NULL, 0);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        producer =
-            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-        TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
-
-        for (i = 0; i < (size_t)msgcnt; i++) {
-                char payload[64];
-                rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
-
-        /* Create consumer */
-        test_conf_init(&conf, NULL, 0);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        test_conf_set(conf, "group.id", group);
-
-        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-        TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
-
-        /* Subscribe */
-        rd_kafka_topic_partition_list_t *subs;
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
-                    "Subscribe failed");
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Consume some messages */
-        TEST_SAY("Consuming messages...\n");
-        while (consumed < msgcnt && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
-                if (error) {
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-
-                for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
-                                consumed++;
-                        rd_kafka_message_destroy(batch[i]);
-                }
-        }
-
-        TEST_SAY("Consumed %d messages\n", consumed);
-        TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d", msgcnt,
-                    consumed);
-
-        /* Inject error response for ShareAcknowledge (session close request).
-         */
-        TEST_SAY("Injecting %s error for ShareAcknowledge\n",
-                 rd_kafka_err2str(error_code));
-        rd_kafka_mock_broker_push_request_error_rtts(
-            mcluster, 1, RD_KAFKAP_ShareAcknowledge, 1, error_code, 0);
-
-        TEST_SAY("Calling close() - should complete despite error...\n");
-        rd_kafka_share_consumer_close(consumer);
-        TEST_SAY("Close completed\n");
-
-        TEST_SAY("SUCCESS: Close handled error %s gracefully (no retry)\n",
-                 rd_kafka_err2str(error_code));
-
-        rd_kafka_share_destroy(consumer);
-        rd_kafka_destroy(producer);
-        test_mock_cluster_destroy(mcluster);
-
-        SUB_TEST_PASS();
-}
+// static void test_close_with_broker_down(void) {
+//         rd_kafka_mock_cluster_t *mcluster;
+//         const char *bootstraps;
+//         rd_kafka_share_t *consumer;
+//         rd_kafka_conf_t *conf;
+//         const char *topic           = "mock-close-broker-down";
+//         const char *group           = "sg-close-broker-down";
+//         const int msgcnt            = 10;
+//         const int socket_timeout_ms = 20000;
+//         rd_kafka_message_t *batch[BATCH_SIZE];
+//         rd_kafka_error_t *error;
+//         rd_kafka_error_t *close_err;
+//         size_t rcvd;
+//         int attempts       = 0;
+//         rd_bool_t got_msgs = rd_false;
+//         size_t i;
+//         rd_ts_t t_start, t_elapsed_ms;
+//         char errstr[512];
+//
+//         SUB_TEST("close-with-broker-down");
+//
+//         /* Suppress the transport-error / all-brokers-down events that the
+//          * test framework's default error_cb would otherwise fail on once we
+//          * set the broker down. Scoped to this test only. */
+//         test_curr->is_fatal_cb = test_close_with_broker_down_is_fatal_cb;
+//
+//         TEST_SAY("\n========================================\n");
+//         TEST_SAY("Test: close with broker down\n");
+//         TEST_SAY("Socket timeout: %dms\n", socket_timeout_ms);
+//         TEST_SAY("========================================\n\n");
+//
+//         mcluster = test_mock_cluster_new(1, &bootstraps);
+//         enable_share_apis(mcluster);
+//
+//         TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+//                         RD_KAFKA_RESP_ERR_NO_ERROR,
+//                     "Failed to create mock topic");
+//
+//         /* Produce msgcnt messages via test helper. */
+//         test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 16,
+//                                  "bootstrap.servers", bootstraps, NULL);
+//
+//         /* Consumer with implicit ack mode and explicit socket timeout. */
+//         test_conf_init(&conf, NULL, 0);
+//         test_conf_set(conf, "bootstrap.servers", bootstraps);
+//         test_conf_set(conf, "group.id", group);
+//         test_conf_set(conf, "share.acknowledgement.mode", "implicit");
+//
+//         consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+//         TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
+//
+//         rd_kafka_topic_partition_list_t *subs =
+//             rd_kafka_topic_partition_list_new(1);
+//         rd_kafka_topic_partition_list_add(subs, topic,
+//         RD_KAFKA_PARTITION_UA);
+//         TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
+//                     "Subscribe failed");
+//         rd_kafka_topic_partition_list_destroy(subs);
+//
+//         /* Consume until we get at least one batch of messages, then break.
+//         */ TEST_SAY("Consuming until first non-empty batch...\n"); while
+//         (!got_msgs && attempts++ < 30) {
+//                 rcvd = 0;
+//                 error =
+//                     rd_kafka_share_consume_batch(consumer, 3000, batch,
+//                     &rcvd);
+//                 if (error) {
+//                         rd_kafka_error_destroy(error);
+//                         continue;
+//                 }
+//
+//                 if (rcvd > 0) {
+//                         TEST_SAY("Received %d messages\n", (int)rcvd);
+//                         for (i = 0; i < rcvd; i++)
+//                                 rd_kafka_message_destroy(batch[i]);
+//                         got_msgs = rd_true;
+//                         break;
+//                 }
+//         }
+//
+//         TEST_ASSERT(got_msgs, "Expected to receive at least one message");
+//
+//         /* Bring the broker down before calling close(). */
+//         TEST_SAY("Setting broker 1 down\n");
+//         TEST_ASSERT(rd_kafka_mock_broker_set_down(mcluster, 1) ==
+//                         RD_KAFKA_RESP_ERR_NO_ERROR,
+//                     "Failed to set broker down");
+//
+//         /* close() should fail fast (broker connection was closed) */
+//         TEST_SAY("Calling close() with broker down\n");
+//         t_start      = test_clock();
+//         close_err    = rd_kafka_share_consumer_close(consumer);
+//         t_elapsed_ms = (test_clock() - t_start) / 1000;
+//
+//         TEST_SAY("Close completed after %" PRId64 " ms (err=%s)\n",
+//                  t_elapsed_ms,
+//                  close_err ? rd_kafka_error_string(close_err) : "NULL");
+//
+//         if (close_err)
+//                 rd_kafka_error_destroy(close_err);
+//
+//         TEST_SAY("SUCCESS: close() returned in %" PRId64
+//                  "ms after broker down\n",
+//                  t_elapsed_ms);
+//
+//         /* Bring the broker back up so the consumer's network threads can
+//          * finish their shutdown handshake cleanly during destroy. */
+//         TEST_ASSERT(rd_kafka_mock_broker_set_up(mcluster, 1) ==
+//                         RD_KAFKA_RESP_ERR_NO_ERROR,
+//                     "Failed to set broker up");
+//
+//         rd_kafka_share_destroy(consumer);
+//         test_mock_cluster_destroy(mcluster);
+//
+//         /* Restore default error-fatal behavior for subsequent tests. */
+//         test_curr->is_fatal_cb = NULL;
+//
+//         SUB_TEST_PASS();
+// }
 
 /**
  * @brief Test: calling share-consumer APIs after close() completes.
@@ -1494,7 +1565,6 @@ static void test_api_calls_on_closed_consumer(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_conf_t *conf;
-        rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         const char *topic = "0178-api-after-close";
         const char *group = "grp-0178-api-after-close";
@@ -1504,37 +1574,16 @@ static void test_api_calls_on_closed_consumer(void) {
         SUB_TEST_QUICK();
 
         mcluster = test_mock_cluster_new(1, &bootstraps);
-
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "ShareGroupHeartbeat apiversion");
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
-                                                 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "ShareFetch apiversion");
-        TEST_ASSERT(
-            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
-                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-            "ShareAcknowledge apiversion");
+        enable_share_apis(mcluster);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Create mock topic");
 
-        /* Producer */
-        test_conf_init(&conf, NULL, 0);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        producer =
-            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-        TEST_ASSERT(producer, "producer: %s", errstr);
-        TEST_ASSERT(rd_kafka_producev(producer, RD_KAFKA_V_TOPIC(topic),
-                                      RD_KAFKA_V_VALUE("msg", 3),
-                                      RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                      RD_KAFKA_V_END) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "produce");
-        rd_kafka_flush(producer, 5000);
+        /* Produce a single message via test helper (creates an internal
+         * producer for the duration of the call). */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, 1, 3, "bootstrap.servers",
+                                 bootstraps, NULL);
 
         /* Consumer */
         test_conf_init(&conf, NULL, 0);
@@ -1561,7 +1610,6 @@ static void test_api_calls_on_closed_consumer(void) {
         verify_all_apis_return_error(consumer, topic);
 
         rd_kafka_share_destroy(consumer);
-        rd_kafka_destroy(producer);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -1580,7 +1628,6 @@ static void test_api_calls_during_closing(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_conf_t *conf;
-        rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
         const char *topic = "0178-api-during-closing";
         const char *group = "grp-0178-api-during-closing";
@@ -1592,41 +1639,19 @@ static void test_api_calls_during_closing(void) {
         SUB_TEST_QUICK();
 
         mcluster = test_mock_cluster_new(1, &bootstraps);
-
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(
-                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "ShareGroupHeartbeat apiversion");
-        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
-                                                 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "ShareFetch apiversion");
-        TEST_ASSERT(
-            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
-                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-            "ShareAcknowledge apiversion");
+        enable_share_apis(mcluster);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Create mock topic");
 
-        test_conf_init(&conf, NULL, 0);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        producer =
-            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
-        TEST_ASSERT(producer, "producer: %s", errstr);
-        TEST_ASSERT(rd_kafka_producev(producer, RD_KAFKA_V_TOPIC(topic),
-                                      RD_KAFKA_V_VALUE("msg", 3),
-                                      RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                      RD_KAFKA_V_END) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "produce");
-        rd_kafka_flush(producer, 5000);
+        /* Produce one message via test helper. */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, 1, 3, "bootstrap.servers",
+                                 bootstraps, NULL);
 
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", bootstraps);
         test_conf_set(conf, "group.id", group);
-        test_conf_set(conf, "debug", "all");
         consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(consumer, "consumer: %s", errstr);
 
@@ -1680,7 +1705,6 @@ static void test_api_calls_during_closing(void) {
 
         rd_kafka_queue_destroy(queue);
         rd_kafka_share_destroy(consumer);
-        rd_kafka_destroy(producer);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -1688,7 +1712,7 @@ static void test_api_calls_during_closing(void) {
 
 int main_0178_share_consumer_close(int argc, char **argv) {
         /* Set overall timeout for all tests */
-        test_timeout_set(600); /* 10 minutes */
+        test_timeout_set(600);
 
         /* Create common handles reused across all real-broker tests */
         common_producer = test_create_producer();
@@ -1708,12 +1732,17 @@ int main_0178_share_consumer_close(int argc, char **argv) {
 int main_0178_share_consumer_close_local(int argc, char **argv) {
         /* Mock broker tests only (no real broker needed) */
         TEST_SKIP_MOCK_CLUSTER(0);
+        test_timeout_set(300);
 
         test_close_with_slow_broker_response();
         test_close_respects_socket_timeout();
         test_close_with_broker_error_response();
+        test_close_with_broker_busy();
         test_api_calls_on_closed_consumer();
         test_api_calls_during_closing();
 
+        /* TODO KIP-932: This test case hangs on destroy.
+         * Include it once destroy is fixed */
+        // test_close_with_broker_down();
         return 0;
 }

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -1406,35 +1406,27 @@ static void test_close_with_broker_error_response(void) {
 
 /**
  * @brief Helper: assert the given rd_kafka_error_t* signals closed/closing.
- *
- * Expects non-NULL error with err code RD_KAFKA_RESP_ERR__STATE and a
- * string containing \p expect_substr ("closed" or "closing").
- * Destroys the error.
  */
-static void assert_state_error(rd_kafka_error_t *error,
-                               const char *api_name,
-                               const char *expect_substr) {
+static void assert_state_error(rd_kafka_error_t *error, const char *api_name) {
         TEST_ASSERT(error != NULL, "%s: expected error, got NULL", api_name);
         TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
                     "%s: expected __STATE, got %s", api_name,
                     rd_kafka_err2name(rd_kafka_error_code(error)));
-        TEST_ASSERT(strstr(rd_kafka_error_string(error), expect_substr) != NULL,
-                    "%s: expected error string to contain '%s', got '%s'",
-                    api_name, expect_substr, rd_kafka_error_string(error));
+        TEST_ASSERT(strstr(rd_kafka_error_string(error), "closed") != NULL,
+                    "%s: expected error string to contain 'closed', got '%s'",
+                    api_name, rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 }
 
 /**
  * @brief Invoke every share-consumer API and assert each returns a
- *        closed/closing state error.
+ *        closed state error.
  *
  * @param consumer    Share consumer (already closed or closing).
  * @param topic       Topic name (for subscribe/acknowledge_offset).
- * @param expect_substr "closed" or "closing" (matched in error string).
  */
-static void verify_all_apis_return_state_error(rd_kafka_share_t *consumer,
-                                               const char *topic,
-                                               const char *expect_substr) {
+static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
+                                         const char *topic) {
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
         rd_kafka_message_t *batch[4];
@@ -1445,15 +1437,15 @@ static void verify_all_apis_return_state_error(rd_kafka_share_t *consumer,
 
         /* 1. consume_batch */
         error = rd_kafka_share_consume_batch(consumer, 100, batch, &rcvd);
-        assert_state_error(error, "consume_batch", expect_substr);
+        assert_state_error(error, "consume_batch");
 
         /* 2. commit_async */
         error = rd_kafka_share_commit_async(consumer);
-        assert_state_error(error, "commit_async", expect_substr);
+        assert_state_error(error, "commit_async");
 
         /* 3. commit_sync */
         error = rd_kafka_share_commit_sync(consumer, 1000, &commit_results);
-        assert_state_error(error, "commit_sync", expect_substr);
+        assert_state_error(error, "commit_sync");
         TEST_ASSERT(commit_results == NULL,
                     "commit_sync: expected no partitions on error");
 
@@ -1488,13 +1480,13 @@ static void verify_all_apis_return_state_error(rd_kafka_share_t *consumer,
 
         /* 8. close */
         error = rd_kafka_share_consumer_close(consumer);
-        assert_state_error(error, "close", expect_substr);
+        assert_state_error(error, "close");
 
         /* 9. async close */
         queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
         error = rd_kafka_share_consumer_close_queue(consumer, queue);
         rd_kafka_queue_destroy(queue);
-        assert_state_error(error, "close", expect_substr);
+        assert_state_error(error, "close");
 }
 
 /**
@@ -1571,7 +1563,7 @@ static void test_api_calls_on_closed_consumer(void) {
                     "consumer should report closed");
 
         TEST_SAY("Exercising APIs on closed consumer\n");
-        verify_all_apis_return_state_error(consumer, topic, "closed");
+        verify_all_apis_return_error(consumer, topic);
 
         rd_kafka_share_destroy(consumer);
         rd_kafka_destroy(producer);
@@ -1683,7 +1675,7 @@ static void test_api_calls_during_closing(void) {
                     "consumer should still be closing, not closed");
 
         TEST_SAY("Exercising APIs on closing consumer\n");
-        verify_all_apis_return_state_error(consumer, topic, "closing");
+        verify_all_apis_return_error(consumer, topic);
 
         /* Wait for async close to complete before destroying. */
         TEST_SAY("Waiting for consumer to finish closing\n");

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -26,9 +26,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "rdkafka_int.h"
-#include "rdkafka_protocol.h"
 #include "test.h"
+#include "rdkafka.h"
+#include "rdkafka_protocol.h"
 
 #define MAX_TOPICS     16
 #define MAX_PARTITIONS 32
@@ -86,7 +86,8 @@ static void set_group_offset_earliest(rd_kafka_share_t *rkshare,
         const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
 
         test_IncrementalAlterConfigs_simple(
-            rkshare->rkshare_rk, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
+            rd_kafka_share_consumer_get_rk(rkshare), RD_KAFKA_RESOURCE_GROUP,
+            group_name, cfg, 1);
 }
 
 /**
@@ -990,7 +991,7 @@ static void test_close_with_slow_broker_response(void) {
                                         sizeof(errstr));
                 TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
 
-                for (i = 0; i < msgcnt; i++) {
+                for (i = 0; i < (size_t)msgcnt; i++) {
                         char payload[64];
                         rd_snprintf(payload, sizeof(payload), "%s-%d", topic,
                                     (int)i);
@@ -1162,7 +1163,7 @@ static void test_close_respects_socket_timeout(void) {
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
         TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
 
-        for (i = 0; i < msgcnt; i++) {
+        for (i = 0; i < (size_t)msgcnt; i++) {
                 char payload[64];
                 rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
                 TEST_ASSERT(rd_kafka_producev(
@@ -1332,7 +1333,7 @@ static void test_close_with_broker_error_response(void) {
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
         TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
 
-        for (i = 0; i < msgcnt; i++) {
+        for (i = 0; i < (size_t)msgcnt; i++) {
                 char payload[64];
                 rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
                 TEST_ASSERT(rd_kafka_producev(
@@ -1490,7 +1491,7 @@ static void verify_all_apis_return_state_error(rd_kafka_share_t *consumer,
         assert_state_error(error, "close", expect_substr);
 
         /* 9. async close */
-        queue = rd_kafka_queue_new(consumer->rkshare_rk);
+        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
         error = rd_kafka_share_consumer_close_queue(consumer, queue);
         rd_kafka_queue_destroy(queue);
         assert_state_error(error, "close", expect_substr);
@@ -1668,7 +1669,7 @@ static void test_api_calls_during_closing(void) {
         TEST_SAY("Injecting %dms RTT delay on broker\n", rtt_delay_ms);
         rd_kafka_mock_broker_set_rtt(mcluster, 1, rtt_delay_ms);
 
-        queue = rd_kafka_queue_new(consumer->rkshare_rk);
+        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
 
         TEST_SAY("Calling close_queue() to initiate async close\n");
         close_error = rd_kafka_share_consumer_close_queue(consumer, queue);

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -1,0 +1,1412 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rdkafka_int.h"
+#include "rdkafka_protocol.h"
+#include "test.h"
+
+#define MAX_TOPICS     16
+#define MAX_PARTITIONS 32
+#define BATCH_SIZE     10000
+
+/**
+ * @brief Commit mode for test scenarios
+ */
+typedef enum {
+        COMMIT_MODE_NONE,  /**< No commit before close */
+        COMMIT_MODE_ASYNC, /**< Call commitAsync before close */
+        COMMIT_MODE_SYNC   /**< Call commitSync before close */
+} commit_mode_t;
+
+/**
+ * @brief Generic test context for topic and message tracking
+ */
+typedef struct {
+        char *topic_names[MAX_TOPICS];
+        int topic_cnt;
+        char *group_id;
+        int total_msgs_produced;
+} test_context_t;
+
+/**
+ * @brief Tracked message info for verification
+ */
+typedef struct {
+        char *topic;
+        int32_t partition;
+        int64_t offset;
+} tracked_msg_t;
+
+/**
+ * @brief Get string representation of commit mode
+ */
+static const char *commit_mode_str(commit_mode_t mode) {
+        switch (mode) {
+        case COMMIT_MODE_NONE:
+                return "no-commit";
+        case COMMIT_MODE_ASYNC:
+                return "commit-async";
+        case COMMIT_MODE_SYNC:
+                return "commit-sync";
+        default:
+                return "unknown";
+        }
+}
+
+/**
+ * @brief Set share.auto.offset.reset=earliest for a share group.
+ */
+static void set_group_offset_earliest(rd_kafka_share_t *rkshare,
+                                      const char *group_name) {
+        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
+
+        test_IncrementalAlterConfigs_simple(
+            rkshare->rkshare_rk, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
+}
+
+/**
+ * @brief Setup topics and produce messages (modular helper)
+ *
+ * @param ctx Test context to populate
+ * @param topic_cnt Number of topics to create
+ * @param partitions Array of partition counts per topic
+ * @param msgs_per_partition Messages to produce per partition
+ *
+ * @returns Total number of messages produced
+ */
+static int setup_topics_and_produce(test_context_t *ctx,
+                                    int topic_cnt,
+                                    const int *partitions,
+                                    int msgs_per_partition) {
+        int t, p;
+        int total_msgs = 0;
+
+        ctx->topic_cnt = topic_cnt;
+
+        for (t = 0; t < topic_cnt; t++) {
+                ctx->topic_names[t] =
+                    rd_strdup(test_mk_topic_name("0178-close-test", 1));
+
+                TEST_SAY("Creating topic %s with %d partition(s)\n",
+                         ctx->topic_names[t], partitions[t]);
+
+                test_create_topic_wait_exists(NULL, ctx->topic_names[t],
+                                              partitions[t], -1, 60 * 1000);
+
+                for (p = 0; p < partitions[t]; p++) {
+                        test_produce_msgs_easy(ctx->topic_names[t], 0, p,
+                                               msgs_per_partition);
+                        total_msgs += msgs_per_partition;
+                }
+
+                TEST_SAY(
+                    "Topic %s: produced %d messages (%d partitions * %d"
+                    "msgs)\n",
+                    ctx->topic_names[t], partitions[t] * msgs_per_partition,
+                    partitions[t], msgs_per_partition);
+        }
+
+        ctx->total_msgs_produced = total_msgs;
+        TEST_SAY("Total messages produced: %d\n", total_msgs);
+        return total_msgs;
+}
+
+/**
+ * @brief Subscribe consumer to topics
+ *
+ * @param rkshare Consumer handle
+ * @param topic_names Array of topic names to subscribe to
+ * @param topic_cnt Number of topics
+ */
+static void subscribe_consumer(rd_kafka_share_t *rkshare,
+                               char **topic_names,
+                               int topic_cnt) {
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        int t;
+
+        /* Build subscription list */
+        subs = rd_kafka_topic_partition_list_new(topic_cnt);
+        for (t = 0; t < topic_cnt; t++) {
+                rd_kafka_topic_partition_list_add(subs, topic_names[t],
+                                                  RD_KAFKA_PARTITION_UA);
+        }
+
+        /* Subscribe */
+        err = rd_kafka_share_subscribe(rkshare, subs);
+        if (err) {
+                TEST_FAIL("Subscribe failed: %s", rd_kafka_err2str(err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(subs);
+}
+
+/**
+ * @brief Consume and optionally acknowledge messages (modular helper)
+ *
+ * @param rkshare Consumer handle
+ * @param consumer_name Name for logging (e.g., "C1", "C2")
+ * @param max_attempts Maximum consume attempts
+ * @param ack_count Number of messages to acknowledge and track (0 = consume
+ * only)
+ * @param tracked_msgs If non-NULL, track acknowledged messages here
+ * @param tracked_cnt If non-NULL, store count of tracked messages here
+ *
+ * @returns Number of messages acknowledged
+ */
+static int consume_and_acknowledge(rd_kafka_share_t *rkshare,
+                                   const char *consumer_name,
+                                   int max_attempts,
+                                   int ack_count,
+                                   tracked_msg_t *tracked_msgs,
+                                   int *tracked_cnt) {
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        int attempt;
+        rd_kafka_error_t *error;
+        int acked = 0;
+
+        TEST_SAY(
+            "%s: Consuming and acknowledging %d messages (max %d "
+            "attempts)...\n",
+            consumer_name, ack_count, max_attempts);
+
+        /* Consume and acknowledge messages until we have ack_count acked */
+        for (attempt = 0; attempt < max_attempts && acked < ack_count;
+             attempt++) {
+                size_t rcvd_msgs = 0;
+                int i;
+
+                error = rd_kafka_share_consume_batch(rkshare, 3000, batch,
+                                                     &rcvd_msgs);
+
+                if (error) {
+                        TEST_SAY("%s: Attempt %d/%d: error: %s\n",
+                                 consumer_name, attempt + 1, max_attempts,
+                                 rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                if (rcvd_msgs == 0)
+                        continue;
+
+                TEST_SAY("%s: Attempt %d/%d: Received %d messages\n",
+                         consumer_name, attempt + 1, max_attempts,
+                         (int)rcvd_msgs);
+
+                /* Process each message in this batch */
+                for (i = 0; i < (int)rcvd_msgs && acked < ack_count; i++) {
+                        rd_kafka_message_t *rkm = batch[i];
+
+                        if (rkm->err) {
+                                TEST_SAY(
+                                    "%s: Skipping message %d with error:"
+                                    "%s\n",
+                                    consumer_name, i,
+                                    rd_kafka_message_errstr(rkm));
+                                rd_kafka_message_destroy(rkm);
+                                continue;
+                        }
+
+                        /* Track this message if tracking enabled */
+                        if (tracked_msgs && acked < BATCH_SIZE) {
+                                tracked_msgs[acked].topic =
+                                    rd_strdup(rd_kafka_topic_name(rkm->rkt));
+                                tracked_msgs[acked].partition = rkm->partition;
+                                tracked_msgs[acked].offset    = rkm->offset;
+                        }
+
+                        TEST_SAY(
+                            "%s: Acking message %d: %s [%d] @ offset "
+                            "%" PRId64 "\n",
+                            consumer_name, acked, rd_kafka_topic_name(rkm->rkt),
+                            rkm->partition, rkm->offset);
+
+                        rd_kafka_share_acknowledge(rkshare, rkm);
+                        rd_kafka_message_destroy(rkm);
+                        acked++;
+                }
+
+                /* Release any remaining messages from this batch that we
+                 * didn't process - they will be redelivered to other consumers
+                 */
+                for (; i < (int)rcvd_msgs; i++) {
+                        rd_kafka_share_acknowledge_type(
+                            rkshare, batch[i],
+                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                        rd_kafka_message_destroy(batch[i]);
+                }
+
+                /* Exit early if we've acknowledged enough */
+                if (acked >= ack_count) {
+                        TEST_SAY(
+                            "%s: Reached target of %d acknowledged "
+                            "messages\n",
+                            consumer_name, ack_count);
+                        break;
+                }
+        }
+
+        TEST_SAY("%s: Finished - acknowledged %d messages\n", consumer_name,
+                 acked);
+
+        if (acked < ack_count) {
+                TEST_FAIL("%s: Expected to acknowledge %d messages, got %d",
+                          consumer_name, ack_count, acked);
+        }
+
+        if (tracked_cnt)
+                *tracked_cnt = acked;
+
+        return acked;
+}
+
+/**
+ * @brief Execute commit based on mode (modular helper)
+ *
+ * @param rkshare Consumer handle
+ * @param consumer_name Name for logging
+ * @param mode Commit mode to execute
+ */
+static void perform_commit(rd_kafka_share_t *rkshare,
+                           const char *consumer_name,
+                           commit_mode_t mode) {
+        rd_kafka_error_t *error;
+
+        switch (mode) {
+        case COMMIT_MODE_NONE:
+                TEST_SAY("%s: Skipping commit (mode: %s)\n", consumer_name,
+                         commit_mode_str(mode));
+                break;
+
+        case COMMIT_MODE_ASYNC:
+                TEST_SAY("%s: Calling commitAsync\n", consumer_name);
+                error = rd_kafka_share_commit_async(rkshare);
+                if (error) {
+                        TEST_FAIL("%s: commitAsync failed: %s", consumer_name,
+                                  rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                }
+                /* Give async commit some time to process */
+                rd_sleep(1);
+                break;
+
+        case COMMIT_MODE_SYNC: {
+                rd_kafka_topic_partition_list_t *partitions = NULL;
+                TEST_SAY("%s: Calling commitSync\n", consumer_name);
+                error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+                if (error) {
+                        TEST_FAIL("%s: commitSync failed: %s", consumer_name,
+                                  rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                }
+                /* Free the partition list returned by commit_sync */
+                if (partitions)
+                        rd_kafka_topic_partition_list_destroy(partitions);
+                TEST_SAY("%s: commitSync completed successfully\n",
+                         consumer_name);
+                break;
+        }
+
+        default:
+                TEST_FAIL("Unknown commit mode: %d", mode);
+        }
+}
+
+/**
+ * @brief Verify no redelivery of tracked messages (modular helper)
+ *
+ * @param rkshare Consumer handle to check
+ * @param consumer_name Name for logging
+ * @param max_attempts Maximum consume attempts
+ * @param expected_msgs Expected number of messages to receive (total -
+ tracked)
+ * @param tracked_msgs Array of tracked messages to check against
+ * @param tracked_cnt Number of tracked messages
+ * @param commit_mode Commit mode used (for error messages)
+ */
+static void verify_no_redelivery(rd_kafka_share_t *rkshare,
+                                 const char *consumer_name,
+                                 int max_attempts,
+                                 int expected_msgs,
+                                 const tracked_msg_t *tracked_msgs,
+                                 int tracked_cnt,
+                                 commit_mode_t commit_mode) {
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        size_t total_rcvd = 0;
+        int attempt;
+        rd_kafka_error_t *error;
+        int redelivered_count = 0;
+
+        TEST_SAY(
+            "%s: Consuming messages for verification (expecting %d "
+            "messages, max %d attempts)...\n",
+            consumer_name, expected_msgs, max_attempts);
+
+        /* Consume messages until we get expected count or max attempts */
+        for (attempt = 0;
+             attempt < max_attempts && (int)total_rcvd < expected_msgs;
+             attempt++) {
+                size_t rcvd_msgs = 0;
+
+                error = rd_kafka_share_consume_batch(
+                    rkshare, 3000, batch + total_rcvd, &rcvd_msgs);
+
+                if (error) {
+                        TEST_SAY("%s: Attempt %d/%d: error: %s\n",
+                                 consumer_name, attempt + 1, max_attempts,
+                                 rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                if (rcvd_msgs > 0) {
+                        TEST_SAY(
+                            "%s: Attempt %d/%d: Received %d messages "
+                            "(total: %d)\n",
+                            consumer_name, attempt + 1, max_attempts,
+                            (int)rcvd_msgs, (int)(total_rcvd + rcvd_msgs));
+                        total_rcvd += rcvd_msgs;
+                }
+        }
+
+        TEST_SAY("%s: Received %d messages\n", consumer_name, (int)total_rcvd);
+
+        /* Verify we received the expected number of messages */
+        if ((int)total_rcvd != expected_msgs) {
+                TEST_FAIL("%s: Expected to receive %d messages, got %d",
+                          consumer_name, expected_msgs, (int)total_rcvd);
+        }
+
+        /* Check if any received message was in tracked list */
+        for (size_t i = 0; i < total_rcvd; i++) {
+                rd_kafka_message_t *rkm = batch[i];
+
+                if (rkm->err) {
+                        rd_kafka_message_destroy(rkm);
+                        continue;
+                }
+
+                const char *topic = rd_kafka_topic_name(rkm->rkt);
+                int partition     = rkm->partition;
+                int64_t offset    = rkm->offset;
+
+                /* Check if this message was in tracked list */
+                for (int j = 0; j < tracked_cnt; j++) {
+                        if (strcmp(topic, tracked_msgs[j].topic) == 0 &&
+                            partition == tracked_msgs[j].partition &&
+                            offset == tracked_msgs[j].offset) {
+                                TEST_WARN(
+                                    "%s: Received previously acknowledged "
+                                    "message: %s [%d] @ offset %ld\n",
+                                    consumer_name, topic, partition, offset);
+                                redelivered_count++;
+                                break;
+                        }
+                }
+
+                rd_kafka_message_destroy(rkm);
+        }
+
+        if (redelivered_count > 0) {
+                TEST_FAIL(
+                    "%s received %d messages that were acknowledged "
+                    "(commit mode: %s)",
+                    consumer_name, redelivered_count,
+                    commit_mode_str(commit_mode));
+        }
+
+        TEST_SAY(
+            "%s: Verification passed - no acknowledged messages were "
+            "redelivered\n",
+            consumer_name);
+}
+
+/**
+ * @brief Free tracked messages (modular helper)
+ *
+ * @param tracked_msgs Array of tracked messages
+ * @param tracked_cnt Number of tracked messages
+ */
+static void free_tracked_messages(tracked_msg_t *tracked_msgs,
+                                  int tracked_cnt) {
+        for (int i = 0; i < tracked_cnt; i++) {
+                if (tracked_msgs[i].topic)
+                        rd_free(tracked_msgs[i].topic);
+        }
+}
+
+/**
+ * @brief Close with acknowledge test scenarios
+ *
+ * Tests consumer close behavior with different commit modes and topologies.
+ * Verifies that acknowledged messages are not redelivered to a second
+ consumer.
+ */
+static void test_close_with_acknowledge(void) {
+        /**
+         * @brief Test configuration for close with acknowledge scenarios
+         */
+        typedef struct {
+                const char *test_name;
+                int topic_cnt;
+                int partitions[MAX_TOPICS];
+                int msgs_per_partition;
+                commit_mode_t commit_mode;
+                int ack_count;
+        } close_ack_test_config_t;
+
+        /* Test matrix: 3 commit modes × 4 topologies = 12 tests */
+        close_ack_test_config_t tests[] = {
+            /* 1 topic, 1 partition */
+            {"close-1t1p-no-commit", 1, {1}, 20, COMMIT_MODE_NONE, 10},
+            {"close-1t1p-commit-async", 1, {1}, 20, COMMIT_MODE_ASYNC, 10},
+            {"close-1t1p-commit-sync", 1, {1}, 20, COMMIT_MODE_SYNC, 10},
+
+            /* 1 topic, multiple partitions */
+            {"close-1t3p-no-commit", 1, {3}, 10, COMMIT_MODE_NONE, 20},
+            {"close-1t3p-commit-async", 1, {3}, 10, COMMIT_MODE_ASYNC, 20},
+            {"close-1t3p-commit-sync", 1, {3}, 10, COMMIT_MODE_SYNC, 15},
+
+            /* Multiple topics, 1 partition each */
+            {"close-3t1p-no-commit", 3, {1, 1, 1}, 10, COMMIT_MODE_NONE, 20},
+            {"close-3t1p-commit-async",
+             3,
+             {1, 1, 1},
+             10,
+             COMMIT_MODE_ASYNC,
+             20},
+            {"close-3t1p-commit-sync", 3, {1, 1, 1}, 10, COMMIT_MODE_SYNC, 20},
+
+            /* Multiple topics, multiple partitions */
+            {"close-2t2p-no-commit", 2, {2, 2}, 10, COMMIT_MODE_NONE, 20},
+            {"close-2t2p-commit-async", 2, {2, 2}, 10, COMMIT_MODE_ASYNC, 20},
+            {"close-2t2p-commit-sync", 2, {2, 2}, 10, COMMIT_MODE_SYNC, 20},
+        };
+
+        for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+                close_ack_test_config_t *config = &tests[i];
+                test_context_t ctx              = {0};
+                rd_kafka_share_t *c1, *c2;
+                tracked_msg_t tracked_msgs[BATCH_SIZE];
+                int tracked_cnt = 0;
+
+                TEST_SAY("\n========================================\n");
+                TEST_SAY("Test: %s\n", config->test_name);
+                TEST_SAY("Topology: %d topic(s), partitions: [",
+                         config->topic_cnt);
+                for (int j = 0; j < config->topic_cnt; j++) {
+                        TEST_SAY("%d%s", config->partitions[j],
+                                 j < config->topic_cnt - 1 ? ", " : "");
+                }
+                TEST_SAY("]\n");
+                TEST_SAY("Commit mode: %s\n",
+                         commit_mode_str(config->commit_mode));
+                TEST_SAY("========================================\n\n");
+
+                ctx.group_id = "0178-group";
+                setup_topics_and_produce(&ctx, config->topic_cnt,
+                                         config->partitions,
+                                         config->msgs_per_partition);
+
+                /* Create C1 with explicit ack mode (will call acknowledge()
+                 * explicitly). C2 will be created after C1 closes. */
+                c1 = test_create_share_consumer(ctx.group_id, "explicit");
+
+                /* Set group offset to earliest */
+                set_group_offset_earliest(c1, ctx.group_id);
+
+                /* Subscribe C1 only - C2 will subscribe after C1 closes */
+                subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
+
+                /* C1: Consume and acknowledge */
+                consume_and_acknowledge(c1, "C1", 30, config->ack_count,
+                                        tracked_msgs, &tracked_cnt);
+
+                /* Execute commit */
+                perform_commit(c1, "C1", config->commit_mode);
+
+                /* Close C1 */
+                TEST_SAY("C1: Closing consumer\n");
+                rd_kafka_share_consumer_close(c1);
+                TEST_SAY("C1: Closed successfully\n");
+                rd_kafka_share_destroy(c1);
+
+                /* Create C2 with implicit ack mode after C1 is fully destroyed
+                 */
+                TEST_SAY("C2: Creating and subscribing after C1 close\n");
+                c2 = test_create_share_consumer(ctx.group_id, "implicit");
+                subscribe_consumer(c2, ctx.topic_names, ctx.topic_cnt);
+
+                /* C2: Consume and verify no redelivery */
+                verify_no_redelivery(
+                    c2, "C2", 30, ctx.total_msgs_produced - tracked_cnt,
+                    tracked_msgs, tracked_cnt, config->commit_mode);
+
+                /* Close C2 */
+                TEST_SAY("C2: Closing consumer\n");
+                rd_kafka_share_consumer_close(c2);
+                TEST_SAY("C2: Closed successfully\n");
+                rd_kafka_share_destroy(c2);
+
+
+                /* Cleanup */
+                free_tracked_messages(tracked_msgs, tracked_cnt);
+
+                TEST_SAY("Test %s completed successfully\n\n",
+                         config->test_name);
+        }
+}
+
+/**
+ * @brief Test close without acknowledge
+ *
+ * Verifies that when a consumer closes without acknowledging consumed records,
+ * those records are released back to the share group and can be consumed by
+ * another consumer.
+ *
+ * Test flow:
+ * 1. C1 consumes records but does NOT acknowledge them
+ * 2. C1 closes (should release the unacknowledged records)
+ * 3. C2 should be able to consume those same records
+ *
+ * Tests multiple topologies: 1t1p, 1t3p, 3t1p, 2t2p
+ */
+static void test_close_without_acknowledge(void) {
+        /**
+         * @brief Test configuration for close without acknowledge scenarios
+         */
+        typedef struct {
+                const char *test_name;
+                int topic_cnt;
+                int partitions[MAX_TOPICS];
+                int msgs_per_partition;
+        } close_no_ack_test_config_t;
+
+        /* Test matrix: various topologies */
+        close_no_ack_test_config_t tests[] = {
+            /* 1 topic, 1 partition */
+            {"close-no-ack-1t1p", 1, {1}, 20},
+
+            /* 1 topic, multiple partitions */
+            {"close-no-ack-1t3p", 1, {3}, 10},
+
+            /* Multiple topics, 1 partition each */
+            {"close-no-ack-3t1p", 3, {1, 1, 1}, 10},
+
+            /* Multiple topics, multiple partitions */
+            {"close-no-ack-2t2p", 2, {2, 2}, 10},
+        };
+
+        for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+                close_no_ack_test_config_t *config = &tests[i];
+                test_context_t ctx                 = {0};
+                rd_kafka_share_t *c1, *c2;
+                rd_kafka_message_t *batch[BATCH_SIZE];
+                rd_kafka_error_t *error;
+                size_t c1_rcvd_msgs = 0;
+                int attempt;
+                tracked_msg_t c1_tracked_msgs[BATCH_SIZE];
+                int c1_tracked_cnt = 0;
+
+                TEST_SAY("\n========================================\n");
+                TEST_SAY("Test: %s\n", config->test_name);
+                TEST_SAY("Topology: %d topic(s), partitions: [",
+                         config->topic_cnt);
+                for (int j = 0; j < config->topic_cnt; j++) {
+                        TEST_SAY("%d%s", config->partitions[j],
+                                 j < config->topic_cnt - 1 ? ", " : "");
+                }
+                TEST_SAY("]\n");
+                TEST_SAY("========================================\n\n");
+
+                ctx.group_id = "0178-group-no-ack";
+                setup_topics_and_produce(&ctx, config->topic_cnt,
+                                         config->partitions,
+                                         config->msgs_per_partition);
+
+                /* Create C1 with implicit ack mode */
+                TEST_SAY("C1: Creating consumer\n");
+                c1 = test_create_share_consumer(ctx.group_id, "implicit");
+
+                /* Set group offset to earliest */
+                set_group_offset_earliest(c1, ctx.group_id);
+
+                /* Subscribe C1 */
+                subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
+
+                /* C1: Consume messages WITHOUT acknowledging */
+                TEST_SAY("C1: Consuming messages WITHOUT acknowledging...\n");
+
+                for (attempt = 0; attempt < 30 && c1_rcvd_msgs == 0;
+                     attempt++) {
+                        error = rd_kafka_share_consume_batch(c1, 3000, batch,
+                                                             &c1_rcvd_msgs);
+
+                        if (error) {
+                                TEST_SAY("C1: Attempt %d: error: %s\n",
+                                         attempt + 1,
+                                         rd_kafka_error_string(error));
+                                rd_kafka_error_destroy(error);
+                                continue;
+                        }
+
+                        if (c1_rcvd_msgs > 0) {
+                                TEST_SAY(
+                                    "C1: Received %d messages (NOT "
+                                    "acknowledging)\n",
+                                    (int)c1_rcvd_msgs);
+
+                                /* Track and destroy messages without
+                                 * acknowledging them */
+                                for (size_t i = 0; i < c1_rcvd_msgs; i++) {
+                                        if (!batch[i]->err) {
+                                                /* Track this message */
+                                                c1_tracked_msgs[c1_tracked_cnt]
+                                                    .topic = rd_strdup(
+                                                    rd_kafka_topic_name(
+                                                        batch[i]->rkt));
+                                                c1_tracked_msgs[c1_tracked_cnt]
+                                                    .partition =
+                                                    batch[i]->partition;
+                                                c1_tracked_msgs[c1_tracked_cnt]
+                                                    .offset = batch[i]->offset;
+                                                c1_tracked_cnt++;
+
+                                                TEST_SAY(
+                                                    "C1: Consumed (no ack): %s "
+                                                    "[%d] @ "
+                                                    "offset %" PRId64 "\n",
+                                                    rd_kafka_topic_name(
+                                                        batch[i]->rkt),
+                                                    batch[i]->partition,
+                                                    batch[i]->offset);
+                                        }
+                                        rd_kafka_message_destroy(batch[i]);
+                                }
+                                break;
+                        }
+                }
+
+                TEST_ASSERT(
+                    c1_rcvd_msgs > 0,
+                    "C1: Expected to receive at least 1 message, got %d",
+                    (int)c1_rcvd_msgs);
+
+                TEST_ASSERT(c1_tracked_cnt == (int)c1_rcvd_msgs,
+                            "C1: Tracked %d messages but received %d",
+                            c1_tracked_cnt, (int)c1_rcvd_msgs);
+
+                TEST_SAY(
+                    "C1: Consumed and tracked %d messages that will be "
+                    "released "
+                    "on close\n",
+                    c1_tracked_cnt);
+
+                /* Close C1 without acknowledging - records should be released
+                 */
+                TEST_SAY(
+                    "C1: Closing consumer WITHOUT acknowledging consumed "
+                    "records\n");
+                rd_kafka_share_consumer_close(c1);
+                TEST_SAY("C1: Closed successfully\n");
+                rd_kafka_share_destroy(c1);
+
+                /* Create C2 after C1 is destroyed */
+                TEST_SAY("C2: Creating consumer after C1 close\n");
+                c2 = test_create_share_consumer(ctx.group_id, "implicit");
+                subscribe_consumer(c2, ctx.topic_names, ctx.topic_cnt);
+
+                /* C2: Should be able to consume all records that C1 released
+                 * (C2 may receive additional messages beyond C1's released set)
+                 */
+                TEST_SAY(
+                    "C2: Attempting to consume records released by C1 "
+                    "(expecting at least %d messages)...\n",
+                    c1_tracked_cnt);
+
+                int c2_matched_cnt = 0;
+                int c2_total_msgs  = 0;
+                rd_bool_t *c1_msg_matched =
+                    rd_calloc(c1_tracked_cnt, sizeof(*c1_msg_matched));
+
+                for (attempt = 0;
+                     attempt < 30 && c2_matched_cnt < c1_tracked_cnt;
+                     attempt++) {
+                        size_t batch_rcvd = 0;
+                        size_t i;
+
+                        error = rd_kafka_share_consume_batch(c2, 3000, batch,
+                                                             &batch_rcvd);
+
+                        if (error) {
+                                TEST_SAY("C2: Attempt %d: error: %s\n",
+                                         attempt + 1,
+                                         rd_kafka_error_string(error));
+                                rd_kafka_error_destroy(error);
+                                continue;
+                        }
+
+                        if (batch_rcvd == 0)
+                                continue;
+
+                        TEST_SAY("C2: Attempt %d: Received %d messages\n",
+                                 attempt + 1, (int)batch_rcvd);
+
+                        /* Check each received message against C1's tracked
+                         * messages */
+                        for (i = 0; i < batch_rcvd; i++) {
+                                rd_kafka_message_t *rkm = batch[i];
+                                int j;
+                                rd_bool_t found = rd_false;
+
+                                if (rkm->err) {
+                                        rd_kafka_message_destroy(rkm);
+                                        continue;
+                                }
+
+                                c2_total_msgs++;
+
+                                const char *topic =
+                                    rd_kafka_topic_name(rkm->rkt);
+                                int32_t partition = rkm->partition;
+                                int64_t offset    = rkm->offset;
+
+                                /* Check if this message matches any from C1's
+                                 * tracked list */
+                                for (j = 0; j < c1_tracked_cnt; j++) {
+                                        if (!c1_msg_matched[j] &&
+                                            strcmp(topic,
+                                                   c1_tracked_msgs[j].topic) ==
+                                                0 &&
+                                            partition ==
+                                                c1_tracked_msgs[j].partition &&
+                                            offset ==
+                                                c1_tracked_msgs[j].offset) {
+                                                found             = rd_true;
+                                                c1_msg_matched[j] = rd_true;
+                                                c2_matched_cnt++;
+
+                                                TEST_SAY(
+                                                    "C2: Matched C1 message "
+                                                    "%d/%d: "
+                                                    "%s [%d] @ offset %" PRId64
+                                                    "\n",
+                                                    c2_matched_cnt,
+                                                    c1_tracked_cnt, topic,
+                                                    partition, offset);
+                                                break;
+                                        }
+                                }
+
+                                if (!found) {
+                                        /* C2 received a message not in C1's
+                                         * list - this is OK, just log it */
+                                        TEST_SAY(
+                                            "C2: Received additional message "
+                                            "(not from C1): %s [%d] @ offset "
+                                            "%" PRId64 "\n",
+                                            topic, partition, offset);
+                                }
+
+                                rd_kafka_message_destroy(rkm);
+                        }
+
+                        /* Break early if we've matched all C1 messages */
+                        if (c2_matched_cnt >= c1_tracked_cnt) {
+                                TEST_SAY(
+                                    "C2: All %d messages from C1 have been "
+                                    "matched, "
+                                    "breaking early (total received: %d)\n",
+                                    c1_tracked_cnt, c2_total_msgs);
+                                break;
+                        }
+                }
+
+                TEST_SAY(
+                    "C2: Total received %d messages, matched %d/%d from "
+                    "C1\n",
+                    c2_total_msgs, c2_matched_cnt, c1_tracked_cnt);
+
+                /* Verify C2 received all the messages C1 released */
+                TEST_ASSERT(
+                    c2_matched_cnt == c1_tracked_cnt,
+                    "C2: Expected to receive all %d messages released by C1, "
+                    "matched only %d",
+                    c1_tracked_cnt, c2_matched_cnt);
+
+                /* Check if any C1 messages were not matched */
+                for (int j = 0; j < c1_tracked_cnt; j++) {
+                        if (!c1_msg_matched[j]) {
+                                TEST_FAIL(
+                                    "C2: Did not receive C1 message: "
+                                    "%s [%d] @ offset %" PRId64,
+                                    c1_tracked_msgs[j].topic,
+                                    c1_tracked_msgs[j].partition,
+                                    c1_tracked_msgs[j].offset);
+                        }
+                }
+
+                TEST_SAY(
+                    "C2: Successfully received all %d messages released "
+                    "by C1 "
+                    "(total messages received: %d)\n",
+                    c2_matched_cnt, c2_total_msgs);
+
+                rd_free(c1_msg_matched);
+
+                /* Close C2 */
+                TEST_SAY("C2: Closing consumer\n");
+                rd_kafka_share_consumer_close(c2);
+                TEST_SAY("C2: Closed successfully\n");
+                rd_kafka_share_destroy(c2);
+
+                /* Cleanup tracked messages */
+                free_tracked_messages(c1_tracked_msgs, c1_tracked_cnt);
+
+                /* Cleanup */
+                for (int t = 0; t < ctx.topic_cnt; t++) {
+                        rd_free(ctx.topic_names[t]);
+                }
+
+                TEST_SAY("Test %s completed successfully\n\n",
+                         config->test_name);
+        }
+}
+
+/**
+ * @brief Test close with slow broker response
+ *
+ * Verifies that close() waits for the broker to respond to the
+ * session close request (sent to partition leader), even when
+ * the broker is slow to respond.
+ *
+ * Tests 3 scenarios with a 3-broker setup:
+ * 1. Only broker 1 has delayed response (10s)
+ * 2. Brokers 1 and 2 have delayed responses (10s each)
+ * 3. All 3 brokers have delayed responses (10s each)
+ *
+ * In each case, close() should wait for the response and complete
+ * successfully after the delay.
+ */
+static void test_close_with_slow_broker_response(void) {
+        typedef struct {
+                const char *test_name;
+                int delayed_broker_cnt;
+                int32_t delayed_brokers[3];
+        } delay_test_config_t;
+
+        delay_test_config_t tests[] = {
+            {"1-broker-delayed", 1, {1, 0, 0}},
+            {"2-brokers-delayed", 2, {1, 2, 0}},
+            {"3-brokers-delayed", 3, {1, 2, 3}},
+        };
+
+        for (size_t test_idx = 0; test_idx < sizeof(tests) / sizeof(tests[0]);
+             test_idx++) {
+                delay_test_config_t *config = &tests[test_idx];
+                rd_kafka_mock_cluster_t *mcluster;
+                const char *bootstraps;
+                rd_kafka_t *producer;
+                rd_kafka_share_t *consumer;
+                rd_kafka_conf_t *conf;
+                const char *topic = "mock-close-delay";
+                char group[64];
+                const int msgcnt       = 10;
+                const int rtt_delay_ms = 10000; /* 10 seconds */
+                rd_kafka_message_t *batch[BATCH_SIZE];
+                rd_kafka_error_t *error;
+                size_t rcvd;
+                int consumed = 0;
+                int attempts = 0;
+                size_t i;
+                rd_ts_t t_start, t_elapsed_ms;
+                char errstr[512];
+
+                rd_snprintf(group, sizeof(group), "sg-close-delay-%s",
+                            config->test_name);
+
+                TEST_SAY("\n========================================\n");
+                TEST_SAY("Test: %s\n", config->test_name);
+                TEST_SAY("Delayed brokers: %d\n", config->delayed_broker_cnt);
+                TEST_SAY("========================================\n\n");
+
+                SUB_TEST("%s", config->test_name);
+
+                /* Create mock cluster with 3 brokers */
+                mcluster = test_mock_cluster_new(3, &bootstraps);
+
+                TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                                mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1,
+                                1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Failed to enable ShareGroupHeartbeat");
+                TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                                mcluster, RD_KAFKAP_ShareFetch, 1, 1) ==
+                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Failed to enable ShareFetch");
+                TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                                mcluster, RD_KAFKAP_ShareAcknowledge, 1, 1) ==
+                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Failed to enable ShareAck");
+
+                /* Create topic */
+                TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Failed to create mock topic");
+
+                /* Create producer and produce messages */
+                test_conf_init(&conf, NULL, 0);
+                test_conf_set(conf, "bootstrap.servers", bootstraps);
+                producer = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr,
+                                        sizeof(errstr));
+                TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
+
+                for (i = 0; i < msgcnt; i++) {
+                        char payload[64];
+                        rd_snprintf(payload, sizeof(payload), "%s-%d", topic,
+                                    (int)i);
+                        TEST_ASSERT(
+                            rd_kafka_producev(
+                                producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
+                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Produce failed");
+                }
+                rd_kafka_flush(producer, 5000);
+
+                /* Create consumer */
+                test_conf_init(&conf, NULL, 0);
+                test_conf_set(conf, "bootstrap.servers", bootstraps);
+                test_conf_set(conf, "group.id", group);
+
+                consumer =
+                    rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+                TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
+
+                /* Subscribe */
+                rd_kafka_topic_partition_list_t *subs;
+                subs = rd_kafka_topic_partition_list_new(1);
+                rd_kafka_topic_partition_list_add(subs, topic,
+                                                  RD_KAFKA_PARTITION_UA);
+                TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
+                            "Subscribe failed");
+                rd_kafka_topic_partition_list_destroy(subs);
+
+                /* Consume some messages */
+                TEST_SAY("Consuming messages...\n");
+                while (consumed < msgcnt && attempts++ < 30) {
+                        rcvd  = 0;
+                        error = rd_kafka_share_consume_batch(consumer, 3000,
+                                                             batch, &rcvd);
+                        if (error) {
+                                rd_kafka_error_destroy(error);
+                                continue;
+                        }
+
+                        for (i = 0; i < rcvd; i++) {
+                                if (!batch[i]->err)
+                                        consumed++;
+                                rd_kafka_message_destroy(batch[i]);
+                        }
+                }
+
+                TEST_SAY("Consumed %d messages\n", consumed);
+                TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d",
+                            msgcnt, consumed);
+
+                /* Inject RTT delay on specified brokers
+                 * This will delay responses from partition leaders including
+                 * the session close request sent during close() */
+                for (i = 0; i < (size_t)config->delayed_broker_cnt; i++) {
+                        TEST_SAY("Injecting %dms RTT delay on broker %d\n",
+                                 rtt_delay_ms, config->delayed_brokers[i]);
+                        rd_kafka_mock_broker_set_rtt(
+                            mcluster, config->delayed_brokers[i], rtt_delay_ms);
+                }
+
+                /* Call close and measure time
+                 * close() should send session close request to partition
+                 * leader and wait for the response */
+                TEST_SAY(
+                    "Calling close() with delayed broker response(s)...\n");
+                t_start = test_clock();
+                rd_kafka_share_consumer_close(consumer);
+                t_elapsed_ms = (test_clock() - t_start) / 1000;
+
+                TEST_SAY("Close completed after %" PRId64 " ms\n",
+                         t_elapsed_ms);
+
+                /* Verify close waited for the delayed response
+                 * Should take approximately rtt_delay_ms
+                 * Allow range: (rtt_delay_ms - 1000ms) to (rtt_delay_ms +
+                 * 2000ms) */
+                int64_t min_expected_ms = rtt_delay_ms - 1000;
+                int64_t max_expected_ms = rtt_delay_ms + 2000;
+
+                TEST_ASSERT(t_elapsed_ms >= min_expected_ms &&
+                                t_elapsed_ms <= max_expected_ms,
+                            "Close took %" PRId64
+                            " ms, expected between %" PRId64 " and %" PRId64
+                            " ms (with %d broker(s) delayed by %dms)",
+                            t_elapsed_ms, min_expected_ms, max_expected_ms,
+                            config->delayed_broker_cnt, rtt_delay_ms);
+
+                TEST_SAY(
+                    "SUCCESS: Close waited approximately %dms for "
+                    "delayed broker response(s)\n",
+                    rtt_delay_ms);
+
+                rd_kafka_share_destroy(consumer);
+                rd_kafka_destroy(producer);
+                test_mock_cluster_destroy(mcluster);
+
+                SUB_TEST_PASS();
+        }
+}
+
+/**
+ * @brief Test close respects socket timeout with very slow broker
+ *
+ * Verifies that when broker takes longer than socket.timeout.ms (60s)
+ * to respond to the session close request, close() should timeout and
+ * not wait indefinitely.
+ *
+ * Setup:
+ * - Single broker with 80s RTT delay (exceeds 60s socket timeout)
+ * - close() should timeout around 60s, not wait for full 80s
+ */
+static void test_close_respects_socket_timeout(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        const char *topic = "mock-close-timeout";
+        const char *group = "sg-close-timeout";
+        const int msgcnt  = 10;
+        const int rtt_delay_ms =
+            80000; /* 80 seconds - exceeds socket timeout */
+        const int socket_timeout_ms = 60000; /* 60 seconds */
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        int consumed = 0;
+        int attempts = 0;
+        size_t i;
+        rd_ts_t t_start, t_elapsed_ms;
+        char errstr[512];
+
+        SUB_TEST("close-respects-socket-timeout");
+
+        TEST_SAY("\n========================================\n");
+        TEST_SAY("Test: close respects socket timeout\n");
+        TEST_SAY("Broker delay: %dms, Socket timeout: %dms\n", rtt_delay_ms,
+                 socket_timeout_ms);
+        TEST_SAY("========================================\n\n");
+
+        /* Create mock cluster with single broker */
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareGroupHeartbeat");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
+                                                 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareFetch");
+        TEST_ASSERT(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
+                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Failed to enable ShareAck");
+
+        /* Create topic */
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        /* Create producer and produce messages */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
+
+        for (i = 0; i < msgcnt; i++) {
+                char payload[64];
+                rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
+                TEST_ASSERT(rd_kafka_producev(
+                                producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
+                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Produce failed");
+        }
+        rd_kafka_flush(producer, 5000);
+
+        /* Create consumer with explicit socket timeout */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+        /* Set socket.timeout.ms to 60 seconds */
+        rd_snprintf(errstr, sizeof(errstr), "%d", socket_timeout_ms);
+        test_conf_set(conf, "socket.timeout.ms", errstr);
+
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
+
+        /* Subscribe */
+        rd_kafka_topic_partition_list_t *subs;
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
+                    "Subscribe failed");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consume some messages */
+        TEST_SAY("Consuming messages...\n");
+        while (consumed < msgcnt && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (i = 0; i < rcvd; i++) {
+                        if (!batch[i]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        TEST_SAY("Consumed %d messages\n", consumed);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d", msgcnt,
+                    consumed);
+
+        /* Inject 80s RTT delay on broker (exceeds 60s socket timeout)
+         * This will cause the session close request to timeout */
+        TEST_SAY(
+            "Injecting %dms RTT delay on broker 1 (exceeds socket "
+            "timeout)\n",
+            rtt_delay_ms);
+        rd_kafka_mock_broker_set_rtt(mcluster, 1, rtt_delay_ms);
+
+        /* Call close and measure time
+         * close() should timeout around socket.timeout.ms (60s)
+         * and NOT wait for the full 80s broker delay */
+        TEST_SAY("Calling close() - should timeout around %dms...\n",
+                 socket_timeout_ms);
+        t_start = test_clock();
+        rd_kafka_share_consumer_close(consumer);
+        t_elapsed_ms = (test_clock() - t_start) / 1000;
+
+        TEST_SAY("Close completed after %" PRId64 " ms\n", t_elapsed_ms);
+
+        /* Verify close did NOT wait for full 80s delay
+         * Should timeout around socket.timeout.ms (60s)
+         * Allow range: 55s to 65s (socket timeout ± 5s margin) */
+        int64_t min_expected_ms = socket_timeout_ms - 5000;
+        int64_t max_expected_ms = socket_timeout_ms + 5000;
+
+        TEST_ASSERT(t_elapsed_ms >= min_expected_ms &&
+                        t_elapsed_ms <= max_expected_ms,
+                    "Close took %" PRId64
+                    " ms, expected timeout around %dms "
+                    "(between %" PRId64 " and %" PRId64
+                    " ms). "
+                    "Should NOT wait for full broker delay of %dms",
+                    t_elapsed_ms, socket_timeout_ms, min_expected_ms,
+                    max_expected_ms, rtt_delay_ms);
+
+        /* Also verify it definitely did NOT wait for the full 80s */
+        TEST_ASSERT(t_elapsed_ms < 70000,
+                    "Close took %" PRId64
+                    " ms, which is too close to broker delay "
+                    "of %dms. Should have timed out at socket.timeout.ms=%dms",
+                    t_elapsed_ms, rtt_delay_ms, socket_timeout_ms);
+
+        TEST_SAY(
+            "SUCCESS: Close respected socket timeout (%dms) and did not "
+            "wait for full broker delay (%dms)\n",
+            socket_timeout_ms, rtt_delay_ms);
+
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test close with broker error response
+ *
+ * Verifies that close() handles error responses from the broker gracefully.
+ * When the broker responds with an error to the ShareAcknowledge request
+ * (session close request), close() should handle it.
+ *
+ * This test injects a COORDINATOR_NOT_AVAILABLE error response and verifies
+ * that close() completes (errors during close are not retriable).
+ */
+static void test_close_with_broker_error_response(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        const char *topic              = "mock-close-error";
+        const char *group              = "sg-close-error";
+        const int msgcnt               = 10;
+        rd_kafka_resp_err_t error_code = RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        int consumed = 0;
+        int attempts = 0;
+        size_t i;
+        char errstr[512];
+
+        SUB_TEST("close-with-broker-error");
+
+        TEST_SAY("\n========================================\n");
+        TEST_SAY("Test: Close with broker error response\n");
+        TEST_SAY("Error code: %s\n", rd_kafka_err2str(error_code));
+        TEST_SAY("========================================\n\n");
+
+        /* Create mock cluster with single broker */
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareGroupHeartbeat");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareFetch,
+                                                 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareFetch");
+        TEST_ASSERT(
+            rd_kafka_mock_set_apiversion(mcluster, RD_KAFKAP_ShareAcknowledge,
+                                         1, 1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Failed to enable ShareAck");
+
+        /* Create topic */
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        /* Create producer and produce messages */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(producer, "Failed to create producer: %s", errstr);
+
+        for (i = 0; i < msgcnt; i++) {
+                char payload[64];
+                rd_snprintf(payload, sizeof(payload), "%s-%d", topic, (int)i);
+                TEST_ASSERT(rd_kafka_producev(
+                                producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
+                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Produce failed");
+        }
+        rd_kafka_flush(producer, 5000);
+
+        /* Create consumer */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group);
+
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create consumer: %s", errstr);
+
+        /* Subscribe */
+        rd_kafka_topic_partition_list_t *subs;
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(!rd_kafka_share_subscribe(consumer, subs),
+                    "Subscribe failed");
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consume some messages */
+        TEST_SAY("Consuming messages...\n");
+        while (consumed < msgcnt && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (i = 0; i < rcvd; i++) {
+                        if (!batch[i]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[i]);
+                }
+        }
+
+        TEST_SAY("Consumed %d messages\n", consumed);
+        TEST_ASSERT(consumed == msgcnt, "Expected %d messages, got %d", msgcnt,
+                    consumed);
+
+        /* Inject error response for ShareAcknowledge (session close request).
+         */
+        TEST_SAY("Injecting %s error for ShareAcknowledge\n",
+                 rd_kafka_err2str(error_code));
+        rd_kafka_mock_broker_push_request_error_rtts(
+            mcluster, 1, RD_KAFKAP_ShareAcknowledge, 1, error_code, 0);
+
+        TEST_SAY("Calling close() - should complete despite error...\n");
+        rd_kafka_share_consumer_close(consumer);
+        TEST_SAY("Close completed\n");
+
+        TEST_SAY("SUCCESS: Close handled error %s gracefully (no retry)\n",
+                 rd_kafka_err2str(error_code));
+
+        rd_kafka_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0178_share_consumer_close(int argc, char **argv) {
+        /* Set overall timeout for all tests */
+        test_timeout_set(600); /* 10 minutes */
+        test_close_with_acknowledge();
+        test_close_without_acknowledge();
+        test_close_with_slow_broker_response();
+        test_close_respects_socket_timeout();
+        test_close_with_broker_error_response();
+
+        return 0;
+}

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -659,6 +659,7 @@ static void setup_3broker_share_consumer(const char *test_name,
 
         mcluster = test_mock_cluster_new(3, &bootstraps);
         enable_share_apis(mcluster);
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(mcluster, 1);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, partition_cnt,
                                                1) == RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -847,7 +848,7 @@ static void test_close_with_acknowledge(void) {
                 TEST_SAY("C2: Closing consumer\n");
                 rd_kafka_share_consumer_close(c2);
                 TEST_SAY("C2: Closed successfully\n");
-                rd_kafka_share_destroy(c2);
+                test_share_destroy(c2);
 
 
                 /* Cleanup */
@@ -859,7 +860,7 @@ static void test_close_with_acknowledge(void) {
 
                 TEST_SAY("Test %s completed successfully\n\n",
                          config->test_name);
-                rd_kafka_share_destroy(c1);
+                test_share_destroy(c1);
         }
 }
 
@@ -959,7 +960,7 @@ static void test_close_without_acknowledge() {
 
                 TEST_SAY("C2: Closing consumer\n");
                 rd_kafka_share_consumer_close(c2);
-                rd_kafka_share_destroy(c2);
+                test_share_destroy(c2);
 
                 free_tracked_messages(tracked_msgs, tracked_cnt);
 
@@ -969,7 +970,7 @@ static void test_close_without_acknowledge() {
 
                 TEST_SAY("Test %s completed successfully\n\n",
                          config->test_name);
-                rd_kafka_share_destroy(c1);
+                test_share_destroy(c1);
         }
 }
 
@@ -1056,7 +1057,7 @@ static void test_close_with_slow_broker_response(void) {
                     "delayed broker response(s)\n",
                     rtt_delay_ms);
 
-                rd_kafka_share_destroy(consumer);
+                test_share_destroy(consumer);
                 test_mock_cluster_destroy(mcluster);
 
                 SUB_TEST_PASS();
@@ -1158,7 +1159,7 @@ static void test_close_respects_socket_timeout(void) {
                     "%d delayed broker(s)\n",
                     socket_timeout_ms, config->delayed_broker_cnt);
 
-                rd_kafka_share_destroy(consumer);
+                test_share_destroy(consumer);
                 test_mock_cluster_destroy(mcluster);
 
                 SUB_TEST_PASS();
@@ -1234,7 +1235,7 @@ static void test_close_with_broker_error_response(void) {
                     "broker(s) (no retry)\n",
                     rd_kafka_err2str(error_code), config->erroring_broker_cnt);
 
-                rd_kafka_share_destroy(consumer);
+                test_share_destroy(consumer);
                 test_mock_cluster_destroy(mcluster);
 
                 SUB_TEST_PASS();
@@ -1291,12 +1292,12 @@ static void test_close_with_broker_busy(void) {
         /* Cluster + APIs + topic */
         mcluster = test_mock_cluster_new(3, &bootstraps);
         enable_share_apis(mcluster);
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(mcluster, 1);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, partition_cnt,
                                                1) == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
 
-        /* Producer */
         /* Implicit-ack consumer */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", bootstraps);
@@ -1383,7 +1384,7 @@ static void test_close_with_broker_busy(void) {
                     "Close took %" PRId64 " ms, expected 8000-12000 ms",
                     t_elapsed_ms);
 
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
 
         /* Verify nothing was redelivered: c2 should consume 0 messages
          * because c1's close() flushed all acks. */
@@ -1418,7 +1419,7 @@ static void test_close_with_broker_busy(void) {
 
         TEST_SAY("SUCCESS: close() flushed acks; c2 received no msgs\n");
 
-        rd_kafka_share_destroy(c2);
+        test_share_destroy(c2);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -1546,7 +1547,7 @@ static void test_close_with_broker_busy(void) {
 //                         RD_KAFKA_RESP_ERR_NO_ERROR,
 //                     "Failed to set broker up");
 //
-//         rd_kafka_share_destroy(consumer);
+//         test_share_destroy(consumer);
 //         test_mock_cluster_destroy(mcluster);
 //
 //         /* Restore default error-fatal behavior for subsequent tests. */
@@ -1609,7 +1610,7 @@ static void test_api_calls_on_closed_consumer(void) {
         TEST_SAY("Exercising APIs on closed consumer\n");
         verify_all_apis_return_error(consumer, topic);
 
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -1704,7 +1705,7 @@ static void test_api_calls_during_closing(void) {
         }
 
         rd_kafka_queue_destroy(queue);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -110,8 +110,7 @@ static int setup_topics_and_produce(test_context_t *ctx,
                 TEST_SAY("Creating topic %s with %d partition(s)\n",
                          ctx->topic_names[t], partitions[t]);
 
-                test_create_topic_wait_exists(common_admin,
-                                              ctx->topic_names[t],
+                test_create_topic_wait_exists(common_admin, ctx->topic_names[t],
                                               partitions[t], -1, 60 * 1000);
 
                 for (p = 0; p < partitions[t]; p++) {

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -34,6 +34,12 @@
 #define MAX_PARTITIONS 32
 #define BATCH_SIZE     10000
 
+/** Common producer reused across all real-broker tests. */
+static rd_kafka_t *common_producer;
+
+/** Common admin client reused across all real-broker tests. */
+static rd_kafka_t *common_admin;
+
 /**
  * @brief Commit mode for test scenarios
  */
@@ -79,18 +85,6 @@ static const char *commit_mode_str(commit_mode_t mode) {
 }
 
 /**
- * @brief Set share.auto.offset.reset=earliest for a share group.
- */
-static void set_group_offset_earliest(rd_kafka_share_t *rkshare,
-                                      const char *group_name) {
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        test_IncrementalAlterConfigs_simple(
-            rd_kafka_share_consumer_get_rk(rkshare), RD_KAFKA_RESOURCE_GROUP,
-            group_name, cfg, 1);
-}
-
-/**
  * @brief Setup topics and produce messages (modular helper)
  *
  * @param ctx Test context to populate
@@ -116,12 +110,14 @@ static int setup_topics_and_produce(test_context_t *ctx,
                 TEST_SAY("Creating topic %s with %d partition(s)\n",
                          ctx->topic_names[t], partitions[t]);
 
-                test_create_topic_wait_exists(NULL, ctx->topic_names[t],
+                test_create_topic_wait_exists(common_admin,
+                                              ctx->topic_names[t],
                                               partitions[t], -1, 60 * 1000);
 
                 for (p = 0; p < partitions[t]; p++) {
-                        test_produce_msgs_easy(ctx->topic_names[t], 0, p,
-                                               msgs_per_partition);
+                        test_produce_msgs_simple(common_producer,
+                                                 ctx->topic_names[t], p,
+                                                 msgs_per_partition);
                         total_msgs += msgs_per_partition;
                 }
 
@@ -463,6 +459,91 @@ static void free_tracked_messages(tracked_msg_t *tracked_msgs,
 }
 
 /**
+ * @brief Helper: assert the given rd_kafka_error_t* signals closed/closing.
+ */
+static void assert_state_error(rd_kafka_error_t *error, const char *api_name) {
+        TEST_ASSERT(error != NULL, "%s: expected error, got NULL", api_name);
+        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
+                    "%s: expected __STATE, got %s", api_name,
+                    rd_kafka_err2name(rd_kafka_error_code(error)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(error), "closed") != NULL,
+                    "%s: expected error string to contain 'closed', got '%s'",
+                    api_name, rd_kafka_error_string(error));
+        rd_kafka_error_destroy(error);
+}
+
+/**
+ * @brief Invoke every share-consumer API and assert each returns a
+ *        closed state error.
+ *
+ * @param consumer    Share consumer (already closed or closing).
+ * @param topic       Topic name (for subscribe/acknowledge_offset).
+ */
+static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
+                                         const char *topic) {
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t err;
+        rd_kafka_message_t *batch[4];
+        size_t rcvd = 0;
+        rd_kafka_topic_partition_list_t *subs, *sub_result = NULL;
+        rd_kafka_topic_partition_list_t *commit_results = NULL;
+        rd_kafka_queue_t *queue                         = NULL;
+
+        /* 1. consume_batch */
+        error = rd_kafka_share_consume_batch(consumer, 100, batch, &rcvd);
+        assert_state_error(error, "consume_batch");
+
+        /* 2. commit_async */
+        error = rd_kafka_share_commit_async(consumer);
+        assert_state_error(error, "commit_async");
+
+        /* 3. commit_sync */
+        error = rd_kafka_share_commit_sync(consumer, 1000, &commit_results);
+        assert_state_error(error, "commit_sync");
+        TEST_ASSERT(commit_results == NULL,
+                    "commit_sync: expected no partitions on error");
+
+        /* 4. acknowledge_offset */
+        err = rd_kafka_share_acknowledge_offset(
+            consumer, topic, 0, 0, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "acknowledge_offset: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+
+        /* 5. subscribe */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "subscribe: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* 6. unsubscribe */
+        err = rd_kafka_share_unsubscribe(consumer);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "unsubscribe: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+
+        /* 7. subscription */
+        err = rd_kafka_share_subscription(consumer, &sub_result);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "subscription: expected __STATE, got %s",
+                    rd_kafka_err2name(err));
+        TEST_ASSERT(sub_result == NULL, "subscription: expected NULL result");
+
+        /* 8. close */
+        error = rd_kafka_share_consumer_close(consumer);
+        assert_state_error(error, "close");
+
+        /* 9. async close */
+        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
+        error = rd_kafka_share_consumer_close_queue(consumer, queue);
+        rd_kafka_queue_destroy(queue);
+        assert_state_error(error, "close");
+}
+
+/**
  * @brief Close with acknowledge test scenarios
  *
  * Tests consumer close behavior with different commit modes and topologies.
@@ -535,12 +616,12 @@ static void test_close_with_acknowledge(void) {
                                          config->partitions,
                                          config->msgs_per_partition);
 
+                /* Set group offset to earliest */
+                test_share_set_auto_offset_reset(ctx.group_id, "earliest");
+
                 /* Create C1 with explicit ack mode (will call acknowledge()
                  * explicitly). C2 will be created after C1 closes. */
                 c1 = test_create_share_consumer(ctx.group_id, "explicit");
-
-                /* Set group offset to earliest */
-                set_group_offset_earliest(c1, ctx.group_id);
 
                 /* Subscribe C1 only - C2 will subscribe after C1 closes */
                 subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
@@ -655,12 +736,12 @@ static void test_close_without_acknowledge(void) {
                                          config->partitions,
                                          config->msgs_per_partition);
 
+                /* Set group offset to earliest */
+                test_share_set_auto_offset_reset(ctx.group_id, "earliest");
+
                 /* Create C1 with implicit ack mode */
                 TEST_SAY("C1: Creating consumer\n");
                 c1 = test_create_share_consumer(ctx.group_id, "implicit");
-
-                /* Set group offset to earliest */
-                set_group_offset_earliest(c1, ctx.group_id);
 
                 /* Subscribe C1 */
                 subscribe_consumer(c1, ctx.topic_names, ctx.topic_cnt);
@@ -1405,91 +1486,6 @@ static void test_close_with_broker_error_response(void) {
 }
 
 /**
- * @brief Helper: assert the given rd_kafka_error_t* signals closed/closing.
- */
-static void assert_state_error(rd_kafka_error_t *error, const char *api_name) {
-        TEST_ASSERT(error != NULL, "%s: expected error, got NULL", api_name);
-        TEST_ASSERT(rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__STATE,
-                    "%s: expected __STATE, got %s", api_name,
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        TEST_ASSERT(strstr(rd_kafka_error_string(error), "closed") != NULL,
-                    "%s: expected error string to contain 'closed', got '%s'",
-                    api_name, rd_kafka_error_string(error));
-        rd_kafka_error_destroy(error);
-}
-
-/**
- * @brief Invoke every share-consumer API and assert each returns a
- *        closed state error.
- *
- * @param consumer    Share consumer (already closed or closing).
- * @param topic       Topic name (for subscribe/acknowledge_offset).
- */
-static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
-                                         const char *topic) {
-        rd_kafka_error_t *error;
-        rd_kafka_resp_err_t err;
-        rd_kafka_message_t *batch[4];
-        size_t rcvd = 0;
-        rd_kafka_topic_partition_list_t *subs, *sub_result = NULL;
-        rd_kafka_topic_partition_list_t *commit_results = NULL;
-        rd_kafka_queue_t *queue                         = NULL;
-
-        /* 1. consume_batch */
-        error = rd_kafka_share_consume_batch(consumer, 100, batch, &rcvd);
-        assert_state_error(error, "consume_batch");
-
-        /* 2. commit_async */
-        error = rd_kafka_share_commit_async(consumer);
-        assert_state_error(error, "commit_async");
-
-        /* 3. commit_sync */
-        error = rd_kafka_share_commit_sync(consumer, 1000, &commit_results);
-        assert_state_error(error, "commit_sync");
-        TEST_ASSERT(commit_results == NULL,
-                    "commit_sync: expected no partitions on error");
-
-        /* 4. acknowledge_offset */
-        err = rd_kafka_share_acknowledge_offset(
-            consumer, topic, 0, 0, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
-                    "acknowledge_offset: expected __STATE, got %s",
-                    rd_kafka_err2name(err));
-
-        /* 5. subscribe */
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        err = rd_kafka_share_subscribe(consumer, subs);
-        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
-                    "subscribe: expected __STATE, got %s",
-                    rd_kafka_err2name(err));
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* 6. unsubscribe */
-        err = rd_kafka_share_unsubscribe(consumer);
-        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
-                    "unsubscribe: expected __STATE, got %s",
-                    rd_kafka_err2name(err));
-
-        /* 7. subscription */
-        err = rd_kafka_share_subscription(consumer, &sub_result);
-        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
-                    "subscription: expected __STATE, got %s",
-                    rd_kafka_err2name(err));
-        TEST_ASSERT(sub_result == NULL, "subscription: expected NULL result");
-
-        /* 8. close */
-        error = rd_kafka_share_consumer_close(consumer);
-        assert_state_error(error, "close");
-
-        /* 9. async close */
-        queue = rd_kafka_queue_new(rd_kafka_share_consumer_get_rk(consumer));
-        error = rd_kafka_share_consumer_close_queue(consumer, queue);
-        rd_kafka_queue_destroy(queue);
-        assert_state_error(error, "close");
-}
-
-/**
  * @brief Test: calling share-consumer APIs after close() completes.
  *
  * Verifies every guarded API returns RD_KAFKA_RESP_ERR__STATE with
@@ -1695,9 +1691,17 @@ int main_0178_share_consumer_close(int argc, char **argv) {
         /* Set overall timeout for all tests */
         test_timeout_set(600); /* 10 minutes */
 
+        /* Create common handles reused across all real-broker tests */
+        common_producer = test_create_producer();
+        common_admin    = test_create_producer();
+
         /* Real broker tests */
         test_close_with_acknowledge();
         test_close_without_acknowledge();
+
+        /* Cleanup common handles */
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_producer);
 
         return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ set(
     0173-share_consumer_commit_async.c
     0176-share_consumer_commit_sync.c
     0177-share_consumer_transactions.c
+    0178-share_consumer_close.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c
     test.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -285,6 +285,7 @@ _TEST_DECL(0173_share_consumer_commit_async);
 _TEST_DECL(0176_share_consumer_commit_sync);
 _TEST_DECL(0176_share_consumer_commit_sync_local);
 _TEST_DECL(0177_share_consumer_transactions);
+_TEST_DECL(0178_share_consumer_close);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -566,6 +567,7 @@ struct test tests[] = {
     _TEST(0176_share_consumer_commit_sync, 0, TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0176_share_consumer_commit_sync_local, TEST_F_LOCAL),
     _TEST(0177_share_consumer_transactions, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0178_share_consumer_close, 0, TEST_BRKVER(0, 4, 0, 0)),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/tests/test.c
+++ b/tests/test.c
@@ -299,6 +299,7 @@ _TEST_DECL(0176_share_consumer_commit_sync);
 _TEST_DECL(0176_share_consumer_commit_sync_local);
 _TEST_DECL(0177_share_consumer_transactions);
 _TEST_DECL(0178_share_consumer_close);
+_TEST_DECL(0178_share_consumer_close_local);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -581,6 +582,7 @@ struct test tests[] = {
     _TEST(0176_share_consumer_commit_sync_local, TEST_F_LOCAL),
     _TEST(0177_share_consumer_transactions, 0, TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0178_share_consumer_close, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0178_share_consumer_close_local, TEST_F_LOCAL),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/tests/test.c
+++ b/tests/test.c
@@ -8207,7 +8207,7 @@ void test_share_set_isolation_level(const char *group_name,
  * @param rkshare The share consumer to close.
  */
 void test_share_consumer_close(rd_kafka_share_t *rkshare) {
-        rd_kafka_resp_err_t error;
+        rd_kafka_error_t *error;
 
         TEST_SAY("Calling rd_kafka_share_consumer_close\n");
         error = rd_kafka_share_consumer_close(rkshare);
@@ -8215,7 +8215,7 @@ void test_share_consumer_close(rd_kafka_share_t *rkshare) {
 
         if (error)
                 TEST_FAIL("Failed to close share consumer: %s\n",
-                          rd_kafka_err2str(error));
+                          rd_kafka_error_string(error));
 }
 
 /**

--- a/tests/test.c
+++ b/tests/test.c
@@ -298,6 +298,7 @@ _TEST_DECL(0173_share_consumer_commit_async);
 _TEST_DECL(0176_share_consumer_commit_sync);
 _TEST_DECL(0176_share_consumer_commit_sync_local);
 _TEST_DECL(0177_share_consumer_transactions);
+_TEST_DECL(0178_share_consumer_close);
 
 /* Manual tests */
 _TEST_DECL(8000_idle);
@@ -579,6 +580,7 @@ struct test tests[] = {
     _TEST(0176_share_consumer_commit_sync, 0, TEST_BRKVER(0, 4, 0, 0)),
     _TEST(0176_share_consumer_commit_sync_local, TEST_F_LOCAL),
     _TEST(0177_share_consumer_transactions, 0, TEST_BRKVER(0, 4, 0, 0)),
+    _TEST(0178_share_consumer_close, 0, TEST_BRKVER(0, 4, 0, 0)),
 
     /* Manual tests */
     _TEST(8000_idle, TEST_F_MANUAL),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -244,6 +244,7 @@
     <ClCompile Include="..\..\tests\0173-share_consumer_commit_async.c" />
     <ClCompile Include="..\..\tests\0176-share_consumer_commit_sync.c" />
     <ClCompile Include="..\..\tests\0177-share_consumer_transactions.c" />
+    <ClCompile Include="..\..\tests\0178-share_consumer_close.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />
     <ClCompile Include="..\..\tests\test.c" />


### PR DESCRIPTION
The PR implements the following Share Consumer APIs:
1. `rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare)`
2. `int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare)`
3. `rd_kafka_error_t *rd_kafka_share_consumer_close_queue(rd_kafka_share_t *rkshare,
                                                      rd_kafka_queue_t *rkqu)`
                                                      
                                                    

Pending:

- [x]  Refactor test cases
- [x]  Base the PR against the commit_sync branch.
- [x] Address the TODO regarding finding brokers with active sessions based on discussion.
- [x] ~~Merge pending sync acks to pending async acks before sending the leave request~~
- [x] Add more test cases and check for memory leaks and flakiness
- [x] Verify if queue forwarding in close() is safe



Test Cases

  ```
  Real-broker tests (main_0178_share_consumer_close)                                                                                                                          
                                                                                                                                                                              
  ┌─────┬────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐  
  │  #  │              Test              │                                                           Description                                                           │  
  ├─────┼────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤  
  │ 1   │ test_close_with_acknowledge    │ Matrix of 12 sub-tests (3 commit modes × 4 topologies). C1 consumes + ACCEPT-acks N messages, optionally calls                  │
  │     │                                │ commitAsync/commitSync, then closes. C2 verifies acknowledged messages are not redelivered.                                     │
  ├─────┼────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤  
  │ 2   │ test_close_without_acknowledge │ Matrix of 4 topology sub-tests. C1 consumes without acking, then closes — close() must release unacked records back to the      │
  │     │                                │ share group. C2 verifies it receives every released message.                                                                    │  
  └─────┴────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                                                                                                                              
  Mock-broker tests (main_0178_share_consumer_close_local)

  ┌─────┬───────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │  #  │                 Test                  │                                                       Description                                                        │
  ├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤  
  │ 3   │ test_close_with_slow_broker_response  │ 1/2/3-broker delay matrix. Injects 10s RTT delay on N partition leaders, then calls close(). Asserts close() waits ~10s  │
  │     │                                       │ for the slowest broker's response.                                                                                       │  
  ├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤  
  │ 4   │ test_close_respects_socket_timeout    │ Same 1/2/3-broker matrix, but with socket.timeout.ms=20s and 40s broker RTT. Asserts close() bails at ~20s (socket       │
  │     │                                       │ timeout) instead of waiting the full broker RTT.                                                                         │  
  ├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 5   │ test_close_with_broker_error_response │ Same 1/2/3-broker matrix. Pushes LEADER_NOT_AVAILABLE onto the next ShareAcknowledge from N brokers. Asserts close()     │  
  │     │                                       │ completes gracefully despite the error (no retry).                                                                       │  
  ├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 6   │ test_close_with_broker_busy           │ 5s ShareAck RTT delays on all 3 brokers, two produce+consume rounds (60 msgs) so brokers have queued/in-flight acks,     │  
  │     │                                       │ then close(). Asserts close() takes ~10s and a second consumer sees zero redeliveries → confirms acks were flushed.      │  
  
├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 7   │ test_api_calls_on_closed_consumer     │ Calls close() to completion, then exercises every guarded share-consumer API. Asserts each returns                       │  
  │     │                                       │ RD_KAFKA_RESP_ERR__STATE with "closed" in the error string.                                                              │  
  ├─────┼───────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ 8   │ test_api_calls_during_closing         │ Injects 5s ShareAck RTT to keep close_queue() in the "closing" state, then exercises every guarded API in that window.   │  
  │     │                                       │ Asserts each is rejected with RD_KAFKA_RESP_ERR__STATE.                                                                  │  
  └─────┴───────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  ```