### PR TITLE
[KIP-932] Fix run-all-tests CI and remove 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -209,8 +209,6 @@ blocks:
           type: s1-prod-ubuntu24-04-amd64-1
       prologue:
         commands:
-          - wget -O rapidjson-dev.deb https://launchpad.net/ubuntu/+archive/primary/+files/rapidjson-dev_1.1.0+dfsg2-3_all.deb
-          - sudo dpkg -i rapidjson-dev.deb
           - (cd tests && python3 -m pip install -r requirements.txt)
           - ./configure --install-deps --enable-werror --enable-devel
           - make -j all

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -54,9 +54,9 @@ if [ ! -z $TEST_PARALLEL ]; then
     TEST_PARALLEL_ARG="-p$TEST_PARALLEL"
 fi
 if [ ! -z $TEST_CONF ]; then
-    TEST_CONF_ARG="--conf '$TEST_CONF'"
+    TEST_CONF_ARG="--conf $TEST_CONF"
 else
-    TEST_CONF_ARG="--conf '[\"group.share.min.record.lock.duration.ms=1000\"]'"
+    TEST_CONF_ARG="--conf [\"group.share.min.record.lock.duration.ms=1000\"]"
 fi
 if [ ! -z $TEST_ENV_VARIABLES ]; then
     IFS=',' read -ra TEST_ENV_VARIABLES_ARRAY <<< "$TEST_ENV_VARIABLES"


### PR DESCRIPTION
- Fix `json.JSONDecodeError` in `run-all-tests.sh` caused by literal single
  quotes being passed to Python's `--conf` argument. When embedded in a shell
  variable, single quotes are not stripped during expansion, so Python received
  `'["..."]'` instead of `["..."]`.
- Remove unnecessary rapidjson-dev install from the single broker test pipeline
  in `semaphore.yml`.