### PR TITLE
fix a race that causes partition metadata stale and never updated

### DIFF
--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -615,11 +615,6 @@ int rd_kafka_toppar_broker_update(rd_kafka_toppar_t *rktp,
         }
 
         if (rktp->rktp_broker) {
-                if (rktp->rktp_broker == rkb) {
-                        /* No change in broker */
-                        return 0;
-                }
-
                 rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC | RD_KAFKA_DBG_FETCH,
                              "TOPICUPD",
                              "Topic %s [%" PRId32


### PR DESCRIPTION
In `rd_kafka_metadata_fast_leader_query`, multiple Metadata requests could be sent. If they are processed by different brokers, the response order is not guaranteed, i.e. the client could see:
1. response 1: leader is `new_leader`
2. response 2: leader is `old_leader`
3. response 3: leader is `new_leader`

Then the following race could happen on a partition (`rktp`):
1. Response 1 is processed, now `rktp_leader_id` and `rktp_broker_id` are both `new_leader_id`, `rktp_broker` is `new_leader`
2. Processing response 2, `rktp_leader_id` is set to `old_leader_id` [1]
3. `PARTITION_LEAVE` is sent to `new_leader_id`'s event loop
4. Processing response 3, `rktp_leader_id` is set to `new_leader_id` [1]. Since `PARTITION_LEAVE` is not processed, `rktp_broker` was still `new_leader`, so it will hit the check here [2] and response 3 is not processed
5. Continue processing `PARTITION_LEAVE` in `old_leader`'s event loop

Eventually, the state of `rktp` will become:
- `rktp_leader_id` and `rktp_broker_id` are both `new_leader_id` (set from response 3)
- `rktp_broker` is a stale leader broker (`old_leader`), where Produce or Fetch requests go through the connection to a follower broker

[1] https://github.com/confluentinc/librdkafka/blob/e0da09cc26241ee123c793f806c27b5df494b094/src/rdkafka_topic.c#L750
[2] https://github.com/confluentinc/librdkafka/blob/e0da09cc26241ee123c793f806c27b5df494b094/src/rdkafka_topic.c#L619-L620

After trapping into this state, even a new Metadata response arrives with the correct leader info, it will be skipped by

https://github.com/confluentinc/librdkafka/blob/e0da09cc26241ee123c793f806c27b5df494b094/src/rdkafka_topic.c#L724-L730

- `fetching_from_follower` is true because `rktp->rktp_broker != leader`
- `rktp->rktp_leader_id == leader_id` because the `rktp_leader_id` has been set to the latest leader when processing response 3

The root cause is the `if (rktp->rktp_broker == rkb) return 0` check is not thread safe:
- `rktp_broker` is updated in the broker event loop https://github.com/confluentinc/librdkafka/blob/e0da09cc26241ee123c793f806c27b5df494b094/src/rdkafka_broker.c#L3324
- `rktp_leader_id` and `rktp_broker_id` are updated immediately when processing the Metadata response and the check happens immediately after the updates