### PR TITLE
FIX: Prevent spurious InitProducerId retry on stale error

### DIFF
--- a/src/rdkafka_idempotence.c
+++ b/src/rdkafka_idempotence.c
@@ -437,6 +437,15 @@ void rd_kafka_idemp_request_pid_failed(rd_kafka_broker_t *rkb,
                     rd_kafka_broker_name(rkb), rd_kafka_err2str(err));
 
         rd_kafka_wrlock(rk);
+        if (rk->rk_eos.idemp_state != RD_KAFKA_IDEMP_STATE_WAIT_PID) {
+                rd_kafka_dbg(rk, EOS, "GETPID",
+                             "Ignoring InitProducerId failure (%s) "
+                             "in state %s",
+                             rd_kafka_err2str(err),
+                             rd_kafka_idemp_state2str(rk->rk_eos.idemp_state));
+                rd_kafka_wrunlock(rk);
+                return;
+        }
 
         if (rd_kafka_idemp_check_error(rk, err, errstr, rd_false)) {
                 rd_kafka_wrunlock(rk);


### PR DESCRIPTION
When an InitProducerId response arrives after the idempotent producer state machine has already moved past WAIT_PID (e.g. due to a concurrent epoch bump triggered from a broker thread),
rd_kafka_idemp_request_pid_failed() would unconditionally reset the state to REQ_PID. This caused a spurious InitProducerId retry that could bump the producer epoch and fence the running producer.

Add a state guard to ignore stale error callbacks when the state is no longer WAIT_PID, matching the existing guard in
rd_kafka_idemp_pid_update() for success responses.

Closes #3928.