### PR TITLE
[KIP-932]: Test 0177 single broker fix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -221,7 +221,7 @@ blocks:
             - (cd tests && python3 -m trivup.clusters.KafkaCluster --kraft
               --version ${KAFKA_VERSION} --cpversion ${CP_VERSION}
               --brokers 1
-              --conf '["share.coordinator.state.topic.replication.factor=1", "share.coordinator.state.topic.min.isr=1", "group.share.min.record.lock.duration.ms=1000"]'
+              --conf '["share.coordinator.state.topic.replication.factor=1", "share.coordinator.state.topic.min.isr=1", "group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
               --cmd 'TESTS_SKIP_BEFORE=0170 python3 run-test-batches.py')
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
 

--- a/packaging/tools/run-share-consumer-tests.sh
+++ b/packaging/tools/run-share-consumer-tests.sh
@@ -19,7 +19,7 @@ make -j -C tests build
 
 echo "arguments: $TEST_ARGS"
 (cd tests && python3 -m trivup.clusters.KafkaCluster $TEST_CONFIGURATION \
- --conf '["group.share.min.record.lock.duration.ms=1000"]' \
+ --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]' \
  --version "$TEST_KAFKA_GIT_REF" \
  --cpversion "$TEST_CP_VERSION" \
  --cmd "TESTS_SKIP_BEFORE=0170 python run-test-batches.py $TEST_ARGS")

--- a/tests/cluster_testing.py
+++ b/tests/cluster_testing.py
@@ -104,6 +104,8 @@ class LibrdkafkaTestCluster(Cluster):
                         'share.coordinator.state.topic.replication.factor=%d' % min(num_brokers, 3),  # noqa: E501
                         'share.coordinator.state.topic.min.isr=%d' % min(num_brokers, 2),  # noqa: E501
                         'group.share.min.record.lock.duration.ms=1000',
+                        'transaction.state.log.replication.factor=%d' % min(num_brokers, 3),  # noqa: E501
+                        'transaction.state.log.min.isr=%d' % min(num_brokers, 2),  # noqa: E501
                     ]
                 defconf_curr.update(
                     {


### PR DESCRIPTION
Fix transaction init timeout with single broker

- Add transaction.state.log.replication.factor=1 and min.isr=1 to Single Broker Tests in CI
- Change default broker count to 1 in interactive_broker_version.py and broker_version_tests.py

Transaction initialization was timing out after 120s because the default
replication factor (3) and min ISR (2) cannot be satisfied with a single broker.