### PR TITLE
 [KIP-932]: Add comprehensive MessageSet error handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ set(
     rdunittest.c
     rdunittest_acknowledge.c
     rdunittest_fetcher.c
+    rdunittest_msgset_errors.c
     rdvarint.c
     rdmap.c
     snappy.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ SRCS=		rdkafka.c rdkafka_broker.c rdkafka_msg.c rdkafka_topic.c \
 		rdkafka_background.c rdkafka_idempotence.c rdkafka_cert.c \
 		rdkafka_txnmgr.c rdkafka_coord.c rdbase64.c \
 		rdvarint.c rdbuf.c rdmap.c rdunittest.c rdunittest_fetcher.c \
-		rdunittest_acknowledge.c \
+		rdunittest_acknowledge.c rdunittest_msgset_errors.c \
 		rdkafka_mock.c rdkafka_mock_handlers.c rdkafka_mock_cgrp.c rdkafka_mock_sharegrp.c \
 		rdkafka_error.c rdkafka_fetcher.c rdkafka_telemetry.c \
 		rdkafka_telemetry_encode.c rdkafka_telemetry_decode.c \

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -932,8 +932,16 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                                     delivery_count;
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
-                                rkm->rkm_u.consumer.ack_type =
-                                    RD_KAFKA_SHARE_INTERNAL_ACK_REJECT;
+                                /* Set ack_type to REJECT only if not already set
+                                 * by rd_kafka_share_consumer_err_range() (which
+                                 * sets REJECT for CRC/unsupported errors, RELEASE
+                                 * for decompression errors). */
+                                if (rkm->rkm_u.consumer.ack_type ==
+                                        RD_KAFKA_SHARE_INTERNAL_ACK_GAP ||
+                                    rkm->rkm_u.consumer.ack_type ==
+                                        RD_KAFKA_SHARE_INTERNAL_ACK_ACQUIRED)
+                                        rkm->rkm_u.consumer.ack_type =
+                                            RD_KAFKA_SHARE_INTERNAL_ACK_REJECT;
                         }
 
                         /* Add to filtered messages list */
@@ -1100,11 +1108,17 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                                         .message_rkos,
                                     msg_rko);
                                 msg_cnt++;
-                        } else {
-                                /* RD_KAFKA_OP_CONSUMER_ERR: forward to
-                                 * consumer group queue */
-                                rd_kafka_q_enq(rkb->rkb_rk->rk_cgrp->rkcg_q,
-                                               msg_rko);
+                        } else if (msg_rko->rko_type ==
+                                   RD_KAFKA_OP_CONSUMER_ERR) {
+                                /* Add error ops to message list along with
+                                 * fetch ops. Error ops have ack_type already set
+                                 * and will be delivered to application in the
+                                 * same message stream. */
+                                rd_list_add(
+                                    response_rko->rko_u.share_fetch_response
+                                        .message_rkos,
+                                    msg_rko);
+                                msg_cnt++;
                         }
                 }
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1102,18 +1102,8 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                         entry->types[offset - entry->start_offset] =
                             rd_kafka_share_ack_type_from_msg_op(msg_rko);
 
-                        if (msg_rko->rko_type == RD_KAFKA_OP_FETCH) {
-                                rd_list_add(
-                                    response_rko->rko_u.share_fetch_response
-                                        .message_rkos,
-                                    msg_rko);
-                                msg_cnt++;
-                        } else if (msg_rko->rko_type ==
-                                   RD_KAFKA_OP_CONSUMER_ERR) {
-                                /* Add error ops to message list along with
-                                 * fetch ops. Error ops have ack_type already
-                                 * set and will be delivered to application in
-                                 * the same message stream. */
+                        if (msg_rko->rko_type == RD_KAFKA_OP_FETCH ||
+                            msg_rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rd_list_add(
                                     response_rko->rko_u.share_fetch_response
                                         .message_rkos,

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -932,10 +932,10 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                                     delivery_count;
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
-                                /* Set ack_type to REJECT only if not already set
-                                 * by rd_kafka_share_consumer_err_range() (which
-                                 * sets REJECT for CRC/unsupported errors, RELEASE
-                                 * for decompression errors). */
+                                /* Set ack_type to REJECT only if not already
+                                 * set by rd_kafka_share_consumer_err_range()
+                                 * (which sets REJECT for CRC/unsupported
+                                 * errors, RELEASE for decompression errors). */
                                 if (rkm->rkm_u.consumer.ack_type ==
                                         RD_KAFKA_SHARE_INTERNAL_ACK_GAP ||
                                     rkm->rkm_u.consumer.ack_type ==
@@ -1111,9 +1111,9 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                         } else if (msg_rko->rko_type ==
                                    RD_KAFKA_OP_CONSUMER_ERR) {
                                 /* Add error ops to message list along with
-                                 * fetch ops. Error ops have ack_type already set
-                                 * and will be delivered to application in the
-                                 * same message stream. */
+                                 * fetch ops. Error ops have ack_type already
+                                 * set and will be delivered to application in
+                                 * the same message stream. */
                                 rd_list_add(
                                     response_rko->rko_u.share_fetch_response
                                         .message_rkos,

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -933,7 +933,7 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
                                 /* Set ack_type to REJECT only if not already
-                                 * set by rd_kafka_share_consumer_err_range()
+                                 * set by rd_kafka_share_message_set_err_ops()
                                  * (which sets REJECT for CRC/unsupported
                                  * errors, RELEASE for decompression errors). */
                                 if (rkm->rkm_u.consumer.ack_type ==
@@ -941,7 +941,7 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                                     rkm->rkm_u.consumer.ack_type ==
                                         RD_KAFKA_SHARE_INTERNAL_ACK_ACQUIRED)
                                         rkm->rkm_u.consumer.ack_type =
-                                            RD_KAFKA_SHARE_INTERNAL_ACK_REJECT;
+                                            RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE;
                         }
 
                         /* Add to filtered messages list */
@@ -1102,6 +1102,10 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                         entry->types[offset - entry->start_offset] =
                             rd_kafka_share_ack_type_from_msg_op(msg_rko);
 
+                        /* Forward the rko to the application only for
+                         * messages and per-message errors; GAP entries
+                         * are tracked in the per-offset ack-type table
+                         * above but not surfaced as rkmessages. */
                         if (msg_rko->rko_type == RD_KAFKA_OP_FETCH ||
                             msg_rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rd_list_add(

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1465,6 +1465,19 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
                  * parse errors (which are partition-specific) */
         }
 
+        /**
+         * Only inner-record parsing errors (RD_KAFKA_RESP_ERR__BAD_MSG /
+         * RD_KAFKA_RESP_ERR__UNDERFLOW) propagate out of
+         * rd_kafka_share_msgset_parse for share consumers — per-batch
+         * codec / CRC / unsupported-MagicByte failures are handled
+         * inline by emitting per-offset RELEASE/REJECT ops and are
+         * swallowed by the v2 reader (msgset_reader.c). When a true
+         * parse error bubbles up the wire data is corrupt and we can no
+         * longer trust the buffer position or any per-batch metadata.
+         * Stop processing the rest of this ShareFetch response and
+         * propagate the error to the caller, which aborts the whole
+         * response handling.
+         */
         if (err)
                 goto done;
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -932,8 +932,16 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                                     delivery_count;
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
-                                rkm->rkm_u.consumer.ack_type =
-                                    RD_KAFKA_SHARE_INTERNAL_ACK_REJECT;
+                                /* Set ack_type to REJECT only if not already
+                                 * set by rd_kafka_share_consumer_err_range()
+                                 * (which sets REJECT for CRC/unsupported
+                                 * errors, RELEASE for decompression errors). */
+                                if (rkm->rkm_u.consumer.ack_type ==
+                                        RD_KAFKA_SHARE_INTERNAL_ACK_GAP ||
+                                    rkm->rkm_u.consumer.ack_type ==
+                                        RD_KAFKA_SHARE_INTERNAL_ACK_ACQUIRED)
+                                        rkm->rkm_u.consumer.ack_type =
+                                            RD_KAFKA_SHARE_INTERNAL_ACK_REJECT;
                         }
 
                         /* Add to filtered messages list */
@@ -1094,17 +1102,13 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                         entry->types[offset - entry->start_offset] =
                             rd_kafka_share_ack_type_from_msg_op(msg_rko);
 
-                        if (msg_rko->rko_type == RD_KAFKA_OP_FETCH) {
+                        if (msg_rko->rko_type == RD_KAFKA_OP_FETCH ||
+                            msg_rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rd_list_add(
                                     response_rko->rko_u.share_fetch_response
                                         .message_rkos,
                                     msg_rko);
                                 msg_cnt++;
-                        } else {
-                                /* RD_KAFKA_OP_CONSUMER_ERR: forward to
-                                 * consumer group queue */
-                                rd_kafka_q_enq(rkb->rkb_rk->rk_cgrp->rkcg_q,
-                                               msg_rko);
                         }
                 }
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -933,7 +933,7 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
                                 /* Set ack_type to REJECT only if not already
-                                 * set by rd_kafka_share_message_set_err_ops()
+                                 * set by rd_kafka_share_msgset_err_ops()
                                  * (which sets REJECT for CRC/unsupported
                                  * errors, RELEASE for decompression errors). */
                                 if (rkm->rkm_u.consumer.ack_type ==
@@ -1102,10 +1102,13 @@ rd_kafka_share_build_response_rko(rd_kafka_broker_t *rkb,
                         entry->types[offset - entry->start_offset] =
                             rd_kafka_share_ack_type_from_msg_op(msg_rko);
 
-                        /* Forward the rko to the application only for
-                         * messages and per-message errors; GAP entries
-                         * are tracked in the per-offset ack-type table
-                         * above but not surfaced as rkmessages. */
+                        /**
+                         * The per message error ops (Decompression error, CRC
+                         * error, or MagicByte Errors are tracked in the same
+                         * list of messages as the successful messages.
+                         * TODO KIP-932: Check if we need a new op for record
+                         * level message errors: RD_KAFKA_OP_CONSUMER_MSG_ERR.
+                         */
                         if (msg_rko->rko_type == RD_KAFKA_OP_FETCH ||
                             msg_rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rd_list_add(
@@ -1442,10 +1445,6 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
         /* No error, clear any previous fetch error. */
         rktp->rktp_last_error = RD_KAFKA_RESP_ERR_NO_ERROR;
 
-        /**
-         * TODO KIP-932: Currently for CRC error, we are sending reject for only
-         * 1 offset. We should send reject for all offsets in the range.
-         */
         if (MessageSetSize > 0) {
                 /**
                  * Parse MessageSet
@@ -1463,23 +1462,23 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
                 rd_slice_widen(&rkbuf->rkbuf_reader, &save_slice);
                 /* Continue with next partition regardless of
                  * parse errors (which are partition-specific) */
-        }
 
-        /**
-         * Only inner-record parsing errors (RD_KAFKA_RESP_ERR__BAD_MSG /
-         * RD_KAFKA_RESP_ERR__UNDERFLOW) propagate out of
-         * rd_kafka_share_msgset_parse for share consumers — per-batch
-         * codec / CRC / unsupported-MagicByte failures are handled
-         * inline by emitting per-offset RELEASE/REJECT ops and are
-         * swallowed by the v2 reader (msgset_reader.c). When a true
-         * parse error bubbles up the wire data is corrupt and we can no
-         * longer trust the buffer position or any per-batch metadata.
-         * Stop processing the rest of this ShareFetch response and
-         * propagate the error to the caller, which aborts the whole
-         * response handling.
-         */
-        if (err)
-                goto done;
+                /**
+                 * Only inner-record parsing errors (RD_KAFKA_RESP_ERR__BAD_MSG
+                 * / RD_KAFKA_RESP_ERR__UNDERFLOW) propagate out of
+                 * rd_kafka_share_msgset_parse for share consumers — per-batch
+                 * codec / CRC / unsupported-MagicByte failures are handled
+                 * inline by emitting per-offset RELEASE/REJECT ops and are
+                 * swallowed by the v2 reader (msgset_reader.c). When a true
+                 * parse error bubbles up the wire data is corrupt and we can no
+                 * longer trust the buffer position or any per-batch metadata.
+                 * Stop processing the rest of this ShareFetch response and
+                 * propagate the error to the caller, which aborts the whole
+                 * response handling.
+                 */
+                if (err)
+                        goto done;
+        }
 
         rd_kafka_buf_read_arraycnt(rkbuf, &AcquiredRecordsArrayCnt,
                                    -1);  // AcquiredRecordsArrayCnt
@@ -1629,7 +1628,7 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         rd_list_t *inflight_acks      = NULL;
         rd_kafka_op_t *rko_orig       = request->rkbuf_opaque;
         rd_kafka_op_t *response_rko   = NULL;
-        rd_kafka_resp_err_t err;
+        rd_kafka_resp_err_t err       = RD_KAFKA_RESP_ERR_NO_ERROR;
 
         rd_kafka_buf_read_throttle_time(rkbuf);
 
@@ -1637,15 +1636,13 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         rd_kafka_buf_read_str(rkbuf, &ErrorStr);
 
         if (ErrorCode) {
+                /**
+                 * TODO KIP_932: Change err log here to debug log
+                 */
                 rd_rkb_log(rkb, LOG_ERR, "SHAREFETCH",
                            "ShareFetch response error %s: '%.*s'",
                            rd_kafka_err2name(ErrorCode),
                            RD_KAFKAP_STR_PR(&ErrorStr));
-                /* TODO KIP-932: Check if the response buffer still needs
-                 * to be parsed in some error cases. For example,
-                 * UNKNOWN_TOPIC_ID may require removing partitions from
-                 * the session, and acknowledgements for that topic id
-                 * should also be destroyed. */
                 return ErrorCode;
         }
 
@@ -1679,6 +1676,21 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
                             filtered_msgs, batches,
                             rko_orig->rko_u.share_fetch.ack_details);
 
+                        /*
+                         * Only inner-record parsing errors
+                         * (RD_KAFKA_RESP_ERR__BAD_MSG /
+                         * RD_KAFKA_RESP_ERR__UNDERFLOW) reach this point —
+                         * per-batch CRC / decompression / MagicByte failures
+                         * are handled inline inside
+                         * rd_kafka_share_msgset_parse by emitting per-offset
+                         * RELEASE/REJECT ops and are swallowed, and
+                         * per-partition broker errors are handled by
+                         * rd_kafka_share_fetch_reply_handle_partition_error
+                         * before MessageSet parsing begins. A parsing error
+                         * means the wire data is corrupt and the buffer
+                         * position can no longer be trusted for subsequent
+                         * partitions, so abort the whole response.
+                         */
                         if (err) {
                                 rd_kafka_share_ack_batches_destroy(batches);
                                 goto done;
@@ -1755,9 +1767,7 @@ done:
 
         if (rkt)
                 rd_kafka_topic_destroy0(rkt);
-        rd_rkb_dbg(rkb, MSG, "BADMSG",
-                   "Bad message (Fetch v%d): "
-                   "is broker.version.fallback incorrectly set?",
+        rd_rkb_dbg(rkb, MSG, "BADMSG", "Bad message (ShareFetch v%d): ",
                    (int)request->rkbuf_reqhdr.ApiVersion);
         return err;
 }
@@ -2239,6 +2249,23 @@ static void rd_kafka_broker_share_acknowledge_reply(rd_kafka_t *rk,
                         break;
                 }
 
+                case RD_KAFKA_RESP_ERR__BAD_MSG:
+                case RD_KAFKA_RESP_ERR__UNDERFLOW:
+                        /* Wire-level parse failure: response envelope or
+                         * an inner MessageSet/record was malformed or
+                         * truncated. Indicates broker bug, on-the-wire
+                         * corruption, or version mismatch — log loudly so
+                         * the user notices, since the LOG_INFO top-level
+                         * log can be easy to miss in production output. */
+                        rd_rkb_log(rkb, LOG_ERR, "SHAREFETCH",
+                                   "ShareFetch response parse failure: %s "
+                                   "(ApiVersion %hd) — broker bug, wire "
+                                   "corruption, or version mismatch; "
+                                   "this response is being dropped",
+                                   rd_kafka_err2str(err),
+                                   request->rkbuf_reqhdr.ApiVersion);
+                        break;
+
                 default:
                         /* No retry for ShareAcknowledge RPC-level
                          * errors. The error semantics (partition
@@ -2360,6 +2387,23 @@ static void rd_kafka_broker_share_fetch_reply(rd_kafka_t *rk,
                             rkb->rkb_rk, NULL, rd_true /*force*/, tmp);
                         break;
                 }
+
+                case RD_KAFKA_RESP_ERR__BAD_MSG:
+                case RD_KAFKA_RESP_ERR__UNDERFLOW:
+                        /* Wire-level parse failure: response envelope or
+                         * an inner MessageSet/record was malformed or
+                         * truncated. Indicates broker bug, on-the-wire
+                         * corruption, or version mismatch — log loudly so
+                         * the user notices, since the LOG_INFO top-level
+                         * log can be easy to miss in production output. */
+                        rd_rkb_log(rkb, LOG_ERR, "SHAREFETCH",
+                                   "ShareFetch response parse failure: %s "
+                                   "(ApiVersion %hd) — broker bug, wire "
+                                   "corruption, or version mismatch; "
+                                   "this response is being dropped",
+                                   rd_kafka_err2str(err),
+                                   request->rkbuf_reqhdr.ApiVersion);
+                        break;
 
                 default:
                         /* No error-specific handling at the request

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1465,6 +1465,9 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
                  * parse errors (which are partition-specific) */
         }
 
+        if (err)
+                goto done;
+
         rd_kafka_buf_read_arraycnt(rkbuf, &AcquiredRecordsArrayCnt,
                                    -1);  // AcquiredRecordsArrayCnt
         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
@@ -1613,6 +1616,7 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         rd_list_t *inflight_acks      = NULL;
         rd_kafka_op_t *rko_orig       = request->rkbuf_opaque;
         rd_kafka_op_t *response_rko   = NULL;
+        rd_kafka_resp_err_t err;
 
         rd_kafka_buf_read_throttle_time(rkbuf);
 
@@ -1657,12 +1661,14 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
                         rd_kafka_share_ack_batches_t *batches =
                             rd_kafka_share_ack_batches_new_empty();
 
-                        if (rd_kafka_share_fetch_reply_handle_partition(
-                                rkb, &topic, topic_id, rkt, rkbuf, request,
-                                filtered_msgs, batches,
-                                rko_orig->rko_u.share_fetch.ack_details)) {
+                        err = rd_kafka_share_fetch_reply_handle_partition(
+                            rkb, &topic, topic_id, rkt, rkbuf, request,
+                            filtered_msgs, batches,
+                            rko_orig->rko_u.share_fetch.ack_details);
+
+                        if (err) {
                                 rd_kafka_share_ack_batches_destroy(batches);
-                                goto err_parse;
+                                goto done;
                         }
 
                         /* Skip unknown topics - don't add to inflight_acks */
@@ -1724,6 +1730,9 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 
 err_parse:
+        err = rkbuf->rkbuf_err;
+
+done:
         /* Free inflight_acks list on error (destructor handles cleanup) */
         rd_list_destroy(inflight_acks);
         rd_list_destroy(filtered_msgs);
@@ -1737,7 +1746,7 @@ err_parse:
                    "Bad message (Fetch v%d): "
                    "is broker.version.fallback incorrectly set?",
                    (int)request->rkbuf_reqhdr.ApiVersion);
-        return rkbuf->rkbuf_err;
+        return err;
 }
 
 

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -94,6 +94,10 @@ typedef struct rd_kafka_lwtopic_s rd_kafka_lwtopic_t;
 
 #define RD_KAFKA_OFFSET_IS_LOGICAL(OFF) ((OFF) < 0)
 
+/**
+ * TODO KIP-932: Remove the check of RD_KAFKA_CONSUMER. Only
+ * checking for is_share_consumer should be sufficient.
+ */
 #define RD_KAFKA_IS_SHARE_CONSUMER(rk)                                         \
         ((rk)->rk_type == RD_KAFKA_CONSUMER &&                                 \
          (rk)->rk_conf.share.is_share_consumer)

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1139,7 +1139,8 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                     hdr.Crc, calc_crc);
 
                                 /* Account for bytes already read */
-                                crc_len -= (2 + 4); /* Attributes + LastOffsetDelta */
+                                crc_len -=
+                                    (2 + 4); /* Attributes + LastOffsetDelta */
                         } else {
                                 rd_kafka_consumer_err(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,
@@ -1213,11 +1214,13 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                     payload_size);
                 if (err) {
                         /* For share consumer: decompression failed, error ops
-                         * already created. Buffer position already advanced past
-                         * compressed payload. Continue parsing next MessageSet.
-                         * For regular consumer: stop parsing. */
-                        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                                rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
+                         * already created. Buffer position already advanced
+                         * past compressed payload. Continue parsing next
+                         * MessageSet. For regular consumer: stop parsing. */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err,
+                                                1);
                                 goto done;
                         } else {
                                 goto err;
@@ -1338,15 +1341,16 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                         rd_kafka_share_consumer_err_range(
                             &msetr->msetr_rkq, msetr->msetr_broker_id,
                             RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-                            msetr->msetr_tver->version, rktp, Offset, LastOffset,
-                            RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                            msetr->msetr_tver->version, rktp, Offset,
+                            LastOffset, RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
                             "Unsupported Message(Set) MagicByte %d at offsets "
                             "%" PRId64 "-%" PRId64,
                             (int)MagicByteActual, Offset, LastOffset);
 
                         /* Skip remaining bytes in MessageSet */
-                        bytes_read = rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
-                        remaining  = Length - bytes_read;
+                        bytes_read =
+                            rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
+                        remaining = Length - bytes_read;
                         rd_kafka_buf_skip(rkbuf, remaining);
                 } else {
                         /* Regular consumer: single error */
@@ -1361,8 +1365,8 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                                     "at offset %" PRId64,
                                     (int)*MagicBytep, Offset);
                                 /* Skip message(set) */
-                                msetr->msetr_rktp->rktp_offsets.fetch_pos.offset =
-                                    Offset + 1;
+                                msetr->msetr_rktp->rktp_offsets.fetch_pos
+                                    .offset = Offset + 1;
                         }
 
                         /* Skip this Message(Set). */
@@ -1410,11 +1414,13 @@ rd_kafka_msgset_reader(rd_kafka_msgset_reader_t *msetr) {
                                  * due to its use of sendfile(2). */
                                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
-                        /* For share consumer: continue on unsupported MsgVersions,
-                         * the MessageSet will be skipped. Reset error so loop
-                         * continues parsing remaining MessageSets.
-                         * For regular consumer: stop parsing (old behavior). */
-                        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                        /* For share consumer: continue on unsupported
+                         * MsgVersions, the MessageSet will be skipped. Reset
+                         * error so loop continues parsing remaining
+                         * MessageSets. For regular consumer: stop parsing (old
+                         * behavior). */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
                                 err = RD_KAFKA_RESP_ERR_NO_ERROR;
                         }
                         continue;

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1137,10 +1137,6 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                     "calculated 0x%" PRIx32 ")",
                                     hdr.BaseOffset, LastOffset, hdr.Length,
                                     hdr.Crc, calc_crc);
-
-                                /* Account for bytes already read */
-                                crc_len -=
-                                    (2 + 4); /* Attributes + LastOffsetDelta */
                         } else {
                                 rd_kafka_consumer_err(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -517,12 +517,35 @@ rd_kafka_msgset_reader_decompress(rd_kafka_msgset_reader_t *msetr,
 err:
         /* Enqueue error messsage:
          * Create op and push on temporary queue. */
-        rd_kafka_consumer_err(
-            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
-            msetr->msetr_tver->version, NULL, rktp, Offset,
-            "Decompression (codec 0x%x) of message at %" PRIu64 " of %" PRIusz
-            " bytes failed: %s",
-            codec, Offset, compressed_size, rd_kafka_err2str(err));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk) &&
+            msetr->msetr_v2_hdr != NULL) {
+                /* For share consumer with MessageSet v2: report error for
+                 * entire batch with RELEASE acknowledgement (decompression
+                 * capability varies by consumer - another consumer might
+                 * succeed). */
+                int64_t LastOffset;
+
+                LastOffset = msetr->msetr_v2_hdr->BaseOffset +
+                             msetr->msetr_v2_hdr->LastOffsetDelta;
+
+                rd_kafka_share_consumer_err_range(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, rktp,
+                    msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                    RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Decompression (codec 0x%x) of MessageSet at offsets "
+                    "%" PRId64 "-%" PRId64 " of %" PRIusz " bytes failed: %s",
+                    codec, msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                    compressed_size, rd_kafka_err2str(err));
+        } else {
+                /* Regular consumer or v0/v1 MessageSet: single error */
+                rd_kafka_consumer_err(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, NULL, rktp, Offset,
+                    "Decompression (codec 0x%x) of message at %" PRIu64
+                    " of %" PRIusz " bytes failed: %s",
+                    codec, Offset, compressed_size, rd_kafka_err2str(err));
+        }
 
         return err;
 }
@@ -1088,19 +1111,52 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                 if (unlikely((uint32_t)hdr.Crc != calc_crc)) {
                         /* Propagate CRC error to application and
                          * continue with next message. */
-                        rd_kafka_consumer_err(
-                            &msetr->msetr_rkq, msetr->msetr_broker_id,
-                            RD_KAFKA_RESP_ERR__BAD_MSG,
-                            msetr->msetr_tver->version, NULL, rktp,
-                            hdr.BaseOffset,
-                            "MessageSet at offset %" PRId64 " (%" PRId32
-                            " bytes) "
-                            "failed CRC32C check "
-                            "(original 0x%" PRIx32
-                            " != "
-                            "calculated 0x%" PRIx32 ")",
-                            hdr.BaseOffset, hdr.Length, hdr.Crc, calc_crc);
-                        rd_kafka_buf_skip_to(rkbuf, crc_len);
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                int16_t Attributes;
+                                int32_t LastOffsetDelta;
+
+                                /* Read LastOffsetDelta to
+                                 * determine full offset range.  */
+                                rd_kafka_buf_read_i16(rkbuf, &Attributes);
+                                rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+                                LastOffset = hdr.BaseOffset + LastOffsetDelta;
+
+                                rd_kafka_share_consumer_err_range(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    msetr->msetr_tver->version, rktp,
+                                    hdr.BaseOffset, LastOffset,
+                                    RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                                    "MessageSet at offsets %" PRId64 "-%" PRId64
+                                    " (%" PRId32
+                                    " bytes) "
+                                    "failed CRC32C check "
+                                    "(original 0x%" PRIx32
+                                    " != "
+                                    "calculated 0x%" PRIx32 ")",
+                                    hdr.BaseOffset, LastOffset, hdr.Length,
+                                    hdr.Crc, calc_crc);
+
+                                /* Account for bytes already read */
+                                crc_len -= (2 + 4); /* Attributes + LastOffsetDelta */
+                        } else {
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    hdr.BaseOffset,
+                                    "MessageSet at offset %" PRId64 " (%" PRId32
+                                    " bytes) "
+                                    "failed CRC32C check "
+                                    "(original 0x%" PRIx32
+                                    " != "
+                                    "calculated 0x%" PRIx32 ")",
+                                    hdr.BaseOffset, hdr.Length, hdr.Crc,
+                                    calc_crc);
+                        }
+                        /* Skip to end of MessageSet */
+                        rd_kafka_buf_skip_to(rkbuf, len_start + hdr.Length);
                         rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
                         return RD_KAFKA_RESP_ERR_NO_ERROR;
                 }
@@ -1155,8 +1211,18 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                     msetr, 2 /*MsgVersion v2*/, hdr.Attributes,
                     hdr.BaseTimestamp, hdr.BaseOffset, compressed,
                     payload_size);
-                if (err)
-                        goto err;
+                if (err) {
+                        /* For share consumer: decompression failed, error ops
+                         * already created. Buffer position already advanced past
+                         * compressed payload. Continue parsing next MessageSet.
+                         * For regular consumer: stop parsing. */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                                rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
+                                goto done;
+                        } else {
+                                goto err;
+                        }
+                }
 
         } else {
                 /* Read uncompressed messages */
@@ -1243,26 +1309,65 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                            (int)*MagicBytep, Offset, read_offset,
                            rd_slice_size(&rkbuf->rkbuf_reader));
 
-                if (Offset >=
-                        msetr->msetr_rktp->rktp_offsets.fetch_pos.offset &&
-                    !RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                        rd_kafka_consumer_err(
+                rd_kafka_buf_read_i32(rkbuf, &Length);
+
+                if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                        /* Share consumer: read LastOffsetDelta to determine
+                         * full range. Speculatively assume future MessageSet
+                         * versions maintain similar header structure. */
+                        size_t len_start;
+                        size_t bytes_read;
+                        size_t remaining;
+                        int32_t PartitionLeaderEpoch;
+                        int8_t MagicByteActual;
+                        int32_t Crc;
+                        int16_t Attributes;
+                        int32_t LastOffsetDelta;
+                        int64_t LastOffset;
+
+                        len_start = rd_slice_offset(&rkbuf->rkbuf_reader);
+
+                        rd_kafka_buf_read_i32(rkbuf, &PartitionLeaderEpoch);
+                        rd_kafka_buf_read_i8(rkbuf, &MagicByteActual);
+                        rd_kafka_buf_read_i32(rkbuf, &Crc);
+                        rd_kafka_buf_read_i16(rkbuf, &Attributes);
+                        rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+
+                        LastOffset = Offset + LastOffsetDelta;
+
+                        rd_kafka_share_consumer_err_range(
                             &msetr->msetr_rkq, msetr->msetr_broker_id,
                             RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-                            msetr->msetr_tver->version, NULL, rktp, Offset,
-                            "Unsupported Message(Set) MagicByte %d "
-                            "at offset %" PRId64,
-                            (int)*MagicBytep, Offset);
-                        /* Skip message(set) */
-                        msetr->msetr_rktp->rktp_offsets.fetch_pos.offset =
-                            Offset + 1;
-                }
+                            msetr->msetr_tver->version, rktp, Offset, LastOffset,
+                            RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                            "Unsupported Message(Set) MagicByte %d at offsets "
+                            "%" PRId64 "-%" PRId64,
+                            (int)MagicByteActual, Offset, LastOffset);
 
-                /* Skip this Message(Set).
-                 * If the message is malformed, the skip may trigger err_parse
-                 * and return ERR__BAD_MSG. */
-                rd_kafka_buf_read_i32(rkbuf, &Length);
-                rd_kafka_buf_skip(rkbuf, Length);
+                        /* Skip remaining bytes in MessageSet */
+                        bytes_read = rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
+                        remaining  = Length - bytes_read;
+                        rd_kafka_buf_skip(rkbuf, remaining);
+                } else {
+                        /* Regular consumer: single error */
+                        if (Offset >=
+                            msetr->msetr_rktp->rktp_offsets.fetch_pos.offset) {
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    Offset,
+                                    "Unsupported Message(Set) MagicByte %d "
+                                    "at offset %" PRId64,
+                                    (int)*MagicBytep, Offset);
+                                /* Skip message(set) */
+                                msetr->msetr_rktp->rktp_offsets.fetch_pos.offset =
+                                    Offset + 1;
+                        }
+
+                        /* Skip this Message(Set). */
+                        rd_kafka_buf_skip(rkbuf, Length);
+                }
 
                 return RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED;
         }
@@ -1305,8 +1410,13 @@ rd_kafka_msgset_reader(rd_kafka_msgset_reader_t *msetr) {
                                  * due to its use of sendfile(2). */
                                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
-                        /* Continue on unsupported MsgVersions, the
-                         * MessageSet will be skipped. */
+                        /* For share consumer: continue on unsupported MsgVersions,
+                         * the MessageSet will be skipped. Reset error so loop
+                         * continues parsing remaining MessageSets.
+                         * For regular consumer: stop parsing (old behavior). */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                                err = RD_KAFKA_RESP_ERR_NO_ERROR;
+                        }
                         continue;
                 }
 

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1111,21 +1111,22 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                          * continue with next message. */
                         if (!RD_KAFKA_IS_SHARE_CONSUMER(
                                 msetr->msetr_rkb->rkb_rk)) {
-                                        rd_kafka_consumer_err(
-                            &msetr->msetr_rkq, msetr->msetr_broker_id,
-                            RD_KAFKA_RESP_ERR__BAD_MSG,
-                            msetr->msetr_tver->version, NULL, rktp,
-                            hdr.BaseOffset,
-                            "MessageSet at offset %" PRId64 " (%" PRId32
-                            " bytes) "
-                            "failed CRC32C check "
-                            "(original 0x%" PRIx32
-                            " != "
-                            "calculated 0x%" PRIx32 ")",
-                            hdr.BaseOffset, hdr.Length, hdr.Crc, calc_crc);
-                        /* Skip to end of MessageSet */
-                        rd_kafka_buf_skip_to(rkbuf, crc_len);
-                                
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    hdr.BaseOffset,
+                                    "MessageSet at offset %" PRId64 " (%" PRId32
+                                    " bytes) "
+                                    "failed CRC32C check "
+                                    "(original 0x%" PRIx32
+                                    " != "
+                                    "calculated 0x%" PRIx32 ")",
+                                    hdr.BaseOffset, hdr.Length, hdr.Crc,
+                                    calc_crc);
+                                /* Skip to end of MessageSet */
+                                rd_kafka_buf_skip_to(rkbuf, crc_len);
+
                         } else {
                                 int16_t Attributes;
                                 int32_t LastOffsetDelta;
@@ -1152,9 +1153,10 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                     hdr.BaseOffset, LastOffset, hdr.Length,
                                     hdr.Crc, calc_crc);
                                 /* Skip to end of MessageSet */
-                                rd_kafka_buf_skip_to(rkbuf, len_start + hdr.Length);
+                                rd_kafka_buf_skip_to(rkbuf,
+                                                     len_start + hdr.Length);
                         }
-                
+
                         rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
                         return RD_KAFKA_RESP_ERR_NO_ERROR;
                 }
@@ -1310,9 +1312,8 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                            rd_slice_size(&rkbuf->rkbuf_reader));
 
                 if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                        if (Offset >=
-                                msetr->msetr_rktp->rktp_offsets.fetch_pos
-                                    .offset &&
+                        if (Offset >= msetr->msetr_rktp->rktp_offsets.fetch_pos
+                                          .offset &&
                             !RD_KAFKA_IS_SHARE_CONSUMER(
                                 msetr->msetr_rkb->rkb_rk)) {
                                 rd_kafka_consumer_err(

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -517,12 +517,35 @@ rd_kafka_msgset_reader_decompress(rd_kafka_msgset_reader_t *msetr,
 err:
         /* Enqueue error messsage:
          * Create op and push on temporary queue. */
-        rd_kafka_consumer_err(
-            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
-            msetr->msetr_tver->version, NULL, rktp, Offset,
-            "Decompression (codec 0x%x) of message at %" PRIu64 " of %" PRIusz
-            " bytes failed: %s",
-            codec, Offset, compressed_size, rd_kafka_err2str(err));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk) &&
+            msetr->msetr_v2_hdr != NULL) {
+                /* For share consumer with MessageSet v2: report error for
+                 * entire batch with RELEASE acknowledgement (decompression
+                 * capability varies by consumer - another consumer might
+                 * succeed). */
+                int64_t LastOffset;
+
+                LastOffset = msetr->msetr_v2_hdr->BaseOffset +
+                             msetr->msetr_v2_hdr->LastOffsetDelta;
+
+                rd_kafka_share_consumer_err_range(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, rktp,
+                    msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                    RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Decompression (codec 0x%x) of MessageSet at offsets "
+                    "%" PRId64 "-%" PRId64 " of %" PRIusz " bytes failed: %s",
+                    codec, msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                    compressed_size, rd_kafka_err2str(err));
+        } else {
+                /* Regular consumer or v0/v1 MessageSet: single error */
+                rd_kafka_consumer_err(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, NULL, rktp, Offset,
+                    "Decompression (codec 0x%x) of message at %" PRIu64
+                    " of %" PRIusz " bytes failed: %s",
+                    codec, Offset, compressed_size, rd_kafka_err2str(err));
+        }
 
         return err;
 }
@@ -1088,19 +1111,49 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                 if (unlikely((uint32_t)hdr.Crc != calc_crc)) {
                         /* Propagate CRC error to application and
                          * continue with next message. */
-                        rd_kafka_consumer_err(
-                            &msetr->msetr_rkq, msetr->msetr_broker_id,
-                            RD_KAFKA_RESP_ERR__BAD_MSG,
-                            msetr->msetr_tver->version, NULL, rktp,
-                            hdr.BaseOffset,
-                            "MessageSet at offset %" PRId64 " (%" PRId32
-                            " bytes) "
-                            "failed CRC32C check "
-                            "(original 0x%" PRIx32
-                            " != "
-                            "calculated 0x%" PRIx32 ")",
-                            hdr.BaseOffset, hdr.Length, hdr.Crc, calc_crc);
-                        rd_kafka_buf_skip_to(rkbuf, crc_len);
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                int16_t Attributes;
+                                int32_t LastOffsetDelta;
+
+                                /* Read LastOffsetDelta to
+                                 * determine full offset range.  */
+                                rd_kafka_buf_read_i16(rkbuf, &Attributes);
+                                rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+                                LastOffset = hdr.BaseOffset + LastOffsetDelta;
+
+                                rd_kafka_share_consumer_err_range(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    msetr->msetr_tver->version, rktp,
+                                    hdr.BaseOffset, LastOffset,
+                                    RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                                    "MessageSet at offsets %" PRId64 "-%" PRId64
+                                    " (%" PRId32
+                                    " bytes) "
+                                    "failed CRC32C check "
+                                    "(original 0x%" PRIx32
+                                    " != "
+                                    "calculated 0x%" PRIx32 ")",
+                                    hdr.BaseOffset, LastOffset, hdr.Length,
+                                    hdr.Crc, calc_crc);
+                        } else {
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__BAD_MSG,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    hdr.BaseOffset,
+                                    "MessageSet at offset %" PRId64 " (%" PRId32
+                                    " bytes) "
+                                    "failed CRC32C check "
+                                    "(original 0x%" PRIx32
+                                    " != "
+                                    "calculated 0x%" PRIx32 ")",
+                                    hdr.BaseOffset, hdr.Length, hdr.Crc,
+                                    calc_crc);
+                        }
+                        /* Skip to end of MessageSet */
+                        rd_kafka_buf_skip_to(rkbuf, len_start + hdr.Length);
                         rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
                         return RD_KAFKA_RESP_ERR_NO_ERROR;
                 }
@@ -1155,8 +1208,20 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                     msetr, 2 /*MsgVersion v2*/, hdr.Attributes,
                     hdr.BaseTimestamp, hdr.BaseOffset, compressed,
                     payload_size);
-                if (err)
-                        goto err;
+                if (err) {
+                        /* For share consumer: decompression failed, error ops
+                         * already created. Buffer position already advanced
+                         * past compressed payload. Continue parsing next
+                         * MessageSet. For regular consumer: stop parsing. */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err,
+                                                1);
+                                goto done;
+                        } else {
+                                goto err;
+                        }
+                }
 
         } else {
                 /* Read uncompressed messages */
@@ -1243,26 +1308,66 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                            (int)*MagicBytep, Offset, read_offset,
                            rd_slice_size(&rkbuf->rkbuf_reader));
 
-                if (Offset >=
-                        msetr->msetr_rktp->rktp_offsets.fetch_pos.offset &&
-                    !RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                        rd_kafka_consumer_err(
+                rd_kafka_buf_read_i32(rkbuf, &Length);
+
+                if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                        /* Share consumer: read LastOffsetDelta to determine
+                         * full range. Speculatively assume future MessageSet
+                         * versions maintain similar header structure. */
+                        size_t len_start;
+                        size_t bytes_read;
+                        size_t remaining;
+                        int32_t PartitionLeaderEpoch;
+                        int8_t MagicByteActual;
+                        int32_t Crc;
+                        int16_t Attributes;
+                        int32_t LastOffsetDelta;
+                        int64_t LastOffset;
+
+                        len_start = rd_slice_offset(&rkbuf->rkbuf_reader);
+
+                        rd_kafka_buf_read_i32(rkbuf, &PartitionLeaderEpoch);
+                        rd_kafka_buf_read_i8(rkbuf, &MagicByteActual);
+                        rd_kafka_buf_read_i32(rkbuf, &Crc);
+                        rd_kafka_buf_read_i16(rkbuf, &Attributes);
+                        rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+
+                        LastOffset = Offset + LastOffsetDelta;
+
+                        rd_kafka_share_consumer_err_range(
                             &msetr->msetr_rkq, msetr->msetr_broker_id,
                             RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-                            msetr->msetr_tver->version, NULL, rktp, Offset,
-                            "Unsupported Message(Set) MagicByte %d "
-                            "at offset %" PRId64,
-                            (int)*MagicBytep, Offset);
-                        /* Skip message(set) */
-                        msetr->msetr_rktp->rktp_offsets.fetch_pos.offset =
-                            Offset + 1;
-                }
+                            msetr->msetr_tver->version, rktp, Offset,
+                            LastOffset, RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                            "Unsupported Message(Set) MagicByte %d at offsets "
+                            "%" PRId64 "-%" PRId64,
+                            (int)MagicByteActual, Offset, LastOffset);
 
-                /* Skip this Message(Set).
-                 * If the message is malformed, the skip may trigger err_parse
-                 * and return ERR__BAD_MSG. */
-                rd_kafka_buf_read_i32(rkbuf, &Length);
-                rd_kafka_buf_skip(rkbuf, Length);
+                        /* Skip remaining bytes in MessageSet */
+                        bytes_read =
+                            rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
+                        remaining = Length - bytes_read;
+                        rd_kafka_buf_skip(rkbuf, remaining);
+                } else {
+                        /* Regular consumer: single error */
+                        if (Offset >=
+                            msetr->msetr_rktp->rktp_offsets.fetch_pos.offset) {
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    Offset,
+                                    "Unsupported Message(Set) MagicByte %d "
+                                    "at offset %" PRId64,
+                                    (int)*MagicBytep, Offset);
+                                /* Skip message(set) */
+                                msetr->msetr_rktp->rktp_offsets.fetch_pos
+                                    .offset = Offset + 1;
+                        }
+
+                        /* Skip this Message(Set). */
+                        rd_kafka_buf_skip(rkbuf, Length);
+                }
 
                 return RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED;
         }
@@ -1305,8 +1410,15 @@ rd_kafka_msgset_reader(rd_kafka_msgset_reader_t *msetr) {
                                  * due to its use of sendfile(2). */
                                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
-                        /* Continue on unsupported MsgVersions, the
-                         * MessageSet will be skipped. */
+                        /* For share consumer: continue on unsupported
+                         * MsgVersions, the MessageSet will be skipped. Reset
+                         * error so loop continues parsing remaining
+                         * MessageSets. For regular consumer: stop parsing (old
+                         * behavior). */
+                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                err = RD_KAFKA_RESP_ERR_NO_ERROR;
+                        }
                         continue;
                 }
 

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -517,18 +517,24 @@ rd_kafka_msgset_reader_decompress(rd_kafka_msgset_reader_t *msetr,
 err:
         /* Enqueue error messsage:
          * Create op and push on temporary queue. */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk) &&
-            msetr->msetr_v2_hdr != NULL) {
-                /* For share consumer with MessageSet v2: report error for
-                 * entire batch with RELEASE acknowledgement (decompression
-                 * capability varies by consumer - another consumer might
-                 * succeed). */
-                int64_t LastOffset;
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk) ||
+            msetr->msetr_v2_hdr == NULL) {
+                /* Regular consumer, or v0/v1 MessageSet: single error. */
+                rd_kafka_consumer_err(
+                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                    msetr->msetr_tver->version, NULL, rktp, Offset,
+                    "Decompression (codec 0x%x) of message at %" PRIu64
+                    " of %" PRIusz " bytes failed: %s",
+                    codec, Offset, compressed_size, rd_kafka_err2str(err));
+        } else {
+                /* Share consumer with MessageSet v2: report error for
+                 * the entire batch with RELEASE acknowledgement —
+                 * decompression capability varies by consumer, so
+                 * another consumer might succeed on the same batch. */
+                int64_t LastOffset = msetr->msetr_v2_hdr->BaseOffset +
+                                     msetr->msetr_v2_hdr->LastOffsetDelta;
 
-                LastOffset = msetr->msetr_v2_hdr->BaseOffset +
-                             msetr->msetr_v2_hdr->LastOffsetDelta;
-
-                rd_kafka_share_consumer_err_range(
+                rd_kafka_share_message_set_err_ops(
                     &msetr->msetr_rkq, msetr->msetr_broker_id, err,
                     msetr->msetr_tver->version, rktp,
                     msetr->msetr_v2_hdr->BaseOffset, LastOffset,
@@ -537,14 +543,6 @@ err:
                     "%" PRId64 "-%" PRId64 " of %" PRIusz " bytes failed: %s",
                     codec, msetr->msetr_v2_hdr->BaseOffset, LastOffset,
                     compressed_size, rd_kafka_err2str(err));
-        } else {
-                /* Regular consumer or v0/v1 MessageSet: single error */
-                rd_kafka_consumer_err(
-                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
-                    msetr->msetr_tver->version, NULL, rktp, Offset,
-                    "Decompression (codec 0x%x) of message at %" PRIu64
-                    " of %" PRIusz " bytes failed: %s",
-                    codec, Offset, compressed_size, rd_kafka_err2str(err));
         }
 
         return err;
@@ -1111,8 +1109,24 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                 if (unlikely((uint32_t)hdr.Crc != calc_crc)) {
                         /* Propagate CRC error to application and
                          * continue with next message. */
-                        if (RD_KAFKA_IS_SHARE_CONSUMER(
+                        if (!RD_KAFKA_IS_SHARE_CONSUMER(
                                 msetr->msetr_rkb->rkb_rk)) {
+                                        rd_kafka_consumer_err(
+                            &msetr->msetr_rkq, msetr->msetr_broker_id,
+                            RD_KAFKA_RESP_ERR__BAD_MSG,
+                            msetr->msetr_tver->version, NULL, rktp,
+                            hdr.BaseOffset,
+                            "MessageSet at offset %" PRId64 " (%" PRId32
+                            " bytes) "
+                            "failed CRC32C check "
+                            "(original 0x%" PRIx32
+                            " != "
+                            "calculated 0x%" PRIx32 ")",
+                            hdr.BaseOffset, hdr.Length, hdr.Crc, calc_crc);
+                        /* Skip to end of MessageSet */
+                        rd_kafka_buf_skip_to(rkbuf, crc_len);
+                                
+                        } else {
                                 int16_t Attributes;
                                 int32_t LastOffsetDelta;
 
@@ -1122,7 +1136,7 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                 rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
                                 LastOffset = hdr.BaseOffset + LastOffsetDelta;
 
-                                rd_kafka_share_consumer_err_range(
+                                rd_kafka_share_message_set_err_ops(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,
                                     RD_KAFKA_RESP_ERR__BAD_MSG,
                                     msetr->msetr_tver->version, rktp,
@@ -1137,23 +1151,10 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                     "calculated 0x%" PRIx32 ")",
                                     hdr.BaseOffset, LastOffset, hdr.Length,
                                     hdr.Crc, calc_crc);
-                        } else {
-                                rd_kafka_consumer_err(
-                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
-                                    RD_KAFKA_RESP_ERR__BAD_MSG,
-                                    msetr->msetr_tver->version, NULL, rktp,
-                                    hdr.BaseOffset,
-                                    "MessageSet at offset %" PRId64 " (%" PRId32
-                                    " bytes) "
-                                    "failed CRC32C check "
-                                    "(original 0x%" PRIx32
-                                    " != "
-                                    "calculated 0x%" PRIx32 ")",
-                                    hdr.BaseOffset, hdr.Length, hdr.Crc,
-                                    calc_crc);
+                                /* Skip to end of MessageSet */
+                                rd_kafka_buf_skip_to(rkbuf, len_start + hdr.Length);
                         }
-                        /* Skip to end of MessageSet */
-                        rd_kafka_buf_skip_to(rkbuf, len_start + hdr.Length);
+                
                         rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err, 1);
                         return RD_KAFKA_RESP_ERR_NO_ERROR;
                 }
@@ -1308,50 +1309,12 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                            (int)*MagicBytep, Offset, read_offset,
                            rd_slice_size(&rkbuf->rkbuf_reader));
 
-                rd_kafka_buf_read_i32(rkbuf, &Length);
-
-                if (RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                        /* Share consumer: read LastOffsetDelta to determine
-                         * full range. Speculatively assume future MessageSet
-                         * versions maintain similar header structure. */
-                        size_t len_start;
-                        size_t bytes_read;
-                        size_t remaining;
-                        int32_t PartitionLeaderEpoch;
-                        int8_t MagicByteActual;
-                        int32_t Crc;
-                        int16_t Attributes;
-                        int32_t LastOffsetDelta;
-                        int64_t LastOffset;
-
-                        len_start = rd_slice_offset(&rkbuf->rkbuf_reader);
-
-                        rd_kafka_buf_read_i32(rkbuf, &PartitionLeaderEpoch);
-                        rd_kafka_buf_read_i8(rkbuf, &MagicByteActual);
-                        rd_kafka_buf_read_i32(rkbuf, &Crc);
-                        rd_kafka_buf_read_i16(rkbuf, &Attributes);
-                        rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
-
-                        LastOffset = Offset + LastOffsetDelta;
-
-                        rd_kafka_share_consumer_err_range(
-                            &msetr->msetr_rkq, msetr->msetr_broker_id,
-                            RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-                            msetr->msetr_tver->version, rktp, Offset,
-                            LastOffset, RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
-                            "Unsupported Message(Set) MagicByte %d at offsets "
-                            "%" PRId64 "-%" PRId64,
-                            (int)MagicByteActual, Offset, LastOffset);
-
-                        /* Skip remaining bytes in MessageSet */
-                        bytes_read =
-                            rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
-                        remaining = Length - bytes_read;
-                        rd_kafka_buf_skip(rkbuf, remaining);
-                } else {
-                        /* Regular consumer: single error */
+                if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
                         if (Offset >=
-                            msetr->msetr_rktp->rktp_offsets.fetch_pos.offset) {
+                                msetr->msetr_rktp->rktp_offsets.fetch_pos
+                                    .offset &&
+                            !RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
                                 rd_kafka_consumer_err(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,
                                     RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
@@ -1365,8 +1328,56 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                                     .offset = Offset + 1;
                         }
 
-                        /* Skip this Message(Set). */
+                        /* Skip this Message(Set).
+                         * If the message is malformed, the skip may trigger
+                         * err_parse and return ERR__BAD_MSG. */
+                        rd_kafka_buf_read_i32(rkbuf, &Length);
                         rd_kafka_buf_skip(rkbuf, Length);
+                } else {
+                        /* Share consumer: peek further into the MessageSet v2
+                         * header so we can compute the full offset range,
+                         * emit a REJECT range-error op, and skip the
+                         * remainder. Speculatively assumes the v2 header
+                         * layout is preserved for any future MessageSet
+                         * version above v2 (the only versions reaching this
+                         * branch — v0/v1 are filtered by the MagicByte
+                         * bounds check above). */
+                        size_t len_start;
+                        size_t bytes_read;
+                        size_t remaining;
+                        int32_t PartitionLeaderEpoch;
+                        int8_t MagicByteActual;
+                        int32_t Crc;
+                        int16_t Attributes;
+                        int32_t LastOffsetDelta;
+                        int64_t LastOffset;
+
+                        rd_kafka_buf_read_i32(rkbuf, &Length);
+
+                        len_start = rd_slice_offset(&rkbuf->rkbuf_reader);
+
+                        rd_kafka_buf_read_i32(rkbuf, &PartitionLeaderEpoch);
+                        rd_kafka_buf_read_i8(rkbuf, &MagicByteActual);
+                        rd_kafka_buf_read_i32(rkbuf, &Crc);
+                        rd_kafka_buf_read_i16(rkbuf, &Attributes);
+                        rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+
+                        LastOffset = Offset + LastOffsetDelta;
+
+                        rd_kafka_share_message_set_err_ops(
+                            &msetr->msetr_rkq, msetr->msetr_broker_id,
+                            RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                            msetr->msetr_tver->version, rktp, Offset,
+                            LastOffset, RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                            "Unsupported Message(Set) MagicByte %d at offsets "
+                            "%" PRId64 "-%" PRId64,
+                            (int)MagicByteActual, Offset, LastOffset);
+
+                        /* Skip remaining bytes in MessageSet. */
+                        bytes_read =
+                            rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
+                        remaining = Length - bytes_read;
+                        rd_kafka_buf_skip(rkbuf, remaining);
                 }
 
                 return RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED;

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1355,25 +1355,27 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                          * version above v2 (the only versions reaching this
                          * branch — v0/v1 are filtered by the MagicByte
                          * bounds check above). */
-                        size_t len_start;
-                        size_t bytes_read;
-                        size_t remaining;
                         int32_t PartitionLeaderEpoch;
                         int8_t MagicByteActual;
                         int32_t Crc;
                         int16_t Attributes;
                         int32_t LastOffsetDelta;
                         int64_t LastOffset;
+                        /* Bytes consumed below from the MessageSet body
+                         * (everything counted by Length): PartitionLeaderEpoch
+                         * (4) + MagicByte (1) + Crc (4) + Attributes (2) +
+                         * LastOffsetDelta (4). */
+                        const size_t header_bytes_read = 4 + 1 + 4 + 2 + 4;
 
                         rd_kafka_buf_read_i32(rkbuf, &Length);
-
-                        len_start = rd_slice_offset(&rkbuf->rkbuf_reader);
-
                         rd_kafka_buf_read_i32(rkbuf, &PartitionLeaderEpoch);
                         rd_kafka_buf_read_i8(rkbuf, &MagicByteActual);
                         rd_kafka_buf_read_i32(rkbuf, &Crc);
                         rd_kafka_buf_read_i16(rkbuf, &Attributes);
                         rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
+
+                        /* Skip remaining bytes in MessageSet. */
+                        rd_kafka_buf_skip(rkbuf, Length - header_bytes_read);
 
                         LastOffset = Offset + LastOffsetDelta;
 
@@ -1385,12 +1387,6 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                             "Unsupported Message(Set) MagicByte %d at offsets "
                             "%" PRId64 "-%" PRId64,
                             (int)MagicByteActual, Offset, LastOffset);
-
-                        /* Skip remaining bytes in MessageSet. */
-                        bytes_read =
-                            rd_slice_offset(&rkbuf->rkbuf_reader) - len_start;
-                        remaining = Length - bytes_read;
-                        rd_kafka_buf_skip(rkbuf, remaining);
                 }
 
                 return RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED;
@@ -1555,19 +1551,35 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                                 err = RD_KAFKA_RESP_ERR_NO_ERROR;
 
                 } else if (!err && msetr->msetr_aborted_cnt == 0) {
-                        /*
-                         * TODO KIP-932: Check how to handle fetch_pos.offset
-                         * for share consumer.
-                         */
-                        rd_kafka_consumer_err(
-                            &msetr->msetr_rkq, msetr->msetr_broker_id,
-                            RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE,
-                            msetr->msetr_tver->version, NULL, rktp,
-                            rktp->rktp_offsets.fetch_pos.offset,
-                            "Message at offset %" PRId64
-                            " might be too large to fetch, try increasing "
-                            "receive.message.max.bytes",
-                            rktp->rktp_offsets.fetch_pos.offset);
+                        if (!RD_KAFKA_IS_SHARE_CONSUMER(
+                                msetr->msetr_rkb->rkb_rk)) {
+                                rd_kafka_consumer_err(
+                                    &msetr->msetr_rkq, msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    rktp->rktp_offsets.fetch_pos.offset,
+                                    "Message at offset %" PRId64
+                                    " might be too large to fetch, try "
+                                    "increasing receive.message.max.bytes",
+                                    rktp->rktp_offsets.fetch_pos.offset);
+                        } else {
+                                /* Share consumer: fetch_pos.offset is not
+                                 * meaningful, and the temp_fetchq
+                                 * acquired-range filter would drop any op
+                                 * without a valid offset. Enqueue the error
+                                 * directly onto the cgrp queue served by
+                                 * rd_kafka_share_consume_batch so the app
+                                 * sees the partition-level failure. */
+                                rd_kafka_consumer_err(
+                                    msetr->msetr_rkb->rkb_rk->rk_cgrp->rkcg_q,
+                                    msetr->msetr_broker_id,
+                                    RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE,
+                                    msetr->msetr_tver->version, NULL, rktp,
+                                    RD_KAFKA_OFFSET_INVALID,
+                                    "Message might be too large to fetch, "
+                                    "try increasing "
+                                    "receive.message.max.bytes");
+                        }
 
                 } else if (msetr->msetr_aborted_cnt > 0) {
                         /* Noop */
@@ -1586,9 +1598,6 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                     msetr->msetr_msgcnt > 0)
                         err = RD_KAFKA_RESP_ERR_NO_ERROR;
         }
-
-        // printf(" +++++++++++++++++++ Received %d messages\n",
-        // msetr->msetr_msgcnt);
 
         rd_rkb_dbg(msetr->msetr_rkb, MSG | RD_KAFKA_DBG_FETCH, "CONSUME",
                    "Enqueue %i %smessage(s) (%" PRId64

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -549,7 +549,13 @@ err:
                             msetr->msetr_v2_hdr->BaseOffset +
                             msetr->msetr_v2_hdr->LastOffsetDelta;
 
-                        rd_kafka_share_message_set_err_ops(
+                        /**
+                         * TODO KIP-932: Add a TODO to translate errors inside
+                         * this function. _BAD_COMPRESSION and _BAD_MSG should
+                         * be sent as INVALID_MSG, and _CRIT_SYS_RESOURCE should
+                         * be sent as _CRIT_SYS_RESOURCE.
+                         */
+                        rd_kafka_share_msgset_err_ops(
                             &msetr->msetr_rkq, msetr->msetr_broker_id, err,
                             msetr->msetr_tver->version, rktp,
                             msetr->msetr_v2_hdr->BaseOffset, LastOffset,
@@ -816,7 +822,11 @@ rd_kafka_msgset_reader_msg_v2(rd_kafka_msgset_reader_t *msetr) {
                 return RD_KAFKA_RESP_ERR_NO_ERROR; /* Continue with next msg */
         }
 
-        /* Handle control messages */
+        /**
+         * Handle control messages
+         * TODO KIP-932: GA: This branch shouldn't hit for share consumers,
+         * as we skip control messages for share consumers.
+         */
         if (msetr->msetr_v2_hdr->Attributes & RD_KAFKA_MSGSET_V2_ATTR_CONTROL) {
                 struct {
                         int64_t KeySize;
@@ -1151,6 +1161,25 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                     hdr.BaseOffset, hdr.Length, hdr.Crc,
                                     calc_crc);
                                 /* Skip to end of MessageSet */
+                                /**
+                                 * FIXME: `crc_len` is a byte *length*
+                                 * (Length - 4 - 1 - 4), but
+                                 * rd_kafka_buf_skip_to() interprets its
+                                 * argument as an absolute slice position.
+                                 * The current call leaves the reader 21
+                                 * bytes short of the end of the MessageSet
+                                 * (when the slice base offset is 0), and
+                                 * for any subsequent MessageSet within
+                                 * the same slice the size_t subtraction
+                                 * inside skip_to underflows and triggers
+                                 * a spurious __UNDERFLOW. The intended
+                                 * target is end-of-MessageSet, i.e.
+                                 * `len_start + hdr.Length` — see the
+                                 * share-consumer branch below which does
+                                 * this correctly. Replace with:
+                                 *     rd_kafka_buf_skip_to(rkbuf,
+                                 *         len_start + hdr.Length);
+                                 */
                                 rd_kafka_buf_skip_to(rkbuf, crc_len);
 
                         } else {
@@ -1163,7 +1192,7 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                 rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
                                 LastOffset = hdr.BaseOffset + LastOffsetDelta;
 
-                                rd_kafka_share_message_set_err_ops(
+                                rd_kafka_share_msgset_err_ops(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,
                                     RD_KAFKA_RESP_ERR__BAD_MSG,
                                     msetr->msetr_tver->version, rktp,
@@ -1266,7 +1295,8 @@ done:
          * to avoid getting stuck on compacted MessageSets where the last
          * Message in the MessageSet has an Offset < MessageSet header's
          * last offset.  See KAFKA-5443 */
-        msetr->msetr_next_offset = LastOffset + 1;
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk))
+                msetr->msetr_next_offset = LastOffset + 1;
 
         msetr->msetr_v2_hdr = NULL;
 
@@ -1354,7 +1384,10 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                          * layout is preserved for any future MessageSet
                          * version above v2 (the only versions reaching this
                          * branch — v0/v1 are filtered by the MagicByte
-                         * bounds check above). */
+                         * bounds check above).
+                         * TODO KIP-932: Check if this handling is correct as
+                         * we dont know the magic byte, and we are assuming
+                         * its v2.*/
                         int32_t PartitionLeaderEpoch;
                         int8_t MagicByteActual;
                         int32_t Crc;
@@ -1379,7 +1412,7 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
 
                         LastOffset = Offset + LastOffsetDelta;
 
-                        rd_kafka_share_message_set_err_ops(
+                        rd_kafka_share_msgset_err_ops(
                             &msetr->msetr_rkq, msetr->msetr_broker_id,
                             RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
                             msetr->msetr_tver->version, rktp, Offset,

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -517,35 +517,59 @@ rd_kafka_msgset_reader_decompress(rd_kafka_msgset_reader_t *msetr,
 err:
         /* Enqueue error messsage:
          * Create op and push on temporary queue. */
-        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk) ||
-            msetr->msetr_v2_hdr == NULL) {
-                /* Regular consumer, or v0/v1 MessageSet: single error. */
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                /* Regular consumer */
                 rd_kafka_consumer_err(
                     &msetr->msetr_rkq, msetr->msetr_broker_id, err,
                     msetr->msetr_tver->version, NULL, rktp, Offset,
                     "Decompression (codec 0x%x) of message at %" PRIu64
                     " of %" PRIusz " bytes failed: %s",
                     codec, Offset, compressed_size, rd_kafka_err2str(err));
+                return err;
         } else {
-                /* Share consumer with MessageSet v2: report error for
-                 * the entire batch with RELEASE acknowledgement —
-                 * decompression capability varies by consumer, so
-                 * another consumer might succeed on the same batch. */
-                int64_t LastOffset = msetr->msetr_v2_hdr->BaseOffset +
-                                     msetr->msetr_v2_hdr->LastOffsetDelta;
+                /**
+                 *  v0/v1 MessageSet: single error
+                 * TODO KIP-932: Check the handling in case of v0/v1 messages
+                 * for Share Consumers.
+                 */
+                if (msetr->msetr_v2_hdr == NULL) {
+                        rd_kafka_consumer_err(
+                            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                            msetr->msetr_tver->version, NULL, rktp, Offset,
+                            "Decompression (codec 0x%x) of message at %" PRIu64
+                            " of %" PRIusz " bytes failed: %s",
+                            codec, Offset, compressed_size,
+                            rd_kafka_err2str(err));
+                } else {
+                        /* Share consumer with MessageSet v2: report error for
+                         * the entire batch with RELEASE acknowledgement —
+                         * decompression capability varies by consumer, so
+                         * another consumer might succeed on the same batch. */
+                        int64_t LastOffset =
+                            msetr->msetr_v2_hdr->BaseOffset +
+                            msetr->msetr_v2_hdr->LastOffsetDelta;
 
-                rd_kafka_share_message_set_err_ops(
-                    &msetr->msetr_rkq, msetr->msetr_broker_id, err,
-                    msetr->msetr_tver->version, rktp,
-                    msetr->msetr_v2_hdr->BaseOffset, LastOffset,
-                    RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
-                    "Decompression (codec 0x%x) of MessageSet at offsets "
-                    "%" PRId64 "-%" PRId64 " of %" PRIusz " bytes failed: %s",
-                    codec, msetr->msetr_v2_hdr->BaseOffset, LastOffset,
-                    compressed_size, rd_kafka_err2str(err));
+                        rd_kafka_share_message_set_err_ops(
+                            &msetr->msetr_rkq, msetr->msetr_broker_id, err,
+                            msetr->msetr_tver->version, rktp,
+                            msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                            RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                            "Decompression (codec 0x%x) of MessageSet at "
+                            "offsets "
+                            "%" PRId64 "-%" PRId64 " of %" PRIusz
+                            " bytes failed: %s",
+                            codec, msetr->msetr_v2_hdr->BaseOffset, LastOffset,
+                            compressed_size, rd_kafka_err2str(err));
+                }
         }
 
-        return err;
+        /**
+         * In case of Share Consumers the errors are propagated
+         * as ops on the queue, but we return no error to make sure the
+         * MessageSet parser continues parsing the next messagesets, which might
+         * succeed even if this one failed.
+         */
+        return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
 
@@ -556,6 +580,8 @@ err:
  * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or on single-message errors,
  *          or any other error code when the MessageSet parser should stop
  *          parsing (such as for partial Messages).
+ * TODO KIP-932: We might need to check the handling of error ops
+ *               for share consumers with v0/v1 messagesets.
  */
 static rd_kafka_resp_err_t
 rd_kafka_msgset_reader_msg_v0_1(rd_kafka_msgset_reader_t *msetr) {
@@ -1211,20 +1237,8 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                     msetr, 2 /*MsgVersion v2*/, hdr.Attributes,
                     hdr.BaseTimestamp, hdr.BaseOffset, compressed,
                     payload_size);
-                if (err) {
-                        /* For share consumer: decompression failed, error ops
-                         * already created. Buffer position already advanced
-                         * past compressed payload. Continue parsing next
-                         * MessageSet. For regular consumer: stop parsing. */
-                        if (RD_KAFKA_IS_SHARE_CONSUMER(
-                                msetr->msetr_rkb->rkb_rk)) {
-                                rd_atomic64_add(&msetr->msetr_rkb->rkb_c.rx_err,
-                                                1);
-                                goto done;
-                        } else {
-                                goto err;
-                        }
-                }
+                if (err)
+                        goto err;
 
         } else {
                 /* Read uncompressed messages */
@@ -1312,10 +1326,8 @@ rd_kafka_msgset_reader_peek_msg_version(rd_kafka_msgset_reader_t *msetr,
                            rd_slice_size(&rkbuf->rkbuf_reader));
 
                 if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
-                        if (Offset >= msetr->msetr_rktp->rktp_offsets.fetch_pos
-                                          .offset &&
-                            !RD_KAFKA_IS_SHARE_CONSUMER(
-                                msetr->msetr_rkb->rkb_rk)) {
+                        if (Offset >=
+                            msetr->msetr_rktp->rktp_offsets.fetch_pos.offset) {
                                 rd_kafka_consumer_err(
                                     &msetr->msetr_rkq, msetr->msetr_broker_id,
                                     RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
@@ -1428,7 +1440,8 @@ rd_kafka_msgset_reader(rd_kafka_msgset_reader_t *msetr) {
                          * MessageSets. For regular consumer: stop parsing (old
                          * behavior). */
                         if (RD_KAFKA_IS_SHARE_CONSUMER(
-                                msetr->msetr_rkb->rkb_rk)) {
+                                msetr->msetr_rkb->rkb_rk) &&
+                            err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED) {
                                 err = RD_KAFKA_RESP_ERR_NO_ERROR;
                         }
                         continue;
@@ -1521,6 +1534,14 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                                 err = RD_KAFKA_RESP_ERR_NO_ERROR;
 
                 } else if (rktp->rktp_fetch_msg_max_bytes < (1 << 30)) {
+                        /**
+                         * TODO KIP-932: Check how to handle fetch_msg_max_bytes
+                         * for share consumer. We keep on bringing up the msg
+                         * for normal consumers, then it is fine but in share
+                         * consumers the delivery count will keep on increasing
+                         * for the same message and it will keep on coming back
+                         * and we will recieve the max delivery attempt limit.
+                         */
                         rktp->rktp_fetch_msg_max_bytes *= 2;
                         rd_rkb_dbg(msetr->msetr_rkb, FETCH, "CONSUME",
                                    "Topic %s [%" PRId32
@@ -1589,24 +1610,22 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
         if (rd_kafka_q_concat(msetr->msetr_par_rkq, &msetr->msetr_rkq) != -1) {
                 /* Update partition's fetch offset based on
                  * last message's offest. */
-                /*
-                 * TODO KIP-932: Might need to remove this handling of
-                 * fetch_pos.offset for share consumer.
-                 */
-                if (likely(last_offset != -1))
+                if (likely(last_offset != -1) &&
+                    !RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk))
                         rktp->rktp_offsets.fetch_pos.offset = last_offset + 1;
         }
 
         /* Adjust next fetch offset if outlier code has indicated
          * an even later next offset. */
-        /*
-         * TODO KIP-932: Might need to remove this handling of fetch_pos.offset
-         * for share consumer.
-         */
-        if (msetr->msetr_next_offset > rktp->rktp_offsets.fetch_pos.offset)
-                rktp->rktp_offsets.fetch_pos.offset = msetr->msetr_next_offset;
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                if (msetr->msetr_next_offset >
+                    rktp->rktp_offsets.fetch_pos.offset)
+                        rktp->rktp_offsets.fetch_pos.offset =
+                            msetr->msetr_next_offset;
 
-        rktp->rktp_offsets.fetch_pos.leader_epoch = msetr->msetr_leader_epoch;
+                rktp->rktp_offsets.fetch_pos.leader_epoch =
+                    msetr->msetr_leader_epoch;
+        }
 
         rd_kafka_q_destroy_owner(&msetr->msetr_rkq);
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -684,6 +684,72 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
 
 
 /**
+ * @brief Enqueue multiple RD_KAFKA_OP_CONSUMER_ERR ops on \p rkq for
+ *        a range of offsets, used for share consumer MessageSet-level errors.
+ *
+ * @param broker_id Is the relevant broker id, or RD_KAFKA_NODEID_UA (-1)
+ *                  if not applicable.
+ * @param err Error code.
+ * @param version Queue version barrier, or 0 if not applicable.
+ * @param rktp Toppar reference (required for share consumers).
+ * @param start_offset First offset in the error range (inclusive).
+ * @param end_offset Last offset in the error range (inclusive).
+ * @param ack_type Acknowledgement type for share consumer
+ *                 (REJECT for permanent errors, RELEASE for retryable).
+ *
+ * Creates one error op per offset in the range [start_offset, end_offset].
+ * Each op has ack_type pre-set for share consumer acknowledgement tracking.
+ *
+ * @sa rd_kafka_consumer_err()
+ */
+void rd_kafka_share_consumer_err_range(
+    rd_kafka_q_t *rkq,
+    int32_t broker_id,
+    rd_kafka_resp_err_t err,
+    int32_t version,
+    rd_kafka_toppar_t *rktp,
+    int64_t start_offset,
+    int64_t end_offset,
+    rd_kafka_share_internal_acknowledgement_type ack_type,
+    const char *fmt,
+    ...) {
+        va_list ap;
+        char buf[2048];
+        char *errstr;
+        int64_t offset;
+
+        /* Format error message once for all offsets */
+        va_start(ap, fmt);
+        rd_vsnprintf(buf, sizeof(buf), fmt, ap);
+        va_end(ap);
+
+        errstr = rd_strdup(buf);
+
+        /* Create one error op per offset in the range */
+        for (offset = start_offset; offset <= end_offset; offset++) {
+                rd_kafka_op_t *rko;
+
+                rko                   = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
+                rko->rko_version      = version;
+                rko->rko_err          = err;
+                rko->rko_u.err.offset = offset;
+                rko->rko_u.err.errstr = rd_strdup(errstr);
+                rko->rko_u.err.rkm.rkm_broker_id = broker_id;
+
+                /* Set acknowledgement type for share consumer */
+                rko->rko_u.err.rkm.rkm_u.consumer.ack_type = ack_type;
+
+                if (rktp)
+                        rko->rko_rktp = rd_kafka_toppar_keep(rktp);
+
+                rd_kafka_q_enq(rkq, rko);
+        }
+
+        rd_free(errstr);
+}
+
+
+/**
  * Creates a reply op based on 'rko_orig'.
  * If 'rko_orig' has rko_op_cb set the reply op will be OR:ed with
  * RD_KAFKA_OP_CB, else the reply type will be the original rko_type OR:ed

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -729,11 +729,11 @@ void rd_kafka_share_consumer_err_range(
         for (offset = start_offset; offset <= end_offset; offset++) {
                 rd_kafka_op_t *rko;
 
-                rko                   = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
-                rko->rko_version      = version;
-                rko->rko_err          = err;
-                rko->rko_u.err.offset = offset;
-                rko->rko_u.err.errstr = rd_strdup(errstr);
+                rko              = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
+                rko->rko_version = version;
+                rko->rko_err     = err;
+                rko->rko_u.err.offset            = offset;
+                rko->rko_u.err.errstr            = rd_strdup(errstr);
                 rko->rko_u.err.rkm.rkm_broker_id = broker_id;
 
                 /* Set acknowledgement type for share consumer */

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -649,7 +649,7 @@ void rd_kafka_q_op_err(rd_kafka_q_t *rkq,
  * @sa rd_kafka_q_op_err()
  */
 /**
- * TODO KIP-932 GA: Improve handling of this particular function
+ * TODO KIP-932: GA: Improve handling of this particular function
  *  as we dont need most information available here.
  */
 void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
@@ -707,7 +707,7 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
  *
  * @sa rd_kafka_consumer_err()
  */
-void rd_kafka_share_message_set_err_ops(
+void rd_kafka_share_msgset_err_ops(
     rd_kafka_q_t *rkq,
     int32_t broker_id,
     rd_kafka_resp_err_t err,
@@ -720,15 +720,12 @@ void rd_kafka_share_message_set_err_ops(
     ...) {
         va_list ap;
         char buf[2048];
-        char *errstr;
         int64_t offset;
 
         /* Format error message once for all offsets */
         va_start(ap, fmt);
         rd_vsnprintf(buf, sizeof(buf), fmt, ap);
         va_end(ap);
-
-        errstr = rd_strdup(buf);
 
         /* Create one error op per offset in the range */
         for (offset = start_offset; offset <= end_offset; offset++) {
@@ -738,7 +735,7 @@ void rd_kafka_share_message_set_err_ops(
                 rko->rko_version = version;
                 rko->rko_err     = err;
                 rko->rko_u.err.offset            = offset;
-                rko->rko_u.err.errstr            = rd_strdup(errstr);
+                rko->rko_u.err.errstr            = rd_strdup(buf);
                 rko->rko_u.err.rkm.rkm_broker_id = broker_id;
 
                 /* Set acknowledgement type for share consumer */
@@ -749,8 +746,6 @@ void rd_kafka_share_message_set_err_ops(
 
                 rd_kafka_q_enq(rkq, rko);
         }
-
-        rd_free(errstr);
 }
 
 
@@ -1198,6 +1193,10 @@ rd_kafka_op_process_share_fetch_response(rd_kafka_op_t *rko,
                     rko->rko_u.share_fetch_response.message_rkos, i);
 
                 /* Return message to application */
+                /**
+                 * TODO KIP-932: We need to expose the error string maybe
+                 * as rd_kafka_error_t in the message op.
+                 */
                 rkmessages[cnt++] = rd_kafka_message_get(msg_rko);
         }
 

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -648,6 +648,10 @@ void rd_kafka_q_op_err(rd_kafka_q_t *rkq,
  *
  * @sa rd_kafka_q_op_err()
  */
+/**
+ * TODO KIP-932 GA: Improve handling of this particular function
+ *  as we dont need most information available here.
+ */
 void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
                            int32_t broker_id,
                            rd_kafka_resp_err_t err,

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -685,6 +685,72 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
 
 
 /**
+ * @brief Enqueue multiple RD_KAFKA_OP_CONSUMER_ERR ops on \p rkq for
+ *        a range of offsets, used for share consumer MessageSet-level errors.
+ *
+ * @param broker_id Is the relevant broker id, or RD_KAFKA_NODEID_UA (-1)
+ *                  if not applicable.
+ * @param err Error code.
+ * @param version Queue version barrier, or 0 if not applicable.
+ * @param rktp Toppar reference (required for share consumers).
+ * @param start_offset First offset in the error range (inclusive).
+ * @param end_offset Last offset in the error range (inclusive).
+ * @param ack_type Acknowledgement type for share consumer
+ *                 (REJECT for permanent errors, RELEASE for retryable).
+ *
+ * Creates one error op per offset in the range [start_offset, end_offset].
+ * Each op has ack_type pre-set for share consumer acknowledgement tracking.
+ *
+ * @sa rd_kafka_consumer_err()
+ */
+void rd_kafka_share_consumer_err_range(
+    rd_kafka_q_t *rkq,
+    int32_t broker_id,
+    rd_kafka_resp_err_t err,
+    int32_t version,
+    rd_kafka_toppar_t *rktp,
+    int64_t start_offset,
+    int64_t end_offset,
+    rd_kafka_share_internal_acknowledgement_type ack_type,
+    const char *fmt,
+    ...) {
+        va_list ap;
+        char buf[2048];
+        char *errstr;
+        int64_t offset;
+
+        /* Format error message once for all offsets */
+        va_start(ap, fmt);
+        rd_vsnprintf(buf, sizeof(buf), fmt, ap);
+        va_end(ap);
+
+        errstr = rd_strdup(buf);
+
+        /* Create one error op per offset in the range */
+        for (offset = start_offset; offset <= end_offset; offset++) {
+                rd_kafka_op_t *rko;
+
+                rko              = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
+                rko->rko_version = version;
+                rko->rko_err     = err;
+                rko->rko_u.err.offset            = offset;
+                rko->rko_u.err.errstr            = rd_strdup(errstr);
+                rko->rko_u.err.rkm.rkm_broker_id = broker_id;
+
+                /* Set acknowledgement type for share consumer */
+                rko->rko_u.err.rkm.rkm_u.consumer.ack_type = ack_type;
+
+                if (rktp)
+                        rko->rko_rktp = rd_kafka_toppar_keep(rktp);
+
+                rd_kafka_q_enq(rkq, rko);
+        }
+
+        rd_free(errstr);
+}
+
+
+/**
  * Creates a reply op based on 'rko_orig'.
  * If 'rko_orig' has rko_op_cb set the reply op will be OR:ed with
  * RD_KAFKA_OP_CB, else the reply type will be the original rko_type OR:ed

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -703,7 +703,7 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
  *
  * @sa rd_kafka_consumer_err()
  */
-void rd_kafka_share_consumer_err_range(
+void rd_kafka_share_message_set_err_ops(
     rd_kafka_q_t *rkq,
     int32_t broker_id,
     rd_kafka_resp_err_t err,

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -950,6 +950,17 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
                            int64_t offset,
                            const char *fmt,
                            ...) RD_FORMAT(printf, 8, 9);
+void rd_kafka_share_consumer_err_range(
+    rd_kafka_q_t *rkq,
+    int32_t broker_id,
+    rd_kafka_resp_err_t err,
+    int32_t version,
+    rd_kafka_toppar_t *rktp,
+    int64_t start_offset,
+    int64_t end_offset,
+    rd_kafka_share_internal_acknowledgement_type ack_type,
+    const char *fmt,
+    ...) RD_FORMAT(printf, 9, 10);
 rd_kafka_op_t *rd_kafka_op_req0(rd_kafka_q_t *destq,
                                 rd_kafka_q_t *recvq,
                                 rd_kafka_op_t *rko,

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -945,7 +945,7 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
                            int64_t offset,
                            const char *fmt,
                            ...) RD_FORMAT(printf, 8, 9);
-void rd_kafka_share_consumer_err_range(
+void rd_kafka_share_message_set_err_ops(
     rd_kafka_q_t *rkq,
     int32_t broker_id,
     rd_kafka_resp_err_t err,

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -945,7 +945,7 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
                            int64_t offset,
                            const char *fmt,
                            ...) RD_FORMAT(printf, 8, 9);
-void rd_kafka_share_message_set_err_ops(
+void rd_kafka_share_msgset_err_ops(
     rd_kafka_q_t *rkq,
     int32_t broker_id,
     rd_kafka_resp_err_t err,

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -945,6 +945,17 @@ void rd_kafka_consumer_err(rd_kafka_q_t *rkq,
                            int64_t offset,
                            const char *fmt,
                            ...) RD_FORMAT(printf, 8, 9);
+void rd_kafka_share_consumer_err_range(
+    rd_kafka_q_t *rkq,
+    int32_t broker_id,
+    rd_kafka_resp_err_t err,
+    int32_t version,
+    rd_kafka_toppar_t *rktp,
+    int64_t start_offset,
+    int64_t end_offset,
+    rd_kafka_share_internal_acknowledgement_type ack_type,
+    const char *fmt,
+    ...) RD_FORMAT(printf, 9, 10);
 rd_kafka_op_t *rd_kafka_op_req0(rd_kafka_q_t *destq,
                                 rd_kafka_q_t *recvq,
                                 rd_kafka_op_t *rko,

--- a/src/rdunittest.c
+++ b/src/rdunittest.c
@@ -425,6 +425,7 @@ extern int unittest_assignors(void);
 extern int unittest_map(void);
 extern int unittest_fetcher_share_filter_forward(void);
 extern int unittest_share_acknowledge(void);
+extern int rd_kafka_unittest_msgset_errors(void);
 #if WITH_CURL
 extern int unittest_http(void);
 #endif
@@ -488,6 +489,7 @@ int rd_unittest(void) {
             {"fetcher_share_filter_forward",
              unittest_fetcher_share_filter_forward},
             {"share_acknowledge", unittest_share_acknowledge},
+            {"msgset_errors", rd_kafka_unittest_msgset_errors},
             {"feature", unittest_feature},
 #if WITH_SSL
             {"ssl", unittest_ssl},

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -95,9 +95,8 @@ static void ut_destroy_share_consumer(rd_kafka_share_t *rkshare) {
 /**
  * @brief Create a mock topic partition
  */
-static rd_kafka_toppar_t *ut_create_mock_toppar(rd_kafka_t *rk,
-                                                const char *topic,
-                                                int32_t partition) {
+static rd_kafka_toppar_t *
+ut_create_mock_toppar(rd_kafka_t *rk, const char *topic, int32_t partition) {
         rd_kafka_topic_t *rkt = rd_kafka_topic_new(rk, topic, NULL);
         if (!rkt)
                 return NULL;
@@ -184,8 +183,8 @@ static uint32_t ut_calc_msgset_crc(const char *buf,
                                    size_t offset_to_attributes,
                                    size_t total_len) {
         /* CRC starts after MagicByte and Crc field itself */
-        const void *data  = buf + offset_to_attributes;
-        size_t data_len   = total_len - offset_to_attributes;
+        const void *data = buf + offset_to_attributes;
+        size_t data_len  = total_len - offset_to_attributes;
         return rd_crc32c(0, data, data_len);
 }
 
@@ -219,8 +218,8 @@ static size_t ut_build_record_v2(char *buf,
         size_t record_start = 0;
         size_t offset       = 0;
         size_t len_offset;
-        int32_t key_len_varint  = key ? (int32_t)key_len : -1;
-        int32_t val_len_varint  = value ? (int32_t)value_len : -1;
+        int32_t key_len_varint = key ? (int32_t)key_len : -1;
+        int32_t val_len_varint = value ? (int32_t)value_len : -1;
 
         /* Reserve space for Length (varint) - we'll fill this in later */
         len_offset = offset;
@@ -264,8 +263,7 @@ static size_t ut_build_record_v2(char *buf,
 
         /* Compact the record if varint was smaller than 5 bytes */
         if (len_size < 5) {
-                memmove(buf + len_offset + len_size,
-                        buf + len_offset + 5,
+                memmove(buf + len_offset + len_size, buf + len_offset + 5,
                         record_body_len);
                 offset = len_offset + len_size + record_body_len;
         }
@@ -296,10 +294,9 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         records_buf = rd_calloc(1, 8192);
         for (i = 0; i < record_count; i++) {
                 records_size += ut_build_record_v2(
-                    records_buf + records_size,
-                    i,   /* offsetDelta */
-                    0,   /* timestampDelta */
-                    NULL, 0, /* no key */
+                    records_buf + records_size, i, /* offsetDelta */
+                    0,                             /* timestampDelta */
+                    NULL, 0,                       /* no key */
                     values ? values[i] : NULL,
                     values && value_lens ? value_lens[i] : 0);
         }
@@ -365,7 +362,7 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         rd_free(records_buf);
 
         /* Calculate and write Length */
-        int32_t length = (int32_t)(offset - len_offset - 4);
+        int32_t length                 = (int32_t)(offset - len_offset - 4);
         *(int32_t *)(buf + len_offset) = htobe32(length);
 
         /* Calculate and write CRC (covers Attributes to end) */
@@ -393,9 +390,10 @@ static int unittest_msgset_crc_error_share_consumer(void) {
         rd_kafka_q_t *response_q;
         char *msgset_data;
         size_t msgset_size;
-        int64_t BaseOffset       = 100;
-        int32_t LastOffsetDelta  = 4; /* Offsets 100-104 inclusive = 5 messages */
-        int expected_err_ops     = 5;
+        int64_t BaseOffset = 100;
+        int32_t LastOffsetDelta =
+            4; /* Offsets 100-104 inclusive = 5 messages */
+        int expected_err_ops = 5;
         int i;
         struct rd_kafka_toppar_ver tver = {.version = 11};
 
@@ -404,8 +402,7 @@ static int unittest_msgset_crc_error_share_consumer(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp =
-            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-crc", 0);
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-crc", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
@@ -413,8 +410,10 @@ static int unittest_msgset_crc_error_share_consumer(void) {
         /* Craft MessageSet v2 with wrong CRC */
         /* MessageSet v2 structure:
          * - BaseOffset (8) + Length (4) = 12 bytes before "Length" data starts
-         * - Length field contains size of: PartitionLeaderEpoch (4) + MagicByte (1)
-         *   + Crc (4) + Attributes (2) + LastOffsetDelta (4) + BaseTimestamp (8)
+         * - Length field contains size of: PartitionLeaderEpoch (4) + MagicByte
+         * (1)
+         *   + Crc (4) + Attributes (2) + LastOffsetDelta (4) + BaseTimestamp
+         * (8)
          *   + MaxTimestamp (8) + ProducerId (8) + ProducerEpoch (2)
          *   + BaseSequence (4) + RecordCount (4) + Records
          * - Minimum Length = 49 (just the header fields after Length)
@@ -423,7 +422,7 @@ static int unittest_msgset_crc_error_share_consumer(void) {
 
         /* CRC validation needs: crc_len = Length - 4 - 1 - 4 bytes available
          * after reading up to Crc field (21 bytes read so far) */
-        int32_t Length = 61 - 12; /* Minimum: just the header, no records */
+        int32_t Length = 61 - 12;     /* Minimum: just the header, no records */
         msgset_size    = 12 + Length; /* BaseOffset + Length + data */
         msgset_data    = rd_calloc(1, msgset_size);
 
@@ -507,9 +506,10 @@ static int unittest_msgset_decompression_error_share_consumer(void) {
         rd_kafka_q_t *response_q;
         char *msgset_data;
         size_t msgset_size;
-        int64_t BaseOffset      = 200;
-        int32_t LastOffsetDelta = 2; /* Offsets 200-202 inclusive = 3 messages */
-        int expected_err_ops    = 3;
+        int64_t BaseOffset = 200;
+        int32_t LastOffsetDelta =
+            2; /* Offsets 200-202 inclusive = 3 messages */
+        int expected_err_ops = 3;
         int i;
         uint32_t correct_crc;
         size_t crc_offset = 17; /* Offset to CRC field in header */
@@ -570,10 +570,9 @@ static int unittest_msgset_decompression_error_share_consumer(void) {
                              expected_err_ops);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
                              "Expected CONSUMER_ERR op, got %d", rko->rko_type);
-                RD_UT_ASSERT(
-                    rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
-                    "Expected BAD_COMPRESSION error, got %s",
-                    rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
                 RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
                              "Expected offset %" PRId64 ", got %" PRId64,
                              BaseOffset + i, rko->rko_u.err.offset);
@@ -617,9 +616,10 @@ static int unittest_msgset_unsupported_magic_share_consumer(void) {
         rd_kafka_q_t *response_q;
         char *msgset_data;
         size_t msgset_size;
-        int64_t BaseOffset      = 300;
-        int32_t LastOffsetDelta = 9; /* Offsets 300-309 inclusive = 10 messages */
-        int expected_err_ops    = 10;
+        int64_t BaseOffset = 300;
+        int32_t LastOffsetDelta =
+            9; /* Offsets 300-309 inclusive = 10 messages */
+        int expected_err_ops = 10;
         int i;
         struct rd_kafka_toppar_ver tver = {.version = 11};
 
@@ -669,10 +669,9 @@ static int unittest_msgset_unsupported_magic_share_consumer(void) {
                              expected_err_ops);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
                              "Expected CONSUMER_ERR op, got %d", rko->rko_type);
-                RD_UT_ASSERT(
-                    rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
-                    "Expected NOT_IMPLEMENTED error, got %s",
-                    rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
                 RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
                              "Expected offset %" PRId64 ", got %" PRId64,
                              BaseOffset + i, rko->rko_u.err.offset);
@@ -714,12 +713,11 @@ static int unittest_msgset_mixed_success_crc_success(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 4096;
-        size_t offset      = 0;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
-        const char *values[]            = {"msg1", "msg2", "msg3",
-                                            "msg4", "msg5"};
-        size_t value_lens[]             = {4, 4, 4, 4, 4};
+        const char *values[] = {"msg1", "msg2", "msg3", "msg4", "msg5"};
+        size_t value_lens[]  = {4, 4, 4, 4, 4};
         int i;
 
         RD_UT_BEGIN();
@@ -727,7 +725,8 @@ static int unittest_msgset_mixed_success_crc_success(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed", 0);
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
@@ -738,32 +737,32 @@ static int unittest_msgset_mixed_success_crc_success(void) {
                                            value_lens);
 
         /* MessageSet 2: CRC error with 5 messages (offsets 103-107) */
-        size_t msgset2_start = offset;
-        int64_t BaseOffset2  = 103;
+        size_t msgset2_start     = offset;
+        int64_t BaseOffset2      = 103;
         int32_t LastOffsetDelta2 = 4;
-        int32_t Length2 = 61 - 12; /* Just header */
-        ut_write_msgset_v2_header(
-            buffer + offset, BaseOffset2, Length2, -1, 2,
-            0xBADC0C, /* Wrong CRC */
-            0, LastOffsetDelta2, 0, 0, -1, -1, -1, 5);
+        int32_t Length2          = 61 - 12; /* Just header */
+        ut_write_msgset_v2_header(buffer + offset, BaseOffset2, Length2, -1, 2,
+                                  0xBADC0C, /* Wrong CRC */
+                                  0, LastOffsetDelta2, 0, 0, -1, -1, -1, 5);
         offset += 12 + Length2;
 
         /* MessageSet 3: Valid with 2 messages (offsets 108-109) */
-        const char *values3[]  = {"msg6", "msg7"};
-        size_t value_lens3[] = {4, 4};
+        const char *values3[] = {"msg6", "msg7"};
+        size_t value_lens3[]  = {4, 4};
         offset += ut_build_valid_msgset_v2(buffer + offset, 108, 2, values3,
                                            value_lens3);
 
         /* Parse all MessageSets */
-        rkbuf                = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
-        rkbuf->rkbuf_rkb     = rd_kafka_broker_internal(rkshare->rkshare_rk);
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
 
         rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
 
         /* Verify MessageSet 1: 3 FETCH ops with offsets 100-102 */
         for (i = 0; i < 3; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
-                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout", i);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
                              "Expected FETCH op, got %d", rko->rko_type);
                 RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 100 + i,
@@ -775,8 +774,8 @@ static int unittest_msgset_mixed_success_crc_success(void) {
         /* Verify MessageSet 2: 5 CONSUMER_ERR ops with offsets 103-107 */
         for (i = 0; i < 5; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
-                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d, got timeout",
-                             i);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected CRC error op %d, got timeout", i);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
                              "Expected CONSUMER_ERR op, got %d", rko->rko_type);
                 RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
@@ -834,8 +833,8 @@ static int unittest_msgset_mixed_crc_success_decomp(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 4096;
-        size_t offset      = 0;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
         const char *values[]            = {"a", "b", "c", "d"};
         size_t value_lens[]             = {1, 1, 1, 1};
@@ -846,7 +845,8 @@ static int unittest_msgset_mixed_crc_success_decomp(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed2", 0);
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed2", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
@@ -861,7 +861,8 @@ static int unittest_msgset_mixed_crc_success_decomp(void) {
         offset += ut_build_valid_msgset_v2(buffer + offset, 202, 4, values,
                                            value_lens);
 
-        /* MessageSet 3: Decompression error with 3 messages (offsets 206-208) */
+        /* MessageSet 3: Decompression error with 3 messages (offsets 206-208)
+         */
         char corrupted_data[16] = {0xDE, 0xAD, 0xBE, 0xEF}; /* Garbage */
         size_t decomp_start     = offset;
         ut_write_msgset_v2_header(buffer + offset, 206,
@@ -952,8 +953,8 @@ static int unittest_msgset_mixed_magic_success_crc_success(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 4096;
-        size_t offset      = 0;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
         const char *value1              = "x";
         size_t value_len1               = 1;
@@ -966,13 +967,15 @@ static int unittest_msgset_mixed_magic_success_crc_success(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed3", 0);
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed3", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
         buffer     = rd_calloc(1, buffer_size);
 
-        /* MessageSet 1: Unsupported MagicByte=99, 3 messages (offsets 300-302) */
+        /* MessageSet 1: Unsupported MagicByte=99, 3 messages (offsets 300-302)
+         */
         ut_write_msgset_v2_header(buffer + offset, 300, 61 - 12, -1,
                                   99, /* Unsupported */
                                   0, 0, 2, 0, 0, -1, -1, -1, 3);
@@ -997,7 +1000,8 @@ static int unittest_msgset_mixed_magic_success_crc_success(void) {
 
         rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
 
-        /* Verify MessageSet 1: 3 unsupported magic error ops (offsets 300-302) */
+        /* Verify MessageSet 1: 3 unsupported magic error ops (offsets 300-302)
+         */
         for (i = 0; i < 3; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
                 RD_UT_ASSERT(rko != NULL, "Expected magic error op %d", i);
@@ -1065,7 +1069,8 @@ static int unittest_msgset_mixed_magic_success_crc_success(void) {
 /**
  * @brief Test all successful MessageSets
  *
- * Verifies parser correctly handles multiple consecutive successful MessageSets:
+ * Verifies parser correctly handles multiple consecutive successful
+ * MessageSets:
  * - MessageSet 1: 2 messages (offsets 400-401)
  * - MessageSet 2: 3 messages (offsets 402-404)
  * - MessageSet 3: 1 message (offset 405)
@@ -1077,8 +1082,8 @@ static int unittest_msgset_all_success(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 4096;
-        size_t offset      = 0;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
         const char *values2[]           = {"m1", "m2"};
         size_t value_lens2[]            = {2, 2};
@@ -1095,7 +1100,8 @@ static int unittest_msgset_all_success(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-success", 0);
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-success", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
@@ -1120,7 +1126,8 @@ static int unittest_msgset_all_success(void) {
         /* Verify all 10 messages received successfully (offsets 400-409) */
         for (i = 0; i < 10; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
-                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout", i);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
                              "Expected FETCH op, got %d", rko->rko_type);
                 RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 400 + i,
@@ -1158,8 +1165,8 @@ static int unittest_msgset_all_errors(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 4096;
-        size_t offset      = 0;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
         int i;
 
@@ -1168,7 +1175,8 @@ static int unittest_msgset_all_errors(void) {
         rkshare = ut_create_test_share_consumer();
         RD_UT_ASSERT(rkshare, "Failed to create share consumer");
 
-        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-errors", 0);
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-errors", 0);
         RD_UT_ASSERT(rktp, "Failed to create toppar");
 
         response_q = rd_kafka_q_new(rkshare->rkshare_rk);
@@ -1180,8 +1188,8 @@ static int unittest_msgset_all_errors(void) {
         offset += 61;
 
         /* MessageSet 2: Unsupported MagicByte, 1 message (offset 502) */
-        ut_write_msgset_v2_header(buffer + offset, 502, 61 - 12, -1, 99, 0, 0, 0,
-                                  0, 0, -1, -1, -1, 1);
+        ut_write_msgset_v2_header(buffer + offset, 502, 61 - 12, -1, 99, 0, 0,
+                                  0, 0, 0, -1, -1, -1, 1);
         offset += 61;
 
         /* MessageSet 3: CRC error, 3 messages (offsets 503-505) */
@@ -1269,11 +1277,11 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         rd_kafka_buf_t *rkbuf;
         rd_kafka_q_t *response_q;
         char *buffer;
-        size_t buffer_size = 8192;
-        size_t offset      = 0;
+        size_t buffer_size              = 8192;
+        size_t offset                   = 0;
         struct rd_kafka_toppar_ver tver = {.version = 11};
         const char *values[]            = {"a", "b", "c", "d", "e",
-                                            "f", "g", "h", "i", "j"};
+                                           "f", "g", "h", "i", "j"};
         size_t value_lens[]             = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
         int i;
 
@@ -1290,8 +1298,8 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         buffer     = rd_calloc(1, buffer_size);
 
         /* MessageSet 1: CRC error with 10 messages (offsets 0-9) */
-        ut_write_msgset_v2_header(buffer + offset, 0, 100, -1, 2, 0xBADC0001,
-                                  0, 9, 0, 0, -1, -1, -1, 10);
+        ut_write_msgset_v2_header(buffer + offset, 0, 100, -1, 2, 0xBADC0001, 0,
+                                  9, 0, 0, -1, -1, -1, 10);
         offset += 112;
 
         /* MessageSet 2: Valid with 10 messages (offsets 10-19) */
@@ -1318,8 +1326,10 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         offset += ut_build_valid_msgset_v2(buffer + offset, 30, 10, values,
                                            value_lens);
 
-        /* MessageSet 5: Unsupported MagicByte with 10 messages (offsets 40-49) */
-        ut_write_msgset_v2_header(buffer + offset, 40, 100, -1, 99, /* Bad magic */
+        /* MessageSet 5: Unsupported MagicByte with 10 messages (offsets 40-49)
+         */
+        ut_write_msgset_v2_header(buffer + offset, 40, 100, -1,
+                                  99, /* Bad magic */
                                   0, 0, 9, 0, 0, -1, -1, -1, 10);
         offset += 112;
 
@@ -1349,10 +1359,9 @@ static int unittest_msgset_all_error_types_with_valid(void) {
                 RD_UT_ASSERT(rko->rko_u.err.offset == 0 + i,
                              "Expected offset %d, got %" PRId64, i,
                              rko->rko_u.err.offset);
-                RD_UT_ASSERT(
-                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
-                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
-                    "Expected REJECT ack_type for CRC error");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for CRC error");
                 rd_kafka_op_destroy(rko);
         }
 
@@ -1394,11 +1403,11 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         RD_UT_SAY("Verifying MessageSet 4: Valid messages after decomp error");
         for (i = 0; i < 10; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
-                RD_UT_ASSERT(
-                    rko != NULL,
-                    "Expected FETCH op %d of 10 after decomp error, got timeout "
-                    "(BUG: parser stopped!)",
-                    i);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected FETCH op %d of 10 after decomp error, "
+                             "got timeout "
+                             "(BUG: parser stopped!)",
+                             i);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
                              "Expected FETCH op, got %d", rko->rko_type);
                 RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 30 + i,
@@ -1407,11 +1416,13 @@ static int unittest_msgset_all_error_types_with_valid(void) {
                 rd_kafka_op_destroy(rko);
         }
 
-        /* Verify MessageSet 5: 10 unsupported magic error ops (offsets 40-49) */
+        /* Verify MessageSet 5: 10 unsupported magic error ops (offsets 40-49)
+         */
         RD_UT_SAY("Verifying MessageSet 5: Unsupported MagicByte errors");
         for (i = 0; i < 10; i++) {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
-                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d of 10", i);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d of 10",
+                             i);
                 RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
                              "Expected CONSUMER_ERR, got %d", rko->rko_type);
                 RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
@@ -1420,10 +1431,9 @@ static int unittest_msgset_all_error_types_with_valid(void) {
                 RD_UT_ASSERT(rko->rko_u.err.offset == 40 + i,
                              "Expected offset %d, got %" PRId64, 40 + i,
                              rko->rko_u.err.offset);
-                RD_UT_ASSERT(
-                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
-                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
-                    "Expected REJECT ack_type for unsupported magic");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for unsupported magic");
                 rd_kafka_op_destroy(rko);
         }
 
@@ -1447,12 +1457,12 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         /* Verify no extra ops */
         {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
-                RD_UT_ASSERT(rko == NULL,
-                             "Unexpected extra op of type %d",
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op of type %d",
                              rko ? rko->rko_type : -1);
         }
 
-        RD_UT_SAY("SUCCESS: All 6 MessageSets processed correctly (60 ops total)");
+        RD_UT_SAY(
+            "SUCCESS: All 6 MessageSets processed correctly (60 ops total)");
 
         rd_kafka_buf_destroy(rkbuf);
         rd_kafka_q_destroy_owner(response_q);

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -1451,8 +1451,7 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         /* Verify no extra ops */
         {
                 rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
-                RD_UT_ASSERT(rko == NULL, "Unexpected extra op of type %d",
-                             rko ? rko->rko_type : -1);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
         }
 
         RD_UT_SAY(

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -215,7 +215,6 @@ static size_t ut_build_record_v2(char *buf,
                                  size_t key_len,
                                  const char *value,
                                  size_t value_len) {
-        size_t record_start = 0;
         size_t offset       = 0;
         size_t len_offset;
         int32_t key_len_varint = key ? (int32_t)key_len : -1;
@@ -282,8 +281,6 @@ static size_t ut_build_valid_msgset_v2(char *buf,
                                        size_t *value_lens) {
         size_t offset     = 0;
         size_t len_offset = 8;
-        size_t header_start;
-        size_t records_start;
         size_t records_size = 0;
         int32_t i;
         char *records_buf;
@@ -308,8 +305,6 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         /* Length - will update later */
         len_offset = offset;
         offset += 4;
-
-        header_start = offset;
 
         /* PartitionLeaderEpoch */
         *(int32_t *)(buf + offset) = htobe32(-1);
@@ -353,8 +348,6 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         /* RecordCount */
         *(int32_t *)(buf + offset) = htobe32(record_count);
         offset += 4;
-
-        records_start = offset;
 
         /* Copy records */
         memcpy(buf + offset, records_buf, records_size);
@@ -737,7 +730,6 @@ static int unittest_msgset_mixed_success_crc_success(void) {
                                            value_lens);
 
         /* MessageSet 2: CRC error with 5 messages (offsets 103-107) */
-        size_t msgset2_start     = offset;
         int64_t BaseOffset2      = 103;
         int32_t LastOffsetDelta2 = 4;
         int32_t Length2          = 61 - 12; /* Just header */

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -1,0 +1,1495 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2025, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @name Unit tests for Share Consumer MessageSet error handling
+ * @{
+ *
+ * Tests cover per-offset error handling for:
+ *   - CRC errors → REJECT ack_type
+ *   - Decompression errors → RELEASE ack_type
+ *   - Unsupported MagicByte → REJECT ack_type
+ *
+ * These tests craft binary MessageSet v2 buffers with intentional corruption
+ * and verify that the msgset reader creates one error op per offset with
+ * correct ack_types for share consumers.
+ */
+
+#include "rd.h"
+#include "rdunittest.h"
+#include "rdkafka_int.h"
+#include "rdkafka_queue.h"
+#include "rdkafka_partition.h"
+#include "rdkafka_share_acknowledgement.h"
+#include "rdkafka_buf.h"
+#include "rdkafka_msgset.h"
+#include "crc32c.h"
+
+#if WITH_ZSTD
+#include "rdkafka_zstd.h"
+#endif
+
+
+/**
+ * @name Test helpers
+ * @{
+ */
+
+/**
+ * @brief Create a minimal share consumer for testing
+ */
+static rd_kafka_share_t *ut_create_test_share_consumer(void) {
+        rd_kafka_conf_t *conf = rd_kafka_conf_new();
+        rd_kafka_share_t *rkshare;
+        char errstr[512];
+
+        if (rd_kafka_conf_set(conf, "group.id", "ut-msgset-errors", errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
+                return NULL;
+        }
+
+        /* Enable CRC checking for tests */
+        if (rd_kafka_conf_set(conf, "check.crcs", "true", errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
+                return NULL;
+        }
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        return rkshare;
+}
+
+static void ut_destroy_share_consumer(rd_kafka_share_t *rkshare) {
+        if (!rkshare)
+                return;
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+/**
+ * @brief Create a mock topic partition
+ */
+static rd_kafka_toppar_t *ut_create_mock_toppar(rd_kafka_t *rk,
+                                                const char *topic,
+                                                int32_t partition) {
+        rd_kafka_topic_t *rkt = rd_kafka_topic_new(rk, topic, NULL);
+        if (!rkt)
+                return NULL;
+        return rd_kafka_toppar_new(rkt, partition);
+}
+
+/**
+ * @brief Helper to write MessageSet v2 header fields in big-endian
+ */
+static void ut_write_msgset_v2_header(char *buf,
+                                      int64_t BaseOffset,
+                                      int32_t Length,
+                                      int32_t PartitionLeaderEpoch,
+                                      int8_t MagicByte,
+                                      int32_t Crc,
+                                      int16_t Attributes,
+                                      int32_t LastOffsetDelta,
+                                      int64_t BaseTimestamp,
+                                      int64_t MaxTimestamp,
+                                      int64_t ProducerId,
+                                      int16_t ProducerEpoch,
+                                      int32_t BaseSequence,
+                                      int32_t RecordCount) {
+        size_t offset = 0;
+
+        /* BaseOffset (int64) */
+        *(int64_t *)(buf + offset) = htobe64(BaseOffset);
+        offset += 8;
+
+        /* Length (int32) */
+        *(int32_t *)(buf + offset) = htobe32(Length);
+        offset += 4;
+
+        /* PartitionLeaderEpoch (int32) */
+        *(int32_t *)(buf + offset) = htobe32(PartitionLeaderEpoch);
+        offset += 4;
+
+        /* MagicByte (int8) */
+        *(int8_t *)(buf + offset) = MagicByte;
+        offset += 1;
+
+        /* Crc (int32) */
+        *(int32_t *)(buf + offset) = htobe32(Crc);
+        offset += 4;
+
+        /* Attributes (int16) */
+        *(int16_t *)(buf + offset) = htobe16(Attributes);
+        offset += 2;
+
+        /* LastOffsetDelta (int32) */
+        *(int32_t *)(buf + offset) = htobe32(LastOffsetDelta);
+        offset += 4;
+
+        /* BaseTimestamp (int64) */
+        *(int64_t *)(buf + offset) = htobe64(BaseTimestamp);
+        offset += 8;
+
+        /* MaxTimestamp (int64) */
+        *(int64_t *)(buf + offset) = htobe64(MaxTimestamp);
+        offset += 8;
+
+        /* ProducerId (int64) */
+        *(int64_t *)(buf + offset) = htobe64(ProducerId);
+        offset += 8;
+
+        /* ProducerEpoch (int16) */
+        *(int16_t *)(buf + offset) = htobe16(ProducerEpoch);
+        offset += 2;
+
+        /* BaseSequence (int32) */
+        *(int32_t *)(buf + offset) = htobe32(BaseSequence);
+        offset += 4;
+
+        /* RecordCount (int32) */
+        *(int32_t *)(buf + offset) = htobe32(RecordCount);
+        offset += 4;
+}
+
+/**
+ * @brief Calculate correct CRC32C for MessageSet v2
+ *        CRC covers from Attributes to end of records
+ */
+static uint32_t ut_calc_msgset_crc(const char *buf,
+                                   size_t offset_to_attributes,
+                                   size_t total_len) {
+        /* CRC starts after MagicByte and Crc field itself */
+        const void *data  = buf + offset_to_attributes;
+        size_t data_len   = total_len - offset_to_attributes;
+        return rd_crc32c(0, data, data_len);
+}
+
+/**
+ * @brief Write a varint (used in Record format)
+ * @returns number of bytes written
+ */
+static size_t ut_write_varint(char *buf, int64_t value) {
+        uint64_t uval = (value << 1) ^ (value >> 63); /* Zigzag encoding */
+        size_t i      = 0;
+
+        while (uval >= 0x80) {
+                buf[i++] = (char)((uval & 0x7F) | 0x80);
+                uval >>= 7;
+        }
+        buf[i++] = (char)(uval & 0x7F);
+        return i;
+}
+
+/**
+ * @brief Build a minimal valid Record v2
+ * @returns size of record written
+ */
+static size_t ut_build_record_v2(char *buf,
+                                 int32_t offset_delta,
+                                 int64_t timestamp_delta,
+                                 const char *key,
+                                 size_t key_len,
+                                 const char *value,
+                                 size_t value_len) {
+        size_t record_start = 0;
+        size_t offset       = 0;
+        size_t len_offset;
+        int32_t key_len_varint  = key ? (int32_t)key_len : -1;
+        int32_t val_len_varint  = value ? (int32_t)value_len : -1;
+
+        /* Reserve space for Length (varint) - we'll fill this in later */
+        len_offset = offset;
+        offset += 5; /* Max varint size for record length */
+
+        /* Attributes (int8) */
+        buf[offset++] = 0;
+
+        /* TimestampDelta (varint) */
+        offset += ut_write_varint(buf + offset, timestamp_delta);
+
+        /* OffsetDelta (varint) */
+        offset += ut_write_varint(buf + offset, offset_delta);
+
+        /* KeyLen (varint) */
+        offset += ut_write_varint(buf + offset, key_len_varint);
+
+        /* Key bytes */
+        if (key) {
+                memcpy(buf + offset, key, key_len);
+                offset += key_len;
+        }
+
+        /* ValueLen (varint) */
+        offset += ut_write_varint(buf + offset, val_len_varint);
+
+        /* Value bytes */
+        if (value) {
+                memcpy(buf + offset, value, value_len);
+                offset += value_len;
+        }
+
+        /* Headers count (varint) - 0 headers */
+        offset += ut_write_varint(buf + offset, 0);
+
+        /* Calculate record length (everything after Length field) */
+        size_t record_body_len = offset - len_offset - 5;
+
+        /* Write actual Length at the beginning */
+        size_t len_size = ut_write_varint(buf + len_offset, record_body_len);
+
+        /* Compact the record if varint was smaller than 5 bytes */
+        if (len_size < 5) {
+                memmove(buf + len_offset + len_size,
+                        buf + len_offset + 5,
+                        record_body_len);
+                offset = len_offset + len_size + record_body_len;
+        }
+
+        return offset;
+}
+
+/**
+ * @brief Build a complete valid MessageSet v2 with records
+ * @returns total size of MessageSet
+ */
+static size_t ut_build_valid_msgset_v2(char *buf,
+                                       int64_t base_offset,
+                                       int32_t record_count,
+                                       const char **values,
+                                       size_t *value_lens) {
+        size_t offset     = 0;
+        size_t len_offset = 8;
+        size_t header_start;
+        size_t records_start;
+        size_t records_size = 0;
+        int32_t i;
+        char *records_buf;
+        uint32_t crc;
+        int32_t last_offset_delta = record_count > 0 ? record_count - 1 : 0;
+
+        /* Build all records first to know total size */
+        records_buf = rd_calloc(1, 8192);
+        for (i = 0; i < record_count; i++) {
+                records_size += ut_build_record_v2(
+                    records_buf + records_size,
+                    i,   /* offsetDelta */
+                    0,   /* timestampDelta */
+                    NULL, 0, /* no key */
+                    values ? values[i] : NULL,
+                    values && value_lens ? value_lens[i] : 0);
+        }
+
+        /* BaseOffset */
+        *(int64_t *)(buf + offset) = htobe64(base_offset);
+        offset += 8;
+
+        /* Length - will update later */
+        len_offset = offset;
+        offset += 4;
+
+        header_start = offset;
+
+        /* PartitionLeaderEpoch */
+        *(int32_t *)(buf + offset) = htobe32(-1);
+        offset += 4;
+
+        /* MagicByte */
+        buf[offset++] = 2;
+
+        /* CRC - placeholder, will calculate later */
+        size_t crc_offset = offset;
+        offset += 4;
+
+        /* Attributes (no compression) */
+        *(int16_t *)(buf + offset) = htobe16(0);
+        offset += 2;
+
+        /* LastOffsetDelta */
+        *(int32_t *)(buf + offset) = htobe32(last_offset_delta);
+        offset += 4;
+
+        /* BaseTimestamp */
+        *(int64_t *)(buf + offset) = htobe64(0);
+        offset += 8;
+
+        /* MaxTimestamp */
+        *(int64_t *)(buf + offset) = htobe64(0);
+        offset += 8;
+
+        /* ProducerId */
+        *(int64_t *)(buf + offset) = htobe64(-1);
+        offset += 8;
+
+        /* ProducerEpoch */
+        *(int16_t *)(buf + offset) = htobe16(-1);
+        offset += 2;
+
+        /* BaseSequence */
+        *(int32_t *)(buf + offset) = htobe32(-1);
+        offset += 4;
+
+        /* RecordCount */
+        *(int32_t *)(buf + offset) = htobe32(record_count);
+        offset += 4;
+
+        records_start = offset;
+
+        /* Copy records */
+        memcpy(buf + offset, records_buf, records_size);
+        offset += records_size;
+        rd_free(records_buf);
+
+        /* Calculate and write Length */
+        int32_t length = (int32_t)(offset - len_offset - 4);
+        *(int32_t *)(buf + len_offset) = htobe32(length);
+
+        /* Calculate and write CRC (covers Attributes to end) */
+        crc = rd_crc32c(0, buf + crc_offset + 4, offset - crc_offset - 4);
+        *(int32_t *)(buf + crc_offset) = htobe32(crc);
+
+        return offset;
+}
+
+/**@}*/
+
+
+/**
+ * @brief Test CRC error generates per-offset error ops with REJECT ack_type
+ *
+ * Creates a MessageSet v2 with intentionally wrong CRC and verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has REJECT ack_type
+ * - Error code is RD_KAFKA_RESP_ERR__BAD_MSG
+ */
+static int unittest_msgset_crc_error_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset       = 100;
+        int32_t LastOffsetDelta  = 4; /* Offsets 100-104 inclusive = 5 messages */
+        int expected_err_ops     = 5;
+        int i;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-crc", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet v2 with wrong CRC */
+        /* MessageSet v2 structure:
+         * - BaseOffset (8) + Length (4) = 12 bytes before "Length" data starts
+         * - Length field contains size of: PartitionLeaderEpoch (4) + MagicByte (1)
+         *   + Crc (4) + Attributes (2) + LastOffsetDelta (4) + BaseTimestamp (8)
+         *   + MaxTimestamp (8) + ProducerId (8) + ProducerEpoch (2)
+         *   + BaseSequence (4) + RecordCount (4) + Records
+         * - Minimum Length = 49 (just the header fields after Length)
+         * - For this test, we need enough space for CRC validation
+         */
+
+        /* CRC validation needs: crc_len = Length - 4 - 1 - 4 bytes available
+         * after reading up to Crc field (21 bytes read so far) */
+        int32_t Length = 61 - 12; /* Minimum: just the header, no records */
+        msgset_size    = 12 + Length; /* BaseOffset + Length + data */
+        msgset_data    = rd_calloc(1, msgset_size);
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length,     /* Length of data after BaseOffset+Length fields */
+            -1,         /* PartitionLeaderEpoch */
+            2,          /* MagicByte v2 */
+            0xDEADBEEF, /* WRONG CRC - will trigger error */
+            0,          /* Attributes: no compression */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            5 /* RecordCount */);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect CRC error */
+        rd_kafka_resp_err_t parse_err =
+            rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        RD_UT_ASSERT(parse_err == RD_KAFKA_RESP_ERR_NO_ERROR ||
+                         parse_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                     "Unexpected parse error: %s", rd_kafka_err2str(parse_err));
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for CRC error, got %d",
+                             rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko;
+                rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Got unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test decompression error generates per-offset error ops with RELEASE
+ *
+ * Creates a MessageSet v2 with ZSTD compression but corrupted compressed data.
+ * Verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has RELEASE ack_type (retryable error)
+ * - Error code is RD_KAFKA_RESP_ERR__BAD_COMPRESSION
+ */
+static int unittest_msgset_decompression_error_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset      = 200;
+        int32_t LastOffsetDelta = 2; /* Offsets 200-202 inclusive = 3 messages */
+        int expected_err_ops    = 3;
+        int i;
+        uint32_t correct_crc;
+        size_t crc_offset = 17; /* Offset to CRC field in header */
+        size_t attr_offset =
+            21; /* Offset to Attributes field (where CRC starts) */
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk,
+                                     "test-topic-decompress", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet v2 with ZSTD compression but corrupted data */
+        msgset_size = 200;
+        msgset_data = rd_calloc(1, msgset_size);
+
+        int32_t Length = msgset_size - 12;
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length, /* Length of data after BaseOffset+Length fields */
+            -1,     /* PartitionLeaderEpoch */
+            2,      /* MagicByte v2 */
+            0,      /* CRC - will calculate correct one below */
+            4,      /* Attributes: ZSTD compression (codec=4) */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            3 /* RecordCount */);
+
+        /* Fill records section with garbage (corrupted ZSTD data) */
+        memset(msgset_data + 61, 0xAB, msgset_size - 61);
+
+        /* Calculate CORRECT CRC so we pass CRC check but fail decompression */
+        correct_crc = ut_calc_msgset_crc(msgset_data, attr_offset, msgset_size);
+        *(int32_t *)(msgset_data + crc_offset) = htobe32(correct_crc);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect decompression error */
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(
+                    rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                    "Expected BAD_COMPRESSION error, got %s",
+                    rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Expected RELEASE ack_type for decompression error, got %d",
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Test unsupported MagicByte generates per-offset error ops with REJECT
+ *
+ * Creates a MessageSet with MagicByte=99 (unsupported future version).
+ * Verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has REJECT ack_type (permanent error)
+ * - Error code is RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED
+ */
+static int unittest_msgset_unsupported_magic_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset      = 300;
+        int32_t LastOffsetDelta = 9; /* Offsets 300-309 inclusive = 10 messages */
+        int expected_err_ops    = 10;
+        int i;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-magic", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet with unsupported MagicByte */
+        msgset_size = 200;
+        msgset_data = rd_calloc(1, msgset_size);
+
+        int32_t Length = msgset_size - 12;
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length, /* Length of data after BaseOffset+Length fields */
+            -1,     /* PartitionLeaderEpoch */
+            99,     /* UNSUPPORTED MagicByte - will trigger error */
+            0,      /* CRC - doesn't matter, won't get that far */
+            0,      /* Attributes */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            10 /* RecordCount */);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect unsupported MagicByte */
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(
+                    rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                    "Expected NOT_IMPLEMENTED error, got %s",
+                    rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                    "Expected REJECT ack_type for unsupported MagicByte, got "
+                    "%d",
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test mixed scenario: Success → CRC Error → Success
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: 3 successful messages (offsets 100-102)
+ * - MessageSet 2: CRC error covering 5 messages (offsets 103-107)
+ * - MessageSet 3: 2 successful messages (offsets 108-109)
+ */
+static int unittest_msgset_mixed_success_crc_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 4096;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[]            = {"msg1", "msg2", "msg3",
+                                            "msg4", "msg5"};
+        size_t value_lens[]             = {4, 4, 4, 4, 4};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: Valid with 3 messages (offsets 100-102) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 100, 3, values,
+                                           value_lens);
+
+        /* MessageSet 2: CRC error with 5 messages (offsets 103-107) */
+        size_t msgset2_start = offset;
+        int64_t BaseOffset2  = 103;
+        int32_t LastOffsetDelta2 = 4;
+        int32_t Length2 = 61 - 12; /* Just header */
+        ut_write_msgset_v2_header(
+            buffer + offset, BaseOffset2, Length2, -1, 2,
+            0xBADC0C, /* Wrong CRC */
+            0, LastOffsetDelta2, 0, 0, -1, -1, -1, 5);
+        offset += 12 + Length2;
+
+        /* MessageSet 3: Valid with 2 messages (offsets 108-109) */
+        const char *values3[]  = {"msg6", "msg7"};
+        size_t value_lens3[] = {4, 4};
+        offset += ut_build_valid_msgset_v2(buffer + offset, 108, 2, values3,
+                                           value_lens3);
+
+        /* Parse all MessageSets */
+        rkbuf                = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb     = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 3 FETCH ops with offsets 100-102 */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 100 + i,
+                             "Expected offset %d, got %" PRId64, 100 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 5 CONSUMER_ERR ops with offsets 103-107 */
+        for (i = 0; i < 5; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d, got timeout",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 103 + i,
+                             "Expected offset %d, got %" PRId64, 103 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 2 FETCH ops with offsets 108-109 */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i + 3);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 108 + i,
+                             "Expected offset %d, got %" PRId64, 108 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test mixed scenario: CRC Error → Success → Decompression Error
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: CRC error covering 2 messages (offsets 200-201)
+ * - MessageSet 2: 4 successful messages (offsets 202-205)
+ * - MessageSet 3: Decompression error covering 3 messages (offsets 206-208)
+ */
+static int unittest_msgset_mixed_crc_success_decomp(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 4096;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[]            = {"a", "b", "c", "d"};
+        size_t value_lens[]             = {1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed2", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error with 2 messages (offsets 200-201) */
+        ut_write_msgset_v2_header(buffer + offset, 200, 61 - 12, -1, 2,
+                                  0xDEADC0C, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 2: Valid with 4 messages (offsets 202-205) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 202, 4, values,
+                                           value_lens);
+
+        /* MessageSet 3: Decompression error with 3 messages (offsets 206-208) */
+        char corrupted_data[16] = {0xDE, 0xAD, 0xBE, 0xEF}; /* Garbage */
+        size_t decomp_start     = offset;
+        ut_write_msgset_v2_header(buffer + offset, 206,
+                                  49 + sizeof(corrupted_data), -1, 2, 0,
+                                  4, /* ZSTD compression */
+                                  2, 0, 0, -1, -1, -1, 3);
+        offset += 61;
+        memcpy(buffer + offset, corrupted_data, sizeof(corrupted_data));
+        offset += sizeof(corrupted_data);
+        /* Fix CRC for decompression error (CRC is valid, data is corrupt) */
+        uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
+                                 49 + sizeof(corrupted_data) - 4 - 1 - 4);
+        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 2 CRC error ops (offsets 200-201) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 4 successful FETCH ops (offsets 202-205) */
+        for (i = 0; i < 4; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 202 + i,
+                             "Expected offset %d", 202 + i);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 3 decompression error ops (offsets 206-208) */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected decomp error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                             "Expected RELEASE");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Test mixed scenario: Unsupported Magic → Success → CRC Error → Success
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: Unsupported MagicByte covering 3 messages (offsets 300-302)
+ * - MessageSet 2: 1 successful message (offset 303)
+ * - MessageSet 3: CRC error covering 2 messages (offsets 304-305)
+ * - MessageSet 4: 5 successful messages (offsets 306-310)
+ */
+static int unittest_msgset_mixed_magic_success_crc_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 4096;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *value1              = "x";
+        size_t value_len1               = 1;
+        const char *values5[]           = {"a", "b", "c", "d", "e"};
+        size_t value_lens5[]            = {1, 1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed3", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: Unsupported MagicByte=99, 3 messages (offsets 300-302) */
+        ut_write_msgset_v2_header(buffer + offset, 300, 61 - 12, -1,
+                                  99, /* Unsupported */
+                                  0, 0, 2, 0, 0, -1, -1, -1, 3);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 2: Valid with 1 message (offset 303) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 303, 1, &value1,
+                                           &value_len1);
+
+        /* MessageSet 3: CRC error, 2 messages (offsets 304-305) */
+        ut_write_msgset_v2_header(buffer + offset, 304, 61 - 12, -1, 2,
+                                  0xBADBAD, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 4: Valid with 5 messages (offsets 306-310) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 306, 5, values5,
+                                           value_lens5);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 3 unsupported magic error ops (offsets 300-302) */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 1 successful FETCH op (offset 303) */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 303,
+                             "Expected offset 303");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 2 CRC error ops (offsets 304-305) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 4: 5 successful FETCH ops (offsets 306-310) */
+        for (i = 0; i < 5; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 306 + i,
+                             "Expected offset %d", 306 + i);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test all successful MessageSets
+ *
+ * Verifies parser correctly handles multiple consecutive successful MessageSets:
+ * - MessageSet 1: 2 messages (offsets 400-401)
+ * - MessageSet 2: 3 messages (offsets 402-404)
+ * - MessageSet 3: 1 message (offset 405)
+ * - MessageSet 4: 4 messages (offsets 406-409)
+ */
+static int unittest_msgset_all_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 4096;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values2[]           = {"m1", "m2"};
+        size_t value_lens2[]            = {2, 2};
+        const char *values3[]           = {"m3", "m4", "m5"};
+        size_t value_lens3[]            = {2, 2, 2};
+        const char *value1              = "m6";
+        size_t value_len1               = 2;
+        const char *values4[]           = {"m7", "m8", "m9", "m10"};
+        size_t value_lens4[]            = {2, 2, 2, 3};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-success", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* Build 4 valid MessageSets */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 400, 2, values2,
+                                           value_lens2);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 402, 3, values3,
+                                           value_lens3);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 405, 1, &value1,
+                                           &value_len1);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 406, 4, values4,
+                                           value_lens4);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify all 10 messages received successfully (offsets 400-409) */
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 400 + i,
+                             "Expected offset %d, got %" PRId64, 400 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test all error MessageSets in sequence
+ *
+ * Verifies parser correctly handles consecutive errors:
+ * - MessageSet 1: CRC error, 2 messages (offsets 500-501)
+ * - MessageSet 2: Unsupported MagicByte, 1 message (offset 502)
+ * - MessageSet 3: CRC error, 3 messages (offsets 503-505)
+ */
+static int unittest_msgset_all_errors(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 4096;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-errors", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error, 2 messages (offsets 500-501) */
+        ut_write_msgset_v2_header(buffer + offset, 500, 61 - 12, -1, 2,
+                                  0xBADC001, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 61;
+
+        /* MessageSet 2: Unsupported MagicByte, 1 message (offset 502) */
+        ut_write_msgset_v2_header(buffer + offset, 502, 61 - 12, -1, 99, 0, 0, 0,
+                                  0, 0, -1, -1, -1, 1);
+        offset += 61;
+
+        /* MessageSet 3: CRC error, 3 messages (offsets 503-505) */
+        ut_write_msgset_v2_header(buffer + offset, 503, 61 - 12, -1, 2,
+                                  0xBADC002, 0, 2, 0, 0, -1, -1, -1, 3);
+        offset += 61;
+
+        RD_UT_SAY("Buffer size: %zu bytes", offset);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_resp_err_t parse_err =
+            rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        RD_UT_SAY("Parse returned: %s", rd_kafka_err2str(parse_err));
+
+        /* Verify MessageSet 1: 2 CRC error ops (offsets 500-501) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 1 unsupported magic error op (offset 502) */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op");
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 3 CRC error ops (offsets 503-505) */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test all 3 error types interleaved with valid messages
+ *
+ * Verifies parser continues through all error types:
+ * - MessageSet 1: CRC error (10 messages, offsets 0-9)
+ * - MessageSet 2: Valid (10 messages, offsets 10-19)
+ * - MessageSet 3: Decompression error (10 messages, offsets 20-29)
+ * - MessageSet 4: Valid (10 messages, offsets 30-39)
+ * - MessageSet 5: Unsupported MagicByte (10 messages, offsets 40-49)
+ * - MessageSet 6: Valid (10 messages, offsets 50-59)
+ *
+ * This is the critical test case: all batches must be processed,
+ * with valid messages delivered even after errors.
+ */
+static int unittest_msgset_all_error_types_with_valid(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size = 8192;
+        size_t offset      = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[]            = {"a", "b", "c", "d", "e",
+                                            "f", "g", "h", "i", "j"};
+        size_t value_lens[]             = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk,
+                                     "test-topic-all-errors", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error with 10 messages (offsets 0-9) */
+        ut_write_msgset_v2_header(buffer + offset, 0, 100, -1, 2, 0xBADC0001,
+                                  0, 9, 0, 0, -1, -1, -1, 10);
+        offset += 112;
+
+        /* MessageSet 2: Valid with 10 messages (offsets 10-19) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 10, 10, values,
+                                           value_lens);
+
+        /* MessageSet 3: Decompression error with 10 messages (offsets 20-29) */
+        char corrupted_data[32];
+        memset(corrupted_data, 0xDE, sizeof(corrupted_data));
+        size_t decomp_start = offset;
+        ut_write_msgset_v2_header(buffer + offset, 20,
+                                  49 + sizeof(corrupted_data), -1, 2, 0,
+                                  4, /* ZSTD compression */
+                                  9, 0, 0, -1, -1, -1, 10);
+        offset += 61;
+        memcpy(buffer + offset, corrupted_data, sizeof(corrupted_data));
+        offset += sizeof(corrupted_data);
+        /* Fix CRC for decompression error (CRC valid, data corrupt) */
+        uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
+                                 49 + sizeof(corrupted_data) - 4 - 1 - 4);
+        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+
+        /* MessageSet 4: Valid with 10 messages (offsets 30-39) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 30, 10, values,
+                                           value_lens);
+
+        /* MessageSet 5: Unsupported MagicByte with 10 messages (offsets 40-49) */
+        ut_write_msgset_v2_header(buffer + offset, 40, 100, -1, 99, /* Bad magic */
+                                  0, 0, 9, 0, 0, -1, -1, -1, 10);
+        offset += 112;
+
+        /* MessageSet 6: Valid with 10 messages (offsets 50-59) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 50, 10, values,
+                                           value_lens);
+
+        RD_UT_SAY("Total buffer size: %zu bytes, 6 MessageSets", offset);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 10 CRC error ops (offsets 0-9) */
+        RD_UT_SAY("Verifying MessageSet 1: CRC errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected CRC error op %d of 10, got timeout", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 0 + i,
+                             "Expected offset %d, got %" PRId64, i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                    "Expected REJECT ack_type for CRC error");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 10 successful FETCH ops (offsets 10-19) */
+        RD_UT_SAY("Verifying MessageSet 2: Valid messages");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d of 10", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 10 + i,
+                             "Expected offset %d, got %" PRId64, 10 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 10 decompression error ops (offsets 20-29) */
+        RD_UT_SAY("Verifying MessageSet 3: Decompression errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected decomp error op %d of 10",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 20 + i,
+                             "Expected offset %d, got %" PRId64, 20 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Expected RELEASE ack_type for decompression error");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 4: 10 successful FETCH ops (offsets 30-39) */
+        RD_UT_SAY("Verifying MessageSet 4: Valid messages after decomp error");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(
+                    rko != NULL,
+                    "Expected FETCH op %d of 10 after decomp error, got timeout "
+                    "(BUG: parser stopped!)",
+                    i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 30 + i,
+                             "Expected offset %d, got %" PRId64, 30 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 5: 10 unsupported magic error ops (offsets 40-49) */
+        RD_UT_SAY("Verifying MessageSet 5: Unsupported MagicByte errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d of 10", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 40 + i,
+                             "Expected offset %d, got %" PRId64, 40 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                    "Expected REJECT ack_type for unsupported magic");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 6: 10 successful FETCH ops (offsets 50-59) */
+        RD_UT_SAY("Verifying MessageSet 6: Valid messages after magic error");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(
+                    rko != NULL,
+                    "Expected FETCH op %d of 10 after magic error, got timeout "
+                    "(BUG: parser stopped!)",
+                    i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 50 + i,
+                             "Expected offset %d, got %" PRId64, 50 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL,
+                             "Unexpected extra op of type %d",
+                             rko ? rko->rko_type : -1);
+        }
+
+        RD_UT_SAY("SUCCESS: All 6 MessageSets processed correctly (60 ops total)");
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Run all MessageSet error handling unit tests
+ */
+int rd_kafka_unittest_msgset_errors(void) {
+        int fails = 0;
+
+        /* Individual error type tests */
+        fails += unittest_msgset_crc_error_share_consumer();
+#if WITH_ZSTD
+        fails += unittest_msgset_decompression_error_share_consumer();
+#endif
+        fails += unittest_msgset_unsupported_magic_share_consumer();
+
+        /* Mixed scenario tests */
+        fails += unittest_msgset_mixed_success_crc_success();
+#if WITH_ZSTD
+        fails += unittest_msgset_mixed_crc_success_decomp();
+#endif
+        fails += unittest_msgset_mixed_magic_success_crc_success();
+        fails += unittest_msgset_all_success();
+        fails += unittest_msgset_all_errors();
+
+        /* Comprehensive test: all error types with valid messages */
+#if WITH_ZSTD
+        fails += unittest_msgset_all_error_types_with_valid();
+#endif
+
+        return fails;
+}

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -175,6 +175,7 @@ static void ut_write_msgset_v2_header(char *buf,
         offset += 4;
 }
 
+#if WITH_ZSTD
 /**
  * @brief Calculate correct CRC32C for MessageSet v2
  *        CRC covers from Attributes to end of records
@@ -187,6 +188,7 @@ static uint32_t ut_calc_msgset_crc(const char *buf,
         size_t data_len  = total_len - offset_to_attributes;
         return rd_crc32c(0, data, data_len);
 }
+#endif /* WITH_ZSTD */
 
 /**
  * @brief Write a varint (used in Record format)
@@ -215,7 +217,7 @@ static size_t ut_build_record_v2(char *buf,
                                  size_t key_len,
                                  const char *value,
                                  size_t value_len) {
-        size_t offset       = 0;
+        size_t offset = 0;
         size_t len_offset;
         int32_t key_len_varint = key ? (int32_t)key_len : -1;
         int32_t val_len_varint = value ? (int32_t)value_len : -1;
@@ -279,8 +281,8 @@ static size_t ut_build_valid_msgset_v2(char *buf,
                                        int32_t record_count,
                                        const char **values,
                                        size_t *value_lens) {
-        size_t offset     = 0;
-        size_t len_offset = 8;
+        size_t offset       = 0;
+        size_t len_offset   = 8;
         size_t records_size = 0;
         int32_t i;
         char *records_buf;

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -380,7 +380,7 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         rd_free(records_buf);
 
         /* Calculate and write Length */
-        int32_t length                 = (int32_t)(offset - len_offset - 4);
+        int32_t length = (int32_t)(offset - len_offset - 4);
         ut_put_be32(buf + len_offset, length);
 
         /* Calculate and write CRC (covers Attributes to end) */

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -1,0 +1,1498 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2025, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @name Unit tests for Share Consumer MessageSet error handling
+ * @{
+ *
+ * Tests cover per-offset error handling for:
+ *   - CRC errors → REJECT ack_type
+ *   - Decompression errors → RELEASE ack_type
+ *   - Unsupported MagicByte → REJECT ack_type
+ *
+ * These tests craft binary MessageSet v2 buffers with intentional corruption
+ * and verify that the msgset reader creates one error op per offset with
+ * correct ack_types for share consumers.
+ */
+
+#include "rd.h"
+#include "rdunittest.h"
+#include "rdkafka_int.h"
+#include "rdkafka_queue.h"
+#include "rdkafka_partition.h"
+#include "rdkafka_share_acknowledgement.h"
+#include "rdkafka_buf.h"
+#include "rdkafka_msgset.h"
+#include "crc32c.h"
+
+#if WITH_ZSTD
+#include "rdkafka_zstd.h"
+#endif
+
+
+/**
+ * @name Test helpers
+ * @{
+ */
+
+/**
+ * @brief Create a minimal share consumer for testing
+ */
+static rd_kafka_share_t *ut_create_test_share_consumer(void) {
+        rd_kafka_conf_t *conf = rd_kafka_conf_new();
+        rd_kafka_share_t *rkshare;
+        char errstr[512];
+
+        if (rd_kafka_conf_set(conf, "group.id", "ut-msgset-errors", errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
+                return NULL;
+        }
+
+        /* Enable CRC checking for tests */
+        if (rd_kafka_conf_set(conf, "check.crcs", "true", errstr,
+                              sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+                rd_kafka_conf_destroy(conf);
+                return NULL;
+        }
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        return rkshare;
+}
+
+static void ut_destroy_share_consumer(rd_kafka_share_t *rkshare) {
+        if (!rkshare)
+                return;
+        rd_kafka_share_consumer_close(rkshare);
+        rd_kafka_share_destroy(rkshare);
+}
+
+/**
+ * @brief Create a mock topic partition
+ */
+static rd_kafka_toppar_t *
+ut_create_mock_toppar(rd_kafka_t *rk, const char *topic, int32_t partition) {
+        rd_kafka_topic_t *rkt = rd_kafka_topic_new(rk, topic, NULL);
+        if (!rkt)
+                return NULL;
+        return rd_kafka_toppar_new(rkt, partition);
+}
+
+/**
+ * @brief Helper to write MessageSet v2 header fields in big-endian
+ */
+static void ut_write_msgset_v2_header(char *buf,
+                                      int64_t BaseOffset,
+                                      int32_t Length,
+                                      int32_t PartitionLeaderEpoch,
+                                      int8_t MagicByte,
+                                      int32_t Crc,
+                                      int16_t Attributes,
+                                      int32_t LastOffsetDelta,
+                                      int64_t BaseTimestamp,
+                                      int64_t MaxTimestamp,
+                                      int64_t ProducerId,
+                                      int16_t ProducerEpoch,
+                                      int32_t BaseSequence,
+                                      int32_t RecordCount) {
+        size_t offset = 0;
+
+        /* BaseOffset (int64) */
+        *(int64_t *)(buf + offset) = htobe64(BaseOffset);
+        offset += 8;
+
+        /* Length (int32) */
+        *(int32_t *)(buf + offset) = htobe32(Length);
+        offset += 4;
+
+        /* PartitionLeaderEpoch (int32) */
+        *(int32_t *)(buf + offset) = htobe32(PartitionLeaderEpoch);
+        offset += 4;
+
+        /* MagicByte (int8) */
+        *(int8_t *)(buf + offset) = MagicByte;
+        offset += 1;
+
+        /* Crc (int32) */
+        *(int32_t *)(buf + offset) = htobe32(Crc);
+        offset += 4;
+
+        /* Attributes (int16) */
+        *(int16_t *)(buf + offset) = htobe16(Attributes);
+        offset += 2;
+
+        /* LastOffsetDelta (int32) */
+        *(int32_t *)(buf + offset) = htobe32(LastOffsetDelta);
+        offset += 4;
+
+        /* BaseTimestamp (int64) */
+        *(int64_t *)(buf + offset) = htobe64(BaseTimestamp);
+        offset += 8;
+
+        /* MaxTimestamp (int64) */
+        *(int64_t *)(buf + offset) = htobe64(MaxTimestamp);
+        offset += 8;
+
+        /* ProducerId (int64) */
+        *(int64_t *)(buf + offset) = htobe64(ProducerId);
+        offset += 8;
+
+        /* ProducerEpoch (int16) */
+        *(int16_t *)(buf + offset) = htobe16(ProducerEpoch);
+        offset += 2;
+
+        /* BaseSequence (int32) */
+        *(int32_t *)(buf + offset) = htobe32(BaseSequence);
+        offset += 4;
+
+        /* RecordCount (int32) */
+        *(int32_t *)(buf + offset) = htobe32(RecordCount);
+        offset += 4;
+}
+
+#if WITH_ZSTD
+/**
+ * @brief Calculate correct CRC32C for MessageSet v2
+ *        CRC covers from Attributes to end of records
+ */
+static uint32_t ut_calc_msgset_crc(const char *buf,
+                                   size_t offset_to_attributes,
+                                   size_t total_len) {
+        /* CRC starts after MagicByte and Crc field itself */
+        const void *data = buf + offset_to_attributes;
+        size_t data_len  = total_len - offset_to_attributes;
+        return rd_crc32c(0, data, data_len);
+}
+#endif /* WITH_ZSTD */
+
+/**
+ * @brief Write a varint (used in Record format)
+ * @returns number of bytes written
+ */
+static size_t ut_write_varint(char *buf, int64_t value) {
+        uint64_t uval = (value << 1) ^ (value >> 63); /* Zigzag encoding */
+        size_t i      = 0;
+
+        while (uval >= 0x80) {
+                buf[i++] = (char)((uval & 0x7F) | 0x80);
+                uval >>= 7;
+        }
+        buf[i++] = (char)(uval & 0x7F);
+        return i;
+}
+
+/**
+ * @brief Build a minimal valid Record v2
+ * @returns size of record written
+ */
+static size_t ut_build_record_v2(char *buf,
+                                 int32_t offset_delta,
+                                 int64_t timestamp_delta,
+                                 const char *key,
+                                 size_t key_len,
+                                 const char *value,
+                                 size_t value_len) {
+        size_t offset = 0;
+        size_t len_offset;
+        int32_t key_len_varint = key ? (int32_t)key_len : -1;
+        int32_t val_len_varint = value ? (int32_t)value_len : -1;
+
+        /* Reserve space for Length (varint) - we'll fill this in later */
+        len_offset = offset;
+        offset += 5; /* Max varint size for record length */
+
+        /* Attributes (int8) */
+        buf[offset++] = 0;
+
+        /* TimestampDelta (varint) */
+        offset += ut_write_varint(buf + offset, timestamp_delta);
+
+        /* OffsetDelta (varint) */
+        offset += ut_write_varint(buf + offset, offset_delta);
+
+        /* KeyLen (varint) */
+        offset += ut_write_varint(buf + offset, key_len_varint);
+
+        /* Key bytes */
+        if (key) {
+                memcpy(buf + offset, key, key_len);
+                offset += key_len;
+        }
+
+        /* ValueLen (varint) */
+        offset += ut_write_varint(buf + offset, val_len_varint);
+
+        /* Value bytes */
+        if (value) {
+                memcpy(buf + offset, value, value_len);
+                offset += value_len;
+        }
+
+        /* Headers count (varint) - 0 headers */
+        offset += ut_write_varint(buf + offset, 0);
+
+        /* Calculate record length (everything after Length field) */
+        size_t record_body_len = offset - len_offset - 5;
+
+        /* Write actual Length at the beginning */
+        size_t len_size = ut_write_varint(buf + len_offset, record_body_len);
+
+        /* Compact the record if varint was smaller than 5 bytes */
+        if (len_size < 5) {
+                memmove(buf + len_offset + len_size, buf + len_offset + 5,
+                        record_body_len);
+                offset = len_offset + len_size + record_body_len;
+        }
+
+        return offset;
+}
+
+/**
+ * @brief Build a complete valid MessageSet v2 with records
+ * @returns total size of MessageSet
+ */
+static size_t ut_build_valid_msgset_v2(char *buf,
+                                       int64_t base_offset,
+                                       int32_t record_count,
+                                       const char **values,
+                                       size_t *value_lens) {
+        size_t offset       = 0;
+        size_t len_offset   = 8;
+        size_t records_size = 0;
+        int32_t i;
+        char *records_buf;
+        uint32_t crc;
+        int32_t last_offset_delta = record_count > 0 ? record_count - 1 : 0;
+
+        /* Build all records first to know total size */
+        records_buf = rd_calloc(1, 8192);
+        for (i = 0; i < record_count; i++) {
+                records_size += ut_build_record_v2(
+                    records_buf + records_size, i, /* offsetDelta */
+                    0,                             /* timestampDelta */
+                    NULL, 0,                       /* no key */
+                    values ? values[i] : NULL,
+                    values && value_lens ? value_lens[i] : 0);
+        }
+
+        /* BaseOffset */
+        *(int64_t *)(buf + offset) = htobe64(base_offset);
+        offset += 8;
+
+        /* Length - will update later */
+        len_offset = offset;
+        offset += 4;
+
+        /* PartitionLeaderEpoch */
+        *(int32_t *)(buf + offset) = htobe32(-1);
+        offset += 4;
+
+        /* MagicByte */
+        buf[offset++] = 2;
+
+        /* CRC - placeholder, will calculate later */
+        size_t crc_offset = offset;
+        offset += 4;
+
+        /* Attributes (no compression) */
+        *(int16_t *)(buf + offset) = htobe16(0);
+        offset += 2;
+
+        /* LastOffsetDelta */
+        *(int32_t *)(buf + offset) = htobe32(last_offset_delta);
+        offset += 4;
+
+        /* BaseTimestamp */
+        *(int64_t *)(buf + offset) = htobe64(0);
+        offset += 8;
+
+        /* MaxTimestamp */
+        *(int64_t *)(buf + offset) = htobe64(0);
+        offset += 8;
+
+        /* ProducerId */
+        *(int64_t *)(buf + offset) = htobe64(-1);
+        offset += 8;
+
+        /* ProducerEpoch */
+        *(int16_t *)(buf + offset) = htobe16(-1);
+        offset += 2;
+
+        /* BaseSequence */
+        *(int32_t *)(buf + offset) = htobe32(-1);
+        offset += 4;
+
+        /* RecordCount */
+        *(int32_t *)(buf + offset) = htobe32(record_count);
+        offset += 4;
+
+        /* Copy records */
+        memcpy(buf + offset, records_buf, records_size);
+        offset += records_size;
+        rd_free(records_buf);
+
+        /* Calculate and write Length */
+        int32_t length                 = (int32_t)(offset - len_offset - 4);
+        *(int32_t *)(buf + len_offset) = htobe32(length);
+
+        /* Calculate and write CRC (covers Attributes to end) */
+        crc = rd_crc32c(0, buf + crc_offset + 4, offset - crc_offset - 4);
+        *(int32_t *)(buf + crc_offset) = htobe32(crc);
+
+        return offset;
+}
+
+/**@}*/
+
+
+/**
+ * @brief Test CRC error generates per-offset error ops with REJECT ack_type
+ *
+ * Creates a MessageSet v2 with intentionally wrong CRC and verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has REJECT ack_type
+ * - Error code is RD_KAFKA_RESP_ERR__BAD_MSG
+ */
+static int unittest_msgset_crc_error_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset = 100;
+        int32_t LastOffsetDelta =
+            4; /* Offsets 100-104 inclusive = 5 messages */
+        int expected_err_ops = 5;
+        int i;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-crc", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet v2 with wrong CRC */
+        /* MessageSet v2 structure:
+         * - BaseOffset (8) + Length (4) = 12 bytes before "Length" data starts
+         * - Length field contains size of: PartitionLeaderEpoch (4) + MagicByte
+         * (1)
+         *   + Crc (4) + Attributes (2) + LastOffsetDelta (4) + BaseTimestamp
+         * (8)
+         *   + MaxTimestamp (8) + ProducerId (8) + ProducerEpoch (2)
+         *   + BaseSequence (4) + RecordCount (4) + Records
+         * - Minimum Length = 49 (just the header fields after Length)
+         * - For this test, we need enough space for CRC validation
+         */
+
+        /* CRC validation needs: crc_len = Length - 4 - 1 - 4 bytes available
+         * after reading up to Crc field (21 bytes read so far) */
+        int32_t Length = 61 - 12;     /* Minimum: just the header, no records */
+        msgset_size    = 12 + Length; /* BaseOffset + Length + data */
+        msgset_data    = rd_calloc(1, msgset_size);
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length,     /* Length of data after BaseOffset+Length fields */
+            -1,         /* PartitionLeaderEpoch */
+            2,          /* MagicByte v2 */
+            0xDEADBEEF, /* WRONG CRC - will trigger error */
+            0,          /* Attributes: no compression */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            5 /* RecordCount */);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect CRC error */
+        rd_kafka_resp_err_t parse_err =
+            rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        RD_UT_ASSERT(parse_err == RD_KAFKA_RESP_ERR_NO_ERROR ||
+                         parse_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                     "Unexpected parse error: %s", rd_kafka_err2str(parse_err));
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for CRC error, got %d",
+                             rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko;
+                rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Got unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test decompression error generates per-offset error ops with RELEASE
+ *
+ * Creates a MessageSet v2 with ZSTD compression but corrupted compressed data.
+ * Verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has RELEASE ack_type (retryable error)
+ * - Error code is RD_KAFKA_RESP_ERR__BAD_COMPRESSION
+ */
+static int unittest_msgset_decompression_error_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset = 200;
+        int32_t LastOffsetDelta =
+            2; /* Offsets 200-202 inclusive = 3 messages */
+        int expected_err_ops = 3;
+        int i;
+        uint32_t correct_crc;
+        size_t crc_offset = 17; /* Offset to CRC field in header */
+        size_t attr_offset =
+            21; /* Offset to Attributes field (where CRC starts) */
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk,
+                                     "test-topic-decompress", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet v2 with ZSTD compression but corrupted data */
+        msgset_size = 200;
+        msgset_data = rd_calloc(1, msgset_size);
+
+        int32_t Length = msgset_size - 12;
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length, /* Length of data after BaseOffset+Length fields */
+            -1,     /* PartitionLeaderEpoch */
+            2,      /* MagicByte v2 */
+            0,      /* CRC - will calculate correct one below */
+            4,      /* Attributes: ZSTD compression (codec=4) */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            3 /* RecordCount */);
+
+        /* Fill records section with garbage (corrupted ZSTD data) */
+        memset(msgset_data + 61, 0xAB, msgset_size - 61);
+
+        /* Calculate CORRECT CRC so we pass CRC check but fail decompression */
+        correct_crc = ut_calc_msgset_crc(msgset_data, attr_offset, msgset_size);
+        *(int32_t *)(msgset_data + crc_offset) = htobe32(correct_crc);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect decompression error */
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Expected RELEASE ack_type for decompression error, got %d",
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Test unsupported MagicByte generates per-offset error ops with REJECT
+ *
+ * Creates a MessageSet with MagicByte=99 (unsupported future version).
+ * Verifies:
+ * - One error op per offset in range [BaseOffset, LastOffset]
+ * - Each error op has REJECT ack_type (permanent error)
+ * - Error code is RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED
+ */
+static int unittest_msgset_unsupported_magic_share_consumer(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *msgset_data;
+        size_t msgset_size;
+        int64_t BaseOffset = 300;
+        int32_t LastOffsetDelta =
+            9; /* Offsets 300-309 inclusive = 10 messages */
+        int expected_err_ops = 10;
+        int i;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-magic", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+
+        /* Craft MessageSet with unsupported MagicByte */
+        msgset_size = 200;
+        msgset_data = rd_calloc(1, msgset_size);
+
+        int32_t Length = msgset_size - 12;
+
+        ut_write_msgset_v2_header(
+            msgset_data, BaseOffset,
+            Length, /* Length of data after BaseOffset+Length fields */
+            -1,     /* PartitionLeaderEpoch */
+            99,     /* UNSUPPORTED MagicByte - will trigger error */
+            0,      /* CRC - doesn't matter, won't get that far */
+            0,      /* Attributes */
+            LastOffsetDelta, 0, /* BaseTimestamp */
+            0,                  /* MaxTimestamp */
+            -1,                 /* ProducerId */
+            -1,                 /* ProducerEpoch */
+            -1,                 /* BaseSequence */
+            10 /* RecordCount */);
+
+        /* Create shadow buffer from raw data */
+        rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        /* Parse the MessageSet - should detect unsupported MagicByte */
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify we got expected number of error ops */
+        for (i = 0; i < expected_err_ops; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected error op %d of %d, got timeout", i + 1,
+                             expected_err_ops);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == BaseOffset + i,
+                             "Expected offset %" PRId64 ", got %" PRId64,
+                             BaseOffset + i, rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                    "Expected REJECT ack_type for unsupported MagicByte, got "
+                    "%d",
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test mixed scenario: Success → CRC Error → Success
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: 3 successful messages (offsets 100-102)
+ * - MessageSet 2: CRC error covering 5 messages (offsets 103-107)
+ * - MessageSet 3: 2 successful messages (offsets 108-109)
+ */
+static int unittest_msgset_mixed_success_crc_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[] = {"msg1", "msg2", "msg3", "msg4", "msg5"};
+        size_t value_lens[]  = {4, 4, 4, 4, 4};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: Valid with 3 messages (offsets 100-102) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 100, 3, values,
+                                           value_lens);
+
+        /* MessageSet 2: CRC error with 5 messages (offsets 103-107) */
+        int64_t BaseOffset2      = 103;
+        int32_t LastOffsetDelta2 = 4;
+        int32_t Length2          = 61 - 12; /* Just header */
+        ut_write_msgset_v2_header(buffer + offset, BaseOffset2, Length2, -1, 2,
+                                  0xBADC0C, /* Wrong CRC */
+                                  0, LastOffsetDelta2, 0, 0, -1, -1, -1, 5);
+        offset += 12 + Length2;
+
+        /* MessageSet 3: Valid with 2 messages (offsets 108-109) */
+        const char *values3[] = {"msg6", "msg7"};
+        size_t value_lens3[]  = {4, 4};
+        offset += ut_build_valid_msgset_v2(buffer + offset, 108, 2, values3,
+                                           value_lens3);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 3 FETCH ops with offsets 100-102 */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 100 + i,
+                             "Expected offset %d, got %" PRId64, 100 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 5 CONSUMER_ERR ops with offsets 103-107 */
+        for (i = 0; i < 5; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected CRC error op %d, got timeout", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG error, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 103 + i,
+                             "Expected offset %d, got %" PRId64, 103 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 2 FETCH ops with offsets 108-109 */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i + 3);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 108 + i,
+                             "Expected offset %d, got %" PRId64, 108 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test mixed scenario: CRC Error → Success → Decompression Error
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: CRC error covering 2 messages (offsets 200-201)
+ * - MessageSet 2: 4 successful messages (offsets 202-205)
+ * - MessageSet 3: Decompression error covering 3 messages (offsets 206-208)
+ */
+static int unittest_msgset_mixed_crc_success_decomp(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[]            = {"a", "b", "c", "d"};
+        size_t value_lens[]             = {1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed2", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error with 2 messages (offsets 200-201) */
+        ut_write_msgset_v2_header(buffer + offset, 200, 61 - 12, -1, 2,
+                                  0xDEADC0C, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 2: Valid with 4 messages (offsets 202-205) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 202, 4, values,
+                                           value_lens);
+
+        /* MessageSet 3: Decompression error with 3 messages (offsets 206-208)
+         */
+        char corrupted_data[16] = {0xDE, 0xAD, 0xBE, 0xEF}; /* Garbage */
+        size_t decomp_start     = offset;
+        ut_write_msgset_v2_header(buffer + offset, 206,
+                                  49 + sizeof(corrupted_data), -1, 2, 0,
+                                  4, /* ZSTD compression */
+                                  2, 0, 0, -1, -1, -1, 3);
+        offset += 61;
+        memcpy(buffer + offset, corrupted_data, sizeof(corrupted_data));
+        offset += sizeof(corrupted_data);
+        /* Fix CRC for decompression error (CRC is valid, data is corrupt) */
+        uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
+                                 49 + sizeof(corrupted_data) - 4 - 1 - 4);
+        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 2 CRC error ops (offsets 200-201) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 4 successful FETCH ops (offsets 202-205) */
+        for (i = 0; i < 4; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 202 + i,
+                             "Expected offset %d", 202 + i);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 3 decompression error ops (offsets 206-208) */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected decomp error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                             "Expected RELEASE");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Test mixed scenario: Unsupported Magic → Success → CRC Error → Success
+ *
+ * Verifies parser correctly handles:
+ * - MessageSet 1: Unsupported MagicByte covering 3 messages (offsets 300-302)
+ * - MessageSet 2: 1 successful message (offset 303)
+ * - MessageSet 3: CRC error covering 2 messages (offsets 304-305)
+ * - MessageSet 4: 5 successful messages (offsets 306-310)
+ */
+static int unittest_msgset_mixed_magic_success_crc_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *value1              = "x";
+        size_t value_len1               = 1;
+        const char *values5[]           = {"a", "b", "c", "d", "e"};
+        size_t value_lens5[]            = {1, 1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-mixed3", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: Unsupported MagicByte=99, 3 messages (offsets 300-302)
+         */
+        ut_write_msgset_v2_header(buffer + offset, 300, 61 - 12, -1,
+                                  99, /* Unsupported */
+                                  0, 0, 2, 0, 0, -1, -1, -1, 3);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 2: Valid with 1 message (offset 303) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 303, 1, &value1,
+                                           &value_len1);
+
+        /* MessageSet 3: CRC error, 2 messages (offsets 304-305) */
+        ut_write_msgset_v2_header(buffer + offset, 304, 61 - 12, -1, 2,
+                                  0xBADBAD, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 12 + (61 - 12);
+
+        /* MessageSet 4: Valid with 5 messages (offsets 306-310) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 306, 5, values5,
+                                           value_lens5);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 3 unsupported magic error ops (offsets 300-302)
+         */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 1 successful FETCH op (offset 303) */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 303,
+                             "Expected offset 303");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 2 CRC error ops (offsets 304-305) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 4: 5 successful FETCH ops (offsets 306-310) */
+        for (i = 0; i < 5; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op");
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 306 + i,
+                             "Expected offset %d", 306 + i);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test all successful MessageSets
+ *
+ * Verifies parser correctly handles multiple consecutive successful
+ * MessageSets:
+ * - MessageSet 1: 2 messages (offsets 400-401)
+ * - MessageSet 2: 3 messages (offsets 402-404)
+ * - MessageSet 3: 1 message (offset 405)
+ * - MessageSet 4: 4 messages (offsets 406-409)
+ */
+static int unittest_msgset_all_success(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values2[]           = {"m1", "m2"};
+        size_t value_lens2[]            = {2, 2};
+        const char *values3[]           = {"m3", "m4", "m5"};
+        size_t value_lens3[]            = {2, 2, 2};
+        const char *value1              = "m6";
+        size_t value_len1               = 2;
+        const char *values4[]           = {"m7", "m8", "m9", "m10"};
+        size_t value_lens4[]            = {2, 2, 2, 3};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-success", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* Build 4 valid MessageSets */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 400, 2, values2,
+                                           value_lens2);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 402, 3, values3,
+                                           value_lens3);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 405, 1, &value1,
+                                           &value_len1);
+        offset += ut_build_valid_msgset_v2(buffer + offset, 406, 4, values4,
+                                           value_lens4);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify all 10 messages received successfully (offsets 400-409) */
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d, got timeout",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 400 + i,
+                             "Expected offset %d, got %" PRId64, 400 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+/**
+ * @brief Test all error MessageSets in sequence
+ *
+ * Verifies parser correctly handles consecutive errors:
+ * - MessageSet 1: CRC error, 2 messages (offsets 500-501)
+ * - MessageSet 2: Unsupported MagicByte, 1 message (offset 502)
+ * - MessageSet 3: CRC error, 3 messages (offsets 503-505)
+ */
+static int unittest_msgset_all_errors(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 4096;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp =
+            ut_create_mock_toppar(rkshare->rkshare_rk, "test-topic-errors", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error, 2 messages (offsets 500-501) */
+        ut_write_msgset_v2_header(buffer + offset, 500, 61 - 12, -1, 2,
+                                  0xBADC001, 0, 1, 0, 0, -1, -1, -1, 2);
+        offset += 61;
+
+        /* MessageSet 2: Unsupported MagicByte, 1 message (offset 502) */
+        ut_write_msgset_v2_header(buffer + offset, 502, 61 - 12, -1, 99, 0, 0,
+                                  0, 0, 0, -1, -1, -1, 1);
+        offset += 61;
+
+        /* MessageSet 3: CRC error, 3 messages (offsets 503-505) */
+        ut_write_msgset_v2_header(buffer + offset, 503, 61 - 12, -1, 2,
+                                  0xBADC002, 0, 2, 0, 0, -1, -1, -1, 3);
+        offset += 61;
+
+        RD_UT_SAY("Buffer size: %zu bytes", offset);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_resp_err_t parse_err =
+            rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        RD_UT_SAY("Parse returned: %s", rd_kafka_err2str(parse_err));
+
+        /* Verify MessageSet 1: 2 CRC error ops (offsets 500-501) */
+        for (i = 0; i < 2; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 1 unsupported magic error op (offset 502) */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op");
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 3 CRC error ops (offsets 503-505) */
+        for (i = 0; i < 3; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected CRC error op %d", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR");
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+
+
+#if WITH_ZSTD
+/**
+ * @brief Test all 3 error types interleaved with valid messages
+ *
+ * Verifies parser continues through all error types:
+ * - MessageSet 1: CRC error (10 messages, offsets 0-9)
+ * - MessageSet 2: Valid (10 messages, offsets 10-19)
+ * - MessageSet 3: Decompression error (10 messages, offsets 20-29)
+ * - MessageSet 4: Valid (10 messages, offsets 30-39)
+ * - MessageSet 5: Unsupported MagicByte (10 messages, offsets 40-49)
+ * - MessageSet 6: Valid (10 messages, offsets 50-59)
+ *
+ * This is the critical test case: all batches must be processed,
+ * with valid messages delivered even after errors.
+ */
+static int unittest_msgset_all_error_types_with_valid(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_toppar_t *rktp;
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_q_t *response_q;
+        char *buffer;
+        size_t buffer_size              = 8192;
+        size_t offset                   = 0;
+        struct rd_kafka_toppar_ver tver = {.version = 11};
+        const char *values[]            = {"a", "b", "c", "d", "e",
+                                           "f", "g", "h", "i", "j"};
+        size_t value_lens[]             = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+        int i;
+
+        RD_UT_BEGIN();
+
+        rkshare = ut_create_test_share_consumer();
+        RD_UT_ASSERT(rkshare, "Failed to create share consumer");
+
+        rktp = ut_create_mock_toppar(rkshare->rkshare_rk,
+                                     "test-topic-all-errors", 0);
+        RD_UT_ASSERT(rktp, "Failed to create toppar");
+
+        response_q = rd_kafka_q_new(rkshare->rkshare_rk);
+        buffer     = rd_calloc(1, buffer_size);
+
+        /* MessageSet 1: CRC error with 10 messages (offsets 0-9) */
+        ut_write_msgset_v2_header(buffer + offset, 0, 100, -1, 2, 0xBADC0001, 0,
+                                  9, 0, 0, -1, -1, -1, 10);
+        offset += 112;
+
+        /* MessageSet 2: Valid with 10 messages (offsets 10-19) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 10, 10, values,
+                                           value_lens);
+
+        /* MessageSet 3: Decompression error with 10 messages (offsets 20-29) */
+        char corrupted_data[32];
+        memset(corrupted_data, 0xDE, sizeof(corrupted_data));
+        size_t decomp_start = offset;
+        ut_write_msgset_v2_header(buffer + offset, 20,
+                                  49 + sizeof(corrupted_data), -1, 2, 0,
+                                  4, /* ZSTD compression */
+                                  9, 0, 0, -1, -1, -1, 10);
+        offset += 61;
+        memcpy(buffer + offset, corrupted_data, sizeof(corrupted_data));
+        offset += sizeof(corrupted_data);
+        /* Fix CRC for decompression error (CRC valid, data corrupt) */
+        uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
+                                 49 + sizeof(corrupted_data) - 4 - 1 - 4);
+        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+
+        /* MessageSet 4: Valid with 10 messages (offsets 30-39) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 30, 10, values,
+                                           value_lens);
+
+        /* MessageSet 5: Unsupported MagicByte with 10 messages (offsets 40-49)
+         */
+        ut_write_msgset_v2_header(buffer + offset, 40, 100, -1,
+                                  99, /* Bad magic */
+                                  0, 0, 9, 0, 0, -1, -1, -1, 10);
+        offset += 112;
+
+        /* MessageSet 6: Valid with 10 messages (offsets 50-59) */
+        offset += ut_build_valid_msgset_v2(buffer + offset, 50, 10, values,
+                                           value_lens);
+
+        RD_UT_SAY("Total buffer size: %zu bytes, 6 MessageSets", offset);
+
+        /* Parse all MessageSets */
+        rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
+        rkbuf->rkbuf_rkb = rd_kafka_broker_internal(rkshare->rkshare_rk);
+
+        rd_kafka_share_msgset_parse(rkbuf, rktp, NULL, &tver, response_q);
+
+        /* Verify MessageSet 1: 10 CRC error ops (offsets 0-9) */
+        RD_UT_SAY("Verifying MessageSet 1: CRC errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected CRC error op %d of 10, got timeout", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_MSG,
+                             "Expected BAD_MSG, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 0 + i,
+                             "Expected offset %d, got %" PRId64, i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for CRC error");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 2: 10 successful FETCH ops (offsets 10-19) */
+        RD_UT_SAY("Verifying MessageSet 2: Valid messages");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected FETCH op %d of 10", i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 10 + i,
+                             "Expected offset %d, got %" PRId64, 10 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 3: 10 decompression error ops (offsets 20-29) */
+        RD_UT_SAY("Verifying MessageSet 3: Decompression errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected decomp error op %d of 10",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__BAD_COMPRESSION,
+                             "Expected BAD_COMPRESSION, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 20 + i,
+                             "Expected offset %d, got %" PRId64, 20 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(
+                    rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                        RD_KAFKA_SHARE_INTERNAL_ACK_RELEASE,
+                    "Expected RELEASE ack_type for decompression error");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 4: 10 successful FETCH ops (offsets 30-39) */
+        RD_UT_SAY("Verifying MessageSet 4: Valid messages after decomp error");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL,
+                             "Expected FETCH op %d of 10 after decomp error, "
+                             "got timeout "
+                             "(BUG: parser stopped!)",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 30 + i,
+                             "Expected offset %d, got %" PRId64, 30 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 5: 10 unsupported magic error ops (offsets 40-49)
+         */
+        RD_UT_SAY("Verifying MessageSet 5: Unsupported MagicByte errors");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(rko != NULL, "Expected magic error op %d of 10",
+                             i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR,
+                             "Expected CONSUMER_ERR, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_err == RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED,
+                             "Expected NOT_IMPLEMENTED, got %s",
+                             rd_kafka_err2str(rko->rko_err));
+                RD_UT_ASSERT(rko->rko_u.err.offset == 40 + i,
+                             "Expected offset %d, got %" PRId64, 40 + i,
+                             rko->rko_u.err.offset);
+                RD_UT_ASSERT(rko->rko_u.err.rkm.rkm_u.consumer.ack_type ==
+                                 RD_KAFKA_SHARE_INTERNAL_ACK_REJECT,
+                             "Expected REJECT ack_type for unsupported magic");
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify MessageSet 6: 10 successful FETCH ops (offsets 50-59) */
+        RD_UT_SAY("Verifying MessageSet 6: Valid messages after magic error");
+        for (i = 0; i < 10; i++) {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 1000, 0);
+                RD_UT_ASSERT(
+                    rko != NULL,
+                    "Expected FETCH op %d of 10 after magic error, got timeout "
+                    "(BUG: parser stopped!)",
+                    i);
+                RD_UT_ASSERT(rko->rko_type == RD_KAFKA_OP_FETCH,
+                             "Expected FETCH op, got %d", rko->rko_type);
+                RD_UT_ASSERT(rko->rko_u.fetch.rkm.rkm_offset == 50 + i,
+                             "Expected offset %d, got %" PRId64, 50 + i,
+                             rko->rko_u.fetch.rkm.rkm_offset);
+                rd_kafka_op_destroy(rko);
+        }
+
+        /* Verify no extra ops */
+        {
+                rd_kafka_op_t *rko = rd_kafka_q_pop(response_q, 100, 0);
+                RD_UT_ASSERT(rko == NULL, "Unexpected extra op");
+        }
+
+        RD_UT_SAY(
+            "SUCCESS: All 6 MessageSets processed correctly (60 ops total)");
+
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_q_destroy_owner(response_q);
+        rd_kafka_toppar_destroy(rktp);
+        ut_destroy_share_consumer(rkshare);
+
+        RD_UT_PASS();
+}
+#endif /* WITH_ZSTD */
+
+
+/**
+ * @brief Run all MessageSet error handling unit tests
+ */
+int rd_kafka_unittest_msgset_errors(void) {
+        int fails = 0;
+
+        /* Individual error type tests */
+        fails += unittest_msgset_crc_error_share_consumer();
+#if WITH_ZSTD
+        fails += unittest_msgset_decompression_error_share_consumer();
+#endif
+        fails += unittest_msgset_unsupported_magic_share_consumer();
+
+        /* Mixed scenario tests */
+        fails += unittest_msgset_mixed_success_crc_success();
+#if WITH_ZSTD
+        fails += unittest_msgset_mixed_crc_success_decomp();
+#endif
+        fails += unittest_msgset_mixed_magic_success_crc_success();
+        fails += unittest_msgset_all_success();
+        fails += unittest_msgset_all_errors();
+
+        /* Comprehensive test: all error types with valid messages */
+#if WITH_ZSTD
+        fails += unittest_msgset_all_error_types_with_valid();
+#endif
+
+        return fails;
+}

--- a/src/rdunittest_msgset_errors.c
+++ b/src/rdunittest_msgset_errors.c
@@ -56,6 +56,29 @@
 
 
 /**
+ * @brief Alignment-safe big-endian writers.
+ *
+ * The msgset crafting helpers below write into a char buffer at arbitrary
+ * offsets. Casting `char *` to `int{16,32,64}_t *` triggers -Wcast-align
+ * on stricter targets (and is undefined behaviour even on x86 strictly
+ * speaking). Use memcpy() — the compiler lowers it to a single move on
+ * supported architectures.
+ */
+static RD_INLINE void ut_put_be16(void *p, int16_t v) {
+        int16_t be = htobe16(v);
+        memcpy(p, &be, sizeof(be));
+}
+static RD_INLINE void ut_put_be32(void *p, int32_t v) {
+        int32_t be = htobe32(v);
+        memcpy(p, &be, sizeof(be));
+}
+static RD_INLINE void ut_put_be64(void *p, int64_t v) {
+        int64_t be = htobe64(v);
+        memcpy(p, &be, sizeof(be));
+}
+
+
+/**
  * @name Test helpers
  * @{
  */
@@ -123,15 +146,15 @@ static void ut_write_msgset_v2_header(char *buf,
         size_t offset = 0;
 
         /* BaseOffset (int64) */
-        *(int64_t *)(buf + offset) = htobe64(BaseOffset);
+        ut_put_be64(buf + offset, BaseOffset);
         offset += 8;
 
         /* Length (int32) */
-        *(int32_t *)(buf + offset) = htobe32(Length);
+        ut_put_be32(buf + offset, Length);
         offset += 4;
 
         /* PartitionLeaderEpoch (int32) */
-        *(int32_t *)(buf + offset) = htobe32(PartitionLeaderEpoch);
+        ut_put_be32(buf + offset, PartitionLeaderEpoch);
         offset += 4;
 
         /* MagicByte (int8) */
@@ -139,39 +162,39 @@ static void ut_write_msgset_v2_header(char *buf,
         offset += 1;
 
         /* Crc (int32) */
-        *(int32_t *)(buf + offset) = htobe32(Crc);
+        ut_put_be32(buf + offset, Crc);
         offset += 4;
 
         /* Attributes (int16) */
-        *(int16_t *)(buf + offset) = htobe16(Attributes);
+        ut_put_be16(buf + offset, Attributes);
         offset += 2;
 
         /* LastOffsetDelta (int32) */
-        *(int32_t *)(buf + offset) = htobe32(LastOffsetDelta);
+        ut_put_be32(buf + offset, LastOffsetDelta);
         offset += 4;
 
         /* BaseTimestamp (int64) */
-        *(int64_t *)(buf + offset) = htobe64(BaseTimestamp);
+        ut_put_be64(buf + offset, BaseTimestamp);
         offset += 8;
 
         /* MaxTimestamp (int64) */
-        *(int64_t *)(buf + offset) = htobe64(MaxTimestamp);
+        ut_put_be64(buf + offset, MaxTimestamp);
         offset += 8;
 
         /* ProducerId (int64) */
-        *(int64_t *)(buf + offset) = htobe64(ProducerId);
+        ut_put_be64(buf + offset, ProducerId);
         offset += 8;
 
         /* ProducerEpoch (int16) */
-        *(int16_t *)(buf + offset) = htobe16(ProducerEpoch);
+        ut_put_be16(buf + offset, ProducerEpoch);
         offset += 2;
 
         /* BaseSequence (int32) */
-        *(int32_t *)(buf + offset) = htobe32(BaseSequence);
+        ut_put_be32(buf + offset, BaseSequence);
         offset += 4;
 
         /* RecordCount (int32) */
-        *(int32_t *)(buf + offset) = htobe32(RecordCount);
+        ut_put_be32(buf + offset, RecordCount);
         offset += 4;
 }
 
@@ -301,7 +324,7 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         }
 
         /* BaseOffset */
-        *(int64_t *)(buf + offset) = htobe64(base_offset);
+        ut_put_be64(buf + offset, base_offset);
         offset += 8;
 
         /* Length - will update later */
@@ -309,7 +332,7 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         offset += 4;
 
         /* PartitionLeaderEpoch */
-        *(int32_t *)(buf + offset) = htobe32(-1);
+        ut_put_be32(buf + offset, -1);
         offset += 4;
 
         /* MagicByte */
@@ -320,35 +343,35 @@ static size_t ut_build_valid_msgset_v2(char *buf,
         offset += 4;
 
         /* Attributes (no compression) */
-        *(int16_t *)(buf + offset) = htobe16(0);
+        ut_put_be16(buf + offset, 0);
         offset += 2;
 
         /* LastOffsetDelta */
-        *(int32_t *)(buf + offset) = htobe32(last_offset_delta);
+        ut_put_be32(buf + offset, last_offset_delta);
         offset += 4;
 
         /* BaseTimestamp */
-        *(int64_t *)(buf + offset) = htobe64(0);
+        ut_put_be64(buf + offset, 0);
         offset += 8;
 
         /* MaxTimestamp */
-        *(int64_t *)(buf + offset) = htobe64(0);
+        ut_put_be64(buf + offset, 0);
         offset += 8;
 
         /* ProducerId */
-        *(int64_t *)(buf + offset) = htobe64(-1);
+        ut_put_be64(buf + offset, -1);
         offset += 8;
 
         /* ProducerEpoch */
-        *(int16_t *)(buf + offset) = htobe16(-1);
+        ut_put_be16(buf + offset, -1);
         offset += 2;
 
         /* BaseSequence */
-        *(int32_t *)(buf + offset) = htobe32(-1);
+        ut_put_be32(buf + offset, -1);
         offset += 4;
 
         /* RecordCount */
-        *(int32_t *)(buf + offset) = htobe32(record_count);
+        ut_put_be32(buf + offset, record_count);
         offset += 4;
 
         /* Copy records */
@@ -358,11 +381,11 @@ static size_t ut_build_valid_msgset_v2(char *buf,
 
         /* Calculate and write Length */
         int32_t length                 = (int32_t)(offset - len_offset - 4);
-        *(int32_t *)(buf + len_offset) = htobe32(length);
+        ut_put_be32(buf + len_offset, length);
 
         /* Calculate and write CRC (covers Attributes to end) */
         crc = rd_crc32c(0, buf + crc_offset + 4, offset - crc_offset - 4);
-        *(int32_t *)(buf + crc_offset) = htobe32(crc);
+        ut_put_be32(buf + crc_offset, crc);
 
         return offset;
 }
@@ -548,7 +571,7 @@ static int unittest_msgset_decompression_error_share_consumer(void) {
 
         /* Calculate CORRECT CRC so we pass CRC check but fail decompression */
         correct_crc = ut_calc_msgset_crc(msgset_data, attr_offset, msgset_size);
-        *(int32_t *)(msgset_data + crc_offset) = htobe32(correct_crc);
+        ut_put_be32(msgset_data + crc_offset, correct_crc);
 
         /* Create shadow buffer from raw data */
         rkbuf = rd_kafka_buf_new_shadow(msgset_data, msgset_size, rd_free);
@@ -869,7 +892,7 @@ static int unittest_msgset_mixed_crc_success_decomp(void) {
         /* Fix CRC for decompression error (CRC is valid, data is corrupt) */
         uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
                                  49 + sizeof(corrupted_data) - 4 - 1 - 4);
-        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+        ut_put_be32(buffer + decomp_start + 17, crc);
 
         /* Parse all MessageSets */
         rkbuf            = rd_kafka_buf_new_shadow(buffer, offset, rd_free);
@@ -1314,7 +1337,7 @@ static int unittest_msgset_all_error_types_with_valid(void) {
         /* Fix CRC for decompression error (CRC valid, data corrupt) */
         uint32_t crc = rd_crc32c(0, buffer + decomp_start + 21,
                                  49 + sizeof(corrupted_data) - 4 - 1 - 4);
-        *(int32_t *)(buffer + decomp_start + 17) = htobe32(crc);
+        ut_put_be32(buffer + decomp_start + 17, crc);
 
         /* MessageSet 4: Valid with 10 messages (offsets 30-39) */
         offset += ut_build_valid_msgset_v2(buffer + offset, 30, 10, values,

--- a/win32/librdkafka.vcxproj
+++ b/win32/librdkafka.vcxproj
@@ -254,6 +254,7 @@
     <ClCompile Include="..\src\rdunittest.c" />
     <ClCompile Include="..\src\rdunittest_acknowledge.c" />
     <ClCompile Include="..\src\rdunittest_fetcher.c" />
+    <ClCompile Include="..\src\rdunittest_msgset_errors.c" />
     <ClCompile Include="..\src\rdvarint.c" />
     <ClCompile Include="..\src\rdmap.c" />
     <ClCompile Include="..\src\snappy.c" />


### PR DESCRIPTION
### Add comprehensive MessageSet error handling and added unit tests
Add unit tests for share consumer MessageSet error handling covering:
- CRC errors (REJECT ack_type)
- Decompression errors (RELEASE ack_type)
- Unsupported MagicByte errors (REJECT ack_type)
- Mixed scenarios: success/error state transitions
- Multiple consecutive errors and successes