### PR TITLE
admin: fix use-after-free in coord_request error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+## Fixes
+
+### Admin client fixes
+
+* Fix use-after-free in `rd_kafka_admin_coord_request()` error path
+  that caused an assertion failure
+  (`rd_kafka_enq_once_del_source_return: Assertion 'eonce->refcnt > 0' failed`)
+  and process abort when a coordinator-targeted Admin API request
+  (e.g., DescribeConsumerGroups, DeleteConsumerGroupOffsets,
+  ListConsumerGroupOffsets) failed to send (#4605, #3663).
+
 # librdkafka v2.14.1
 
 librdkafka v2.14.1 is a maintenance release:

--- a/src/rdkafka_admin.c
+++ b/src/rdkafka_admin.c
@@ -480,7 +480,6 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
                              rd_kafka_replyq_t replyq,
                              rd_kafka_resp_cb_t *resp_cb,
                              void *opaque) {
-        rd_kafka_t *rk             = rkb->rkb_rk;
         rd_kafka_enq_once_t *eonce = opaque;
         rd_kafka_op_t *rko;
         char errstr[512];
@@ -499,13 +498,17 @@ rd_kafka_admin_coord_request(rd_kafka_broker_t *rkb,
             &rko->rko_u.admin_request.options, errstr, sizeof(errstr), replyq,
             rd_kafka_admin_handle_response, eonce);
 
-        if (err) {
-                rd_kafka_admin_result_fail(
-                    rko, err, "%s worker failed to send request: %s",
-                    rd_kafka_op2str(rko->rko_type), errstr);
-                rd_kafka_admin_common_worker_destroy(rk, rko,
-                                                     rd_true /*destroy*/);
-        }
+        /* On error, do not call worker_destroy() here.
+         * The caller (rd_kafka_coord_req_fsm) will call coord_req_fail()
+         * which enqueues a dummy error response carrying the eonce as
+         * opaque. coord_response_parse() will then retrieve the rko via
+         * del_source_return("coordinator response"), see the error, and
+         * call worker_destroy() itself.
+         *
+         * Calling worker_destroy() here would free the eonce while the
+         * caller still holds a reference to it, leading to a
+         * use-after-free / assertion failure in
+         * rd_kafka_enq_once_del_source_return(). */
         return err;
 }
 

--- a/src/rdkafka_coord.c
+++ b/src/rdkafka_coord.c
@@ -316,6 +316,14 @@ static void rd_kafka_coord_req_fail(rd_kafka_t *rk,
         rd_kafka_op_t *reply;
         rd_kafka_buf_t *rkbuf;
 
+        if (!creq->creq_reply_opaque) {
+                /* The admin operation has already timed out and been
+                 * destroyed.  The eonce (creq_reply_opaque) may be
+                 * freed.  Do not enqueue a response referencing it. */
+                rd_kafka_coord_req_destroy(rk, creq, rd_true /*done*/);
+                return;
+        }
+
         reply         = rd_kafka_op_new(RD_KAFKA_OP_RECV_BUF);
         reply->rko_rk = rk; /* Set rk since the rkbuf will not have a rkb
                              * to reach it. */
@@ -495,7 +503,15 @@ static void rd_kafka_coord_req_fsm(rd_kafka_t *rk, rd_kafka_coord_req_t *creq) {
                                                      replyq, creq->creq_resp_cb,
                                                      creq->creq_reply_opaque);
 
-                        if (err) {
+                        if (err == RD_KAFKA_RESP_ERR__DESTROY) {
+                                /* Admin op already timed out.  Clear
+                                 * opaque to prevent coord_req_fail from
+                                 * using freed eonce. */
+                                creq->creq_reply_opaque = NULL;
+                                rd_kafka_replyq_destroy(&replyq);
+                                rd_kafka_coord_req_destroy(rk, creq,
+                                                           rd_true /*done*/);
+                        } else if (err) {
                                 /* Permanent error, e.g., request not
                                  *  supported by broker. */
                                 rd_kafka_replyq_destroy(&replyq);


### PR DESCRIPTION
## Description

Fix a use-after-free bug in `rd_kafka_admin_coord_request()` that causes a
process abort with:

```
rd_kafka_enq_once_del_source_return: Assertion \`eonce->refcnt > 0' failed
```

This affects all coordinator-targeted Admin API operations:
`DescribeConsumerGroups`, `DeleteConsumerGroupOffsets`,
`ListConsumerGroupOffsets`, and similar.

## Root cause

When \`rd_kafka_admin_coord_request()\`'s inner \`request()\` call fails
(e.g., connection dropped), the error path called
\`rd_kafka_admin_common_worker_destroy()\` which freed the \`eonce\` object.
However, the caller (\`rd_kafka_coord_req_fsm\`) still holds a reference to
the \`eonce\` and passes it to \`rd_kafka_coord_req_fail()\`, which enqueues
a dummy error response with the now-freed \`eonce\` as opaque.

When \`rd_kafka_admin_coord_response_parse()\` later processes that response
and calls \`rd_kafka_enq_once_del_source_return()\`, it accesses freed memory,
triggering the assertion failure.

## Fix

Three changes:

1. **`rdkafka_admin.c`**: Remove the premature `worker_destroy()` call from
   the error path of `rd_kafka_admin_coord_request()`. The error is returned
   to the caller, which calls `coord_req_fail()` → `coord_response_parse()`.
   That function already handles the error correctly.

2. **`rdkafka_coord.c` (`coord_req_fail`)**: Guard against a freed `eonce`
   by checking `creq_reply_opaque` for NULL before enqueuing a response.

3. **`rdkafka_coord.c` (`coord_req_fsm`)**: Handle `RESP_ERR__DESTROY`
   (admin op already timed out) by nulling out the opaque before cleanup,
   preventing `coord_req_fail` from referencing a freed `eonce`.

## Testing

Validated with a Kafka admin client running `DescribeConsumerGroups` against
large Kafka clusters with thousands of consumer groups, which was reliably
reproducing the assertion crash. The patched version runs indefinitely without
any crashes.

Fixes #4605
Fixes #3663