### PR TITLE
[KIP-932]: Refactor test files to make the build pass

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3047,6 +3047,12 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
         return rkshare;
 }
 
+rd_kafka_t *rd_kafka_share_consumer_get_rk(rd_kafka_share_t *rkshare) {
+        if (!rkshare)
+                return NULL;
+        return rkshare->rkshare_rk;
+}
+
 
 /**
  * @locality main thread

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3335,6 +3335,25 @@ rd_kafka_error_t *
 rd_kafka_share_sasl_background_callbacks_enable(rd_kafka_share_t *rkshare);
 
 /**
+ * @brief Get the underlying rd_kafka_t handle from a share consumer instance.
+ *
+ * This function retrieves the internal rd_kafka_t handle associated with
+ * the share consumer. This is useful for accessing low-level consumer
+ * information such as assignment, fatal errors, etc.
+ *
+ * @param rkshare Share consumer instance.
+ *
+ * @returns The underlying rd_kafka_t handle, or NULL if \p rkshare is NULL.
+ *
+ * @remark The returned handle is owned by the share consumer and must not
+ *         be destroyed by the application.
+ *
+ * @sa rd_kafka_share_consumer_new()
+ */
+RD_EXPORT
+rd_kafka_t *rd_kafka_share_consumer_get_rk(rd_kafka_share_t *rkshare);
+
+/**
  * @brief Flags for rd_kafka_destroy_flags()
  */
 

--- a/tests/0126-oauthbearer_oidc.c
+++ b/tests/0126-oauthbearer_oidc.c
@@ -135,7 +135,7 @@ do_test_produce_share_consumer_with_OIDC(const char *test_name,
         test_produce_msgs_easy(topic, 0, 0, msg_cnt);
 
         /* Create share consumer (picks up SASL config from test_conf_init) */
-        sc1 = test_create_share_consumer("oidc-share-group");
+        sc1 = test_create_share_consumer("oidc-share-group", NULL);
 
         /* Set group config for earliest offset */
         test_IncrementalAlterConfigs_simple(p1, RD_KAFKA_RESOURCE_GROUP,

--- a/tests/0142-reauthentication.c
+++ b/tests/0142-reauthentication.c
@@ -139,7 +139,7 @@ void do_test_share_consumer(int64_t reauth_time) {
         TEST_SAY("Topic: %s is created\n", topic);
 
         /* Create share consumer */
-        sc1 = test_create_share_consumer(group);
+        sc1 = test_create_share_consumer(group, NULL);
 
         /* Set group config for earliest offset */
         test_IncrementalAlterConfigs_simple(p1, RD_KAFKA_RESOURCE_GROUP, group,

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -5,9 +5,9 @@
 /**
  * @name Mock tests for share consumer and ShareGroupHeartbeat
  *
- * TODO: rd_kafka_assignment() and rd_kafka_fatal_error() are called via
- *       test_share_consumer_get_rk() to access the underlying rd_kafka_t
- *       handle. Need to be updated later to avoid this.
+ * Note: rd_kafka_assignment() and rd_kafka_fatal_error() are called via
+ *       rd_kafka_share_consumer_get_rk() to access the underlying rd_kafka_t
+ *       handle from the share consumer.
  */
 
 static rd_bool_t is_share_heartbeat_request(rd_kafka_mock_request_t *request,
@@ -67,7 +67,8 @@ static rd_kafka_resp_err_t wait_fatal_error(rd_kafka_share_t *share_c,
         errstr[0] = '\0';
         while (test_clock() < deadline) {
                 rd_kafka_resp_err_t err = rd_kafka_fatal_error(
-                    test_share_consumer_get_rk(share_c), errstr, errstr_size);
+                    rd_kafka_share_consumer_get_rk(share_c), errstr,
+                    errstr_size);
                 if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
                         return err;
                 rd_usleep(100 * 1000, 0);
@@ -104,7 +105,7 @@ static int wait_assignment_count(rd_kafka_share_t *share_c,
                 rd_kafka_topic_partition_list_t *assignment;
 
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c), &assignment));
+                    rd_kafka_share_consumer_get_rk(share_c), &assignment));
                 cnt = assignment->cnt;
                 rd_kafka_topic_partition_list_destroy(assignment);
 
@@ -227,12 +228,12 @@ static void do_test_share_group_assignment_rebalance(void) {
         deadline = test_clock() + 15000 * 1000;
         while (test_clock() < deadline) {
 
-                TEST_CALL_ERR__(
-                    rd_kafka_assignment(test_share_consumer_get_rk(share_c1),
-                                        &share_c1_assignment));
-                TEST_CALL_ERR__(
-                    rd_kafka_assignment(test_share_consumer_get_rk(share_c2),
-                                        &share_c2_assignment));
+                TEST_CALL_ERR__(rd_kafka_assignment(
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assignment));
+                TEST_CALL_ERR__(rd_kafka_assignment(
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assignment));
 
                 if (share_c1_assignment->cnt + share_c2_assignment->cnt == 3 &&
                     share_c1_assignment->cnt > 0 &&
@@ -249,9 +250,9 @@ static void do_test_share_group_assignment_rebalance(void) {
         }
         /* Final check after loop */
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assignment));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assignment));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assignment));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assignment));
         TEST_ASSERT(share_c1_assignment->cnt + share_c2_assignment->cnt == 3,
                     "Expected total 3 partitions, got %d + %d = %d",
                     share_c1_assignment->cnt, share_c2_assignment->cnt,
@@ -338,9 +339,11 @@ static void do_test_share_group_multi_topic_assignment(void) {
         deadline = test_clock() + 15000 * 1000;
         while (test_clock() < deadline) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
 
                 total_orders =
                     count_topic_partitions(share_c1_assign, topic_orders) +
@@ -360,9 +363,9 @@ static void do_test_share_group_multi_topic_assignment(void) {
                 rd_usleep(200 * 1000, 0);
         }
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         total_orders = count_topic_partitions(share_c1_assign, topic_orders) +
                        count_topic_partitions(share_c2_assign, topic_orders);
         total_events = count_topic_partitions(share_c1_assign, topic_events) +
@@ -385,11 +388,14 @@ static void do_test_share_group_multi_topic_assignment(void) {
         while (test_clock() < deadline) {
 
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c3), &share_c3_assign));
+                    rd_kafka_share_consumer_get_rk(share_c3),
+                    &share_c3_assign));
 
                 total_orders =
                     count_topic_partitions(share_c1_assign, topic_orders) +
@@ -413,11 +419,11 @@ static void do_test_share_group_multi_topic_assignment(void) {
                 rd_usleep(200 * 1000, 0);
         }
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c3), &share_c3_assign));
+            rd_kafka_share_consumer_get_rk(share_c3), &share_c3_assign));
         total_orders = count_topic_partitions(share_c1_assign, topic_orders) +
                        count_topic_partitions(share_c2_assign, topic_orders) +
                        count_topic_partitions(share_c3_assign, topic_orders);
@@ -442,9 +448,11 @@ static void do_test_share_group_multi_topic_assignment(void) {
         deadline = test_clock() + 15000 * 1000;
         while (test_clock() < deadline) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c3), &share_c3_assign));
+                    rd_kafka_share_consumer_get_rk(share_c3),
+                    &share_c3_assign));
 
                 if (count_topic_partitions(share_c2_assign, topic_orders) ==
                         4 &&
@@ -459,9 +467,9 @@ static void do_test_share_group_multi_topic_assignment(void) {
                 rd_usleep(200 * 1000, 0);
         }
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c3), &share_c3_assign));
+            rd_kafka_share_consumer_get_rk(share_c3), &share_c3_assign));
         TEST_ASSERT(count_topic_partitions(share_c2_assign, topic_orders) == 4,
                     "C2 should have all 4 orders partitions, got %d",
                     count_topic_partitions(share_c2_assign, topic_orders));
@@ -478,7 +486,7 @@ static void do_test_share_group_multi_topic_assignment(void) {
         /* Wait for C3 to stabilize with 2 events, 0 orders */
         cnt = wait_assignment_count(share_c3, 2, 10000);
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c3), &share_c3_assign));
+            rd_kafka_share_consumer_get_rk(share_c3), &share_c3_assign));
         TEST_ASSERT(count_topic_partitions(share_c3_assign, topic_events) == 2,
                     "C3 should still have 2 events partitions, got %d",
                     count_topic_partitions(share_c3_assign, topic_events));
@@ -610,8 +618,8 @@ static void do_test_share_group_rtt_injection(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify initial assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -635,8 +643,8 @@ static void do_test_share_group_rtt_injection(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify consumer recovered and still has assignment */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions after timeout recovery, got %d",
                     assignment->cnt);
@@ -702,9 +710,11 @@ static void do_test_share_group_session_timeout(void) {
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 share_c1_initial = share_c1_assign->cnt;
                 share_c2_initial = share_c2_assign->cnt;
                 rd_kafka_topic_partition_list_destroy(share_c1_assign);
@@ -784,9 +794,11 @@ static void do_test_share_group_target_assignment(void) {
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 if (share_c1_assign->cnt + share_c2_assign->cnt == 4 &&
                     share_c1_assign->cnt > 0 && share_c2_assign->cnt > 0) {
                         rd_kafka_topic_partition_list_destroy(share_c1_assign);
@@ -799,9 +811,9 @@ static void do_test_share_group_target_assignment(void) {
         }
         /* Final check */
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         TEST_ASSERT(share_c1_assign->cnt + share_c2_assign->cnt == 4,
                     "Total should be 4 partitions, got %d",
                     share_c1_assign->cnt + share_c2_assign->cnt);
@@ -840,9 +852,11 @@ static void do_test_share_group_target_assignment(void) {
         while (test_clock() < dl) {
 
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
 
                 if ((share_c1_assign->cnt == 4 && share_c2_assign->cnt == 0) ||
                     (share_c1_assign->cnt == 0 && share_c2_assign->cnt == 4)) {
@@ -857,9 +871,9 @@ static void do_test_share_group_target_assignment(void) {
 
         /* Verify manual assignment was applied */
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
 
         TEST_ASSERT(share_c1_assign->cnt + share_c2_assign->cnt == 4,
                     "Total should still be 4 partitions, got %d",
@@ -942,7 +956,7 @@ static void do_test_share_group_no_spurious_fencing(void) {
 
                 /* Verify assignment is still intact */
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c), &assignment));
+                    rd_kafka_share_consumer_get_rk(share_c), &assignment));
                 TEST_ASSERT(assignment->cnt == 3,
                             "Assignment dropped at %ds (spurious fencing!)",
                             i + 1);
@@ -1396,8 +1410,8 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify initial assignment (member is now in stable state) */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -1474,9 +1488,11 @@ static void do_test_leaving_member_bumps_group_epoch(void) {
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 if (share_c1_assign->cnt + share_c2_assign->cnt == 4 &&
                     share_c1_assign->cnt > 0 && share_c2_assign->cnt > 0) {
                         rd_kafka_topic_partition_list_destroy(share_c1_assign);
@@ -1547,8 +1563,8 @@ static void do_test_partition_assignment_with_multiple_topics(void) {
                     "Expected 5 partitions (3+2)");
 
         /* Verify assignment includes partitions from both topics */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
 
         /* Count partitions per topic */
         for (i = 0; i < assignment->cnt; i++) {
@@ -1620,11 +1636,14 @@ static void do_test_multiple_members_partition_distribution(void) {
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c3), &share_c3_assign));
+                    rd_kafka_share_consumer_get_rk(share_c3),
+                    &share_c3_assign));
                 total_partitions = share_c1_assign->cnt + share_c2_assign->cnt +
                                    share_c3_assign->cnt;
                 if (share_c1_assign->cnt >= 1 && share_c2_assign->cnt >= 1 &&
@@ -1641,11 +1660,11 @@ static void do_test_multiple_members_partition_distribution(void) {
         }
         /* Final check */
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c3), &share_c3_assign));
+            rd_kafka_share_consumer_get_rk(share_c3), &share_c3_assign));
         total_partitions =
             share_c1_assign->cnt + share_c2_assign->cnt + share_c3_assign->cnt;
         TEST_ASSERT(share_c1_assign->cnt >= 1,
@@ -1837,8 +1856,8 @@ static void do_test_subscription_change(void) {
                     "Expected 2 partitions from topicA");
 
         /* Verify assignment has topic A only */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         for (i = 0; i < assignment->cnt; i++) {
                 TEST_ASSERT(strcmp(assignment->elems[i].topic, topicA) == 0,
                             "Expected topicA, got %s",
@@ -1857,7 +1876,7 @@ static void do_test_subscription_change(void) {
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c), &assignment));
+                    rd_kafka_share_consumer_get_rk(share_c), &assignment));
                 found_topicA = 0;
                 found_topicB = 0;
                 for (i = 0; i < assignment->cnt; i++) {
@@ -1943,8 +1962,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify consumer is NOT in fatal state - error should be benign */
-        fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(share_c),
-                                         errstr, sizeof(errstr));
+        fatal_err = rd_kafka_fatal_error(
+            rd_kafka_share_consumer_get_rk(share_c), errstr, sizeof(errstr));
         TEST_ASSERT(fatal_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected no fatal error when GROUP_ID_NOT_FOUND arrives "
                     "while unsubscribed, but got: %s (%s)",
@@ -2000,7 +2019,7 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
 //         rd_usleep(500 * 1000, 0);
 
 //         /* Verify initial assignment - member is in stable state */
-//         TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
+//         TEST_CALL_ERR__(rd_kafka_assignment(rd_kafka_share_consumer_get_rk(share_c),
 //                                             &assignment));
 //         TEST_ASSERT(assignment->cnt == 3,
 //                     "Expected 3 partitions initially, got %d",
@@ -2017,7 +2036,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
 //         rd_usleep(500 * 1000, 0);
 
 //         /* Verify consumer entered fatal state */
-//         fatal_err = rd_kafka_fatal_error(test_share_consumer_get_rk(share_c),
+//         fatal_err =
+//         rd_kafka_fatal_error(rd_kafka_share_consumer_get_rk(share_c),
 //                                          errstr, sizeof(errstr));
 //         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
 //                     "Expected consumer to be in fatal state after "
@@ -2255,8 +2275,8 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify initial assignment - member is in stable state */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions initially, got %d", assignment->cnt);
         rd_kafka_topic_partition_list_destroy(assignment);
@@ -2316,8 +2336,8 @@ static void do_test_resubscribe_after_unsubscribe(void) {
         wait_share_heartbeats(mcluster, 1, 1000);
         rd_usleep(500 * 1000, 0);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 3,
                     "Expected 3 partitions on first subscribe, got %d",
                     assignment->cnt);
@@ -2329,8 +2349,8 @@ static void do_test_resubscribe_after_unsubscribe(void) {
         rd_usleep(500 * 1000, 0);
 
         /* Verify no assignment after unsubscribe */
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_ASSERT(assignment->cnt == 0,
                     "Expected 0 partitions after unsubscribe, got %d",
                     assignment->cnt);
@@ -2399,9 +2419,9 @@ static void do_test_consumer_leave_rebalance(void) {
 
         /* Get initial assignments */
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         TEST_SAY(
             "Initial: share consumer 1=%d, share consumer 2=%d (before share "
             "consumer 3 leaves)\n",
@@ -2419,9 +2439,11 @@ static void do_test_consumer_leave_rebalance(void) {
         while (test_clock() < dl) {
 
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c1), &share_c1_assign));
+                    rd_kafka_share_consumer_get_rk(share_c1),
+                    &share_c1_assign));
                 TEST_CALL_ERR__(rd_kafka_assignment(
-                    test_share_consumer_get_rk(share_c2), &share_c2_assign));
+                    rd_kafka_share_consumer_get_rk(share_c2),
+                    &share_c2_assign));
                 final_total = share_c1_assign->cnt + share_c2_assign->cnt;
                 rd_kafka_topic_partition_list_destroy(share_c1_assign);
                 rd_kafka_topic_partition_list_destroy(share_c2_assign);
@@ -2430,9 +2452,9 @@ static void do_test_consumer_leave_rebalance(void) {
                 rd_usleep(200 * 1000, 0);
         }
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
+            rd_kafka_share_consumer_get_rk(share_c1), &share_c1_assign));
         TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
+            rd_kafka_share_consumer_get_rk(share_c2), &share_c2_assign));
         final_total = share_c1_assign->cnt + share_c2_assign->cnt;
         TEST_SAY(
             "After share consumer 3 leave: share consumer 1=%d, "
@@ -2533,8 +2555,8 @@ static void do_test_empty_topic_subscription(void) {
         /* Wait for assignment on empty topic */
         rd_usleep(500 * 1000, 0);
 
-        TEST_CALL_ERR__(rd_kafka_assignment(test_share_consumer_get_rk(share_c),
-                                            &assignment));
+        TEST_CALL_ERR__(rd_kafka_assignment(
+            rd_kafka_share_consumer_get_rk(share_c), &assignment));
         TEST_SAY("Empty topic: %d partitions\n", assignment->cnt);
         TEST_ASSERT(assignment->cnt == 3, "Expected 3 partitions, got %d",
                     assignment->cnt);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -54,17 +54,6 @@ static rd_kafka_t *common_producer;
 static rd_kafka_t *common_admin;
 
 /**
- * @brief Produce messages using the common producer.
- */
-static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
-        rd_kafka_topic_t *rkt;
-        rkt = test_create_producer_topic(common_producer, topic, NULL);
-        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
-                          0);
-        rd_kafka_topic_destroy(rkt);
-}
-
-/**
  * @brief Operation types for subscription tests
  */
 typedef enum {
@@ -204,14 +193,6 @@ typedef struct {
 #define TEST_OPS_END()                                                         \
         { .op = TEST_OP_END }
 
-
-/**
- * @brief Set group config to earliest offset
- */
-static void state_set_offset_earliest(sub_test_state_t *state) {
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-        test_alter_group_configurations(state->group_name, cfg, 1);
-}
 
 /**
  * @brief Create a new topic with auto-generated name
@@ -379,7 +360,8 @@ static void exec_produce_to_topic(sub_test_state_t *state,
         TEST_SAY("  PRODUCE_TO_TOPIC: %d msgs to topic[%d] (%s)\n",
                  op->msgs_per_topic, op->topic_idx, state->all_topics[idx]);
 
-        produce_to_topic(state->all_topics[idx], 0, op->msgs_per_topic);
+        test_produce_msgs_simple(common_producer, state->all_topics[idx], 0,
+                                 op->msgs_per_topic);
         state->msgs_produced[idx] += op->msgs_per_topic;
 }
 
@@ -454,7 +436,8 @@ static void exec_produce(sub_test_state_t *state, const test_op_t *op) {
 
         for (i = 0; i < count; i++) {
                 int idx = start_idx + i;
-                produce_to_topic(state->all_topics[idx], 0, op->msgs_per_topic);
+                test_produce_msgs_simple(common_producer, state->all_topics[idx],
+                                         0, op->msgs_per_topic);
                 state->msgs_produced[idx] += op->msgs_per_topic;
         }
 }
@@ -600,7 +583,7 @@ static void state_init(sub_test_state_t *state,
         }
 
         /* Set group offset to earliest */
-        state_set_offset_earliest(state);
+        test_share_set_auto_offset_reset(state->group_name, "earliest");
 }
 
 /**
@@ -818,7 +801,6 @@ static void do_test_multi_consumer_overlap(void) {
         rd_kafka_share_t *rkshare0, *rkshare1;
         int c0_cnt = 0, c1_cnt = 0;
         int attempts;
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -833,16 +815,16 @@ static void do_test_multi_consumer_overlap(void) {
         test_create_topic_wait_exists(NULL, c1_only, 1, -1, 30000);
 
         /* Produce messages */
-        produce_to_topic(shared, 0, 20);
-        produce_to_topic(c0_only, 0, 10);
-        produce_to_topic(c1_only, 0, 10);
+        test_produce_msgs_simple(common_producer, shared, 0, 20);
+        test_produce_msgs_simple(common_producer, c0_only, 0, 10);
+        test_produce_msgs_simple(common_producer, c1_only, 0, 10);
 
         /* Create consumers */
         rkshare0 = test_create_share_consumer(group, NULL);
         rkshare1 = test_create_share_consumer(group, NULL);
 
         /* Set group offset */
-        test_alter_group_configurations(group, cfg, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         /* Subscribe with overlapping topics */
         test_share_consumer_subscribe_multi(rkshare0, 2, shared, c0_only);
@@ -904,7 +886,6 @@ static void do_test_subscribe_15_topics(void) {
         int consumed = 0;
         int attempts;
         int t;
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -923,7 +904,8 @@ static void do_test_subscribe_15_topics(void) {
 
         /* Produce messages to each topic */
         for (t = 0; t < topic_cnt; t++) {
-                produce_to_topic(topics[t], 0, msgs_per_topic);
+                test_produce_msgs_simple(common_producer, topics[t], 0,
+                                         msgs_per_topic);
         }
         TEST_SAY("Produced %d messages to %d topics\n", total_expected,
                  topic_cnt);
@@ -932,7 +914,7 @@ static void do_test_subscribe_15_topics(void) {
         rkshare = test_create_share_consumer(group, NULL);
 
         /* Set group offset */
-        test_alter_group_configurations(group, cfg, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         /* Subscribe to all topics */
         subs = rd_kafka_topic_partition_list_new(topic_cnt);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -122,7 +122,7 @@ typedef struct {
         /* Topics: all created topics */
         char *all_topics[MAX_TOPICS];
         int all_topic_cnt;
-        int msgs_produced[MAX_TOPICS];       /**< Messages produced per topic */
+        int msgs_produced[MAX_TOPICS]; /**< Messages produced per topic */
 
         /* Current subscription tracking per consumer */
         int sub_start_idx[MAX_CONSUMERS]; /**< Start index in all_topics */

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -123,7 +123,6 @@ typedef struct {
         char *all_topics[MAX_TOPICS];
         int all_topic_cnt;
         int msgs_produced[MAX_TOPICS];       /**< Messages produced per topic */
-        rd_bool_t topic_deleted[MAX_TOPICS]; /**< Track deleted topics */
 
         /* Current subscription tracking per consumer */
         int sub_start_idx[MAX_CONSUMERS]; /**< Start index in all_topics */
@@ -511,9 +510,9 @@ static void exec_delete_topic(sub_test_state_t *state, const test_op_t *op) {
         TEST_SAY("  DELETE_TOPIC: index %d (%s)\n", op->topic_idx,
                  state->all_topics[idx]);
 
-
-        /* Mark as deleted to skip during cleanup */
-        state->topic_deleted[idx] = rd_true;
+        /* Actually delete the topic */
+        test_DeleteTopics_simple(common_admin, NULL, &state->all_topics[idx], 1,
+                                 NULL);
 }
 
 /**

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -47,6 +47,23 @@
 #define MAX_CONSUMERS 4
 #define MAX_OPS       50
 
+/** Common producer reused across all tests. */
+static rd_kafka_t *common_producer;
+
+/** Common admin client reused across all tests. */
+static rd_kafka_t *common_admin;
+
+/**
+ * @brief Produce messages using the common producer.
+ */
+static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
+        rd_kafka_topic_t *rkt;
+        rkt = test_create_producer_topic(common_producer, topic, NULL);
+        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
+                          0);
+        rd_kafka_topic_destroy(rkt);
+}
+
 /**
  * @brief Operation types for subscription tests
  */
@@ -193,9 +210,7 @@ typedef struct {
  */
 static void state_set_offset_earliest(sub_test_state_t *state) {
         const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(state->consumers[0]),
-            RD_KAFKA_RESOURCE_GROUP, state->group_name, cfg, 1);
+        test_alter_group_configurations(state->group_name, cfg, 1);
 }
 
 /**
@@ -364,8 +379,7 @@ static void exec_produce_to_topic(sub_test_state_t *state,
         TEST_SAY("  PRODUCE_TO_TOPIC: %d msgs to topic[%d] (%s)\n",
                  op->msgs_per_topic, op->topic_idx, state->all_topics[idx]);
 
-        test_produce_msgs_easy(state->all_topics[idx], 0, 0,
-                               op->msgs_per_topic);
+        produce_to_topic(state->all_topics[idx], 0, op->msgs_per_topic);
         state->msgs_produced[idx] += op->msgs_per_topic;
 }
 
@@ -440,8 +454,7 @@ static void exec_produce(sub_test_state_t *state, const test_op_t *op) {
 
         for (i = 0; i < count; i++) {
                 int idx = start_idx + i;
-                test_produce_msgs_easy(state->all_topics[idx], 0, 0,
-                                       op->msgs_per_topic);
+                produce_to_topic(state->all_topics[idx], 0, op->msgs_per_topic);
                 state->msgs_produced[idx] += op->msgs_per_topic;
         }
 }
@@ -514,8 +527,6 @@ static void exec_delete_topic(sub_test_state_t *state, const test_op_t *op) {
         TEST_SAY("  DELETE_TOPIC: index %d (%s)\n", op->topic_idx,
                  state->all_topics[idx]);
 
-        test_delete_topic(test_share_consumer_get_rk(state->consumers[0]),
-                          state->all_topics[idx]);
 
         /* Mark as deleted to skip during cleanup */
         state->topic_deleted[idx] = rd_true;
@@ -543,7 +554,8 @@ static void exec_create_consumer(sub_test_state_t *state, const test_op_t *op) {
         TEST_ASSERT(state->consumers[cidx] == NULL,
                     "Consumer %d already exists", cidx);
 
-        state->consumers[cidx] = test_create_share_consumer(state->group_name);
+        state->consumers[cidx] =
+            test_create_share_consumer(state->group_name, NULL);
         if (cidx >= state->consumer_cnt)
                 state->consumer_cnt = cidx + 1;
 }
@@ -584,7 +596,7 @@ static void state_init(sub_test_state_t *state,
         /* Create initial consumers */
         for (i = 0; i < state->consumer_cnt; i++) {
                 state->consumers[i] =
-                    test_create_share_consumer(state->group_name);
+                    test_create_share_consumer(state->group_name, NULL);
         }
 
         /* Set group offset to earliest */
@@ -597,14 +609,8 @@ static void state_init(sub_test_state_t *state,
 static void state_cleanup(sub_test_state_t *state) {
         int i;
 
-        /* Delete all created topics (skip already deleted ones) */
         for (i = 0; i < state->all_topic_cnt; i++) {
                 if (state->all_topics[i]) {
-                        if (!state->topic_deleted[i]) {
-                                test_delete_topic(test_share_consumer_get_rk(
-                                                      state->consumers[0]),
-                                                  state->all_topics[i]);
-                        }
                         rd_free(state->all_topics[i]);
                 }
         }
@@ -827,18 +833,16 @@ static void do_test_multi_consumer_overlap(void) {
         test_create_topic_wait_exists(NULL, c1_only, 1, -1, 30000);
 
         /* Produce messages */
-        test_produce_msgs_easy(shared, 0, 0, 20);
-        test_produce_msgs_easy(c0_only, 0, 0, 10);
-        test_produce_msgs_easy(c1_only, 0, 0, 10);
+        produce_to_topic(shared, 0, 20);
+        produce_to_topic(c0_only, 0, 10);
+        produce_to_topic(c1_only, 0, 10);
 
         /* Create consumers */
-        rkshare0 = test_create_share_consumer(group);
-        rkshare1 = test_create_share_consumer(group);
+        rkshare0 = test_create_share_consumer(group, NULL);
+        rkshare1 = test_create_share_consumer(group, NULL);
 
         /* Set group offset */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(rkshare0), RD_KAFKA_RESOURCE_GROUP,
-            group, cfg, 1);
+        test_alter_group_configurations(group, cfg, 1);
 
         /* Subscribe with overlapping topics */
         test_share_consumer_subscribe_multi(rkshare0, 2, shared, c0_only);
@@ -919,18 +923,16 @@ static void do_test_subscribe_15_topics(void) {
 
         /* Produce messages to each topic */
         for (t = 0; t < topic_cnt; t++) {
-                test_produce_msgs_easy(topics[t], 0, 0, msgs_per_topic);
+                produce_to_topic(topics[t], 0, msgs_per_topic);
         }
         TEST_SAY("Produced %d messages to %d topics\n", total_expected,
                  topic_cnt);
 
         /* Create consumer */
-        rkshare = test_create_share_consumer(group);
+        rkshare = test_create_share_consumer(group, NULL);
 
         /* Set group offset */
-        test_IncrementalAlterConfigs_simple(test_share_consumer_get_rk(rkshare),
-                                            RD_KAFKA_RESOURCE_GROUP, group, cfg,
-                                            1);
+        test_alter_group_configurations(group, cfg, 1);
 
         /* Subscribe to all topics */
         subs = rd_kafka_topic_partition_list_new(topic_cnt);
@@ -984,6 +986,11 @@ static void do_test_subscribe_15_topics(void) {
 
 
 int main_0170_share_consumer_subscription(int argc, char **argv) {
+        /* Create common handles for all tests */
+        common_producer = test_create_producer();
+        common_admin    = test_create_producer();
+
+        test_timeout_set(200);
 
         /* Basic subscription tests */
         do_test_scenario(&test_single_subscribe);
@@ -1014,6 +1021,10 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
 
         /* Scale tests (many topics) */
         do_test_subscribe_15_topics();
+
+        /* Cleanup common handles */
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_producer);
 
         return 0;
 }

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -436,8 +436,9 @@ static void exec_produce(sub_test_state_t *state, const test_op_t *op) {
 
         for (i = 0; i < count; i++) {
                 int idx = start_idx + i;
-                test_produce_msgs_simple(common_producer, state->all_topics[idx],
-                                         0, op->msgs_per_topic);
+                test_produce_msgs_simple(common_producer,
+                                         state->all_topics[idx], 0,
+                                         op->msgs_per_topic);
                 state->msgs_produced[idx] += op->msgs_per_topic;
         }
 }

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -43,17 +43,6 @@ static rd_kafka_t *common_producer;
 static rd_kafka_t *common_admin;
 
 /**
- * @brief Produce messages using the common producer.
- */
-static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
-        rd_kafka_topic_t *rkt;
-        rkt = test_create_producer_topic(common_producer, topic, NULL);
-        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
-                          0);
-        rd_kafka_topic_destroy(rkt);
-}
-
-/**
  * @brief Test configuration structure
  *
  * This structure defines all parameters for a share consumer test scenario.
@@ -131,8 +120,9 @@ static void setup_topics_and_produce(share_test_config_t *config,
 
                 /* Produce messages to each partition */
                 for (p = 0; p < config->partitions[t]; p++) {
-                        produce_to_topic(state->topic_names[t], p,
-                                         config->msgs_per_partition);
+                        test_produce_msgs_simple(common_producer,
+                                                 state->topic_names[t], p,
+                                                 config->msgs_per_partition);
                         state->total_expected += config->msgs_per_partition;
                 }
 
@@ -154,11 +144,10 @@ static void setup_topics_and_produce(share_test_config_t *config,
 static void subscribe_consumers(share_test_config_t *config,
                                 share_test_state_t *state) {
         rd_kafka_topic_partition_list_t *subs;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int t, i;
 
         /* Set group config using a dedicated admin client */
-        test_alter_group_configurations(config->group_name, grp_conf, 1);
+        test_share_set_auto_offset_reset(config->group_name, "earliest");
 
         /* Build subscription list */
         subs = rd_kafka_topic_partition_list_new(config->topic_cnt);
@@ -538,7 +527,6 @@ static void test_rapid_produce_consume_cycles(void) {
         const char *topic;
         const char *group = "share-rapid-cycles";
         rd_kafka_topic_partition_list_t *subs;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int round, total_consumed = 0;
         const int rounds         = 20;
         const int msgs_per_round = 500;
@@ -554,7 +542,7 @@ static void test_rapid_produce_consume_cycles(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         /* Configure group */
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         /* Subscribe */
         subs = rd_kafka_topic_partition_list_new(1);
@@ -568,7 +556,8 @@ static void test_rapid_produce_consume_cycles(void) {
                 int attempts       = 100;
 
                 /* Produce */
-                produce_to_topic(topic, 0, msgs_per_round);
+                test_produce_msgs_simple(common_producer, topic, 0,
+                                         msgs_per_round);
 
                 /* Consume */
                 while (round_consumed < msgs_per_round && attempts-- > 0) {
@@ -616,7 +605,6 @@ static void test_empty_then_produce(void) {
         const char *topic;
         const char *group = "share-empty-then-produce";
         rd_kafka_topic_partition_list_t *subs;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int consumed           = 0, attempts;
 
         TEST_SAY("\n");
@@ -628,7 +616,7 @@ static void test_empty_then_produce(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         /* Configure and subscribe */
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         rd_kafka_share_subscribe(consumer, subs);
@@ -649,7 +637,7 @@ static void test_empty_then_produce(void) {
 
         /* Now produce messages */
         TEST_SAY("Producing 100 messages...\n");
-        produce_to_topic(topic, 0, 100);
+        test_produce_msgs_simple(common_producer, topic, 0, 100);
 
         /* Consume - should get messages now */
         attempts = 100;
@@ -690,7 +678,6 @@ static void test_sparse_partitions(void) {
         const char *topic;
         const char *group = "share-sparse-partitions";
         rd_kafka_topic_partition_list_t *subs;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int consumed           = 0, attempts;
         const int msgs_per_partition = 100;
         const int expected = 3 * msgs_per_partition; /* partitions 0,2,4 */
@@ -706,16 +693,16 @@ static void test_sparse_partitions(void) {
         test_create_topic_wait_exists(NULL, topic, 5, -1, 60 * 1000);
 
         /* Configure and subscribe */
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
         /* Produce only to partitions 0, 2, 4 (skip 1, 3) */
-        produce_to_topic(topic, 0, msgs_per_partition);
-        produce_to_topic(topic, 2, msgs_per_partition);
-        produce_to_topic(topic, 4, msgs_per_partition);
+        test_produce_msgs_simple(common_producer, topic, 0, msgs_per_partition);
+        test_produce_msgs_simple(common_producer, topic, 2, msgs_per_partition);
+        test_produce_msgs_simple(common_producer, topic, 4, msgs_per_partition);
 
         TEST_SAY("Produced %d messages to partitions 0, 2, 4\n", expected);
 

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -36,6 +36,23 @@
 #define MAX_PARTITIONS 32
 #define BATCH_SIZE     10000
 
+/** Common producer reused across all tests. */
+static rd_kafka_t *common_producer;
+
+/** Common admin client reused across all tests. */
+static rd_kafka_t *common_admin;
+
+/**
+ * @brief Produce messages using the common producer.
+ */
+static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
+        rd_kafka_topic_t *rkt;
+        rkt = test_create_producer_topic(common_producer, topic, NULL);
+        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
+                          0);
+        rd_kafka_topic_destroy(rkt);
+}
+
 /**
  * @brief Test configuration structure
  *
@@ -86,7 +103,7 @@ static void create_share_consumers(share_test_config_t *config,
 
         for (i = 0; i < config->consumer_cnt; i++) {
                 state->consumers[i] =
-                    test_create_share_consumer(config->group_name);
+                    test_create_share_consumer(config->group_name, NULL);
         }
 
         TEST_SAY("Created %d share consumer(s)\n", config->consumer_cnt);
@@ -114,8 +131,8 @@ static void setup_topics_and_produce(share_test_config_t *config,
 
                 /* Produce messages to each partition */
                 for (p = 0; p < config->partitions[t]; p++) {
-                        test_produce_msgs_easy(state->topic_names[t], p, p,
-                                               config->msgs_per_partition);
+                        produce_to_topic(state->topic_names[t], p,
+                                         config->msgs_per_partition);
                         state->total_expected += config->msgs_per_partition;
                 }
 
@@ -140,10 +157,8 @@ static void subscribe_consumers(share_test_config_t *config,
         const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int t, i;
 
-        /* Set group config using first consumer */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(state->consumers[0]),
-            RD_KAFKA_RESOURCE_GROUP, config->group_name, grp_conf, 1);
+        /* Set group config using a dedicated admin client */
+        test_alter_group_configurations(config->group_name, grp_conf, 1);
 
         /* Build subscription list */
         subs = rd_kafka_topic_partition_list_new(config->topic_cnt);
@@ -255,12 +270,8 @@ static void cleanup_test(share_test_config_t *config,
                          share_test_state_t *state) {
         int t, i;
 
-        /* Delete topics using first consumer */
         for (t = 0; t < config->topic_cnt; t++) {
                 if (state->topic_names[t]) {
-                        test_delete_topic(
-                            test_share_consumer_get_rk(state->consumers[0]),
-                            state->topic_names[t]);
                         rd_free(state->topic_names[t]);
                         state->topic_names[t] = NULL;
                 }
@@ -538,14 +549,12 @@ static void test_rapid_produce_consume_cycles(void) {
                  rounds, msgs_per_round);
 
         /* Create consumer and topic */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         topic    = test_mk_topic_name("0171-rapid-cycles", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         /* Configure group */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(consumer), RD_KAFKA_RESOURCE_GROUP,
-            group, grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
 
         /* Subscribe */
         subs = rd_kafka_topic_partition_list_new(1);
@@ -559,7 +568,7 @@ static void test_rapid_produce_consume_cycles(void) {
                 int attempts       = 100;
 
                 /* Produce */
-                test_produce_msgs_easy(topic, 0, 0, msgs_per_round);
+                produce_to_topic(topic, 0, msgs_per_round);
 
                 /* Consume */
                 while (round_consumed < msgs_per_round && attempts-- > 0) {
@@ -594,8 +603,6 @@ static void test_rapid_produce_consume_cycles(void) {
         TEST_SAY("SUCCESS: Rapid cycles completed - %d messages\n",
                  total_consumed);
 
-        /* Cleanup */
-        test_delete_topic(test_share_consumer_get_rk(consumer), topic);
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 }
@@ -616,14 +623,12 @@ static void test_empty_then_produce(void) {
         TEST_SAY("=== Empty topic then produce test ===\n");
 
         /* Create consumer and empty topic */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         topic    = test_mk_topic_name("0171-empty-then-produce", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         /* Configure and subscribe */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(consumer), RD_KAFKA_RESOURCE_GROUP,
-            group, grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         rd_kafka_share_subscribe(consumer, subs);
@@ -644,7 +649,7 @@ static void test_empty_then_produce(void) {
 
         /* Now produce messages */
         TEST_SAY("Producing 100 messages...\n");
-        test_produce_msgs_easy(topic, 0, 0, 100);
+        produce_to_topic(topic, 0, 100);
 
         /* Consume - should get messages now */
         attempts = 100;
@@ -672,8 +677,6 @@ static void test_empty_then_produce(void) {
         TEST_SAY("SUCCESS: Empty then produce - consumed %d messages\n",
                  consumed);
 
-        /* Cleanup */
-        test_delete_topic(test_share_consumer_get_rk(consumer), topic);
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 }
@@ -698,23 +701,21 @@ static void test_sparse_partitions(void) {
             "===\n");
 
         /* Create consumer and topic with 5 partitions */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         topic    = test_mk_topic_name("0171-sparse-partitions", 1);
         test_create_topic_wait_exists(NULL, topic, 5, -1, 60 * 1000);
 
         /* Configure and subscribe */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(consumer), RD_KAFKA_RESOURCE_GROUP,
-            group, grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
         /* Produce only to partitions 0, 2, 4 (skip 1, 3) */
-        test_produce_msgs_easy(topic, 0, 0, msgs_per_partition);
-        test_produce_msgs_easy(topic, 0, 2, msgs_per_partition);
-        test_produce_msgs_easy(topic, 0, 4, msgs_per_partition);
+        produce_to_topic(topic, 0, msgs_per_partition);
+        produce_to_topic(topic, 2, msgs_per_partition);
+        produce_to_topic(topic, 4, msgs_per_partition);
 
         TEST_SAY("Produced %d messages to partitions 0, 2, 4\n", expected);
 
@@ -746,184 +747,17 @@ static void test_sparse_partitions(void) {
         TEST_SAY("SUCCESS: Sparse partitions - consumed %d messages\n",
                  consumed);
 
-        /* Cleanup */
-        test_delete_topic(test_share_consumer_get_rk(consumer), topic);
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 }
 
 
-/**
- * @brief Test acquisition lock expiry and redelivery to another consumer
- *
- * This test verifies that:
- * 1. Records acquired by a consumer are locked for the configured duration
- * 2. When a consumer closes without acknowledging, the lock eventually expires
- * 3. After lock expiry, records are redelivered to another consumer
- *
- * Steps:
- * 1. Set group.share.record.lock.duration.ms to 15 seconds
- * 2. Consumer 1 receives 10 messages but doesn't acknowledge
- * 3. Consumer 1 closes without acknowledging
- * 4. Wait for lock to expire (15+ seconds)
- * 5. Consumer 2 should receive the same 10 messages
- */
-static void test_acquisition_lock_expiry_redelivery(void) {
-        rd_kafka_share_t *consumer1, *consumer2;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        const char *topic;
-        const char *group = "share-lock-expiry-test";
-        rd_kafka_topic_partition_list_t *subs;
-        const char *grp_conf_offset[] = {"share.auto.offset.reset", "SET",
-                                         "earliest"};
-        /* TODO KIP-932: Decrease this timeout */
-        const char *grp_conf_lock[] = {"share.record.lock.duration.ms", "SET",
-                                       "15000"};
-        int consumed1 = 0, consumed2 = 0, attempts;
-        const int msg_cnt          = 10;
-        const int lock_duration_ms = 15000;
-
-        TEST_SAY("\n");
-        TEST_SAY("=== Acquisition lock expiry and redelivery test ===\n");
-        TEST_SAY("Lock duration: %d ms, Messages: %d\n", lock_duration_ms,
-                 msg_cnt);
-
-        /* Create first consumer */
-        consumer1 = test_create_share_consumer(group);
-        topic     = test_mk_topic_name("0171-lock-expiry", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-
-        /* Configure group: set lock duration to 15 seconds */
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(consumer1), RD_KAFKA_RESOURCE_GROUP,
-            group, grp_conf_lock, 1);
-        test_IncrementalAlterConfigs_simple(
-            test_share_consumer_get_rk(consumer1), RD_KAFKA_RESOURCE_GROUP,
-            group, grp_conf_offset, 1);
-
-        /* Produce messages */
-        TEST_SAY("Producing %d messages...\n", msg_cnt);
-        test_produce_msgs_easy(topic, 0, 0, msg_cnt);
-
-        /* Subscribe consumer 1 */
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        rd_kafka_share_subscribe(consumer1, subs);
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Consumer 1: receive messages but DO NOT acknowledge */
-        TEST_SAY("Consumer 1: receiving messages without acknowledging...\n");
-        attempts = 50;
-        while (consumed1 < msg_cnt && attempts-- > 0) {
-                size_t rcvd = 0;
-                size_t m;
-                rd_kafka_error_t *err;
-
-                err =
-                    rd_kafka_share_consume_batch(consumer1, 2000, batch, &rcvd);
-                if (err) {
-                        rd_kafka_error_destroy(err);
-                        continue;
-                }
-
-                for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err) {
-                                /* Verify delivery_count = 1 on first delivery
-                                 */
-                                TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(batch[m]) ==
-                                        1,
-                                    "Consumer 1: expected delivery_count=1, "
-                                    "got %d",
-                                    rd_kafka_message_delivery_count(batch[m]));
-                                consumed1++;
-                        }
-                        rd_kafka_message_destroy(batch[m]);
-                }
-        }
-
-        TEST_SAY("Consumer 1: received %d/%d messages (not acknowledged)\n",
-                 consumed1, msg_cnt);
-        TEST_ASSERT(consumed1 == msg_cnt,
-                    "Consumer 1 should receive all %d messages, got %d",
-                    msg_cnt, consumed1);
-
-        /* Close consumer 1 WITHOUT acknowledging - records should be released
-         * after lock expires */
-        TEST_SAY("Closing consumer 1 without acknowledging...\n");
-        rd_kafka_share_consumer_close(consumer1);
-        rd_kafka_share_destroy(consumer1);
-
-        /* Wait for lock to expire + buffer time */
-        TEST_SAY("Waiting %d ms for acquisition lock to expire...\n",
-                 lock_duration_ms + 2000);
-        rd_sleep(lock_duration_ms / 1000 + 2);
-
-        /* Create second consumer */
-        TEST_SAY("Creating consumer 2...\n");
-        consumer2 = test_create_share_consumer(group);
-
-        /* Subscribe consumer 2 */
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        rd_kafka_share_subscribe(consumer2, subs);
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Consumer 2: should receive the same messages (redelivered) */
-        TEST_SAY("Consumer 2: receiving redelivered messages...\n");
-        attempts = 50;
-        while (consumed2 < msg_cnt && attempts-- > 0) {
-                size_t rcvd = 0;
-                size_t m;
-                rd_kafka_error_t *err;
-
-                err =
-                    rd_kafka_share_consume_batch(consumer2, 2000, batch, &rcvd);
-                if (err) {
-                        rd_kafka_error_destroy(err);
-                        continue;
-                }
-
-                for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err) {
-                                /* Verify delivery_count = 2 on redelivery */
-                                TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(batch[m]) ==
-                                        2,
-                                    "Consumer 2: expected delivery_count=2 on "
-                                    "redelivery, got %d",
-                                    rd_kafka_message_delivery_count(batch[m]));
-                                consumed2++;
-                                TEST_SAY(
-                                    "Consumer 2: received redelivered "
-                                    "message at offset %" PRId64
-                                    " (delivery_count=%d)\n",
-                                    batch[m]->offset,
-                                    rd_kafka_message_delivery_count(batch[m]));
-                        }
-                        rd_kafka_message_destroy(batch[m]);
-                }
-        }
-
-        TEST_SAY("Consumer 2: received %d/%d redelivered messages\n", consumed2,
-                 msg_cnt);
-        TEST_ASSERT(consumed2 == msg_cnt,
-                    "Consumer 2 should receive all %d redelivered messages, "
-                    "got %d",
-                    msg_cnt, consumed2);
-
-        TEST_SAY(
-            "SUCCESS: Acquisition lock expiry verified - %d messages "
-            "redelivered\n",
-            consumed2);
-
-        /* Cleanup */
-        test_delete_topic(test_share_consumer_get_rk(consumer2), topic);
-        rd_kafka_share_consumer_close(consumer2);
-        rd_kafka_share_destroy(consumer2);
-}
-
 int main_0171_share_consumer_consume(int argc, char **argv) {
+        /* Create common handles for all tests */
+        common_producer = test_create_producer();
+        common_admin    = test_create_producer();
+
+        test_timeout_set(200);
 
         /* Single-consumer tests */
         test_single_consumer_single_topic_single_partition();      /* Single
@@ -983,8 +817,11 @@ int main_0171_share_consumer_consume(int argc, char **argv) {
         test_empty_then_produce();
         test_sparse_partitions();
 
-        /* Acquisition lock tests */
-        test_acquisition_lock_expiry_redelivery();
+        TEST_SAY("\nAll share consumer consume tests passed successfully!\n");
+
+        /* Cleanup common handles */
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_producer);
 
         return 0;
 }

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -605,7 +605,7 @@ static void test_empty_then_produce(void) {
         const char *topic;
         const char *group = "share-empty-then-produce";
         rd_kafka_topic_partition_list_t *subs;
-        int consumed           = 0, attempts;
+        int consumed = 0, attempts;
 
         TEST_SAY("\n");
         TEST_SAY("=== Empty topic then produce test ===\n");
@@ -678,7 +678,7 @@ static void test_sparse_partitions(void) {
         const char *topic;
         const char *group = "share-sparse-partitions";
         rd_kafka_topic_partition_list_t *subs;
-        int consumed           = 0, attempts;
+        int consumed                 = 0, attempts;
         const int msgs_per_partition = 100;
         const int expected = 3 * msgs_per_partition; /* partitions 0,2,4 */
 

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -714,7 +714,7 @@ static void test_ack_invalid_type(void) {
         const char *topic;
         size_t rcvd = 0;
         int attempts;
-TEST_SAY("\n");
+        TEST_SAY("\n");
         TEST_SAY("=== test_ack_invalid_type ===\n");
 
         rkshare = test_create_share_consumer(group, "explicit");
@@ -777,8 +777,8 @@ static void test_release_then_reject_no_redelivery(void) {
         size_t rcvd = 0;
         size_t m;
         int attempts;
-        int redelivered        = 0;
-TEST_SAY("\n");
+        int redelivered = 0;
+        TEST_SAY("\n");
         TEST_SAY("=== test_release_then_reject_no_redelivery ===\n");
 
         rkshare = test_create_share_consumer(group, "explicit");
@@ -882,7 +882,7 @@ static void test_max_delivery_attempts(void) {
         int delivery_attempt;
         int attempts;
         const int max_deliveries = 5;
-TEST_SAY("\n");
+        TEST_SAY("\n");
         TEST_SAY("=== test_max_delivery_attempts ===\n");
         TEST_SAY(
             "Testing that record is not redelivered after %d RELEASE "
@@ -892,7 +892,8 @@ TEST_SAY("\n");
         rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-max-delivery", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_simple(common_producer, topic, 0, 1); /* Just 1 message */
+        test_produce_msgs_simple(common_producer, topic, 0,
+                                 1); /* Just 1 message */
 
         test_share_set_auto_offset_reset(group, "earliest");
 

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -35,17 +35,6 @@ static rd_kafka_t *common_producer;
 static rd_kafka_t *common_admin;
 
 /**
- * @brief Produce messages using the common producer.
- */
-static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
-        rd_kafka_topic_t *rkt;
-        rkt = test_create_producer_topic(common_producer, topic, NULL);
-        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
-                          0);
-        rd_kafka_topic_destroy(rkt);
-}
-
-/**
  * @brief Share consumer acknowledge API integration tests.
  *
  * Tests the acknowledge APIs (ACCEPT, REJECT, RELEASE) with real/mock broker.
@@ -112,14 +101,6 @@ static rd_kafka_share_AcknowledgeType_t get_random_ack_type(void) {
 }
 
 /**
- * @brief Set group offset to earliest
- */
-static void set_group_offset_earliest(const char *group_name) {
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-        test_alter_group_configurations(group_name, cfg, 1);
-}
-
-/**
  * @brief Create topics and produce messages
  */
 static void setup_topics_and_produce(ack_test_config_t *config,
@@ -148,8 +129,9 @@ static void setup_topics_and_produce(ack_test_config_t *config,
                                               60 * 1000);
 
                 for (p = 0; p < config->partitions[t]; p++) {
-                        produce_to_topic(state->topic_names[t], p,
-                                         msgs_per_partition);
+                        test_produce_msgs_simple(common_producer,
+                                                 state->topic_names[t], p,
+                                                 msgs_per_partition);
                         state->msgs_produced += msgs_per_partition;
                 }
 
@@ -169,7 +151,7 @@ static void subscribe_consumers(ack_test_config_t *config,
         rd_kafka_topic_partition_list_t *subs;
         int t, i;
 
-        set_group_offset_earliest(state->group_name);
+        test_share_set_auto_offset_reset(state->group_name, "earliest");
 
         subs = rd_kafka_topic_partition_list_new(config->topic_cnt);
         for (t = 0; t < config->topic_cnt; t++) {
@@ -732,17 +714,15 @@ static void test_ack_invalid_type(void) {
         const char *topic;
         size_t rcvd = 0;
         int attempts;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        TEST_SAY("\n");
+TEST_SAY("\n");
         TEST_SAY("=== test_ack_invalid_type ===\n");
 
         rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-invalid-type", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 1);
+        test_produce_msgs_simple(common_producer, topic, 0, 1);
 
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
@@ -798,17 +778,15 @@ static void test_release_then_reject_no_redelivery(void) {
         size_t m;
         int attempts;
         int redelivered        = 0;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        TEST_SAY("\n");
+TEST_SAY("\n");
         TEST_SAY("=== test_release_then_reject_no_redelivery ===\n");
 
         rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-release-reject", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
@@ -904,9 +882,7 @@ static void test_max_delivery_attempts(void) {
         int delivery_attempt;
         int attempts;
         const int max_deliveries = 5;
-        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        TEST_SAY("\n");
+TEST_SAY("\n");
         TEST_SAY("=== test_max_delivery_attempts ===\n");
         TEST_SAY(
             "Testing that record is not redelivered after %d RELEASE "
@@ -916,9 +892,9 @@ static void test_max_delivery_attempts(void) {
         rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-max-delivery", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 1); /* Just 1 message */
+        test_produce_msgs_simple(common_producer, topic, 0, 1); /* Just 1 message */
 
-        test_alter_group_configurations(group, grp_conf, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -28,6 +28,23 @@
 
 #include "test.h"
 
+/** Common producer reused across all tests. */
+static rd_kafka_t *common_producer;
+
+/** Common admin client reused across all tests. */
+static rd_kafka_t *common_admin;
+
+/**
+ * @brief Produce messages using the common producer.
+ */
+static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
+        rd_kafka_topic_t *rkt;
+        rkt = test_create_producer_topic(common_producer, topic, NULL);
+        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
+                          0);
+        rd_kafka_topic_destroy(rkt);
+}
+
 /**
  * @brief Share consumer acknowledge API integration tests.
  *
@@ -88,28 +105,6 @@ typedef struct {
 
 
 /**
- * @brief Create share consumer with explicit acknowledgement mode
- */
-static rd_kafka_share_t *create_explicit_ack_consumer(const char *group_id) {
-        rd_kafka_share_t *rk;
-        rd_kafka_conf_t *conf;
-        char errstr[512];
-
-        test_conf_init(&conf, NULL, 60);
-
-        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
-        rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,
-                          sizeof(errstr));
-        rd_kafka_conf_set(conf, "share.acknowledgement.mode", "explicit",
-                          errstr, sizeof(errstr));
-
-        rk = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-        TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
-
-        return rk;
-}
-
-/**
  * @brief Generate random ack type with roughly equal distribution
  */
 static rd_kafka_share_AcknowledgeType_t get_random_ack_type(void) {
@@ -119,12 +114,9 @@ static rd_kafka_share_AcknowledgeType_t get_random_ack_type(void) {
 /**
  * @brief Set group offset to earliest
  */
-static void set_group_offset_earliest(rd_kafka_share_t *rkshare,
-                                      const char *group_name) {
+static void set_group_offset_earliest(const char *group_name) {
         const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-        test_IncrementalAlterConfigs_simple(test_share_consumer_get_rk(rkshare),
-                                            RD_KAFKA_RESOURCE_GROUP, group_name,
-                                            cfg, 1);
+        test_alter_group_configurations(group_name, cfg, 1);
 }
 
 /**
@@ -156,8 +148,8 @@ static void setup_topics_and_produce(ack_test_config_t *config,
                                               60 * 1000);
 
                 for (p = 0; p < config->partitions[t]; p++) {
-                        test_produce_msgs_easy(state->topic_names[t], 0, p,
-                                               msgs_per_partition);
+                        produce_to_topic(state->topic_names[t], p,
+                                         msgs_per_partition);
                         state->msgs_produced += msgs_per_partition;
                 }
 
@@ -177,7 +169,7 @@ static void subscribe_consumers(ack_test_config_t *config,
         rd_kafka_topic_partition_list_t *subs;
         int t, i;
 
-        set_group_offset_earliest(state->consumers[0], state->group_name);
+        set_group_offset_earliest(state->group_name);
 
         subs = rd_kafka_topic_partition_list_new(config->topic_cnt);
         for (t = 0; t < config->topic_cnt; t++) {
@@ -554,9 +546,6 @@ static void cleanup_test(ack_test_config_t *config, ack_test_state_t *state) {
 
         for (t = 0; t < config->topic_cnt; t++) {
                 if (state->topic_names[t]) {
-                        test_delete_topic(
-                            test_share_consumer_get_rk(state->consumers[0]),
-                            state->topic_names[t]);
                         rd_free(state->topic_names[t]);
                         state->topic_names[t] = NULL;
                 }
@@ -607,7 +596,7 @@ static int run_ack_test(ack_test_config_t *config) {
 
         for (i = 0; i < config->consumer_cnt; i++) {
                 state.consumers[i] =
-                    create_explicit_ack_consumer(state.group_name);
+                    test_create_share_consumer(state.group_name, "explicit");
         }
 
         setup_topics_and_produce(config, &state);
@@ -684,7 +673,7 @@ static void test_ack_null_message(void) {
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_null_message ===\n");
 
-        rkshare = create_explicit_ack_consumer(group);
+        rkshare = test_create_share_consumer(group, "explicit");
 
         err = rd_kafka_share_acknowledge(rkshare, NULL);
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
@@ -748,14 +737,12 @@ static void test_ack_invalid_type(void) {
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_invalid_type ===\n");
 
-        rkshare = create_explicit_ack_consumer(group);
+        rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-invalid-type", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 1);
+        produce_to_topic(topic, 0, 1);
 
-        test_IncrementalAlterConfigs_simple(test_share_consumer_get_rk(rkshare),
-                                            RD_KAFKA_RESOURCE_GROUP, group,
-                                            grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
@@ -790,7 +777,6 @@ static void test_ack_invalid_type(void) {
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
         rd_kafka_message_destroy(batch[0]);
 
-        test_delete_topic(test_share_consumer_get_rk(rkshare), topic);
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
@@ -817,14 +803,12 @@ static void test_release_then_reject_no_redelivery(void) {
         TEST_SAY("\n");
         TEST_SAY("=== test_release_then_reject_no_redelivery ===\n");
 
-        rkshare = create_explicit_ack_consumer(group);
+        rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-release-reject", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 5);
+        produce_to_topic(topic, 0, 5);
 
-        test_IncrementalAlterConfigs_simple(test_share_consumer_get_rk(rkshare),
-                                            RD_KAFKA_RESOURCE_GROUP, group,
-                                            grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
@@ -892,7 +876,6 @@ static void test_release_then_reject_no_redelivery(void) {
                     "Expected 0 redelivered (REJECT overrides RELEASE), got %d",
                     redelivered);
 
-        test_delete_topic(test_share_consumer_get_rk(rkshare), topic);
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
@@ -930,14 +913,12 @@ static void test_max_delivery_attempts(void) {
             "attempts\n",
             max_deliveries);
 
-        rkshare = create_explicit_ack_consumer(group);
+        rkshare = test_create_share_consumer(group, "explicit");
         topic   = test_mk_topic_name("0172-max-delivery", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_easy(topic, 0, 0, 1); /* Just 1 message */
+        produce_to_topic(topic, 0, 1); /* Just 1 message */
 
-        test_IncrementalAlterConfigs_simple(test_share_consumer_get_rk(rkshare),
-                                            RD_KAFKA_RESOURCE_GROUP, group,
-                                            grp_conf, 1);
+        test_alter_group_configurations(group, grp_conf, 1);
 
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
@@ -1010,7 +991,6 @@ static void test_max_delivery_attempts(void) {
         TEST_SAY("SUCCESS: Message not redelivered after %d RELEASE attempts\n",
                  max_deliveries);
 
-        test_delete_topic(test_share_consumer_get_rk(rkshare), topic);
         rd_kafka_share_consumer_close(rkshare);
         rd_kafka_share_destroy(rkshare);
 
@@ -1176,6 +1156,10 @@ int main_0172_share_consumer_acknowledge(int argc, char **argv) {
 
         test_timeout_set(600); /* 10 minutes for all tests */
 
+        /* Create common handles for all tests */
+        common_producer = test_create_producer();
+        common_admin    = test_create_producer();
+
         /* Core tests */
         test_release_redelivery();
         test_reject_no_redelivery();
@@ -1202,6 +1186,10 @@ int main_0172_share_consumer_acknowledge(int argc, char **argv) {
         test_scale_8_topics_4_partitions();
         test_scale_single_topic_8_partitions();
         test_scale_10_topics_3_partitions();
+
+        /* Cleanup common handles */
+        rd_kafka_destroy(common_admin);
+        rd_kafka_destroy(common_producer);
 
         return 0;
 }

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -540,7 +540,8 @@ static void do_test_produce_consume_loop(void) {
                 int consumed = 0;
                 int attempts = 0;
 
-                test_produce_msgs_simple(common_producer, topic, 0, msgs_per_round);
+                test_produce_msgs_simple(common_producer, topic, 0,
+                                         msgs_per_round);
                 TEST_SAY("Round %d: produced %d messages\n", round,
                          msgs_per_round);
 
@@ -621,7 +622,8 @@ static void do_test_multi_round_mixed_second_consumer(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         for (round = 0; round < rounds; round++) {
-                test_produce_msgs_simple(common_producer, topic, 0, msgs_per_round);
+                test_produce_msgs_simple(common_producer, topic, 0,
+                                         msgs_per_round);
                 int consumed     = 0;
                 int released_cnt = 0;
                 int redelivered  = 0;

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -63,29 +63,6 @@ static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
 
 
 /**
- * @brief Create share consumer with specified ack mode.
- * @param ack_mode "implicit" or "explicit"
- */
-static rd_kafka_share_t *create_share_consumer(const char *group_id,
-                                               const char *ack_mode) {
-        rd_kafka_share_t *rkshare;
-        rd_kafka_conf_t *conf;
-        char errstr[512];
-
-        test_conf_init(&conf, NULL, 0);
-
-        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
-        rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode, errstr,
-                          sizeof(errstr));
-
-        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-        TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
-
-        return rkshare;
-}
-
-
-/**
  * @brief Set share.auto.offset.reset=earliest for a share group.
  */
 static void set_group_offset_earliest(const char *group_name) {
@@ -170,7 +147,7 @@ static void do_test_implicit_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
@@ -213,7 +190,7 @@ static void do_test_implicit_second_consumer(void) {
         /* Second consumer: should only get the 5 verification records.
          * No lock wait needed — implicit mode close tears down the
          * connection and broker releases records immediately. */
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
@@ -271,7 +248,7 @@ static void do_test_explicit_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
@@ -317,7 +294,7 @@ static void do_test_explicit_second_consumer(void) {
         /* Second consumer: should only get the 5 verification records.
          * Records are either committed by the last commit_async or
          * released on the broker side when the connection is closed. */
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
@@ -378,7 +355,7 @@ static void do_test_mixed_acks_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -497,7 +474,7 @@ static void do_test_multi_topic_partition(void) {
                                               60 * 1000);
         }
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, topics, topic_cnt);
 
@@ -574,7 +551,7 @@ static void do_test_produce_consume_loop(void) {
         topic = test_mk_topic_name("0173-ca-loop", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -658,7 +635,7 @@ static void do_test_multi_round_mixed_second_consumer(void) {
         topic = test_mk_topic_name("0173-ca-mr-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -756,7 +733,7 @@ static void do_test_no_pending_acks(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
 
         error = rd_kafka_share_commit_async(rkshare);
         TEST_SAY("commit_async with no acks: error=%s\n",
@@ -789,7 +766,7 @@ static void do_test_multiple_commit_async_calls(void) {
         topic = test_mk_topic_name("0173-ca-multi-call", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -882,7 +859,7 @@ static void do_test_commit_between_produces(void) {
         topic = test_mk_topic_name("0173-ca-between", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
@@ -976,7 +953,7 @@ static void do_test_commit_between_produces(void) {
         /* Second consumer: should only get the 5 verification records.
          * No lock wait needed — implicit mode close tears down the
          * connection and broker releases records immediately. */
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
@@ -1029,7 +1006,7 @@ static void do_test_all_release_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -1105,7 +1082,7 @@ static void do_test_all_reject_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
@@ -1157,7 +1134,7 @@ static void do_test_all_reject_second_consumer(void) {
 
         /* Second consumer: should only get the 5 verification records.
          * REJECT'd records are archived and not redelivered. */
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
@@ -1212,7 +1189,7 @@ static void do_test_per_record_commit_async(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, MAX_MSGS);
 
-        rkshare = create_share_consumer(group, "explicit");
+        rkshare = test_create_share_consumer(group, "explicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
@@ -1269,7 +1246,7 @@ static void do_test_per_record_commit_async(void) {
 
         /* Second consumer: should only get the 5 verification records.
          * All previous records were ACCEPT'd via per-record commit_async. */
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
@@ -1548,7 +1525,7 @@ static void do_test_lock_timeout_redelivery(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_to_topic(topic, 0, msg_cnt);
 
-        rkshare = create_share_consumer(group, "implicit");
+        rkshare = test_create_share_consumer(group, "implicit");
         set_group_offset_earliest(group);
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -50,27 +50,6 @@ static rd_kafka_t *common_producer;
 /** Common admin client reused across all non-mock subtests. */
 static rd_kafka_t *common_admin;
 
-/**
- * @brief Produce messages using the common producer.
- */
-static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
-        rd_kafka_topic_t *rkt;
-        rkt = test_create_producer_topic(common_producer, topic, NULL);
-        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
-                          0);
-        rd_kafka_topic_destroy(rkt);
-}
-
-
-/**
- * @brief Set share.auto.offset.reset=earliest for a share group.
- */
-static void set_group_offset_earliest(const char *group_name) {
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        test_IncrementalAlterConfigs_simple(
-            common_admin, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
-}
 
 /**
  * @brief Set share.record.lock.duration.ms for a share group.
@@ -145,10 +124,10 @@ static void do_test_implicit_second_consumer(void) {
 
         topic = test_mk_topic_name("0173-ca-impl-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -185,7 +164,7 @@ static void do_test_implicit_second_consumer(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records.
          * No lock wait needed — implicit mode close tears down the
@@ -246,10 +225,10 @@ static void do_test_explicit_second_consumer(void) {
 
         topic = test_mk_topic_name("0173-ca-expl-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -289,7 +268,7 @@ static void do_test_explicit_second_consumer(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records.
          * Records are either committed by the last commit_async or
@@ -353,10 +332,10 @@ static void do_test_mixed_acks_second_consumer(void) {
 
         topic = test_mk_topic_name("0173-ca-mixed-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         released_offsets = rd_calloc(MAX_MSGS, sizeof(*released_offsets));
@@ -475,7 +454,7 @@ static void do_test_multi_topic_partition(void) {
         }
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, topics, topic_cnt);
 
         for (round = 0; round < rounds; round++) {
@@ -484,7 +463,9 @@ static void do_test_multi_topic_partition(void) {
 
                 for (t = 0; t < topic_cnt; t++) {
                         for (p = 0; p < part_cnt; p++)
-                                produce_to_topic(topics[t], p, msgs_per_part);
+                                test_produce_msgs_simple(common_producer,
+                                                         topics[t], p,
+                                                         msgs_per_part);
                 }
 
                 while (consumed < msgs_per_round && attempts++ < 100) {
@@ -552,14 +533,14 @@ static void do_test_produce_consume_loop(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         for (round = 0; round < rounds; round++) {
                 int consumed = 0;
                 int attempts = 0;
 
-                produce_to_topic(topic, 0, msgs_per_round);
+                test_produce_msgs_simple(common_producer, topic, 0, msgs_per_round);
                 TEST_SAY("Round %d: produced %d messages\n", round,
                          msgs_per_round);
 
@@ -636,11 +617,11 @@ static void do_test_multi_round_mixed_second_consumer(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         for (round = 0; round < rounds; round++) {
-                produce_to_topic(topic, 0, msgs_per_round);
+                test_produce_msgs_simple(common_producer, topic, 0, msgs_per_round);
                 int consumed     = 0;
                 int released_cnt = 0;
                 int redelivered  = 0;
@@ -767,10 +748,10 @@ static void do_test_multiple_commit_async_calls(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
-        produce_to_topic(topic, 0, first_produce);
+        test_produce_msgs_simple(common_producer, topic, 0, first_produce);
 
         while (consumed < first_produce && attempts++ < 100) {
                 rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
@@ -796,7 +777,7 @@ static void do_test_multiple_commit_async_calls(void) {
         TEST_ASSERT(consumed == first_produce, "Expected %d, got %d",
                     first_produce, consumed);
 
-        produce_to_topic(topic, 0, second_produce);
+        test_produce_msgs_simple(common_producer, topic, 0, second_produce);
 
         for (call = 0; call < 10; call++) {
                 error = rd_kafka_share_commit_async(rkshare);
@@ -860,12 +841,12 @@ static void do_test_commit_between_produces(void) {
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* First half: produce, wait for records, commit_async */
-        produce_to_topic(topic, 0, half);
+        test_produce_msgs_simple(common_producer, topic, 0, half);
 
         while (consumed1 == 0 && attempts++ < 30) {
                 rcvd  = 0;
@@ -906,7 +887,7 @@ static void do_test_commit_between_produces(void) {
         rd_sleep(4);
 
         /* Second half: produce more, wait for records, commit_async */
-        produce_to_topic(topic, 0, half);
+        test_produce_msgs_simple(common_producer, topic, 0, half);
 
         attempts = 0;
         while (consumed2 == 0 && attempts++ < 30) {
@@ -948,7 +929,7 @@ static void do_test_commit_between_produces(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records.
          * No lock wait needed — implicit mode close tears down the
@@ -1004,10 +985,10 @@ static void do_test_all_release_second_consumer(void) {
 
         topic = test_mk_topic_name("0173-ca-allrel-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume all records: RELEASE new records, ACCEPT redeliveries.
@@ -1080,10 +1061,10 @@ static void do_test_all_reject_second_consumer(void) {
 
         topic = test_mk_topic_name("0173-ca-allrej-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -1130,7 +1111,7 @@ static void do_test_all_reject_second_consumer(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records.
          * REJECT'd records are archived and not redelivered. */
@@ -1187,10 +1168,10 @@ static void do_test_per_record_commit_async(void) {
 
         topic = test_mk_topic_name("0173-ca-per-rec", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, MAX_MSGS);
+        test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
 
         rkshare = test_create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -1242,7 +1223,7 @@ static void do_test_per_record_commit_async(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records.
          * All previous records were ACCEPT'd via per-record commit_async. */
@@ -1523,10 +1504,10 @@ static void do_test_lock_timeout_redelivery(void) {
 
         topic = test_mk_topic_name("0173-ca-lock-to", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, msg_cnt);
+        test_produce_msgs_simple(common_producer, topic, 0, msg_cnt);
 
         rkshare = test_create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -871,9 +871,8 @@ static void do_test_multi_topic_partition(void) {
                                               MULTI_TP_PARTITIONS, -1,
                                               60 * 1000);
                 for (p = 0; p < MULTI_TP_PARTITIONS; p++)
-                        test_produce_msgs_simple(
-                            common_producer, topics[i], p,
-                            MULTI_TP_MSGS_PER_PARTITION);
+                        test_produce_msgs_simple(common_producer, topics[i], p,
+                                                 MULTI_TP_MSGS_PER_PARTITION);
         }
 
         rkshare = create_share_consumer(group, "explicit");

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -46,17 +46,6 @@ static rd_kafka_t *common_producer;
 /** Common admin client reused across all non-mock subtests. */
 static rd_kafka_t *common_admin;
 
-/**
- * @brief Produce messages using the common producer.
- */
-static void produce_to_topic(const char *topic, int32_t partition, int msgcnt) {
-        rd_kafka_topic_t *rkt;
-        rkt = test_create_producer_topic(common_producer, topic, NULL);
-        test_produce_msgs(common_producer, rkt, 0, partition, 0, msgcnt, NULL,
-                          0);
-        rd_kafka_topic_destroy(rkt);
-}
-
 
 /**
  * @brief Create share consumer with specified ack mode.
@@ -80,16 +69,6 @@ static rd_kafka_share_t *create_share_consumer(const char *group_id,
         return rkshare;
 }
 
-
-/**
- * @brief Set share.auto.offset.reset=earliest for a share group.
- */
-static void set_group_offset_earliest(const char *group_name) {
-        const char *cfg[] = {"share.auto.offset.reset", "SET", "earliest"};
-
-        test_IncrementalAlterConfigs_simple(
-            common_admin, RD_KAFKA_RESOURCE_GROUP, group_name, cfg, 1);
-}
 
 /**
  * @brief Set share.record.lock.duration.ms for a share group.
@@ -147,10 +126,10 @@ static void do_test_basic_implicit_commit_sync(void) {
 
         topic = test_mk_topic_name("0176-cs-impl-basic", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         rkshare = create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -206,7 +185,7 @@ static void do_test_basic_implicit_commit_sync(void) {
         /* Produce 5 verification records and consume with the same
          * consumer — should get only these 5 (dc == 1), proving
          * the first batch was committed and not redelivered. */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         consumed = 0;
         attempts = 0;
@@ -265,10 +244,10 @@ static void do_test_basic_explicit_commit_sync(void) {
 
         topic = test_mk_topic_name("0176-cs-expl-basic", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         set_group_lock_duration(group, "3000");
         subscribe_consumer(rkshare, &topic, 1);
 
@@ -327,7 +306,7 @@ static void do_test_basic_explicit_commit_sync(void) {
         /* Produce 5 verification records and consume with the same
          * consumer — should get only these 5 (dc == 1), proving
          * the first batch was committed and not redelivered. */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         consumed = 0;
         attempts = 0;
@@ -382,7 +361,7 @@ static void do_test_no_pending_acks(void) {
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
 
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* commit_sync with no consumed records */
@@ -423,11 +402,11 @@ static void do_test_commit_sync_prevents_redelivery(void) {
 
         topic = test_mk_topic_name("0176-cs-no-redeliver", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Consumer A: consume all and commit_sync */
         rkshare = create_share_consumer(group, "implicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed == 0 && attempts++ < 30) {
@@ -458,7 +437,7 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Consumer B: should only get the 5 verification records.
          * Close tears down the connection and broker releases
@@ -519,12 +498,12 @@ static void do_test_mixed_ack_types(void) {
 
         topic = test_mk_topic_name("0176-cs-mixed-acks", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 10);
+        test_produce_msgs_simple(common_producer, topic, 0, 10);
 
         /* Consumer A: consume all 10 in a single batch, apply mixed ack
          * types */
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed == 0 && attempts++ < 30) {
@@ -695,10 +674,10 @@ static void do_test_multiple_commit_sync_calls(void) {
 
         topic = test_mk_topic_name("0176-cs-multi-calls", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 50);
+        test_produce_msgs_simple(common_producer, topic, 0, 50);
 
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume all 50, commit_sync every 10 records */
@@ -802,7 +781,7 @@ static void do_test_multiple_commit_sync_calls(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Consumer B: should only get the 5 verification records */
         rkshare = create_share_consumer(group, "implicit");
@@ -892,12 +871,13 @@ static void do_test_multi_topic_partition(void) {
                                               MULTI_TP_PARTITIONS, -1,
                                               60 * 1000);
                 for (p = 0; p < MULTI_TP_PARTITIONS; p++)
-                        produce_to_topic(topics[i], p,
-                                         MULTI_TP_MSGS_PER_PARTITION);
+                        test_produce_msgs_simple(
+                            common_producer, topics[i], p,
+                            MULTI_TP_MSGS_PER_PARTITION);
         }
 
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, (const char **)topics, MULTI_TP_TOPICS);
 
         /* Consume until all records are settled
@@ -1537,10 +1517,10 @@ static void do_test_mixed_commit_types(void) {
 
         topic = test_mk_topic_name("0176-cs-mixed-types", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
-        produce_to_topic(topic, 0, 50);
+        test_produce_msgs_simple(common_producer, topic, 0, 50);
 
         rkshare = create_share_consumer(group, "explicit");
-        set_group_offset_earliest(group);
+        test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume all 50 records, ACCEPT each, alternate between
@@ -1670,7 +1650,7 @@ static void do_test_mixed_commit_types(void) {
         rd_kafka_share_destroy(rkshare);
 
         /* Produce 5 verification records */
-        produce_to_topic(topic, 0, 5);
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
 
         /* Second consumer: should only get the 5 verification records */
         rkshare = create_share_consumer(group, "implicit");

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -54,12 +54,12 @@ static rd_kafka_t *create_txn_producer(const char *txn_id) {
         rd_kafka_t *rk;
         rd_kafka_conf_t *conf;
 
-        test_conf_init(&conf, NULL, 60);
+        test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "transactional.id", txn_id);
         rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         rk = test_create_handle(RD_KAFKA_PRODUCER, conf);
-        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, 30000));
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, -1));
 
         return rk;
 }
@@ -288,7 +288,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -367,7 +367,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -463,7 +463,7 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -547,7 +547,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -635,7 +635,7 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -722,7 +722,7 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         producer2 = create_txn_producer("txn-producer-2");
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -810,7 +810,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         txn_producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -896,7 +896,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer with READ_UNCOMMITTED */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, "read_uncommitted");
         subscribe_share_consumer(consumer, topic);
 
@@ -1010,7 +1010,7 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         producer = create_txn_producer(txn_id);
 
         /* Create share consumer and set group config */
-        consumer = test_create_share_consumer(group);
+        consumer = test_create_share_consumer(group, NULL);
         configure_share_group(group, isolation_level);
         subscribe_share_consumer(consumer, topic);
 
@@ -1087,6 +1087,8 @@ int main_0177_share_consumer_transactions(int argc, char **argv) {
         /* Test both isolation levels */
         const char *isolation_levels[] = {"read_committed", "read_uncommitted"};
         int i;
+
+        test_timeout_set(200);
 
         /* Create common handles for all tests */
         common_admin            = test_create_producer();

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -76,12 +76,8 @@ static rd_kafka_t *create_txn_producer(const char *txn_id) {
  */
 static void configure_share_group(const char *group,
                                   const char *isolation_level) {
-        const char *configs[] = {
-            "share.auto.offset.reset", "SET", "earliest",
-            "share.isolation.level",   "SET", isolation_level};
-
-        test_IncrementalAlterConfigs_simple(
-            common_admin, RD_KAFKA_RESOURCE_GROUP, group, configs, 2);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_set_isolation_level(group, isolation_level);
 }
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -180,6 +180,11 @@ be it `make`, `run-test.sh`, `until-fail.sh`, etc.
  * `TEST_DEBUG=...` - this will automatically set the `debug` config property
                       of all instantiated clients to the value.
                       E.g.. `TEST_DEBUG=broker,protocol TESTS=0001 make`
+ * `TESTS_TO_DEBUG=0nnn,0mmm` - when used with `TEST_DEBUG`, limits debug
+                      logging to only the specified comma-separated test numbers.
+                      This is useful when running multiple tests but only wanting
+                      debug output from specific ones.
+                      E.g., `TESTS_TO_DEBUG=0172,0171 TEST_DEBUG=all make`
  * `TEST_LEVEL=n` - controls the `TEST_SAY()` output level, a higher number
                       yields more test output. Default level is 2.
  * `RD_UT_TEST=name` - only run unittest containing `name`, should be used

--- a/tests/test.c
+++ b/tests/test.c
@@ -8151,3 +8151,17 @@ void test_share_set_auto_offset_reset(const char *group_name,
         const char *cfg[] = {"share.auto.offset.reset", "SET", reset_policy};
         test_alter_group_configurations(group_name, cfg, 1);
 }
+
+
+/**
+ * @brief Set share.isolation.level configuration for a share group.
+ *
+ * @param group_name The share group name.
+ * @param isolation_level The isolation level ("read_committed" or
+ * "read_uncommitted").
+ */
+void test_share_set_isolation_level(const char *group_name,
+                                    const char *isolation_level) {
+        const char *cfg[] = {"share.isolation.level", "SET", isolation_level};
+        test_alter_group_configurations(group_name, cfg, 1);
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -45,18 +45,6 @@
  * is built from within the librdkafka source tree and thus differs. */
 #include "rdkafka.h"
 
-/**
- * Local definition of rd_kafka_share_s to access rkshare_rk
- * without pulling in rdkafka_int.h (which causes Windows link errors
- * due to internal inline functions referencing unexported symbols).
- *
- * TODO: Replace with a proper public API (e.g.
- * rd_kafka_share_consumer_get_rk()) so tests don't depend on the
- * internal struct layout.
- */
-struct rd_kafka_share_s {
-        rd_kafka_t *rkshare_rk;
-};
 
 int test_level = 2;
 int test_seed  = 0;
@@ -1051,10 +1039,81 @@ const char *test_getenv(const char *env, const char *def) {
         return rd_getenv(env, def);
 }
 
+/**
+ * @brief Check if debug logging should be enabled for the current test.
+ *
+ * If TESTS_TO_DEBUG environment variable is set with comma-separated test
+ * numbers (e.g., "0172,0171"), only enable debug for those tests.
+ * Otherwise, enable debug for all tests if TEST_DEBUG is set.
+ *
+ * @returns 1 if debug should be enabled, 0 otherwise.
+ */
+static int test_should_enable_debug(void) {
+        const char *tests_to_debug;
+        const char *test_debug;
+        int should_debug = 0;
+
+        /* If TEST_DEBUG is not set, no debug logging */
+        test_debug = test_getenv("TEST_DEBUG", NULL);
+        if (!test_debug)
+                return 0;
+
+        /* If TESTS_TO_DEBUG is not set, enable for all tests */
+        tests_to_debug = test_getenv("TESTS_TO_DEBUG", NULL);
+        if (!tests_to_debug)
+                return 1;
+
+        /* Extract test number from current test name (e.g., "0172" from
+         * "0172-share_consumer_acknowledge") */
+        if (!test_curr || !test_curr->name)
+                return 1; /* Enable by default if test name not available */
+
+        /* Simple comma-separated parsing */
+        const char *p = tests_to_debug;
+        while (*p) {
+                const char *comma;
+                size_t token_len;
+
+                /* Skip leading whitespace */
+                while (*p && isspace((unsigned char)*p))
+                        p++;
+
+                if (!*p)
+                        break;
+
+                /* Find next comma or end of string */
+                comma = strchr(p, ',');
+                if (comma)
+                        token_len = (size_t)(comma - p);
+                else
+                        token_len = strlen(p);
+
+                /* Trim trailing whitespace */
+                while (token_len > 0 &&
+                       isspace((unsigned char)p[token_len - 1]))
+                        token_len--;
+
+                /* Check if current test name starts with this token */
+                if (token_len > 0 &&
+                    strncmp(test_curr->name, p, token_len) == 0) {
+                        should_debug = 1;
+                        break;
+                }
+
+                /* Move to next token */
+                if (comma)
+                        p = comma + 1;
+                else
+                        break;
+        }
+
+        return should_debug;
+}
+
 void test_conf_common_init(rd_kafka_conf_t *conf, int timeout) {
         if (conf) {
                 const char *tmp = test_getenv("TEST_DEBUG", NULL);
-                if (tmp)
+                if (tmp && test_should_enable_debug())
                         test_conf_set(conf, "debug", tmp);
         }
 
@@ -2800,16 +2859,22 @@ rd_kafka_t *test_create_consumer(
  *         once these properties are added as defaults to
  *         rd_kafka_share_consumer_new().
  */
-rd_kafka_share_t *test_create_share_consumer(const char *group_id) {
+rd_kafka_share_t *test_create_share_consumer(const char *group_id,
+                                             const char *ack_mode) {
         rd_kafka_share_t *rk;
         rd_kafka_conf_t *conf;
         char errstr[512];
 
-        test_conf_init(&conf, NULL, 60);
+        test_conf_init(&conf, NULL, 0);
 
         rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,
                           sizeof(errstr));
+
+        if (ack_mode) {
+                rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode,
+                                  errstr, sizeof(errstr));
+        }
 
         rk = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
@@ -3481,7 +3546,7 @@ void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
         err = rd_kafka_share_subscribe(rk, topics);
         if (err)
                 TEST_FAIL("%s: Failed to subscribe to topics: %s\n",
-                          rd_kafka_name(test_share_consumer_get_rk(rk)),
+                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
                           rd_kafka_err2str(err));
 
         rd_kafka_topic_partition_list_destroy(topics);
@@ -3494,9 +3559,6 @@ void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
  * @param rkshare Share consumer handle.
  * @returns The underlying rd_kafka_t handle.
  */
-rd_kafka_t *test_share_consumer_get_rk(rd_kafka_share_t *rkshare) {
-        return rkshare->rkshare_rk;
-}
 
 
 /**
@@ -3512,12 +3574,12 @@ rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk) {
         err = rd_kafka_share_subscription(rk, &subscription);
         if (err)
                 TEST_FAIL("%s: Failed to get subscription: %s\n",
-                          rd_kafka_name(test_share_consumer_get_rk(rk)),
+                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
                           rd_kafka_err2str(err));
 
         TEST_ASSERT(subscription != NULL,
                     "%s: subscription() returned NULL list",
-                    rd_kafka_name(test_share_consumer_get_rk(rk)));
+                    rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)));
 
         return subscription;
 }
@@ -5586,6 +5648,29 @@ void test_delete_topic(rd_kafka_t *use_rk, const char *topicname) {
                 test_delete_topic_sh(topicname);
         else
                 test_admin_delete_topic(use_rk, topicname);
+}
+
+
+/**
+ * @brief Alter group configurations using a dedicated producer handle.
+ *        Admin client APIs should not reuse consumer handles.
+ *        Works for both share groups and regular consumer groups.
+ */
+void test_alter_group_configurations(const char *group_name,
+                                     const char **cfg,
+                                     size_t cfg_cnt) {
+        rd_kafka_t *admin;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 0);
+        admin = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(admin, "Failed to create admin client: %s", errstr);
+
+        test_IncrementalAlterConfigs_simple(admin, RD_KAFKA_RESOURCE_GROUP,
+                                            group_name, cfg, cfg_cnt);
+
+        rd_kafka_destroy(admin);
 }
 
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -2848,147 +2848,29 @@ rd_kafka_t *test_create_consumer(
         return rk;
 }
 
-/**
- * @brief Create a share consumer with standard configuration.
- *
- * @param group_id The share group ID.
- *
- * @returns A new share consumer instance.
- *
- * @remark TODO: Remove explicit group.id and enable.auto.commit settings
- *         once these properties are added as defaults to
- *         rd_kafka_share_consumer_new().
- */
-rd_kafka_share_t *test_create_share_consumer(const char *group_id,
-                                             const char *ack_mode) {
-        rd_kafka_share_t *rk;
-        rd_kafka_conf_t *conf;
-        char errstr[512];
-
-        test_conf_init(&conf, NULL, 0);
-
-        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
-        rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,
-                          sizeof(errstr));
-
-        if (ack_mode) {
-                rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode,
-                                  errstr, sizeof(errstr));
-        }
-
-        rk = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
-        TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
-
-        return rk;
-}
-
 
 /**
- * @brief Consume share messages and verify they come from expected topics.
+ * @brief Produce messages to a topic using a specific producer handle.
  *
- * @param rk Share consumer handle.
- * @param timeout_ms Poll timeout in milliseconds.
- * @param expected_topics Array of topic names that are valid sources
- *                        (NULL to skip verification).
- * @param expected_topic_cnt Number of topics in expected_topics array.
- * @param out_valid Output: count of valid (non-error) messages received.
+ * This is a convenience wrapper that creates a producer topic, produces
+ * messages, and cleans up. Commonly used with a shared producer instance
+ * across multiple test cases.
  *
- * @returns 0 on success, -1 if message from unexpected topic received.
+ * @param rk Producer handle to use.
+ * @param topic Topic name.
+ * @param partition Partition to produce to.
+ * @param msgcnt Number of messages to produce.
  */
-int test_share_consume_batch(rd_kafka_share_t *rk,
-                             int timeout_ms,
-                             const char **expected_topics,
-                             int expected_topic_cnt,
-                             int *out_valid) {
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
-        rd_kafka_error_t *err;
-        size_t rcvd = 0;
-        int valid   = 0;
-        size_t i;
-        int j;
-        int ret = 0;
+void test_produce_msgs_simple(rd_kafka_t *rk,
+                              const char *topic,
+                              int32_t partition,
+                              int msgcnt) {
+        rd_kafka_topic_t *rkt;
 
-        err = rd_kafka_share_consume_batch(rk, timeout_ms, batch, &rcvd);
-        if (err) {
-                rd_kafka_error_destroy(err);
-                *out_valid = 0;
-                return 0;
-        }
-
-        for (i = 0; i < rcvd; i++) {
-                if (batch[i]->err) {
-                        /* Skip error messages */
-                        rd_kafka_message_destroy(batch[i]);
-                        continue;
-                }
-
-                if (expected_topics) {
-                        const char *msg_topic =
-                            rd_kafka_topic_name(batch[i]->rkt);
-                        int found = 0;
-
-                        /* Verify message is from expected topic */
-                        for (j = 0; j < expected_topic_cnt; j++) {
-                                if (strcmp(msg_topic, expected_topics[j]) ==
-                                    0) {
-                                        found = 1;
-                                        break;
-                                }
-                        }
-
-                        if (!found) {
-                                TEST_SAY(
-                                    "ERROR: Received message from "
-                                    "unexpected topic '%s'\n",
-                                    msg_topic);
-                                ret = -1;
-                        }
-                }
-                valid++;
-                rd_kafka_message_destroy(batch[i]);
-        }
-
-        *out_valid = valid;
-        return ret;
+        rkt = test_create_producer_topic(rk, topic, NULL);
+        test_produce_msgs(rk, rkt, 0, partition, 0, msgcnt, NULL, 0);
+        rd_kafka_topic_destroy(rkt);
 }
-
-
-/**
- * @brief Consume share messages until expected count or max attempts.
- *
- * @param rk Share consumer handle.
- * @param expected Number of messages to consume.
- * @param max_attempts Maximum poll attempts.
- * @param timeout_ms Timeout per poll in milliseconds.
- * @param expected_topics Array of valid topic names (NULL to skip
- * verification).
- * @param expected_topic_cnt Number of topics in expected_topics.
- *
- * @returns Number of messages consumed, or -1 if message from wrong topic.
- */
-int test_share_consume_msgs(rd_kafka_share_t *rk,
-                            int expected,
-                            int max_attempts,
-                            int timeout_ms,
-                            const char **expected_topics,
-                            int expected_topic_cnt) {
-        int total = 0;
-
-        while (total < expected && max_attempts-- > 0) {
-                int batch_cnt = 0;
-                int ret;
-
-                ret = test_share_consume_batch(rk, timeout_ms, expected_topics,
-                                               expected_topic_cnt, &batch_cnt);
-                if (ret < 0)
-                        return -1; /* Wrong topic detected */
-
-                total += batch_cnt;
-        }
-
-        return total;
-}
-
 
 rd_kafka_topic_t *test_create_consumer_topic(rd_kafka_t *rk,
                                              const char *topic) {
@@ -3520,70 +3402,6 @@ void test_consumer_subscribe_multi(rd_kafka_t *rk, int topic_count, ...) {
 
         rd_kafka_topic_partition_list_destroy(topics);
 }
-
-
-/**
- * @brief Start subscribing for multiple topics (share consumers).
- */
-void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
-                                         int topic_count,
-                                         ...) {
-        rd_kafka_topic_partition_list_t *topics;
-        rd_kafka_resp_err_t err;
-        va_list ap;
-        int i;
-
-        topics = rd_kafka_topic_partition_list_new(topic_count);
-
-        va_start(ap, topic_count);
-        for (i = 0; i < topic_count; i++) {
-                const char *topic = va_arg(ap, const char *);
-                rd_kafka_topic_partition_list_add(topics, topic,
-                                                  RD_KAFKA_PARTITION_UA);
-        }
-        va_end(ap);
-
-        err = rd_kafka_share_subscribe(rk, topics);
-        if (err)
-                TEST_FAIL("%s: Failed to subscribe to topics: %s\n",
-                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
-                          rd_kafka_err2str(err));
-
-        rd_kafka_topic_partition_list_destroy(topics);
-}
-
-
-/**
- * @brief Get underlying rd_kafka_t handle from share consumer.
- *
- * @param rkshare Share consumer handle.
- * @returns The underlying rd_kafka_t handle.
- */
-
-
-/**
- * @brief Get current subscription list for share consumers.
- *
- * @returns The subscription list. Caller must destroy with
- *          rd_kafka_topic_partition_list_destroy().
- */
-rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk) {
-        rd_kafka_topic_partition_list_t *subscription = NULL;
-        rd_kafka_resp_err_t err;
-
-        err = rd_kafka_share_subscription(rk, &subscription);
-        if (err)
-                TEST_FAIL("%s: Failed to get subscription: %s\n",
-                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
-                          rd_kafka_err2str(err));
-
-        TEST_ASSERT(subscription != NULL,
-                    "%s: subscription() returned NULL list",
-                    rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)));
-
-        return subscription;
-}
-
 
 void test_consumer_assign(const char *what,
                           rd_kafka_t *rk,
@@ -8118,4 +7936,218 @@ const char *test_consumer_group_protocol() {
 int test_consumer_group_protocol_classic() {
         return !test_consumer_group_protocol_str ||
                !strcmp(test_consumer_group_protocol_str, "classic");
+}
+
+
+/****************************************************************************
+ * Share Consumer helpers
+ ****************************************************************************/
+
+/**
+ * @brief Create a share consumer with standard configuration.
+ *
+ * @param group_id The share group ID.
+ *
+ * @returns A new share consumer instance.
+ *
+ * @remark TODO: Remove explicit group.id and enable.auto.commit settings
+ *         once these properties are added as defaults to
+ *         rd_kafka_share_consumer_new().
+ */
+rd_kafka_share_t *test_create_share_consumer(const char *group_id,
+                                             const char *ack_mode) {
+        rd_kafka_share_t *rk;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 0);
+
+        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "enable.auto.commit", "false", errstr,
+                          sizeof(errstr));
+
+        if (ack_mode) {
+                rd_kafka_conf_set(conf, "share.acknowledgement.mode", ack_mode,
+                                  errstr, sizeof(errstr));
+        }
+
+        rk = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
+
+        return rk;
+}
+
+
+/**
+ * @brief Consume share messages and verify they come from expected topics.
+ *
+ * @param rk Share consumer handle.
+ * @param timeout_ms Poll timeout in milliseconds.
+ * @param expected_topics Array of topic names that are valid sources
+ *                        (NULL to skip verification).
+ * @param expected_topic_cnt Number of topics in expected_topics array.
+ * @param out_valid Output: count of valid (non-error) messages received.
+ *
+ * @returns 0 on success, -1 if message from unexpected topic received.
+ */
+int test_share_consume_batch(rd_kafka_share_t *rk,
+                             int timeout_ms,
+                             const char **expected_topics,
+                             int expected_topic_cnt,
+                             int *out_valid) {
+        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_error_t *err;
+        size_t rcvd = 0;
+        int valid   = 0;
+        size_t i;
+        int j;
+        int ret = 0;
+
+        err = rd_kafka_share_consume_batch(rk, timeout_ms, batch, &rcvd);
+        if (err) {
+                rd_kafka_error_destroy(err);
+                *out_valid = 0;
+                return 0;
+        }
+
+        for (i = 0; i < rcvd; i++) {
+                if (batch[i]->err) {
+                        /* Skip error messages */
+                        rd_kafka_message_destroy(batch[i]);
+                        continue;
+                }
+
+                if (expected_topics) {
+                        const char *msg_topic =
+                            rd_kafka_topic_name(batch[i]->rkt);
+                        int found = 0;
+
+                        /* Verify message is from expected topic */
+                        for (j = 0; j < expected_topic_cnt; j++) {
+                                if (strcmp(msg_topic, expected_topics[j]) ==
+                                    0) {
+                                        found = 1;
+                                        break;
+                                }
+                        }
+
+                        if (!found) {
+                                TEST_SAY(
+                                    "ERROR: Received message from "
+                                    "unexpected topic '%s'\n",
+                                    msg_topic);
+                                ret = -1;
+                        }
+                }
+                valid++;
+                rd_kafka_message_destroy(batch[i]);
+        }
+
+        *out_valid = valid;
+        return ret;
+}
+
+
+/**
+ * @brief Consume share messages until expected count or max attempts.
+ *
+ * @param rk Share consumer handle.
+ * @param expected Number of messages to consume.
+ * @param max_attempts Maximum poll attempts.
+ * @param timeout_ms Timeout per poll in milliseconds.
+ * @param expected_topics Array of valid topic names (NULL to skip
+ * verification).
+ * @param expected_topic_cnt Number of topics in expected_topics.
+ *
+ * @returns Number of messages consumed, or -1 if message from wrong topic.
+ */
+int test_share_consume_msgs(rd_kafka_share_t *rk,
+                            int expected,
+                            int max_attempts,
+                            int timeout_ms,
+                            const char **expected_topics,
+                            int expected_topic_cnt) {
+        int total = 0;
+
+        while (total < expected && max_attempts-- > 0) {
+                int batch_cnt = 0;
+                int ret;
+
+                ret = test_share_consume_batch(rk, timeout_ms, expected_topics,
+                                               expected_topic_cnt, &batch_cnt);
+                if (ret < 0)
+                        return -1; /* Wrong topic detected */
+
+                total += batch_cnt;
+        }
+
+        return total;
+}
+
+
+/**
+ * @brief Start subscribing for multiple topics (share consumers).
+ */
+void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
+                                         int topic_count,
+                                         ...) {
+        rd_kafka_topic_partition_list_t *topics;
+        rd_kafka_resp_err_t err;
+        va_list ap;
+        int i;
+
+        topics = rd_kafka_topic_partition_list_new(topic_count);
+
+        va_start(ap, topic_count);
+        for (i = 0; i < topic_count; i++) {
+                const char *topic = va_arg(ap, const char *);
+                rd_kafka_topic_partition_list_add(topics, topic,
+                                                  RD_KAFKA_PARTITION_UA);
+        }
+        va_end(ap);
+
+        err = rd_kafka_share_subscribe(rk, topics);
+        if (err)
+                TEST_FAIL("%s: Failed to subscribe to topics: %s\n",
+                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
+                          rd_kafka_err2str(err));
+
+        rd_kafka_topic_partition_list_destroy(topics);
+}
+
+
+/**
+ * @brief Get current subscription list for share consumers.
+ *
+ * @returns The subscription list. Caller must destroy with
+ *          rd_kafka_topic_partition_list_destroy().
+ */
+rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk) {
+        rd_kafka_topic_partition_list_t *subscription = NULL;
+        rd_kafka_resp_err_t err;
+
+        err = rd_kafka_share_subscription(rk, &subscription);
+        if (err)
+                TEST_FAIL("%s: Failed to get subscription: %s\n",
+                          rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)),
+                          rd_kafka_err2str(err));
+
+        TEST_ASSERT(subscription != NULL,
+                    "%s: subscription() returned NULL list",
+                    rd_kafka_name(rd_kafka_share_consumer_get_rk(rk)));
+
+        return subscription;
+}
+
+
+/**
+ * @brief Set share.auto.offset.reset configuration for a share group.
+ *
+ * @param group_name The share group name.
+ * @param reset_policy The offset reset policy ("earliest" or "latest").
+ */
+void test_share_set_auto_offset_reset(const char *group_name,
+                                      const char *reset_policy) {
+        const char *cfg[] = {"share.auto.offset.reset", "SET", reset_policy};
+        test_alter_group_configurations(group_name, cfg, 1);
 }

--- a/tests/test.h
+++ b/tests/test.h
@@ -1057,6 +1057,9 @@ rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk);
 void test_share_set_auto_offset_reset(const char *group_name,
                                       const char *reset_policy);
 
+void test_share_set_isolation_level(const char *group_name,
+                                    const char *isolation_level);
+
 
 /**
  * @name rusage.c

--- a/tests/test.h
+++ b/tests/test.h
@@ -555,9 +555,9 @@ rd_kafka_t *test_create_consumer(
     rd_kafka_conf_t *conf,
     rd_kafka_topic_conf_t *default_topic_conf);
 
-rd_kafka_share_t *test_create_share_consumer(const char *group_id);
+rd_kafka_share_t *test_create_share_consumer(const char *group_id,
+                                             const char *ack_mode);
 
-rd_kafka_t *test_share_consumer_get_rk(rd_kafka_share_t *rkshare);
 
 #define TEST_SHARE_BATCH_SIZE 500
 
@@ -888,6 +888,10 @@ test_IncrementalAlterConfigs_simple(rd_kafka_t *rk,
                                     const char *resname,
                                     const char **configs,
                                     size_t config_cnt);
+
+void test_alter_group_configurations(const char *group_name,
+                                     const char **cfg,
+                                     size_t cfg_cnt);
 
 rd_kafka_resp_err_t test_DeleteGroups_simple(rd_kafka_t *rk,
                                              rd_kafka_queue_t *useq,

--- a/tests/test.h
+++ b/tests/test.h
@@ -1033,7 +1033,7 @@ int test_consumer_group_protocol_classic();
 rd_kafka_share_t *test_create_share_consumer(const char *group_id,
                                              const char *ack_mode);
 
-#define TEST_SHARE_BATCH_SIZE 500
+#define TEST_SHARE_BATCH_SIZE 10001
 
 int test_share_consume_batch(rd_kafka_share_t *rk,
                              int timeout_ms,

--- a/tests/test.h
+++ b/tests/test.h
@@ -555,24 +555,10 @@ rd_kafka_t *test_create_consumer(
     rd_kafka_conf_t *conf,
     rd_kafka_topic_conf_t *default_topic_conf);
 
-rd_kafka_share_t *test_create_share_consumer(const char *group_id,
-                                             const char *ack_mode);
-
-
-#define TEST_SHARE_BATCH_SIZE 500
-
-int test_share_consume_batch(rd_kafka_share_t *rk,
-                             int timeout_ms,
-                             const char **expected_topics,
-                             int expected_topic_cnt,
-                             int *out_valid);
-
-int test_share_consume_msgs(rd_kafka_share_t *rk,
-                            int expected,
-                            int max_attempts,
-                            int timeout_ms,
-                            const char **expected_topics,
-                            int expected_topic_cnt);
+void test_produce_msgs_simple(rd_kafka_t *rk,
+                              const char *topic,
+                              int32_t partition,
+                              int msgcnt);
 
 rd_kafka_topic_t *test_create_consumer_topic(rd_kafka_t *rk, const char *topic);
 rd_kafka_topic_t *
@@ -613,12 +599,6 @@ void test_verify_rkmessage0(const char *func,
 void test_consumer_subscribe(rd_kafka_t *rk, const char *topic);
 
 void test_consumer_subscribe_multi(rd_kafka_t *rk, int topic_count, ...);
-
-void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
-                                         int topic_count,
-                                         ...);
-
-rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk);
 
 void test_consume_msgs_easy_mv0(const char *group_id,
                                 const char *topic,
@@ -1045,6 +1025,38 @@ int test_consumer_group_protocol_classic();
                 TEST_SAY0("Error: %s: %s" _C_CLR "\n",                         \
                           rd_kafka_error_name(_e), rd_kafka_error_string(_e)); \
         } while (0)
+
+/****************************************************************************
+ * Share Consumer helpers
+ ****************************************************************************/
+
+rd_kafka_share_t *test_create_share_consumer(const char *group_id,
+                                             const char *ack_mode);
+
+#define TEST_SHARE_BATCH_SIZE 500
+
+int test_share_consume_batch(rd_kafka_share_t *rk,
+                             int timeout_ms,
+                             const char **expected_topics,
+                             int expected_topic_cnt,
+                             int *out_valid);
+
+int test_share_consume_msgs(rd_kafka_share_t *rk,
+                            int expected,
+                            int max_attempts,
+                            int timeout_ms,
+                            const char **expected_topics,
+                            int expected_topic_cnt);
+
+void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
+                                         int topic_count,
+                                         ...);
+
+rd_kafka_topic_partition_list_t *test_get_subscription(rd_kafka_share_t *rk);
+
+void test_share_set_auto_offset_reset(const char *group_name,
+                                      const char *reset_policy);
+
 
 /**
  * @name rusage.c


### PR DESCRIPTION
Refactors share consumer tests to use common infrastructure pattern, fixes MSVC build error, and adds new utility functions.

Key Changes
1. Common Producer/Admin Pattern (tests 0170, 0171, 0172, 0173, 0177)

- Share producer and admin client handles across tests
- Reduces test execution time and code duplication

2. Enhanced test_create_share_consumer() API

// New signature supports acknowledgement mode configuration
rd_kafka_share_t *test_create_share_consumer(const char *group_name, 
                                               const char *ack_mode);

3. New API: rd_kafka_share_consumer_get_rk()

// Get the underlying rd_kafka_t handle from a share consumer
rd_kafka_t *rd_kafka_share_consumer_get_rk(rd_kafka_share_t *rkshare);

- Enables access to low-level Kafka client for advanced operations
- Useful for testing and debugging scenarios

4. MSVC Build Fix

- Replaced POSIX-specific strtok_r() with C89-standard string functions
- Fixes Windows build compatibility

5. Debug Test Selection

- Added TESTS_TO_DEBUG environment variable for selective test execution during development
- Example: TESTS_TO_DEBUG="0170,0171,0172" ./test-runner
- Speeds up development cycle by running only specific tests