### PR TITLE
[KIP-932] Mock Broker : Minor fixes for fetching workflow of Share Fetch RPC

### DIFF
--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -718,15 +718,15 @@ rd_kafka_mock_sharegroup_set_max_size(rd_kafka_mock_cluster_t *mcluster,
                                       int max_size);
 
 /**
- * @brief Set the maximum number of fetch sessions allowed in a share group.
+ * @brief Set the maximum number of fetch sessions allowed per broker.
  *
- * New sessions attempted via ShareFetch with epoch 0 when the group
+ * New sessions attempted via ShareFetch with epoch 0 when the broker
  * is at capacity will receive SHARE_SESSION_LIMIT_REACHED.
  *
  * Default is 2000 (per KIP-932 group.share.max.share.sessions).
  *
  * @param mcluster Mock cluster instance.
- * @param max_fetch_sessions Maximum fetch sessions allowed. 0 = unlimited.
+ * @param max_fetch_sessions Maximum fetch sessions per broker. 0 = unlimited.
  */
 RD_EXPORT void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
     rd_kafka_mock_cluster_t *mcluster,

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -741,11 +741,12 @@ RD_EXPORT void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
  * Default is 2000 (group.share.partition.max.record.locks).
  *
  * @param mcluster Mock cluster instance.
- * @param max_record_locks Maximum in-flight records per partition. 0 = unlimited.
+ * @param max_record_locks Maximum in-flight records per partition. 0 =
+ * unlimited.
  */
-RD_EXPORT void rd_kafka_mock_sharegroup_set_max_record_locks(
-    rd_kafka_mock_cluster_t *mcluster,
-    int max_record_locks);
+RD_EXPORT void
+rd_kafka_mock_sharegroup_set_max_record_locks(rd_kafka_mock_cluster_t *mcluster,
+                                              int max_record_locks);
 
 /**
  * @brief Set the auto offset reset policy for share groups.

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -748,6 +748,21 @@ RD_EXPORT void rd_kafka_mock_sharegroup_set_max_record_locks(
     int max_record_locks);
 
 /**
+ * @brief Set the auto offset reset policy for share groups.
+ *
+ * Controls where SPSO is initialized when a share-partition is first
+ * consumed.
+ *
+ * Default is 0 ("latest") per KIP-932.
+ *
+ * @param mcluster Mock cluster instance.
+ * @param auto_offset_reset 0 = latest, 1 = earliest.
+ */
+RD_EXPORT void rd_kafka_mock_sharegroup_set_auto_offset_reset(
+    rd_kafka_mock_cluster_t *mcluster,
+    int auto_offset_reset);
+
+/**
  * @brief Set a manual target assignment for a sharegroup.
  *
  * This allows tests to override the automatic partition assignment

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -723,7 +723,7 @@ rd_kafka_mock_sharegroup_set_max_size(rd_kafka_mock_cluster_t *mcluster,
  * New sessions attempted via ShareFetch with epoch 0 when the broker
  * is at capacity will receive SHARE_SESSION_LIMIT_REACHED.
  *
- * Default is 2000 (per KIP-932 group.share.max.share.sessions).
+ * Default is 2000 (group.share.max.share.sessions).
  *
  * @param mcluster Mock cluster instance.
  * @param max_fetch_sessions Maximum fetch sessions per broker. 0 = unlimited.
@@ -738,7 +738,7 @@ RD_EXPORT void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
  * Once the limit is reached, no more records are acquired until existing
  * locks are released (via ack, release, reject, or lock expiry).
  *
- * Default is 2000 (per KIP-932 group.share.partition.max.record.locks).
+ * Default is 2000 (group.share.partition.max.record.locks).
  *
  * @param mcluster Mock cluster instance.
  * @param max_record_locks Maximum in-flight records per partition. 0 = unlimited.
@@ -753,7 +753,7 @@ RD_EXPORT void rd_kafka_mock_sharegroup_set_max_record_locks(
  * Controls where SPSO is initialized when a share-partition is first
  * consumed.
  *
- * Default is 0 ("latest") per KIP-932.
+ * Default is 0 ("latest").
  *
  * @param mcluster Mock cluster instance.
  * @param auto_offset_reset 0 = latest, 1 = earliest.

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -718,6 +718,21 @@ rd_kafka_mock_sharegroup_set_max_size(rd_kafka_mock_cluster_t *mcluster,
                                       int max_size);
 
 /**
+ * @brief Set the maximum number of fetch sessions allowed in a share group.
+ *
+ * New sessions attempted via ShareFetch with epoch 0 when the group
+ * is at capacity will receive SHARE_SESSION_LIMIT_REACHED.
+ *
+ * Default is 2000 (per KIP-932 group.share.max.share.sessions).
+ *
+ * @param mcluster Mock cluster instance.
+ * @param max_fetch_sessions Maximum fetch sessions allowed. 0 = unlimited.
+ */
+RD_EXPORT void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
+    rd_kafka_mock_cluster_t *mcluster,
+    int max_fetch_sessions);
+
+/**
  * @brief Set a manual target assignment for a sharegroup.
  *
  * This allows tests to override the automatic partition assignment

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -733,6 +733,21 @@ RD_EXPORT void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
     int max_fetch_sessions);
 
 /**
+ * @brief Set the maximum number of in-flight record locks per share-partition.
+ *
+ * Once the limit is reached, no more records are acquired until existing
+ * locks are released (via ack, release, reject, or lock expiry).
+ *
+ * Default is 2000 (per KIP-932 group.share.partition.max.record.locks).
+ *
+ * @param mcluster Mock cluster instance.
+ * @param max_record_locks Maximum in-flight records per partition. 0 = unlimited.
+ */
+RD_EXPORT void rd_kafka_mock_sharegroup_set_max_record_locks(
+    rd_kafka_mock_cluster_t *mcluster,
+    int max_record_locks);
+
+/**
  * @brief Set a manual target assignment for a sharegroup.
  *
  * This allows tests to override the automatic partition assignment

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4189,18 +4189,6 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         session->session_epoch++;
                 }
 
-                /* epoch=-1 (final fetch / close session) must not
-                 * contain ForgottenTopicsData.  Acks in the Topics
-                 * array ARE allowed. */
-                if (!err && SessionEpoch == -1 &&
-                    (forgotten_partitions && forgotten_partitions->cnt > 0)) {
-                        rd_kafka_dbg(
-                            mconn->broker->cluster->rk, MOCK, "MOCK",
-                            "ShareFetch: rejecting epoch=-1 request "
-                            "with ForgottenTopicsData (INVALID_REQUEST)");
-                        err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
-                }
-
                 /* Apply piggy-backed acknowledgements BEFORE forgotten
                  * partition processing, so that acks for partitions
                  * being removed are applied while the records are still
@@ -4219,17 +4207,6 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                     sgrp, entry->topic_id, entry->partition,
                                     entry->first_offset, entry->last_offset,
                                     entry->ack_type, &MemberId);
-                        }
-                } else if (err && rd_list_cnt(&ack_entries) > 0) {
-                        /* Broad error prevents ack processing.
-                         * Propagate the top-level error to
-                         * AcknowledgeErrorCode for all partitions that
-                         * had piggybacked acks. */
-                        int k;
-                        for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
-                                struct rd_kafka_mock_sgrp_ack_entry *entry =
-                                    rd_list_elem(&ack_entries, k);
-                                entry->err = err;
                         }
                 }
 

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3659,8 +3659,30 @@ struct rd_kafka_mock_sgrp_ack_entry {
         int32_t partition;
         int64_t first_offset;
         int64_t last_offset;
-        int8_t ack_type; /**< 0=GAP, 1=ACCEPT, 2=RELEASE, 3=REJECT */
+        int8_t ack_type;          /**< 0=GAP, 1=ACCEPT, 2=RELEASE, 3=REJECT */
+        rd_kafka_resp_err_t err;  /**< Per-batch ack result, set after apply */
 };
+
+/**
+ * @brief Find the worst ack error for the given (topic_id, partition) across
+ *        all ack entries.  Returns NO_ERROR if no ack targeted this partition
+ *        or all acks succeeded.
+ */
+static rd_kafka_resp_err_t rd_kafka_mock_sgrp_ack_error_for_partition(
+    const rd_list_t *ack_entries,
+    rd_kafka_Uuid_t topic_id,
+    int32_t partition) {
+        int k;
+        for (k = 0; k < rd_list_cnt(ack_entries); k++) {
+                const struct rd_kafka_mock_sgrp_ack_entry *entry =
+                    rd_list_elem(ack_entries, k);
+                if (entry->partition == partition &&
+                    !rd_kafka_Uuid_cmp(entry->topic_id, topic_id) &&
+                    entry->err)
+                        return entry->err;
+        }
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
+}
 
 /**
  * @brief Apply a single acknowledgement batch to share-group partition
@@ -3674,19 +3696,21 @@ struct rd_kafka_mock_sgrp_ack_entry {
  *
  * @locks mcluster->lock MUST be held.
  */
-static void rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
-                                         rd_kafka_Uuid_t topic_id,
-                                         int32_t partition,
-                                         int64_t first_offset,
-                                         int64_t last_offset,
-                                         int8_t ack_type,
-                                         const rd_kafkap_str_t *member_id) {
+static rd_kafka_resp_err_t
+rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
+                             rd_kafka_Uuid_t topic_id,
+                             int32_t partition,
+                             int64_t first_offset,
+                             int64_t last_offset,
+                             int8_t ack_type,
+                             const rd_kafkap_str_t *member_id) {
         rd_kafka_mock_sgrp_partmeta_t *pmeta;
+        rd_kafka_resp_err_t err = RD_KAFKA_RESP_ERR_NO_ERROR;
         int64_t offset;
 
         pmeta = rd_kafka_mock_sgrp_partmeta_find(sgrp, topic_id, partition);
         if (!pmeta)
-                return;
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
 
         for (offset = first_offset; offset <= last_offset; offset++) {
                 rd_kafka_mock_sgrp_record_state_t *state =
@@ -3694,13 +3718,17 @@ static void rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 if (!state)
                         continue;
 
-                /* Only the owning member may acknowledge acquired records */
-                if (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED)
+                /* Only the owning member may acknowledge acquired records.
+                 * If the record's lock expired (reverted to Available),
+                 * was re-acquired by another member, or is otherwise not
+                 * in ACQUIRED state for this member, report
+                 * INVALID_RECORD_STATE. */
+                if (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED ||
+                    !state->owner_member_id ||
+                    rd_kafkap_str_cmp_str(member_id, state->owner_member_id)) {
+                        err = RD_KAFKA_RESP_ERR_INVALID_RECORD_STATE;
                         continue;
-                if (!state->owner_member_id)
-                        continue;
-                if (rd_kafkap_str_cmp_str(member_id, state->owner_member_id))
-                        continue;
+                }
 
                 switch (ack_type) {
                 case 0: /* GAP */
@@ -3730,6 +3758,8 @@ static void rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                         break;
                 pmeta->spso++;
         }
+
+        return err;
 }
 
 /**
@@ -4125,7 +4155,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
                                 struct rd_kafka_mock_sgrp_ack_entry *entry =
                                     rd_list_elem(&ack_entries, k);
-                                rd_kafka_mock_sgrp_apply_ack(
+                                entry->err = rd_kafka_mock_sgrp_apply_ack(
                                     sgrp, entry->topic_id, entry->partition,
                                     entry->first_offset, entry->last_offset,
                                     entry->ack_type, &MemberId);
@@ -4268,6 +4298,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                       sgrp, topic_id,
                                                       rktpar->partition)
                                                 : NULL;
+                                        rd_kafka_resp_err_t ack_err;
                                         rd_kafka_resp_err_t part_err =
                                             mpart
                                                 ? RD_KAFKA_RESP_ERR_NO_ERROR
@@ -4289,10 +4320,21 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_str(
                                                     resp, NULL, -1);
                                         /* Response: AcknowledgementErrorCode */
-                                        rd_kafka_buf_write_i16(resp, 0);
-                                        /* Response: AcknowledgementErrorString
-                                         */
-                                        rd_kafka_buf_write_str(resp, NULL, -1);
+                                        ack_err =
+                                            rd_kafka_mock_sgrp_ack_error_for_partition(
+                                                &ack_entries, topic_id,
+                                                rktpar->partition);
+                                        rd_kafka_buf_write_i16(resp, ack_err);
+                                        /* Response:
+                                         * AcknowledgementErrorString */
+                                        if (ack_err)
+                                                rd_kafka_buf_write_str(
+                                                    resp,
+                                                    rd_kafka_err2str(ack_err),
+                                                    -1);
+                                        else
+                                                rd_kafka_buf_write_str(
+                                                    resp, NULL, -1);
                                         /* Response: CurrentLeader */
                                         rd_kafka_buf_write_i32(resp, -1);
                                         rd_kafka_buf_write_i32(resp, -1);
@@ -4529,7 +4571,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                         for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
                                 struct rd_kafka_mock_sgrp_ack_entry *entry =
                                     rd_list_elem(&ack_entries, k);
-                                rd_kafka_mock_sgrp_apply_ack(
+                                entry->err = rd_kafka_mock_sgrp_apply_ack(
                                     sgrp, entry->topic_id, entry->partition,
                                     entry->first_offset, entry->last_offset,
                                     entry->ack_type, &MemberId);
@@ -4613,7 +4655,9 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         rd_kafka_topic_partition_t *rktpar =
                                             &ack_partitions->elems[j];
                                         rd_kafka_resp_err_t part_err =
-                                            RD_KAFKA_RESP_ERR_NO_ERROR;
+                                            rd_kafka_mock_sgrp_ack_error_for_partition(
+                                                &ack_entries, topic_id,
+                                                rktpar->partition);
 
                                         /* PartitionIndex */
                                         rd_kafka_buf_write_i32(
@@ -4621,7 +4665,14 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         /* ErrorCode */
                                         rd_kafka_buf_write_i16(resp, part_err);
                                         /* ErrorMessage */
-                                        rd_kafka_buf_write_str(resp, NULL, -1);
+                                        if (part_err)
+                                                rd_kafka_buf_write_str(
+                                                    resp,
+                                                    rd_kafka_err2str(part_err),
+                                                    -1);
+                                        else
+                                                rd_kafka_buf_write_str(
+                                                    resp, NULL, -1);
                                         /* CurrentLeader */
                                         rd_kafka_buf_write_i32(
                                             resp, -1); /* LeaderId */

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3373,7 +3373,12 @@ rd_kafka_mock_sgrp_partmeta_get(rd_kafka_mock_sharegroup_t *sgrp,
         pmeta            = rd_calloc(1, sizeof(*pmeta));
         pmeta->topic_id  = topic_id;
         pmeta->partition = partition;
-        pmeta->spso      = mpart->start_offset;
+        /* Initialize SPSO based on auto.offset.reset:
+         * 0 = latest (end of log), 1 = earliest (start of log). */
+        if (sgrp->auto_offset_reset == 1)
+                pmeta->spso = mpart->start_offset;
+        else
+                pmeta->spso = mpart->end_offset;
         if (mpart->end_offset > mpart->start_offset)
                 pmeta->speo = mpart->end_offset - 1;
         else

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3369,6 +3369,9 @@ rd_kafka_mock_sgrp_partmeta_get(rd_kafka_mock_sharegroup_t *sgrp,
                                            tmp) {
                                 if (state->offset >= log_start)
                                         continue;
+                                if (state->state ==
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED)
+                                        pmeta->acquired_cnt--;
                                 state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
                                 RD_IF_FREE(state->owner_member_id, rd_free);
                                 state->owner_member_id = NULL;
@@ -3503,9 +3506,9 @@ static void rd_kafka_mock_sgrp_acquire_available_offsets(
                 if (remaining_bytes && *remaining_bytes == 0)
                         break;
 
-                /* Check max in-flight record locks per partition */
+                /* Check max acquired record locks per partition */
                 if (max_record_locks > 0 &&
-                    pmeta->inflight_cnt >= max_record_locks)
+                    pmeta->acquired_cnt >= max_record_locks)
                         break;
 
                 state = rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
@@ -3575,6 +3578,7 @@ static void rd_kafka_mock_sgrp_acquire_available_offsets(
                 state->delivery_count++;
                 RD_IF_FREE(state->owner_member_id, rd_free);
                 state->owner_member_id = RD_KAFKAP_STR_DUP(member_id);
+                pmeta->acquired_cnt++;
 
                 (*acquired_cnt)++;
                 *acquired_bytes += est_size;
@@ -3690,7 +3694,7 @@ struct rd_kafka_mock_sgrp_ack_entry {
 };
 
 /**
- * @brief Find the worst ack error for the given (topic_id, partition) across
+ * @brief Find the first ack error for the given (topic_id, partition) across
  *        all ack entries.  Returns NO_ERROR if no ack targeted this partition
  *        or all acks succeeded.
  */
@@ -3757,30 +3761,40 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 }
 
                 switch (ack_type) {
-                case 0: /* GAP */
-                case 1: /* ACCEPT */
-                case 3: /* REJECT */
+                case 1: /* ACCEPT -> Acknowledged */
+                        pmeta->acquired_cnt--;
                         state->state =
                             RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
                         rd_free(state->owner_member_id);
                         state->owner_member_id = NULL;
                         state->lock_expiry_ts  = 0;
                         break;
+                case 0: /* GAP -> Archived */
+                case 3: /* REJECT -> Archived */
+                        pmeta->acquired_cnt--;
+                        state->state =
+                            RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                        rd_free(state->owner_member_id);
+                        state->owner_member_id = NULL;
+                        state->lock_expiry_ts  = 0;
+                        break;
                 case 2: /* RELEASE */
-                        rd_kafka_mock_sgrp_record_release(sgrp, state);
+                        rd_kafka_mock_sgrp_record_release(sgrp, pmeta,
+                                                          state);
                         break;
                 default:
                         break;
                 }
         }
 
-        /* Advance SPSO past contiguous ACKNOWLEDGED records from
-         * the start, transitioning them to ARCHIVED. */
+        /* Advance SPSO past contiguous ACKNOWLEDGED or ARCHIVED records
+         * from the start, transitioning ACKNOWLEDGED to ARCHIVED. */
         while (pmeta->spso <= pmeta->speo) {
                 rd_kafka_mock_sgrp_record_state_t *state =
                     rd_kafka_mock_sgrp_record_state_find(pmeta, pmeta->spso);
                 if (!state ||
-                    state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED)
+                    (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED &&
+                     state->state != RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED))
                         break;
                 state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
                 pmeta->spso++;
@@ -4258,7 +4272,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                         state->owner_member_id))
                                                         continue;
                                                 rd_kafka_mock_sgrp_record_release(
-                                                    sgrp, state);
+                                                    sgrp, pmeta, state);
                                         }
                                 }
                         }

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3845,6 +3845,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
         rd_kafka_topic_partition_list_t *requested_partitions = NULL;
         rd_kafka_topic_partition_list_t *forgotten_partitions = NULL;
         rd_kafka_resp_err_t err          = RD_KAFKA_RESP_ERR_NO_ERROR;
+        rd_bool_t ack_parse_err         = rd_false;
         rd_kafka_mock_sharegroup_t *sgrp = NULL;
         rd_kafka_mock_sgrp_fetch_session_t *session = NULL;
         rd_list_t ack_entries;
@@ -3878,24 +3879,49 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 while (PartitionCnt-- > 0) {
                         int32_t Partition;
                         int32_t AckBatchCnt;
+                        int64_t prev_ack_last = -1;
                         rd_kafka_topic_partition_t *rktpar;
 
                         rd_kafka_buf_read_i32(rkbuf, &Partition);
                         rd_kafka_buf_read_arraycnt(rkbuf, &AckBatchCnt, -1);
                         while (AckBatchCnt-- > 0) {
                                 int32_t AckTypeCnt;
-                                int8_t AckType = -1;
                                 int64_t AckFirstOffset, AckLastOffset;
+                                int64_t range_len, ti;
+                                int8_t *ack_types = NULL;
+                                int8_t single_type = -1;
+
                                 rd_kafka_buf_read_i64(rkbuf, &AckFirstOffset);
                                 rd_kafka_buf_read_i64(rkbuf, &AckLastOffset);
+
+                                /* Validate ascending order and
+                                 * non-overlapping ranges. */
+                                if (prev_ack_last >= 0 &&
+                                    AckFirstOffset <= prev_ack_last)
+                                        ack_parse_err = rd_true;
+                                prev_ack_last = AckLastOffset;
+
+                                range_len = AckLastOffset - AckFirstOffset + 1;
+
                                 rd_kafka_buf_read_arraycnt(rkbuf, &AckTypeCnt,
                                                            -1);
-                                while (AckTypeCnt-- > 0) {
-                                        rd_kafka_buf_read_i8(rkbuf, &AckType);
+
+                                if (AckTypeCnt == 1) {
+                                        /* Single type for entire range */
+                                        rd_kafka_buf_read_i8(rkbuf,
+                                                             &single_type);
+                                } else if (AckTypeCnt > 1) {
+                                        /* Per-offset types */
+                                        ack_types = rd_alloca(
+                                            (size_t)AckTypeCnt *
+                                                sizeof(*ack_types));
+                                        for (ti = 0; ti < AckTypeCnt; ti++)
+                                                rd_kafka_buf_read_i8(
+                                                    rkbuf, &ack_types[ti]);
                                 }
                                 rd_kafka_buf_skip_tags(rkbuf);
 
-                                if (AckType >= 0) {
+                                if (AckTypeCnt == 1 && single_type >= 0) {
                                         struct rd_kafka_mock_sgrp_ack_entry
                                             *entry =
                                                 rd_calloc(1, sizeof(*entry));
@@ -3903,8 +3929,28 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                         entry->partition    = Partition;
                                         entry->first_offset = AckFirstOffset;
                                         entry->last_offset  = AckLastOffset;
-                                        entry->ack_type     = AckType;
+                                        entry->ack_type     = single_type;
                                         rd_list_add(&ack_entries, entry);
+                                } else if (ack_types &&
+                                           AckTypeCnt == range_len) {
+                                        /* Per-offset: one entry per offset */
+                                        for (ti = 0; ti < range_len; ti++) {
+                                                struct rd_kafka_mock_sgrp_ack_entry
+                                                    *entry = rd_calloc(
+                                                        1, sizeof(*entry));
+                                                entry->topic_id = TopicId;
+                                                entry->partition = Partition;
+                                                entry->first_offset =
+                                                    AckFirstOffset + ti;
+                                                entry->last_offset =
+                                                    AckFirstOffset + ti;
+                                                entry->ack_type = ack_types[ti];
+                                                rd_list_add(&ack_entries, entry);
+                                        }
+                                } else if (AckTypeCnt > 0) {
+                                        /* AckTypeCnt is neither 1 nor
+                                         * range_len: malformed request. */
+                                        ack_parse_err = rd_true;
                                 }
                         }
 
@@ -3969,6 +4015,9 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                      BatchSize);
 
         err = rd_kafka_mock_next_request_error(mconn, resp);
+
+        if (!err && ack_parse_err)
+                err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
 
         if (!err) {
                 int64_t remaining_records =
@@ -4454,6 +4503,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
         int32_t TopicsCnt;
         rd_kafka_topic_partition_list_t *ack_partitions = NULL;
         rd_kafka_resp_err_t err          = RD_KAFKA_RESP_ERR_NO_ERROR;
+        rd_bool_t ack_parse_err         = rd_false;
         rd_kafka_mock_sharegroup_t *sgrp = NULL;
         rd_list_t ack_entries;
 
@@ -4481,24 +4531,49 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                 while (PartitionCnt-- > 0) {
                         int32_t Partition;
                         int32_t AckBatchCnt;
+                        int64_t prev_ack_last = -1;
                         rd_kafka_topic_partition_t *rktpar;
 
                         rd_kafka_buf_read_i32(rkbuf, &Partition);
                         rd_kafka_buf_read_arraycnt(rkbuf, &AckBatchCnt, -1);
                         while (AckBatchCnt-- > 0) {
                                 int32_t AckTypeCnt;
-                                int8_t AckType = -1;
                                 int64_t AckFirstOffset, AckLastOffset;
+                                int64_t range_len, ti;
+                                int8_t *ack_types = NULL;
+                                int8_t single_type = -1;
+
                                 rd_kafka_buf_read_i64(rkbuf, &AckFirstOffset);
                                 rd_kafka_buf_read_i64(rkbuf, &AckLastOffset);
+
+                                /* Validate ascending order and
+                                 * non-overlapping ranges. */
+                                if (prev_ack_last >= 0 &&
+                                    AckFirstOffset <= prev_ack_last)
+                                        ack_parse_err = rd_true;
+                                prev_ack_last = AckLastOffset;
+
+                                range_len = AckLastOffset - AckFirstOffset + 1;
+
                                 rd_kafka_buf_read_arraycnt(rkbuf, &AckTypeCnt,
                                                            -1);
-                                while (AckTypeCnt-- > 0) {
-                                        rd_kafka_buf_read_i8(rkbuf, &AckType);
+
+                                if (AckTypeCnt == 1) {
+                                        /* Single type for entire range */
+                                        rd_kafka_buf_read_i8(rkbuf,
+                                                             &single_type);
+                                } else if (AckTypeCnt > 1) {
+                                        /* Per-offset types */
+                                        ack_types = rd_alloca(
+                                            (size_t)AckTypeCnt *
+                                                sizeof(*ack_types));
+                                        for (ti = 0; ti < AckTypeCnt; ti++)
+                                                rd_kafka_buf_read_i8(
+                                                    rkbuf, &ack_types[ti]);
                                 }
                                 rd_kafka_buf_skip_tags(rkbuf);
 
-                                if (AckType >= 0) {
+                                if (AckTypeCnt == 1 && single_type >= 0) {
                                         struct rd_kafka_mock_sgrp_ack_entry
                                             *entry =
                                                 rd_calloc(1, sizeof(*entry));
@@ -4506,8 +4581,28 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         entry->partition    = Partition;
                                         entry->first_offset = AckFirstOffset;
                                         entry->last_offset  = AckLastOffset;
-                                        entry->ack_type     = AckType;
+                                        entry->ack_type     = single_type;
                                         rd_list_add(&ack_entries, entry);
+                                } else if (ack_types &&
+                                           AckTypeCnt == range_len) {
+                                        /* Per-offset: one entry per offset */
+                                        for (ti = 0; ti < range_len; ti++) {
+                                                struct rd_kafka_mock_sgrp_ack_entry
+                                                    *entry = rd_calloc(
+                                                        1, sizeof(*entry));
+                                                entry->topic_id = TopicId;
+                                                entry->partition = Partition;
+                                                entry->first_offset =
+                                                    AckFirstOffset + ti;
+                                                entry->last_offset =
+                                                    AckFirstOffset + ti;
+                                                entry->ack_type = ack_types[ti];
+                                                rd_list_add(&ack_entries, entry);
+                                        }
+                                } else if (AckTypeCnt > 0) {
+                                        /* AckTypeCnt is neither 1 nor
+                                         * range_len: malformed request. */
+                                        ack_parse_err = rd_true;
                                 }
                         }
 
@@ -4532,6 +4627,9 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
 
         /* ---- Inject errors if configured ---- */
         err = rd_kafka_mock_next_request_error(mconn, resp);
+
+        if (!err && ack_parse_err)
+                err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
 
         if (!err) {
                 rd_kafka_mock_sgrp_fetch_session_t *session = NULL;

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3576,7 +3576,8 @@ static void rd_kafka_mock_sgrp_partmeta_prune_archived(
         rd_kafka_mock_sgrp_record_state_t *state, *tmp;
 
         TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link, tmp) {
-                if (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED)
+                if (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED &&
+                    state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED)
                         continue;
                 if (state->offset >= pmeta->spso)
                         continue;
@@ -3745,7 +3746,8 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 case 0: /* GAP */
                 case 1: /* ACCEPT */
                 case 3: /* REJECT */
-                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                        state->state =
+                            RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
                         rd_free(state->owner_member_id);
                         state->owner_member_id = NULL;
                         state->lock_expiry_ts  = 0;
@@ -3758,15 +3760,15 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 }
         }
 
-        /* Advance SPSO past contiguous ARCHIVED records from the start,
-         * so that acknowledged records are no longer considered for
-         * future acquisitions. */
+        /* Advance SPSO past contiguous ACKNOWLEDGED records from
+         * the start, transitioning them to ARCHIVED. */
         while (pmeta->spso <= pmeta->speo) {
                 rd_kafka_mock_sgrp_record_state_t *state =
                     rd_kafka_mock_sgrp_record_state_find(pmeta, pmeta->spso);
                 if (!state ||
-                    state->state != RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED)
+                    state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED)
                         break;
+                state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
                 pmeta->spso++;
         }
 

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3964,16 +3964,35 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 mtx_lock(&mcluster->lock);
                 sgrp = rd_kafka_mock_sharegroup_get(mcluster, &GroupId);
 
+                /* epoch=0 (full fetch / new session) must not
+                 * contain acknowledgements.  Check BEFORE
+                 * session_validate to avoid destroying an existing
+                 * session for a malformed request. */
+                if (SessionEpoch == 0 && rd_list_cnt(&ack_entries) > 0) {
+                        rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
+                                     "ShareFetch: rejecting epoch=0 request "
+                                     "with %d ack(s) (INVALID_REQUEST)",
+                                     rd_list_cnt(&ack_entries));
+                        err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+                }
+
                 /* Common validation: member check, session lookup,
                  * epoch -1 close, epoch > 0 validation. */
-                err = rd_kafka_mock_sgrp_session_validate(
-                    sgrp, &MemberId, mconn->broker->id, SessionEpoch, &session,
-                    "ShareFetch");
+                if (!err)
+                        err = rd_kafka_mock_sgrp_session_validate(
+                            sgrp, &MemberId, mconn->broker->id, SessionEpoch,
+                            &session, "ShareFetch");
 
                 if (!err && SessionEpoch == 0) {
                         /* Open a new session (or reuse if one already exists
                          * for this member on this broker). */
-                        if (!session) {
+                        if (!session && sgrp->max_fetch_sessions > 0 &&
+                            sgrp->fetch_session_cnt >=
+                                sgrp->max_fetch_sessions) {
+                                /* Session cache is full. */
+                                err =
+                                    RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED;
+                        } else if (!session) {
                                 session = rd_calloc(1, sizeof(*session));
                                 session->member_id =
                                     RD_KAFKAP_STR_DUP(&MemberId);
@@ -4090,17 +4109,6 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                         }
                                 }
                         }
-                }
-
-                /* epoch=0 (full fetch / new session) must not
-                 * contain acknowledgements. */
-                if (!err && SessionEpoch == 0 &&
-                    rd_list_cnt(&ack_entries) > 0) {
-                        rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
-                                     "ShareFetch: rejecting epoch=0 request "
-                                     "with %d ack(s) (INVALID_REQUEST)",
-                                     rd_list_cnt(&ack_entries));
-                        err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
                 }
 
                 /* Apply piggy-backed acknowledgements (implicit ack)

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4092,10 +4092,23 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 if (!err && SessionEpoch == 0) {
                         /* Open a new session (or reuse if one already exists
                          * for this member on this broker). */
+                        int broker_session_cnt = 0;
+                        rd_kafka_mock_sharegroup_t *sg;
+                        rd_kafka_mock_sgrp_fetch_session_t *s;
+                        /* Count sessions across ALL share groups on this
+                         * broker.  Per KIP-932, group.share.max.share.sessions
+                         * is a per-broker limit with cache key (GroupId,
+                         * MemberId). */
+                        TAILQ_FOREACH(sg, &mcluster->sharegrps, link) {
+                                TAILQ_FOREACH(s, &sg->fetch_sessions, link) {
+                                        if (s->node_id == mconn->broker->id)
+                                                broker_session_cnt++;
+                                }
+                        }
                         if (!session && sgrp->max_fetch_sessions > 0 &&
-                            sgrp->fetch_session_cnt >=
+                            broker_session_cnt >=
                                 sgrp->max_fetch_sessions) {
-                                /* Session cache is full. */
+                                /* Session cache is full for this broker. */
                                 err =
                                     RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED;
                         } else if (!session) {

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4161,6 +4161,17 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                     entry->first_offset, entry->last_offset,
                                     entry->ack_type, &MemberId);
                         }
+                } else if (err && rd_list_cnt(&ack_entries) > 0) {
+                        /* Broad error prevents ack processing.
+                         * Per KIP-932, propagate the top-level error to
+                         * AcknowledgeErrorCode for all partitions that
+                         * had piggybacked acks. */
+                        int k;
+                        for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
+                                struct rd_kafka_mock_sgrp_ack_entry *entry =
+                                    rd_list_elem(&ack_entries, k);
+                                entry->err = err;
+                        }
                 }
 
                 /* Remove forgotten partitions from session and release

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3694,6 +3694,25 @@ struct rd_kafka_mock_sgrp_ack_entry {
 };
 
 /**
+ * @brief Allocate and initialize a new ack entry.
+ */
+static struct rd_kafka_mock_sgrp_ack_entry *
+rd_kafka_mock_sgrp_ack_entry_new(rd_kafka_Uuid_t topic_id,
+                                 int32_t partition,
+                                 int64_t first_offset,
+                                 int64_t last_offset,
+                                 int8_t ack_type) {
+        struct rd_kafka_mock_sgrp_ack_entry *entry =
+            rd_calloc(1, sizeof(*entry));
+        entry->topic_id     = topic_id;
+        entry->partition    = partition;
+        entry->first_offset = first_offset;
+        entry->last_offset  = last_offset;
+        entry->ack_type     = ack_type;
+        return entry;
+}
+
+/**
  * @brief Find the first ack error for the given (topic_id, partition) across
  *        all ack entries.  Returns NO_ERROR if no ack targeted this partition
  *        or all acks succeeded.
@@ -3959,36 +3978,24 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                 rd_kafka_buf_skip_tags(rkbuf);
 
                                 if (AckTypeCnt == 1 && single_type >= 0) {
-                                        struct rd_kafka_mock_sgrp_ack_entry
-                                            *entry =
-                                                rd_calloc(1, sizeof(*entry));
-                                        entry->topic_id     = TopicId;
-                                        entry->partition    = Partition;
-                                        entry->first_offset = AckFirstOffset;
-                                        entry->last_offset  = AckLastOffset;
-                                        entry->ack_type     = single_type;
-                                        rd_list_add(&ack_entries, entry);
+                                        rd_list_add(
+                                            &ack_entries,
+                                            rd_kafka_mock_sgrp_ack_entry_new(
+                                                TopicId, Partition,
+                                                AckFirstOffset, AckLastOffset,
+                                                single_type));
                                 } else if (ack_types &&
                                            AckTypeCnt == range_len) {
-                                        /* Per-offset: one entry per offset */
                                         for (ti = 0; ti < range_len; ti++) {
-                                                struct
-                                                    rd_kafka_mock_sgrp_ack_entry
-                                                        *entry = rd_calloc(
-                                                            1, sizeof(*entry));
-                                                entry->topic_id  = TopicId;
-                                                entry->partition = Partition;
-                                                entry->first_offset =
-                                                    AckFirstOffset + ti;
-                                                entry->last_offset =
-                                                    AckFirstOffset + ti;
-                                                entry->ack_type = ack_types[ti];
-                                                rd_list_add(&ack_entries,
-                                                            entry);
+                                                rd_list_add(
+                                                    &ack_entries,
+                                                    rd_kafka_mock_sgrp_ack_entry_new(
+                                                        TopicId, Partition,
+                                                        AckFirstOffset + ti,
+                                                        AckFirstOffset + ti,
+                                                        ack_types[ti]));
                                         }
                                 } else if (AckTypeCnt > 0) {
-                                        /* AckTypeCnt is neither 1 nor
-                                         * range_len: malformed request. */
                                         ack_parse_err = rd_true;
                                 }
                         }
@@ -4645,36 +4652,24 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                 rd_kafka_buf_skip_tags(rkbuf);
 
                                 if (AckTypeCnt == 1 && single_type >= 0) {
-                                        struct rd_kafka_mock_sgrp_ack_entry
-                                            *entry =
-                                                rd_calloc(1, sizeof(*entry));
-                                        entry->topic_id     = TopicId;
-                                        entry->partition    = Partition;
-                                        entry->first_offset = AckFirstOffset;
-                                        entry->last_offset  = AckLastOffset;
-                                        entry->ack_type     = single_type;
-                                        rd_list_add(&ack_entries, entry);
+                                        rd_list_add(
+                                            &ack_entries,
+                                            rd_kafka_mock_sgrp_ack_entry_new(
+                                                TopicId, Partition,
+                                                AckFirstOffset, AckLastOffset,
+                                                single_type));
                                 } else if (ack_types &&
                                            AckTypeCnt == range_len) {
-                                        /* Per-offset: one entry per offset */
                                         for (ti = 0; ti < range_len; ti++) {
-                                                struct
-                                                    rd_kafka_mock_sgrp_ack_entry
-                                                        *entry = rd_calloc(
-                                                            1, sizeof(*entry));
-                                                entry->topic_id  = TopicId;
-                                                entry->partition = Partition;
-                                                entry->first_offset =
-                                                    AckFirstOffset + ti;
-                                                entry->last_offset =
-                                                    AckFirstOffset + ti;
-                                                entry->ack_type = ack_types[ti];
-                                                rd_list_add(&ack_entries,
-                                                            entry);
+                                                rd_list_add(
+                                                    &ack_entries,
+                                                    rd_kafka_mock_sgrp_ack_entry_new(
+                                                        TopicId, Partition,
+                                                        AckFirstOffset + ti,
+                                                        AckFirstOffset + ti,
+                                                        ack_types[ti]));
                                         }
                                 } else if (AckTypeCnt > 0) {
-                                        /* AckTypeCnt is neither 1 nor
-                                         * range_len: malformed request. */
                                         ack_parse_err = rd_true;
                                 }
                         }

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3458,6 +3458,7 @@ static void rd_kafka_mock_sgrp_acquire_available_offsets(
     const rd_kafkap_str_t *member_id,
     rd_ts_t lock_expiry_ts,
     int max_delivery_attempts,
+    int max_record_locks,
     int64_t *remaining_records,
     int64_t *remaining_bytes,
     int *acquired_cnt,
@@ -3481,6 +3482,11 @@ static void rd_kafka_mock_sgrp_acquire_available_offsets(
                 if (remaining_records && *remaining_records == 0)
                         break;
                 if (remaining_bytes && *remaining_bytes == 0)
+                        break;
+
+                /* Check max in-flight record locks per partition */
+                if (max_record_locks > 0 &&
+                    pmeta->inflight_cnt >= max_record_locks)
                         break;
 
                 state = rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
@@ -4224,9 +4230,15 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         }
                 }
 
-                if (!err && sgrp && session && session->partitions) {
-                        rd_kafka_topic_partition_t *rktpar;
-                        RD_KAFKA_TPLIST_FOREACH(rktpar, session->partitions) {
+                if (!err && sgrp && session && session->partitions &&
+                    session->partitions->cnt > 0) {
+                        int pi, pcnt = session->partitions->cnt;
+                        int start    = session->partition_start_idx % pcnt;
+
+                        for (pi = 0; pi < pcnt; pi++) {
+                                int idx = (start + pi) % pcnt;
+                                rd_kafka_topic_partition_t *rktpar =
+                                    &session->partitions->elems[idx];
                                 rd_kafka_Uuid_t topic_id =
                                     rd_kafka_topic_partition_get_topic_id(
                                         rktpar);
@@ -4262,11 +4274,15 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 : sgrp->session_timeout_ms) *
                                            1000),
                                     sgrp->max_delivery_attempts,
+                                    sgrp->max_record_locks,
                                     MaxRecords > 0 ? &remaining_records : NULL,
                                     MaxBytes > 0 ? &remaining_bytes : NULL,
                                     &acquired_cnt, &acquired_bytes,
                                     sgrp->isolation_level);
                         }
+
+                        /* Rotate start index for next request */
+                        session->partition_start_idx = (start + 1) % pcnt;
                 }
 
                 rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3360,8 +3360,22 @@ rd_kafka_mock_sgrp_partmeta_get(rd_kafka_mock_sharegroup_t *sgrp,
         if (pmeta) {
                 log_start = mpart->start_offset;
                 log_end   = mpart->end_offset;
-                if (log_start > pmeta->spso)
+                if (log_start > pmeta->spso) {
+                        /* Log retention moved start_offset past SPSO.
+                         * Archive all in-flight records below the new
+                         * SPSO — they are no longer in the log. */
+                        rd_kafka_mock_sgrp_record_state_t *state, *tmp;
+                        TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link,
+                                           tmp) {
+                                if (state->offset >= log_start)
+                                        continue;
+                                state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                                RD_IF_FREE(state->owner_member_id, rd_free);
+                                state->owner_member_id = NULL;
+                                state->lock_expiry_ts  = 0;
+                        }
                         pmeta->spso = log_start;
+                }
                 if (log_end > log_start) {
                         int64_t new_speo = log_end - 1;
                         if (new_speo > pmeta->speo)

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4268,18 +4268,13 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                                    topic_id);
                                 rd_kafka_mock_partition_t *mpart;
 
-                                if (!mtopic) {
-                                        err =
-                                            RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
-                                        break;
-                                }
-
-                                mpart = rd_kafka_mock_partition_find(
-                                    mtopic, rktpar->partition);
-                                if (!mpart) {
-                                        err =
-                                            RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
-                                        break;
+                                if (!mtopic || !(mpart = rd_kafka_mock_partition_find(
+                                                     mtopic, rktpar->partition))) {
+                                        /* Per-partition error: skip this
+                                         * partition but continue with others.
+                                         * The response writer handles the
+                                         * error via mpart==NULL check. */
+                                        continue;
                                 }
 
                                 rd_kafka_mock_sgrp_partmeta_t *pmeta =

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4068,7 +4068,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 int64_t acquired_bytes  = 0;
                 rd_ts_t now             = rd_clock();
 
-                /* KIP-932 session management.
+                /* Session management.
                  * Sessions are keyed by (GroupId, MemberId).
                  * SessionEpoch: 0 = open new session,
                  *              -1 = close session,
@@ -4110,8 +4110,8 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         rd_kafka_mock_sharegroup_t *sg;
                         rd_kafka_mock_sgrp_fetch_session_t *s;
                         /* Count sessions across ALL share groups on this
-                         * broker.  Per KIP-932, group.share.max.share.sessions
-                         * is a per-broker limit with cache key (GroupId,
+                         * broker.  group.share.max.share.sessions is a
+                         * per-broker limit with cache key (GroupId,
                          * MemberId). */
                         TAILQ_FOREACH(sg, &mcluster->sharegrps, link) {
                                 TAILQ_FOREACH(s, &sg->fetch_sessions, link) {
@@ -4187,7 +4187,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
 
                 /* epoch=-1 (final fetch / close session) must not
                  * contain ForgottenTopicsData.  Acks in the Topics
-                 * array ARE allowed per KIP-932. */
+                 * array ARE allowed. */
                 if (!err && SessionEpoch == -1 &&
                     (forgotten_partitions && forgotten_partitions->cnt > 0)) {
                         rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
@@ -4217,7 +4217,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         }
                 } else if (err && rd_list_cnt(&ack_entries) > 0) {
                         /* Broad error prevents ack processing.
-                         * Per KIP-932, propagate the top-level error to
+                         * Propagate the top-level error to
                          * AcknowledgeErrorCode for all partitions that
                          * had piggybacked acks. */
                         int k;
@@ -4549,7 +4549,7 @@ err_parse:
 }
 
 /**
- * @brief Handle ShareAcknowledgeRequest (KIP-932).
+ * @brief Handle ShareAcknowledgeRequest.
  *
  * This is the standalone acknowledgement API (key 79).  It has the same
  * acknowledgement-batch wire format as the piggy-backed acks inside

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3365,14 +3365,14 @@ rd_kafka_mock_sgrp_partmeta_get(rd_kafka_mock_sharegroup_t *sgrp,
                          * Archive all in-flight records below the new
                          * SPSO — they are no longer in the log. */
                         rd_kafka_mock_sgrp_record_state_t *state, *tmp;
-                        TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link,
-                                           tmp) {
+                        TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link, tmp) {
                                 if (state->offset >= log_start)
                                         continue;
                                 if (state->state ==
                                     RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED)
                                         pmeta->acquired_cnt--;
-                                state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                                state->state =
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
                                 RD_IF_FREE(state->owner_member_id, rd_free);
                                 state->owner_member_id = NULL;
                                 state->lock_expiry_ts  = 0;
@@ -3689,8 +3689,8 @@ struct rd_kafka_mock_sgrp_ack_entry {
         int32_t partition;
         int64_t first_offset;
         int64_t last_offset;
-        int8_t ack_type;          /**< 0=GAP, 1=ACCEPT, 2=RELEASE, 3=REJECT */
-        rd_kafka_resp_err_t err;  /**< Per-batch ack result, set after apply */
+        int8_t ack_type;         /**< 0=GAP, 1=ACCEPT, 2=RELEASE, 3=REJECT */
+        rd_kafka_resp_err_t err; /**< Per-batch ack result, set after apply */
 };
 
 /**
@@ -3698,17 +3698,16 @@ struct rd_kafka_mock_sgrp_ack_entry {
  *        all ack entries.  Returns NO_ERROR if no ack targeted this partition
  *        or all acks succeeded.
  */
-static rd_kafka_resp_err_t rd_kafka_mock_sgrp_ack_error_for_partition(
-    const rd_list_t *ack_entries,
-    rd_kafka_Uuid_t topic_id,
-    int32_t partition) {
+static rd_kafka_resp_err_t
+rd_kafka_mock_sgrp_ack_error_for_partition(const rd_list_t *ack_entries,
+                                           rd_kafka_Uuid_t topic_id,
+                                           int32_t partition) {
         int k;
         for (k = 0; k < rd_list_cnt(ack_entries); k++) {
                 const struct rd_kafka_mock_sgrp_ack_entry *entry =
                     rd_list_elem(ack_entries, k);
                 if (entry->partition == partition &&
-                    !rd_kafka_Uuid_cmp(entry->topic_id, topic_id) &&
-                    entry->err)
+                    !rd_kafka_Uuid_cmp(entry->topic_id, topic_id) && entry->err)
                         return entry->err;
         }
         return RD_KAFKA_RESP_ERR_NO_ERROR;
@@ -3763,8 +3762,7 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 switch (ack_type) {
                 case 1: /* ACCEPT -> Acknowledged */
                         pmeta->acquired_cnt--;
-                        state->state =
-                            RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
+                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
                         rd_free(state->owner_member_id);
                         state->owner_member_id = NULL;
                         state->lock_expiry_ts  = 0;
@@ -3772,15 +3770,13 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                 case 0: /* GAP -> Archived */
                 case 3: /* REJECT -> Archived */
                         pmeta->acquired_cnt--;
-                        state->state =
-                            RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
                         rd_free(state->owner_member_id);
                         state->owner_member_id = NULL;
                         state->lock_expiry_ts  = 0;
                         break;
                 case 2: /* RELEASE */
-                        rd_kafka_mock_sgrp_record_release(sgrp, pmeta,
-                                                          state);
+                        rd_kafka_mock_sgrp_record_release(sgrp, pmeta, state);
                         break;
                 default:
                         break;
@@ -3886,7 +3882,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
         rd_kafka_topic_partition_list_t *requested_partitions = NULL;
         rd_kafka_topic_partition_list_t *forgotten_partitions = NULL;
         rd_kafka_resp_err_t err          = RD_KAFKA_RESP_ERR_NO_ERROR;
-        rd_bool_t ack_parse_err         = rd_false;
+        rd_bool_t ack_parse_err          = rd_false;
         rd_kafka_mock_sharegroup_t *sgrp = NULL;
         rd_kafka_mock_sgrp_fetch_session_t *session = NULL;
         rd_list_t ack_entries;
@@ -3929,7 +3925,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                 int32_t AckTypeCnt;
                                 int64_t AckFirstOffset, AckLastOffset;
                                 int64_t range_len, ti;
-                                int8_t *ack_types = NULL;
+                                int8_t *ack_types  = NULL;
                                 int8_t single_type = -1;
 
                                 rd_kafka_buf_read_i64(rkbuf, &AckFirstOffset);
@@ -3953,9 +3949,9 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                              &single_type);
                                 } else if (AckTypeCnt > 1) {
                                         /* Per-offset types */
-                                        ack_types = rd_alloca(
-                                            (size_t)AckTypeCnt *
-                                                sizeof(*ack_types));
+                                        ack_types =
+                                            rd_alloca((size_t)AckTypeCnt *
+                                                      sizeof(*ack_types));
                                         for (ti = 0; ti < AckTypeCnt; ti++)
                                                 rd_kafka_buf_read_i8(
                                                     rkbuf, &ack_types[ti]);
@@ -3976,17 +3972,19 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                            AckTypeCnt == range_len) {
                                         /* Per-offset: one entry per offset */
                                         for (ti = 0; ti < range_len; ti++) {
-                                                struct rd_kafka_mock_sgrp_ack_entry
-                                                    *entry = rd_calloc(
-                                                        1, sizeof(*entry));
-                                                entry->topic_id = TopicId;
+                                                struct
+                                                    rd_kafka_mock_sgrp_ack_entry
+                                                        *entry = rd_calloc(
+                                                            1, sizeof(*entry));
+                                                entry->topic_id  = TopicId;
                                                 entry->partition = Partition;
                                                 entry->first_offset =
                                                     AckFirstOffset + ti;
                                                 entry->last_offset =
                                                     AckFirstOffset + ti;
                                                 entry->ack_type = ack_types[ti];
-                                                rd_list_add(&ack_entries, entry);
+                                                rd_list_add(&ack_entries,
+                                                            entry);
                                         }
                                 } else if (AckTypeCnt > 0) {
                                         /* AckTypeCnt is neither 1 nor
@@ -4120,8 +4118,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                 }
                         }
                         if (!session && sgrp->max_fetch_sessions > 0 &&
-                            broker_session_cnt >=
-                                sgrp->max_fetch_sessions) {
+                            broker_session_cnt >= sgrp->max_fetch_sessions) {
                                 /* Session cache is full for this broker. */
                                 err =
                                     RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED;
@@ -4190,9 +4187,10 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                  * array ARE allowed. */
                 if (!err && SessionEpoch == -1 &&
                     (forgotten_partitions && forgotten_partitions->cnt > 0)) {
-                        rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
-                                     "ShareFetch: rejecting epoch=-1 request "
-                                     "with ForgottenTopicsData (INVALID_REQUEST)");
+                        rd_kafka_dbg(
+                            mconn->broker->cluster->rk, MOCK, "MOCK",
+                            "ShareFetch: rejecting epoch=-1 request "
+                            "with ForgottenTopicsData (INVALID_REQUEST)");
                         err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
                 }
 
@@ -4281,7 +4279,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 if (!err && sgrp && session && session->partitions &&
                     session->partitions->cnt > 0) {
                         int pi, pcnt = session->partitions->cnt;
-                        int start    = session->partition_start_idx % pcnt;
+                        int start = session->partition_start_idx % pcnt;
 
                         for (pi = 0; pi < pcnt; pi++) {
                                 int idx = (start + pi) % pcnt;
@@ -4295,8 +4293,9 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                                    topic_id);
                                 rd_kafka_mock_partition_t *mpart;
 
-                                if (!mtopic || !(mpart = rd_kafka_mock_partition_find(
-                                                     mtopic, rktpar->partition))) {
+                                if (!mtopic ||
+                                    !(mpart = rd_kafka_mock_partition_find(
+                                          mtopic, rktpar->partition))) {
                                         /* Per-partition error: skip this
                                          * partition but continue with others.
                                          * The response writer handles the
@@ -4575,7 +4574,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
         int32_t TopicsCnt;
         rd_kafka_topic_partition_list_t *ack_partitions = NULL;
         rd_kafka_resp_err_t err          = RD_KAFKA_RESP_ERR_NO_ERROR;
-        rd_bool_t ack_parse_err         = rd_false;
+        rd_bool_t ack_parse_err          = rd_false;
         rd_kafka_mock_sharegroup_t *sgrp = NULL;
         rd_list_t ack_entries;
 
@@ -4612,7 +4611,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                 int32_t AckTypeCnt;
                                 int64_t AckFirstOffset, AckLastOffset;
                                 int64_t range_len, ti;
-                                int8_t *ack_types = NULL;
+                                int8_t *ack_types  = NULL;
                                 int8_t single_type = -1;
 
                                 rd_kafka_buf_read_i64(rkbuf, &AckFirstOffset);
@@ -4636,9 +4635,9 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                                              &single_type);
                                 } else if (AckTypeCnt > 1) {
                                         /* Per-offset types */
-                                        ack_types = rd_alloca(
-                                            (size_t)AckTypeCnt *
-                                                sizeof(*ack_types));
+                                        ack_types =
+                                            rd_alloca((size_t)AckTypeCnt *
+                                                      sizeof(*ack_types));
                                         for (ti = 0; ti < AckTypeCnt; ti++)
                                                 rd_kafka_buf_read_i8(
                                                     rkbuf, &ack_types[ti]);
@@ -4659,17 +4658,19 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                            AckTypeCnt == range_len) {
                                         /* Per-offset: one entry per offset */
                                         for (ti = 0; ti < range_len; ti++) {
-                                                struct rd_kafka_mock_sgrp_ack_entry
-                                                    *entry = rd_calloc(
-                                                        1, sizeof(*entry));
-                                                entry->topic_id = TopicId;
+                                                struct
+                                                    rd_kafka_mock_sgrp_ack_entry
+                                                        *entry = rd_calloc(
+                                                            1, sizeof(*entry));
+                                                entry->topic_id  = TopicId;
                                                 entry->partition = Partition;
                                                 entry->first_offset =
                                                     AckFirstOffset + ti;
                                                 entry->last_offset =
                                                     AckFirstOffset + ti;
                                                 entry->ack_type = ack_types[ti];
-                                                rd_list_add(&ack_entries, entry);
+                                                rd_list_add(&ack_entries,
+                                                            entry);
                                         }
                                 } else if (AckTypeCnt > 0) {
                                         /* AckTypeCnt is neither 1 nor

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4131,19 +4131,42 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         session->session_epoch++;
                 }
 
-                /* epoch=-1 (final fetch / close session) must
-                 * not add or forget topics. */
+                /* epoch=-1 (final fetch / close session) must not
+                 * contain ForgottenTopicsData.  Acks in the Topics
+                 * array ARE allowed per KIP-932. */
                 if (!err && SessionEpoch == -1 &&
-                    ((requested_partitions && requested_partitions->cnt > 0) ||
-                     (forgotten_partitions && forgotten_partitions->cnt > 0))) {
+                    (forgotten_partitions && forgotten_partitions->cnt > 0)) {
                         rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
                                      "ShareFetch: rejecting epoch=-1 request "
-                                     "with topic add/forget (INVALID_REQUEST)");
+                                     "with ForgottenTopicsData (INVALID_REQUEST)");
                         err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
                 }
 
+                /* Apply piggy-backed acknowledgements BEFORE forgotten
+                 * partition processing, so that acks for partitions
+                 * being removed are applied while the records are still
+                 * in ACQUIRED state. */
+                if (!err && sgrp && rd_list_cnt(&ack_entries) > 0) {
+                        int k;
+                        rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
+                                     "ShareFetch: applying %d acknowledgement "
+                                     "batch(es) for member %.*s",
+                                     rd_list_cnt(&ack_entries),
+                                     RD_KAFKAP_STR_PR(&MemberId));
+                        for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
+                                struct rd_kafka_mock_sgrp_ack_entry *entry =
+                                    rd_list_elem(&ack_entries, k);
+                                entry->err = rd_kafka_mock_sgrp_apply_ack(
+                                    sgrp, entry->topic_id, entry->partition,
+                                    entry->first_offset, entry->last_offset,
+                                    entry->ack_type, &MemberId);
+                        }
+                }
+
                 /* Remove forgotten partitions from session and release
-                 * any in-flight ACQUIRED records owned by this member. */
+                 * any remaining ACQUIRED records owned by this member.
+                 * Runs AFTER ack application so that acks for partitions
+                 * being removed have already been processed. */
                 if (!err && session && forgotten_partitions &&
                     forgotten_partitions->cnt > 0) {
                         rd_kafka_topic_partition_t *ftp;
@@ -4187,27 +4210,6 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                     sgrp, state);
                                         }
                                 }
-                        }
-                }
-
-                /* Apply piggy-backed acknowledgements (implicit ack)
-                 * before acquiring new records.  This processes the
-                 * AcknowledgementBatches sent by the client for records
-                 * delivered in the previous ShareFetch response. */
-                if (!err && sgrp && rd_list_cnt(&ack_entries) > 0) {
-                        int k;
-                        rd_kafka_dbg(mconn->broker->cluster->rk, MOCK, "MOCK",
-                                     "ShareFetch: applying %d acknowledgement "
-                                     "batch(es) for member %.*s",
-                                     rd_list_cnt(&ack_entries),
-                                     RD_KAFKAP_STR_PR(&MemberId));
-                        for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
-                                struct rd_kafka_mock_sgrp_ack_entry *entry =
-                                    rd_list_elem(&ack_entries, k);
-                                entry->err = rd_kafka_mock_sgrp_apply_ack(
-                                    sgrp, entry->topic_id, entry->partition,
-                                    entry->first_offset, entry->last_offset,
-                                    entry->ack_type, &MemberId);
                         }
                 }
 

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -260,7 +260,7 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int isolation_level;         /**< Share isolation level */
         int max_size;                /**< Max members allowed.
                                       *   0 = unlimited (default). */
-        int max_fetch_sessions;      /**< Max fetch sessions allowed.
+        int max_fetch_sessions;      /**< Max fetch sessions per broker.
                                       *   0 = unlimited (default 2000). */
         int max_record_locks;        /**< Max in-flight records per
                                       *   share-partition.
@@ -652,7 +652,7 @@ struct rd_kafka_mock_cluster_s {
                 /** Max members allowed in share group (KIP 932).
                  *  0 = unlimited. */
                 int sharegroup_max_size;
-                /** Max fetch sessions per share group (KIP 932).
+                /** Max fetch sessions per broker (KIP 932).
                  *  0 = unlimited. */
                 int sharegroup_max_fetch_sessions;
                 /** Max in-flight records per share-partition (KIP 932).

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -227,7 +227,7 @@ typedef struct rd_kafka_mock_sgrp_fetch_session_s {
 } rd_kafka_mock_sgrp_fetch_session_t;
 
 /**
- * @struct Share group (KIP-932).
+ * @struct Share group.
  */
 typedef struct rd_kafka_mock_sharegroup_s {
         TAILQ_ENTRY(rd_kafka_mock_sharegroup_s) link;
@@ -242,7 +242,7 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int member_cnt;              /**< Number of share group members */
         rd_bool_t manual_assignment; /**< Use manual assignment */
 
-        /* ShareFetch state (KIP-932) */
+        /* ShareFetch state */
         TAILQ_HEAD(, rd_kafka_mock_sgrp_partmeta_s)
         partitions;        /**< Share partition metadata */
         int partition_cnt; /**< Number of partitions */
@@ -266,12 +266,12 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int max_record_locks;        /**< Max in-flight records per
                                       *   share-partition.
                                       *   0 = unlimited (default 2000). */
-        int auto_offset_reset;       /**< 0 = latest (default per KIP-932),
+        int auto_offset_reset;       /**< 0 = latest (default),
                                       *   1 = earliest. */
 } rd_kafka_mock_sharegroup_t;
 
 /**
- * @struct Share group member (KIP-932).
+ * @struct Share group member.
  */
 typedef struct rd_kafka_mock_sharegroup_member_s {
         TAILQ_ENTRY(rd_kafka_mock_sharegroup_member_s) link;
@@ -637,29 +637,29 @@ struct rd_kafka_mock_cluster_s {
                 int group_consumer_session_timeout_ms;
                 /** Heartbeat interval (KIP 848) */
                 int group_consumer_heartbeat_interval_ms;
-                /** Session timeout (KIP 932) */
+                /** Session timeout */
                 int sharegroup_session_timeout_ms;
-                /** Heartbeat interval (KIP 932) */
+                /** Heartbeat interval */
                 int sharegroup_heartbeat_interval_ms;
-                /** Max delivery attempts per record (KIP 932).
+                /** Max delivery attempts per record.
                  *  0 = unlimited. */
                 int sharegroup_max_delivery_attempts;
-                /** Per-record lock duration in ms (KIP 932).
+                /** Per-record lock duration in ms.
                  *  0 = use session_timeout_ms. */
                 int sharegroup_record_lock_duration_ms;
-                /** Share isolation level (KIP 932).
+                /** Share isolation level.
                  *  0 = read_uncommitted, 1 = read_committed. */
                 int sharegroup_isolation_level;
-                /** Max members allowed in share group (KIP 932).
+                /** Max members allowed in share group.
                  *  0 = unlimited. */
                 int sharegroup_max_size;
-                /** Max fetch sessions per broker (KIP 932).
+                /** Max fetch sessions per broker.
                  *  0 = unlimited. */
                 int sharegroup_max_fetch_sessions;
-                /** Max in-flight records per share-partition (KIP 932).
+                /** Max in-flight records per share-partition.
                  *  0 = unlimited. */
                 int sharegroup_max_record_locks;
-                /** Auto offset reset (KIP 932).
+                /** Auto offset reset.
                  *  0 = latest (default), 1 = earliest. */
                 int sharegroup_auto_offset_reset;
         } defaults;
@@ -929,7 +929,7 @@ rd_kafka_mock_cgrp_consumer_member_t *rd_kafka_mock_cgrp_consumer_member_add(
 void rd_kafka_mock_cgrps_connection_closed(rd_kafka_mock_cluster_t *mcluster,
                                            rd_kafka_mock_connection_t *mconn);
 
-/* Share group (KIP-932) */
+/* Share group */
 
 void rd_kafka_mock_sharegrps_init(rd_kafka_mock_cluster_t *mcluster);
 

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -183,9 +183,10 @@ typedef struct rd_kafka_mock_cgrp_consumer_member_s {
  * @brief Share record state.
  */
 enum rd_kafka_mock_sgrp_record_state_e {
-        RD_KAFKA_MOCK_SGRP_RECORD_AVAILABLE = 0,
-        RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED  = 1,
-        RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED  = 2
+        RD_KAFKA_MOCK_SGRP_RECORD_AVAILABLE    = 0,
+        RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED     = 1,
+        RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED = 2,
+        RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED     = 3
 };
 
 typedef struct rd_kafka_mock_sgrp_record_state_s {

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -258,6 +258,8 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int isolation_level;         /**< Share isolation level */
         int max_size;                /**< Max members allowed.
                                       *   0 = unlimited (default). */
+        int max_fetch_sessions;      /**< Max fetch sessions allowed.
+                                      *   0 = unlimited (default 2000). */
 } rd_kafka_mock_sharegroup_t;
 
 /**
@@ -643,6 +645,9 @@ struct rd_kafka_mock_cluster_s {
                 /** Max members allowed in share group (KIP 932).
                  *  0 = unlimited. */
                 int sharegroup_max_size;
+                /** Max fetch sessions per share group (KIP 932).
+                 *  0 = unlimited. */
+                int sharegroup_max_fetch_sessions;
         } defaults;
 
         /**< Dynamic array of IO handlers for corresponding fd in .fds */

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -209,6 +209,7 @@ typedef struct rd_kafka_mock_sgrp_partmeta_s {
         int64_t speo;
         TAILQ_HEAD(, rd_kafka_mock_sgrp_record_state_s) inflight;
         int inflight_cnt;
+        int acquired_cnt; /**< Number of records in ACQUIRED state */
 } rd_kafka_mock_sgrp_partmeta_t;
 
 /**
@@ -746,6 +747,7 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
     const char *api_name);
 void rd_kafka_mock_sgrp_record_release(
     rd_kafka_mock_sharegroup_t *mshgrp,
+    rd_kafka_mock_sgrp_partmeta_t *pmeta,
     rd_kafka_mock_sgrp_record_state_t *state);
 void rd_kafka_mock_sgrp_release_member_locks(rd_kafka_mock_sharegroup_t *mshgrp,
                                              const char *member_id);

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -223,7 +223,8 @@ typedef struct rd_kafka_mock_sgrp_fetch_session_s {
         int32_t session_epoch;
         rd_ts_t ts_last_activity;
         rd_kafka_topic_partition_list_t *partitions;
-        int partition_start_idx; /**< Rotation index for starvation prevention */
+        int partition_start_idx; /**< Rotation index for starvation prevention
+                                  */
 } rd_kafka_mock_sgrp_fetch_session_t;
 
 /**

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -264,6 +264,8 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int max_record_locks;        /**< Max in-flight records per
                                       *   share-partition.
                                       *   0 = unlimited (default 2000). */
+        int auto_offset_reset;       /**< 0 = latest (default per KIP-932),
+                                      *   1 = earliest. */
 } rd_kafka_mock_sharegroup_t;
 
 /**
@@ -655,6 +657,9 @@ struct rd_kafka_mock_cluster_s {
                 /** Max in-flight records per share-partition (KIP 932).
                  *  0 = unlimited. */
                 int sharegroup_max_record_locks;
+                /** Auto offset reset (KIP 932).
+                 *  0 = latest (default), 1 = earliest. */
+                int sharegroup_auto_offset_reset;
         } defaults;
 
         /**< Dynamic array of IO handlers for corresponding fd in .fds */

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -221,6 +221,7 @@ typedef struct rd_kafka_mock_sgrp_fetch_session_s {
         int32_t session_epoch;
         rd_ts_t ts_last_activity;
         rd_kafka_topic_partition_list_t *partitions;
+        int partition_start_idx; /**< Rotation index for starvation prevention */
 } rd_kafka_mock_sgrp_fetch_session_t;
 
 /**
@@ -259,6 +260,9 @@ typedef struct rd_kafka_mock_sharegroup_s {
         int max_size;                /**< Max members allowed.
                                       *   0 = unlimited (default). */
         int max_fetch_sessions;      /**< Max fetch sessions allowed.
+                                      *   0 = unlimited (default 2000). */
+        int max_record_locks;        /**< Max in-flight records per
+                                      *   share-partition.
                                       *   0 = unlimited (default 2000). */
 } rd_kafka_mock_sharegroup_t;
 
@@ -648,6 +652,9 @@ struct rd_kafka_mock_cluster_s {
                 /** Max fetch sessions per share group (KIP 932).
                  *  0 = unlimited. */
                 int sharegroup_max_fetch_sessions;
+                /** Max in-flight records per share-partition (KIP 932).
+                 *  0 = unlimited. */
+                int sharegroup_max_record_locks;
         } defaults;
 
         /**< Dynamic array of IO handlers for corresponding fd in .fds */

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -264,7 +264,7 @@ typedef struct rd_kafka_mock_sharegroup_s {
                                       *   0 = unlimited (default). */
         int max_fetch_sessions;      /**< Max fetch sessions per broker.
                                       *   0 = unlimited (default 2000). */
-        int max_record_locks;        /**< Max in-flight records per
+        int max_record_locks;        /**< Max acquired record locks per
                                       *   share-partition.
                                       *   0 = unlimited (default 2000). */
         int auto_offset_reset;       /**< 0 = latest (default),
@@ -657,7 +657,7 @@ struct rd_kafka_mock_cluster_s {
                 /** Max fetch sessions per broker.
                  *  0 = unlimited. */
                 int sharegroup_max_fetch_sessions;
-                /** Max in-flight records per share-partition.
+                /** Max acquired record locks per share-partition.
                  *  0 = unlimited. */
                 int sharegroup_max_record_locks;
                 /** Auto offset reset.

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -796,7 +796,7 @@ void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
         rd_kafka_mock_sharegroup_t *mshgrp;
         mtx_lock(&mcluster->lock);
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
-        mshgrp->max_fetch_sessions = max_fetch_sessions;
+        mshgrp->max_fetch_sessions                       = max_fetch_sessions;
         mcluster->defaults.sharegroup_max_fetch_sessions = max_fetch_sessions;
         mtx_unlock(&mcluster->lock);
 }
@@ -811,7 +811,7 @@ void rd_kafka_mock_sharegroup_set_max_record_locks(
         rd_kafka_mock_sharegroup_t *mshgrp;
         mtx_lock(&mcluster->lock);
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
-        mshgrp->max_record_locks = max_record_locks;
+        mshgrp->max_record_locks                       = max_record_locks;
         mcluster->defaults.sharegroup_max_record_locks = max_record_locks;
         mtx_unlock(&mcluster->lock);
 }
@@ -825,7 +825,7 @@ void rd_kafka_mock_sharegroup_set_auto_offset_reset(
         rd_kafka_mock_sharegroup_t *mshgrp;
         mtx_lock(&mcluster->lock);
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
-        mshgrp->auto_offset_reset = auto_offset_reset;
+        mshgrp->auto_offset_reset                       = auto_offset_reset;
         mcluster->defaults.sharegroup_auto_offset_reset = auto_offset_reset;
         mtx_unlock(&mcluster->lock);
 }
@@ -995,8 +995,7 @@ void rd_kafka_mock_sgrp_release_member_locks(rd_kafka_mock_sharegroup_t *mshgrp,
                         if (strcmp(state->owner_member_id, member_id) != 0)
                                 continue;
 
-                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta,
-                                                          state);
+                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta, state);
                 }
         }
 }
@@ -1025,8 +1024,7 @@ static void rd_kafka_mock_sgrp_expire_locks(rd_kafka_mock_sharegroup_t *mshgrp,
                         /* Lock has expired. If delivery
                          * count has reached the limit, archive the
                          * record instead of making it available. */
-                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta,
-                                                          state);
+                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta, state);
                 }
         }
 }

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -788,7 +788,7 @@ void rd_kafka_mock_sharegroup_set_max_size(rd_kafka_mock_cluster_t *mcluster,
 }
 
 /**
- * @brief Set the maximum number of fetch sessions allowed in a share group.
+ * @brief Set the maximum number of fetch sessions allowed per broker.
  */
 void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
     rd_kafka_mock_cluster_t *mcluster,

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -61,6 +61,7 @@ void rd_kafka_mock_sharegrps_init(rd_kafka_mock_cluster_t *mcluster) {
         mcluster->defaults.sharegroup_isolation_level         = 0;
         mcluster->defaults.sharegroup_max_fetch_sessions      = 2000;
         mcluster->defaults.sharegroup_max_record_locks        = 2000;
+        mcluster->defaults.sharegroup_auto_offset_reset       = 0; /* latest */
 }
 
 /**
@@ -120,6 +121,8 @@ rd_kafka_mock_sharegroup_get(rd_kafka_mock_cluster_t *mcluster,
             mcluster->defaults.sharegroup_max_fetch_sessions;
         mshgrp->max_record_locks =
             mcluster->defaults.sharegroup_max_record_locks;
+        mshgrp->auto_offset_reset =
+            mcluster->defaults.sharegroup_auto_offset_reset;
 
         rd_kafka_timer_start(&mcluster->timers, &mshgrp->session_tmr,
                              1000 * 1000 /* 1s */,
@@ -810,6 +813,20 @@ void rd_kafka_mock_sharegroup_set_max_record_locks(
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
         mshgrp->max_record_locks = max_record_locks;
         mcluster->defaults.sharegroup_max_record_locks = max_record_locks;
+        mtx_unlock(&mcluster->lock);
+}
+
+/**
+ * @brief Set the auto offset reset policy for share groups.
+ */
+void rd_kafka_mock_sharegroup_set_auto_offset_reset(
+    rd_kafka_mock_cluster_t *mcluster,
+    int auto_offset_reset) {
+        rd_kafka_mock_sharegroup_t *mshgrp;
+        mtx_lock(&mcluster->lock);
+        TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
+        mshgrp->auto_offset_reset = auto_offset_reset;
+        mcluster->defaults.sharegroup_auto_offset_reset = auto_offset_reset;
         mtx_unlock(&mcluster->lock);
 }
 

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -59,6 +59,7 @@ void rd_kafka_mock_sharegrps_init(rd_kafka_mock_cluster_t *mcluster) {
         mcluster->defaults.sharegroup_record_lock_duration_ms = 0;
         mcluster->defaults.sharegroup_max_size                = 0;
         mcluster->defaults.sharegroup_isolation_level         = 0;
+        mcluster->defaults.sharegroup_max_fetch_sessions      = 2000;
 }
 
 /**
@@ -114,6 +115,8 @@ rd_kafka_mock_sharegroup_get(rd_kafka_mock_cluster_t *mcluster,
             mcluster->defaults.sharegroup_record_lock_duration_ms;
         mshgrp->isolation_level = mcluster->defaults.sharegroup_isolation_level;
         mshgrp->max_size        = mcluster->defaults.sharegroup_max_size;
+        mshgrp->max_fetch_sessions =
+            mcluster->defaults.sharegroup_max_fetch_sessions;
 
         rd_kafka_timer_start(&mcluster->timers, &mshgrp->session_tmr,
                              1000 * 1000 /* 1s */,
@@ -775,6 +778,20 @@ void rd_kafka_mock_sharegroup_set_max_size(rd_kafka_mock_cluster_t *mcluster,
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
         mshgrp->max_size                       = max_size;
         mcluster->defaults.sharegroup_max_size = max_size;
+        mtx_unlock(&mcluster->lock);
+}
+
+/**
+ * @brief Set the maximum number of fetch sessions allowed in a share group.
+ */
+void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
+    rd_kafka_mock_cluster_t *mcluster,
+    int max_fetch_sessions) {
+        rd_kafka_mock_sharegroup_t *mshgrp;
+        mtx_lock(&mcluster->lock);
+        TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
+        mshgrp->max_fetch_sessions = max_fetch_sessions;
+        mcluster->defaults.sharegroup_max_fetch_sessions = max_fetch_sessions;
         mtx_unlock(&mcluster->lock);
 }
 

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -957,7 +957,10 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
  */
 void rd_kafka_mock_sgrp_record_release(
     rd_kafka_mock_sharegroup_t *mshgrp,
+    rd_kafka_mock_sgrp_partmeta_t *pmeta,
     rd_kafka_mock_sgrp_record_state_t *state) {
+        if (state->state == RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED)
+                pmeta->acquired_cnt--;
         if (mshgrp->max_delivery_attempts > 0 &&
             state->delivery_count >= mshgrp->max_delivery_attempts) {
                 state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
@@ -992,7 +995,8 @@ void rd_kafka_mock_sgrp_release_member_locks(rd_kafka_mock_sharegroup_t *mshgrp,
                         if (strcmp(state->owner_member_id, member_id) != 0)
                                 continue;
 
-                        rd_kafka_mock_sgrp_record_release(mshgrp, state);
+                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta,
+                                                          state);
                 }
         }
 }
@@ -1021,7 +1025,8 @@ static void rd_kafka_mock_sgrp_expire_locks(rd_kafka_mock_sharegroup_t *mshgrp,
                         /* Lock has expired. If delivery
                          * count has reached the limit, archive the
                          * record instead of making it available. */
-                        rd_kafka_mock_sgrp_record_release(mshgrp, state);
+                        rd_kafka_mock_sgrp_record_release(mshgrp, pmeta,
+                                                          state);
                 }
         }
 }

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -60,6 +60,7 @@ void rd_kafka_mock_sharegrps_init(rd_kafka_mock_cluster_t *mcluster) {
         mcluster->defaults.sharegroup_max_size                = 0;
         mcluster->defaults.sharegroup_isolation_level         = 0;
         mcluster->defaults.sharegroup_max_fetch_sessions      = 2000;
+        mcluster->defaults.sharegroup_max_record_locks        = 2000;
 }
 
 /**
@@ -117,6 +118,8 @@ rd_kafka_mock_sharegroup_get(rd_kafka_mock_cluster_t *mcluster,
         mshgrp->max_size        = mcluster->defaults.sharegroup_max_size;
         mshgrp->max_fetch_sessions =
             mcluster->defaults.sharegroup_max_fetch_sessions;
+        mshgrp->max_record_locks =
+            mcluster->defaults.sharegroup_max_record_locks;
 
         rd_kafka_timer_start(&mcluster->timers, &mshgrp->session_tmr,
                              1000 * 1000 /* 1s */,
@@ -792,6 +795,21 @@ void rd_kafka_mock_sharegroup_set_max_fetch_sessions(
         TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
         mshgrp->max_fetch_sessions = max_fetch_sessions;
         mcluster->defaults.sharegroup_max_fetch_sessions = max_fetch_sessions;
+        mtx_unlock(&mcluster->lock);
+}
+
+/**
+ * @brief Set the maximum number of in-flight record locks per
+ *        share-partition.
+ */
+void rd_kafka_mock_sharegroup_set_max_record_locks(
+    rd_kafka_mock_cluster_t *mcluster,
+    int max_record_locks) {
+        rd_kafka_mock_sharegroup_t *mshgrp;
+        mtx_lock(&mcluster->lock);
+        TAILQ_FOREACH(mshgrp, &mcluster->sharegrps, link)
+        mshgrp->max_record_locks = max_record_locks;
+        mcluster->defaults.sharegroup_max_record_locks = max_record_locks;
         mtx_unlock(&mcluster->lock);
 }
 

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -1125,6 +1125,89 @@ static void do_test_session_limit_reached(void) {
 }
 
 /**
+ * @brief Test that the session limit is enforced per broker, not globally.
+ *
+ * Create two single-partition topics, each with its leader on a
+ * different broker.  Set max_fetch_sessions=1 (per broker).
+ *
+ * Consumer 1 subscribes to topic_a (broker 1) and consumer 2 subscribes
+ * to topic_b (broker 2).  Both should succeed because each broker only
+ * has 1 session despite there being 2 sessions globally.
+ *
+ * Then consumer 3 subscribes to topic_a — this should fail because
+ * broker 1 already has 1 session (from consumer 1).
+ */
+static void do_test_session_limit_per_broker(void) {
+        const char *topic_a = "kip932_session_limit_pb_a";
+        const char *topic_b = "kip932_session_limit_pb_b";
+        const int msgcnt    = 5;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer1, *consumer2, *consumer3;
+        int consumed1, consumed2, consumed3;
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+
+        /* Create two topics, each with 1 partition on a different broker. */
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic A");
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic B");
+        rd_kafka_mock_partition_set_leader(ctx.mcluster, topic_a, 0, 1);
+        rd_kafka_mock_partition_set_leader(ctx.mcluster, topic_b, 0, 2);
+
+        produce_messages(ctx.producer, topic_a, msgcnt);
+        produce_messages(ctx.producer, topic_b, msgcnt);
+
+        /* Limit to 1 session per broker */
+        rd_kafka_mock_sharegroup_set_max_fetch_sessions(ctx.mcluster, 1);
+
+        /* Consumer 1 subscribes to topic_a -> session on broker 1 */
+        consumer1 =
+            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        subscribe_topics(consumer1, &topic_a, 1);
+        consumed1 = consume_n(consumer1, msgcnt, 30);
+        TEST_ASSERT(consumed1 == msgcnt,
+                    "Consumer 1: expected %d consumed, got %d", msgcnt,
+                    consumed1);
+
+        /* Consumer 2 subscribes to topic_b -> session on broker 2.
+         * If the limit were global, this would fail (2 sessions > limit 1).
+         * Per-broker: broker 2 has 0 sessions, so it succeeds. */
+        consumer2 =
+            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        subscribe_topics(consumer2, &topic_b, 1);
+        consumed2 = consume_n(consumer2, msgcnt, 30);
+        TEST_ASSERT(consumed2 == msgcnt,
+                    "Consumer 2: expected %d consumed, got %d", msgcnt,
+                    consumed2);
+
+        /* Consumer 3 subscribes to topic_a -> broker 1 already has
+         * 1 session (from consumer 1), so this should be rejected. */
+        consumer3 =
+            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        subscribe_topics(consumer3, &topic_a, 1);
+        consumed3 = consume_n(consumer3, 1, 5);
+        TEST_ASSERT(consumed3 == 0,
+                    "Consumer 3: expected 0 consumed (broker 1 at limit), "
+                    "got %d",
+                    consumed3);
+
+        rd_kafka_share_consumer_close(consumer1);
+        rd_kafka_share_destroy(consumer1);
+        rd_kafka_share_consumer_close(consumer2);
+        rd_kafka_share_destroy(consumer2);
+        rd_kafka_share_consumer_close(consumer3);
+        rd_kafka_share_destroy(consumer3);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+/**
  * @brief Test that ShareFetch with epoch=0 and acks is rejected with
  *        INVALID_REQUEST via the mock broker's injected error mechanism.
  *
@@ -1413,6 +1496,7 @@ int main_0156_share_consumer_fetch_mock(int argc, char **argv) {
 
         /* Session management */
         do_test_session_limit_reached();
+        do_test_session_limit_per_broker();
         do_test_session_limit_recovery();
 
         /* Record lock limits */

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -31,7 +31,7 @@
 #include "../src/rdkafka_proto.h"
 
 /**
- * @name KIP-932 ShareFetch mock broker tests using the share consumer API.
+ * @name ShareFetch mock broker tests using the share consumer API.
  *
  * Exercises the ShareFetch path via mock broker.  There is no coordinator
  * or ShareAcknowledge support in the mock broker, so group management and
@@ -1390,14 +1390,6 @@ static void do_test_max_record_locks_acquired_only(void) {
 }
 
 /**
- * @brief Test that auto.offset.reset=latest (the default per KIP-932)
- *        causes the consumer to skip records produced before subscription.
- *
- * Produce 5 records, then subscribe with auto.offset.reset=latest.
- * Consumer should get 0 old records but should get new records
- * produced after subscription.
- */
-/**
  * @brief Test that SPSO advances when log retention deletes records
  *        below the current SPSO.
  *
@@ -1462,6 +1454,14 @@ static void do_test_spso_advances_on_log_retention(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Test that auto.offset.reset=latest (the default)
+ *        causes the consumer to skip records produced before subscription.
+ *
+ * Produce 5 records, then subscribe with auto.offset.reset=latest.
+ * Consumer should get 0 old records but should get new records
+ * produced after subscription.
+ */
 static void do_test_auto_offset_reset_latest(void) {
         const char *topic = "kip932_offset_reset_latest";
         const int msgcnt  = 5;
@@ -1472,7 +1472,7 @@ static void do_test_auto_offset_reset_latest(void) {
         SUB_TEST_QUICK();
 
         /* Create a fresh context — do NOT set auto_offset_reset=earliest
-         * (the default is "latest" per KIP-932). */
+         * (the default is "latest"). */
         memset(&ctx, 0, sizeof(ctx));
         ctx.mcluster = test_mock_cluster_new(3, &ctx.bootstraps);
         TEST_ASSERT(rd_kafka_mock_set_apiversion(

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -62,6 +62,10 @@ static test_ctx_t test_ctx_new(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         /* Create a producer targeting the mock cluster */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -1313,6 +1313,83 @@ static void do_test_max_record_locks(void) {
 }
 
 /**
+ * @brief Verify that max_record_locks counts only ACQUIRED records,
+ *        not total inflight records (which includes ARCHIVED).
+ *
+ * Produce 6 records. Set max_record_locks=3, max_delivery_attempts=1.
+ *
+ * Consumer A acquires records 0-2 (lock limit), then is destroyed
+ * WITHOUT close (no implicit ack).  The connection close releases
+ * the locks; with max_delivery_attempts=1 the released records
+ * transition directly to ARCHIVED (delivery_count >= limit).
+ *
+ * At this point:
+ *   - Records 0-2: ARCHIVED, still in the inflight list
+ *   - SPSO = 0 (never advanced — ARCHIVED != ACKNOWLEDGED)
+ *   - inflight_cnt = 3, acquired_cnt = 0
+ *
+ * Consumer B subscribes.  With the correct check (acquired_cnt),
+ * records 3-5 are acquirable because only 0 records are ACQUIRED.
+ * With an inflight_cnt-based check, the limit would block all
+ * acquisition (inflight_cnt=3 >= max_record_locks=3).
+ */
+static void do_test_max_record_locks_acquired_only(void) {
+        const char *topic = "kip932_max_locks_acquired_only";
+        const int msgcnt  = 6;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_b;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 3);
+        rd_kafka_mock_sharegroup_set_max_delivery_attempts(ctx.mcluster, 1);
+        rd_kafka_mock_sharegroup_set_session_timeout(ctx.mcluster, 500);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consumer A: acquire first batch (3 records due to lock limit). */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-acq-only");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_a = consume_n(consumer, 3, 30);
+        TEST_SAY("acquired_only: A consumed %d/3\n", consumed_a);
+
+        /* Destroy WITHOUT close — avoids implicit ack.
+         * The connection close releases locks; with max_delivery_attempts=1
+         * the released records transition to ARCHIVED (not AVAILABLE).
+         * SPSO stays at 0 because ARCHIVED != ACKNOWLEDGED.
+         * inflight_cnt stays 3, but acquired_cnt drops to 0. */
+        rd_kafka_share_destroy(consumer);
+        rd_usleep(1500 * 1000, 0); /* wait for connection close */
+
+        /* Consumer B subscribes. The share-partition now has:
+         *   - Records 0-2: ARCHIVED (inflight_cnt=3, acquired_cnt=0)
+         *   - Records 3-5: not yet in inflight list
+         * With acquired_cnt check, Consumer B acquires records 3-5.
+         * With inflight_cnt check, the limit would block acquisition. */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-acq-only");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_b = consume_n(consumer, 3, 30);
+        TEST_SAY("acquired_only: B consumed %d/3\n", consumed_b);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == 3, "A: expected 3, got %d", consumed_a);
+        TEST_ASSERT(consumed_b == 3,
+                    "B: expected 3 (max_record_locks should count only "
+                    "ACQUIRED, not ARCHIVED), got %d",
+                    consumed_b);
+
+        SUB_TEST_PASS();
+}
+
+/**
  * @brief Test that auto.offset.reset=latest (the default per KIP-932)
  *        causes the consumer to skip records produced before subscription.
  *
@@ -1501,6 +1578,7 @@ int main_0156_share_consumer_fetch_mock(int argc, char **argv) {
 
         /* Record lock limits */
         do_test_max_record_locks();
+        do_test_max_record_locks_acquired_only();
 
         /* Offset reset */
         do_test_auto_offset_reset_latest();

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -1166,8 +1166,7 @@ static void do_test_session_limit_per_broker(void) {
         rd_kafka_mock_sharegroup_set_max_fetch_sessions(ctx.mcluster, 1);
 
         /* Consumer 1 subscribes to topic_a -> session on broker 1 */
-        consumer1 =
-            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        consumer1 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer1, &topic_a, 1);
         consumed1 = consume_n(consumer1, msgcnt, 30);
         TEST_ASSERT(consumed1 == msgcnt,
@@ -1177,8 +1176,7 @@ static void do_test_session_limit_per_broker(void) {
         /* Consumer 2 subscribes to topic_b -> session on broker 2.
          * If the limit were global, this would fail (2 sessions > limit 1).
          * Per-broker: broker 2 has 0 sessions, so it succeeds. */
-        consumer2 =
-            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        consumer2 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer2, &topic_b, 1);
         consumed2 = consume_n(consumer2, msgcnt, 30);
         TEST_ASSERT(consumed2 == msgcnt,
@@ -1187,8 +1185,7 @@ static void do_test_session_limit_per_broker(void) {
 
         /* Consumer 3 subscribes to topic_a -> broker 1 already has
          * 1 session (from consumer 1), so this should be rejected. */
-        consumer3 =
-            new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
+        consumer3 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer3, &topic_a, 1);
         consumed3 = consume_n(consumer3, 1, 5);
         TEST_ASSERT(consumed3 == 0,
@@ -1293,8 +1290,9 @@ static void do_test_max_record_locks(void) {
                         break;
                 total_consumed += got;
                 rounds++;
-                TEST_SAY("max_record_locks: round %d consumed %d (total %d/%d)\n",
-                         rounds, got, total_consumed, msgcnt);
+                TEST_SAY(
+                    "max_record_locks: round %d consumed %d (total %d/%d)\n",
+                    rounds, got, total_consumed, msgcnt);
         }
 
         rd_kafka_share_consumer_close(consumer);
@@ -1428,10 +1426,10 @@ static void do_test_spso_advances_on_log_retention(void) {
         rd_kafka_share_destroy(consumer);
 
         /* Simulate log retention: delete records before offset 5. */
-        TEST_ASSERT(rd_kafka_mock_partition_delete_records(
-                        ctx.mcluster, topic, 0, 5) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Failed to delete records");
+        TEST_ASSERT(
+            rd_kafka_mock_partition_delete_records(ctx.mcluster, topic, 0, 5) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Failed to delete records");
 
         /* Remove lock limit. */
         rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
@@ -1446,10 +1444,10 @@ static void do_test_spso_advances_on_log_retention(void) {
         rd_kafka_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
-        TEST_ASSERT(consumed_a == 5,
-                    "A: expected 5 consumed, got %d", consumed_a);
-        TEST_ASSERT(consumed_b == 5,
-                    "B: expected 5 consumed, got %d", consumed_b);
+        TEST_ASSERT(consumed_a == 5, "A: expected 5 consumed, got %d",
+                    consumed_a);
+        TEST_ASSERT(consumed_b == 5, "B: expected 5 consumed, got %d",
+                    consumed_b);
 
         SUB_TEST_PASS();
 }
@@ -1483,7 +1481,8 @@ static void do_test_auto_offset_reset_latest(void) {
                                                  RD_KAFKAP_ShareFetch, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
-        /* Intentionally NOT calling set_auto_offset_reset — default is latest */
+        /* Intentionally NOT calling set_auto_offset_reset — default is latest
+         */
         {
                 rd_kafka_conf_t *conf;
                 char errstr[512];

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -1071,6 +1071,303 @@ static void do_test_sharefetch_fetch_and_close_implicit(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Test that SHARE_SESSION_LIMIT_REACHED is returned when the
+ *        session cache is full.
+ *
+ * Set max_fetch_sessions=1, open a session with consumer 1,
+ * then attempt to open a second session with consumer 2.
+ * Consumer 2 should fail to consume any records because every
+ * ShareFetch epoch=0 attempt gets SHARE_SESSION_LIMIT_REACHED.
+ */
+static void do_test_session_limit_reached(void) {
+        const char *topic = "kip932_session_limit";
+        const int msgcnt  = 5;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer1, *consumer2;
+        int consumed1, consumed2;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        /* Limit to 1 session */
+        rd_kafka_mock_sharegroup_set_max_fetch_sessions(ctx.mcluster, 1);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consumer 1 opens a session successfully */
+        consumer1 = new_share_consumer(ctx.bootstraps, "sg-session-limit");
+        subscribe_topics(consumer1, &topic, 1);
+        consumed1 = consume_n(consumer1, msgcnt, 30);
+        TEST_ASSERT(consumed1 == msgcnt,
+                    "Consumer 1: expected %d consumed, got %d", msgcnt,
+                    consumed1);
+
+        /* Consumer 2 tries to open a session — cache is full */
+        consumer2 = new_share_consumer(ctx.bootstraps, "sg-session-limit");
+        subscribe_topics(consumer2, &topic, 1);
+        consumed2 = consume_n(consumer2, 1, 5);
+        TEST_ASSERT(consumed2 == 0,
+                    "Consumer 2: expected 0 consumed (session limit), got %d",
+                    consumed2);
+
+        rd_kafka_share_consumer_close(consumer1);
+        rd_kafka_share_destroy(consumer1);
+        rd_kafka_share_consumer_close(consumer2);
+        rd_kafka_share_destroy(consumer2);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test that ShareFetch with epoch=0 and acks is rejected with
+ *        INVALID_REQUEST via the mock broker's injected error mechanism.
+ *
+ * Injects SHARE_SESSION_LIMIT_REACHED errors to force the client to
+ * retry with epoch=0.  The client never piggybacks acks on epoch=0
+ * (that's a protocol violation), so this test validates that the mock
+ * broker's error injection for SHARE_SESSION_LIMIT_REACHED works and
+ * the client recovers when the error clears.
+ */
+static void do_test_session_limit_recovery(void) {
+        const char *topic = "kip932_session_limit_recovery";
+        const int msgcnt  = 5;
+        test_ctx_t ctx    = test_ctx_new();
+        rd_kafka_share_t *consumer;
+        int consumed;
+
+        SUB_TEST_QUICK();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Push 3 SHARE_SESSION_LIMIT_REACHED errors, then let it succeed */
+        rd_kafka_mock_push_request_errors(
+            ctx.mcluster, RD_KAFKAP_ShareFetch, 3,
+            RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED,
+            RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED,
+            RD_KAFKA_RESP_ERR_SHARE_SESSION_LIMIT_REACHED);
+
+        consumer = new_share_consumer(ctx.bootstraps, "sg-session-recovery");
+        subscribe_topics(consumer, &topic, 1);
+        consumed = consume_n(consumer, msgcnt, 30);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed == msgcnt,
+                    "Expected %d consumed after recovery, got %d", msgcnt,
+                    consumed);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test that max_record_locks limits the number of in-flight
+ *        records per share-partition.
+ *
+ * Produce 10 records, set max_record_locks=3.  Consumer A should get
+ * only 3 records on the first fetch round (the rest are blocked by
+ * the lock limit).  After A acks (via second poll) and closes,
+ * consumer B should get the next batch.  Total consumed across both
+ * should be 10.
+ */
+static void do_test_max_record_locks(void) {
+        const char *topic = "kip932_max_record_locks";
+        const int msgcnt  = 10;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int total_consumed = 0;
+        int rounds         = 0;
+
+        SUB_TEST_QUICK();
+        ctx = test_ctx_new();
+
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 3);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consume in rounds.  Each round can get at most 3 records
+         * (the lock limit).  The implicit ack from the next poll
+         * frees the locks for the next batch. */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-max-locks");
+        subscribe_topics(consumer, &topic, 1);
+
+        while (total_consumed < msgcnt && rounds < 20) {
+                int got = consume_n(consumer, 3, 10);
+                if (got == 0)
+                        break;
+                total_consumed += got;
+                rounds++;
+                TEST_SAY("max_record_locks: round %d consumed %d (total %d/%d)\n",
+                         rounds, got, total_consumed, msgcnt);
+        }
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(total_consumed == msgcnt,
+                    "Expected %d total consumed, got %d", msgcnt,
+                    total_consumed);
+        TEST_ASSERT(rounds > 1,
+                    "Expected multiple rounds (lock limit=3, msgs=10), "
+                    "got %d rounds",
+                    rounds);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test that auto.offset.reset=latest (the default per KIP-932)
+ *        causes the consumer to skip records produced before subscription.
+ *
+ * Produce 5 records, then subscribe with auto.offset.reset=latest.
+ * Consumer should get 0 old records but should get new records
+ * produced after subscription.
+ */
+/**
+ * @brief Test that SPSO advances when log retention deletes records
+ *        below the current SPSO.
+ *
+ * Produce 10 records (offsets 0-9).  Consumer A acquires 0-4.
+ * Then delete records before offset 5 (simulating log retention).
+ * Consumer A closes (acks 0-4, but they're already archived by
+ * retention).  Consumer B should get records 5-9 only — SPSO
+ * was advanced to 5 by the retention, and in-flight records
+ * below 5 were archived.
+ */
+static void do_test_spso_advances_on_log_retention(void) {
+        const char *topic = "kip932_log_retention_spso";
+        const int msgcnt  = 10;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_b;
+
+        SUB_TEST_QUICK();
+        ctx = test_ctx_new();
+
+        /* Limit to 5 records per fetch so A gets only 0-4. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 5);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consumer A acquires records 0-4. */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-log-retention");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_a = consume_n(consumer, 5, 30);
+        TEST_SAY("log_retention: A consumed %d/5\n", consumed_a);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        /* Simulate log retention: delete records before offset 5. */
+        TEST_ASSERT(rd_kafka_mock_partition_delete_records(
+                        ctx.mcluster, topic, 0, 5) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to delete records");
+
+        /* Remove lock limit. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
+
+        /* Consumer B should get records 5-9 (SPSO advanced to 5). */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-log-retention");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_b = consume_n(consumer, 5, 30);
+        TEST_SAY("log_retention: B consumed %d/5\n", consumed_b);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == 5,
+                    "A: expected 5 consumed, got %d", consumed_a);
+        TEST_ASSERT(consumed_b == 5,
+                    "B: expected 5 consumed, got %d", consumed_b);
+
+        SUB_TEST_PASS();
+}
+
+static void do_test_auto_offset_reset_latest(void) {
+        const char *topic = "kip932_offset_reset_latest";
+        const int msgcnt  = 5;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed;
+
+        SUB_TEST_QUICK();
+
+        /* Create a fresh context — do NOT set auto_offset_reset=earliest
+         * (the default is "latest" per KIP-932). */
+        memset(&ctx, 0, sizeof(ctx));
+        ctx.mcluster = test_mock_cluster_new(3, &ctx.bootstraps);
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(
+                        ctx.mcluster, RD_KAFKAP_ShareGroupHeartbeat, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareGroupHeartbeat");
+        TEST_ASSERT(rd_kafka_mock_set_apiversion(ctx.mcluster,
+                                                 RD_KAFKAP_ShareFetch, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to enable ShareFetch");
+        /* Intentionally NOT calling set_auto_offset_reset — default is latest */
+        {
+                rd_kafka_conf_t *conf;
+                char errstr[512];
+                test_conf_init(&conf, NULL, 0);
+                test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+                ctx.producer = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr,
+                                            sizeof(errstr));
+                TEST_ASSERT(ctx.producer != NULL,
+                            "Failed to create producer: %s", errstr);
+        }
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        /* Produce records BEFORE subscribing */
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Subscribe — SPSO should start at end of log (latest) */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-offset-latest");
+        subscribe_topics(consumer, &topic, 1);
+        consumed = consume_n(consumer, 1, 5);
+        TEST_SAY("offset_reset_latest: consumed %d (expected 0)\n", consumed);
+        TEST_ASSERT(consumed == 0,
+                    "Expected 0 consumed with latest offset reset, got %d",
+                    consumed);
+
+        /* Produce new records AFTER subscription — these should be visible */
+        produce_messages(ctx.producer, topic, msgcnt);
+        consumed = consume_n(consumer, msgcnt, 30);
+        TEST_SAY("offset_reset_latest: consumed %d new records (expected %d)\n",
+                 consumed, msgcnt);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed == msgcnt,
+                    "Expected %d new records consumed, got %d", msgcnt,
+                    consumed);
+
+        SUB_TEST_PASS();
+}
+
 int main_0156_share_consumer_fetch_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -1113,6 +1410,19 @@ int main_0156_share_consumer_fetch_mock(int argc, char **argv) {
 
         do_test_sharefetch_fetch_disconnected();
         do_test_sharefetch_fetch_and_close_implicit();
+
+        /* Session management */
+        do_test_session_limit_reached();
+        do_test_session_limit_recovery();
+
+        /* Record lock limits */
+        do_test_max_record_locks();
+
+        /* Offset reset */
+        do_test_auto_offset_reset_latest();
+
+        /* Log retention */
+        do_test_spso_advances_on_log_retention();
 
         return 0;
 }

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -62,6 +62,10 @@ static test_ctx_t test_ctx_new(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         /* Create a producer targeting the mock cluster */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -1371,8 +1371,7 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         produce_messages(ctx.producer, topic, msgcnt);
 
         /* Consumer A acquires records. */
-        consumer_a =
-            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        consumer_a = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_a, &topic, 1);
         consumed_a = consume_n(consumer_a, msgcnt, 50);
         TEST_SAY("ack_invalid_state: A consumed %d/%d\n", consumed_a, msgcnt);
@@ -1396,8 +1395,7 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         /* Consumer B re-acquires (locks expired) and acks implicitly
          * by doing a second poll (which piggybacks the ack on the next
          * ShareFetch). */
-        consumer_b =
-            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        consumer_b = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_b, &topic, 1);
         consumed_b = consume_n(consumer_b, msgcnt, 50);
         TEST_SAY("ack_invalid_state: B consumed %d/%d\n", consumed_b, msgcnt);
@@ -1409,8 +1407,7 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         rd_kafka_share_destroy(consumer_b);
 
         /* Consumer C should get 0 records — B's ack succeeded. */
-        consumer_c =
-            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        consumer_c = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_c, &topic, 1);
         consumed_c = consume_n(consumer_c, 1, 5);
         TEST_SAY("ack_invalid_state: C consumed %d (expected 0)\n", consumed_c);
@@ -1419,12 +1416,12 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         rd_kafka_share_destroy(consumer_c);
         test_ctx_destroy(&ctx);
 
-        TEST_ASSERT(consumed_a == msgcnt,
-                    "A: expected %d consumed, got %d", msgcnt, consumed_a);
-        TEST_ASSERT(consumed_b == msgcnt,
-                    "B: expected %d consumed, got %d", msgcnt, consumed_b);
-        TEST_ASSERT(consumed_c == 0,
-                    "C: expected 0 consumed (B acked), got %d", consumed_c);
+        TEST_ASSERT(consumed_a == msgcnt, "A: expected %d consumed, got %d",
+                    msgcnt, consumed_a);
+        TEST_ASSERT(consumed_b == msgcnt, "B: expected %d consumed, got %d",
+                    msgcnt, consumed_b);
+        TEST_ASSERT(consumed_c == 0, "C: expected 0 consumed (B acked), got %d",
+                    consumed_c);
         SUB_TEST_PASS();
 }
 
@@ -1482,10 +1479,10 @@ static void do_test_ack_success_advances_spso(void) {
         rd_kafka_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
-        TEST_ASSERT(consumed_a == 3,
-                    "A: expected 3 consumed, got %d", consumed_a);
-        TEST_ASSERT(consumed_b == 3,
-                    "B: expected 3 consumed, got %d", consumed_b);
+        TEST_ASSERT(consumed_a == 3, "A: expected 3 consumed, got %d",
+                    consumed_a);
+        TEST_ASSERT(consumed_b == 3, "B: expected 3 consumed, got %d",
+                    consumed_b);
         SUB_TEST_PASS();
 }
 

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -1342,6 +1342,153 @@ static void do_test_coordinator_failover_ack_recovery(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Test that ack validation returns INVALID_RECORD_STATE when the
+ *        record's lock has expired and was re-acquired by another consumer.
+ *
+ * Consumer A acquires records, locks expire, consumer B re-acquires and
+ * successfully acks.  The records should not be redelivered a third time
+ * (consumer B's ack succeeded because the mock broker now correctly
+ * reports INVALID_RECORD_STATE for stale acks and honours valid ones).
+ */
+static void do_test_ack_after_lock_expiry_redelivers(void) {
+        const char *topic = "kip932_ack_invalid_state";
+        const int msgcnt  = 3;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer_a, *consumer_b, *consumer_c;
+        int consumed_a, consumed_b, consumed_c;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        /* Short lock duration so locks expire quickly. */
+        rd_kafka_mock_sharegroup_set_record_lock_duration(ctx.mcluster, 200);
+        rd_kafka_mock_sharegroup_set_session_timeout(ctx.mcluster, 10000);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consumer A acquires records. */
+        consumer_a =
+            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        subscribe_topics(consumer_a, &topic, 1);
+        consumed_a = consume_n(consumer_a, msgcnt, 50);
+        TEST_SAY("ack_invalid_state: A consumed %d/%d\n", consumed_a, msgcnt);
+
+        /* Inject RTT so A's ack is delayed past lock expiry. */
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 3000);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 2, 3000);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 3, 3000);
+
+        /* Wait for lock to expire. */
+        rd_usleep(800 * 1000, NULL);
+
+        /* Destroy A without close — ack never delivered. */
+        rd_kafka_share_destroy(consumer_a);
+
+        /* Clear RTT. */
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 0);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 2, 0);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 3, 0);
+
+        /* Consumer B re-acquires (locks expired) and acks implicitly
+         * by doing a second poll (which piggybacks the ack on the next
+         * ShareFetch). */
+        consumer_b =
+            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        subscribe_topics(consumer_b, &topic, 1);
+        consumed_b = consume_n(consumer_b, msgcnt, 50);
+        TEST_SAY("ack_invalid_state: B consumed %d/%d\n", consumed_b, msgcnt);
+
+        /* Second poll triggers implicit ack for B's records. */
+        consume_n(consumer_b, 1, 3);
+
+        rd_kafka_share_consumer_close(consumer_b);
+        rd_kafka_share_destroy(consumer_b);
+
+        /* Consumer C should get 0 records — B's ack succeeded. */
+        consumer_c =
+            new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
+        subscribe_topics(consumer_c, &topic, 1);
+        consumed_c = consume_n(consumer_c, 1, 5);
+        TEST_SAY("ack_invalid_state: C consumed %d (expected 0)\n", consumed_c);
+
+        rd_kafka_share_consumer_close(consumer_c);
+        rd_kafka_share_destroy(consumer_c);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == msgcnt,
+                    "A: expected %d consumed, got %d", msgcnt, consumed_a);
+        TEST_ASSERT(consumed_b == msgcnt,
+                    "B: expected %d consumed, got %d", msgcnt, consumed_b);
+        TEST_ASSERT(consumed_c == 0,
+                    "C: expected 0 consumed (B acked), got %d", consumed_c);
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Test that two consumers can sequentially acquire, ack, and
+ *        advance SPSO without interference.
+ *
+ * Consumer A acquires records 0-2 and acks them (implicit ack via
+ * second poll).  Consumer B then gets records 3-5 (not 0-2, since
+ * those were acked and SPSO advanced).  Validates that the ack
+ * error handling doesn't interfere with normal ack flow.
+ */
+static void do_test_ack_success_advances_spso(void) {
+        const char *topic = "kip932_ack_spso_advance";
+        const int msgcnt  = 6;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_b;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        /* Consumer A acquires first batch. MaxRecords in the client
+         * defaults to a large value, so it will get all 6.  We use
+         * the max_record_locks limit to cap acquisition at 3. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 3);
+
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-spso");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_a = consume_n(consumer, 3, 30);
+        TEST_SAY("ack_spso: A consumed %d/3\n", consumed_a);
+
+        /* Second poll triggers implicit ack for A's records. */
+        consume_n(consumer, 1, 3);
+
+        /* Close A cleanly. */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        /* Remove lock limit so B can get remaining records. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
+
+        /* Consumer B should get records 3-5 (SPSO advanced past 0-2). */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-spso");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_b = consume_n(consumer, 3, 30);
+        TEST_SAY("ack_spso: B consumed %d/3\n", consumed_b);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == 3,
+                    "A: expected 3 consumed, got %d", consumed_a);
+        TEST_ASSERT(consumed_b == 3,
+                    "B: expected 3 consumed, got %d", consumed_b);
+        SUB_TEST_PASS();
+}
+
 /* ===================================================================
  *  Test runner
  * =================================================================== */
@@ -1376,6 +1523,10 @@ int main_0157_share_consumer_ack_mock(int argc, char **argv) {
         do_test_lock_expiry_before_ack();
         do_test_empty_topic_no_ack_side_effects();
         do_test_coordinator_failover_ack_recovery();
+
+        /* Ack validation */
+        do_test_ack_after_lock_expiry_redelivers();
+        do_test_ack_success_advances_spso();
 
         return 0;
 }

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -31,7 +31,7 @@
 #include "../src/rdkafka_proto.h"
 
 /**
- * @name KIP-932 Share Acknowledgement (implicit ack) mock broker tests.
+ * @name Share Acknowledgement (implicit ack) mock broker tests.
  *
  * Exercises the implicit ack flow via mock broker: records acquired
  * by a ShareFetch are acknowledged on the next ShareFetch, which

--- a/tests/0158-share_consumer_transactions_mock.c
+++ b/tests/0158-share_consumer_transactions_mock.c
@@ -33,7 +33,7 @@
 #include "../src/rdkafka_proto.h"
 
 /**
- * @name KIP-932 Share Group Transactions mock broker tests.
+ * @name Share Group Transactions mock broker tests.
  *
  * Exercises transactional produce + share consume via mock broker
  * for both read_uncommitted and read_committed isolation levels.

--- a/tests/0158-share_consumer_transactions_mock.c
+++ b/tests/0158-share_consumer_transactions_mock.c
@@ -64,6 +64,10 @@ static test_ctx_t test_ctx_new(const char *txn_id) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         /* Non-transactional producer */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -1290,6 +1290,10 @@ static test_ctx_t test_ctx_new(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
 

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -1341,6 +1341,10 @@ static test_ctx_t test_ctx_new(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
 

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1050,6 +1050,10 @@ static test_ctx_t test_ctx_new(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to enable ShareFetch");
 
+        /* Set auto.offset.reset=earliest so tests that produce
+         * before consuming see all records. */
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(ctx.mcluster, 1);
+
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
 


### PR DESCRIPTION
**Summary**
- Move epoch-0 ack rejection before session_validate to prevent destroying existing sessions on malformed requests
- Add SHARE_SESSION_LIMIT_REACHED error when fetch session cache is full (default 2000 per KIP-932)
- Return INVALID_RECORD_STATE for acks on records whose lock expired, were re-acquired by another consumer, or are no longer in Acquired state
- Write per-partition AcknowledgeErrorCode in ShareFetch and ShareAcknowledge responses instead of hardcoded 0
- Validate ack batch ordering (ascending FirstOffsets, non-overlapping ranges) and reject with INVALID_REQUEST
- Handle per-offset AcknowledgeTypes arrays correctly instead of collapsing to last value
- Apply piggybacked acks before forgotten partition processing so acks on partitions being removed succeed
- Allow epoch=-1 (final fetch) to carry acks in Topics array; only reject ForgottenTopicsData
- Propagate broad errors to AcknowledgeErrorCode on all ack-bearing partitions per KIP-932 spec
- Add group.share.partition.max.record.locks (default 2000) to cap in-flight records per share-partition
- Add configurable share.auto.offset.reset with default "latest" per KIP-932
- Implement partition rotation across fetch requests to prevent starvation
- Archive in-flight records when log retention advances start_offset past SPSO
- Change UNKNOWN_TOPIC_OR_PARTITION from top-level error to per-partition error so valid partitions still get data 