### PR TITLE
[KIP-932] Mock Broker : Minor fixes for ack workflow of Share Consumer

### DIFF
--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3760,9 +3760,21 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
         if (!pmeta)
                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
+        /* Pass 1: Validate all offsets in the range.
+         * Acks for a partition in a single request are atomic —
+         * all succeed or all fail together. */
         for (offset = first_offset; offset <= last_offset; offset++) {
-                rd_kafka_mock_sgrp_record_state_t *state =
-                    rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
+                rd_kafka_mock_sgrp_record_state_t *state;
+
+                /* Offsets below SPSO are already logically archived
+                 * (e.g. due to log retention).  Acks for such
+                 * records are silently accepted — no error is
+                 * thrown for a record that is about to become
+                 * Archived. */
+                if (offset < pmeta->spso)
+                        continue;
+
+                state = rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
                 if (!state)
                         continue;
 
@@ -3775,30 +3787,48 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                     !state->owner_member_id ||
                     rd_kafkap_str_cmp_str(member_id, state->owner_member_id)) {
                         err = RD_KAFKA_RESP_ERR_INVALID_RECORD_STATE;
-                        continue;
+                        break;
                 }
+        }
 
-                switch (ack_type) {
-                case 1: /* ACCEPT -> Acknowledged */
-                        pmeta->acquired_cnt--;
-                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
-                        rd_free(state->owner_member_id);
-                        state->owner_member_id = NULL;
-                        state->lock_expiry_ts  = 0;
-                        break;
-                case 0: /* GAP -> Archived */
-                case 3: /* REJECT -> Archived */
-                        pmeta->acquired_cnt--;
-                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
-                        rd_free(state->owner_member_id);
-                        state->owner_member_id = NULL;
-                        state->lock_expiry_ts  = 0;
-                        break;
-                case 2: /* RELEASE */
-                        rd_kafka_mock_sgrp_record_release(sgrp, pmeta, state);
-                        break;
-                default:
-                        break;
+        /* Pass 2: Apply state transitions only if validation passed. */
+        if (!err) {
+                for (offset = first_offset; offset <= last_offset; offset++) {
+                        rd_kafka_mock_sgrp_record_state_t *state;
+
+                        if (offset < pmeta->spso)
+                                continue;
+
+                        state = rd_kafka_mock_sgrp_record_state_find(pmeta,
+                                                                     offset);
+                        if (!state)
+                                continue;
+
+                        switch (ack_type) {
+                        case 1: /* ACCEPT -> Acknowledged */
+                                pmeta->acquired_cnt--;
+                                state->state =
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
+                                rd_free(state->owner_member_id);
+                                state->owner_member_id = NULL;
+                                state->lock_expiry_ts  = 0;
+                                break;
+                        case 0: /* GAP -> Archived */
+                        case 3: /* REJECT -> Archived */
+                                pmeta->acquired_cnt--;
+                                state->state =
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                                rd_free(state->owner_member_id);
+                                state->owner_member_id = NULL;
+                                state->lock_expiry_ts  = 0;
+                                break;
+                        case 2: /* RELEASE */
+                                rd_kafka_mock_sgrp_record_release(sgrp, pmeta,
+                                                                  state);
+                                break;
+                        default:
+                                break;
+                        }
                 }
         }
 
@@ -4189,6 +4219,19 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         session->session_epoch++;
                 }
 
+                /* epoch=-1 (final fetch / close session) must not
+                 * contain ForgottenTopicsData.  Partitions
+                 * in the Topics array ARE allowed — they carry
+                 * piggybacked acks for the final request. */
+                if (!err && SessionEpoch == -1 &&
+                    (forgotten_partitions && forgotten_partitions->cnt > 0)) {
+                        rd_kafka_dbg(
+                            mconn->broker->cluster->rk, MOCK, "MOCK",
+                            "ShareFetch: rejecting epoch=-1 request "
+                            "with ForgottenTopicsData (INVALID_REQUEST)");
+                        err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+                }
+
                 /* Apply piggy-backed acknowledgements BEFORE forgotten
                  * partition processing, so that acks for partitions
                  * being removed are applied while the records are still
@@ -4260,8 +4303,10 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         }
                 }
 
-                if (!err && sgrp && session && session->partitions &&
-                    session->partitions->cnt > 0) {
+                /* epoch=-1 is a final fetch: no new records are
+                 * acquired ("No data will be fetched"). */
+                if (!err && SessionEpoch != -1 && sgrp && session &&
+                    session->partitions && session->partitions->cnt > 0) {
                         int pi, pcnt = session->partitions->cnt;
                         int start = session->partition_start_idx % pcnt;
 
@@ -4286,6 +4331,13 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                          * error via mpart==NULL check. */
                                         continue;
                                 }
+
+                                /* Skip acquisition if this broker is
+                                 * not the partition leader.  The
+                                 * response writer returns
+                                 * NOT_LEADER_OR_FOLLOWER. */
+                                if (mpart->leader != mconn->broker)
+                                        continue;
 
                                 rd_kafka_mock_sgrp_partmeta_t *pmeta =
                                     rd_kafka_mock_sgrp_partmeta_get(
@@ -4403,10 +4455,18 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                       rktpar->partition)
                                                 : NULL;
                                         rd_kafka_resp_err_t ack_err;
-                                        rd_kafka_resp_err_t part_err =
-                                            mpart
-                                                ? RD_KAFKA_RESP_ERR_NO_ERROR
-                                                : RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        rd_kafka_resp_err_t part_err;
+
+                                        if (!mpart)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        else if (mpart->leader !=
+                                                 mconn->broker)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
+                                        else
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NO_ERROR;
 
                                         /* Response: Partition */
                                         rd_kafka_buf_write_i32(
@@ -4440,8 +4500,18 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_str(
                                                     resp, NULL, -1);
                                         /* Response: CurrentLeader */
-                                        rd_kafka_buf_write_i32(resp, -1);
-                                        rd_kafka_buf_write_i32(resp, -1);
+                                        if (mpart && mpart->leader)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader->id);
+                                        else
+                                                rd_kafka_buf_write_i32(resp, -1);
+                                        if (mpart)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader_epoch);
+                                        else
+                                                rd_kafka_buf_write_i32(resp, -1);
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Response: Records (all acquired
                                          * batches concatenated) */
@@ -4797,10 +4867,28 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                 for (j = i; j < i + part_cnt; j++) {
                                         rd_kafka_topic_partition_t *rktpar =
                                             &ack_partitions->elems[j];
-                                        rd_kafka_resp_err_t part_err =
-                                            rd_kafka_mock_sgrp_ack_error_for_partition(
-                                                &ack_entries, topic_id,
-                                                rktpar->partition);
+                                        rd_kafka_mock_topic_t *mtopic =
+                                            rd_kafka_mock_topic_find_by_id(
+                                                mcluster, topic_id);
+                                        rd_kafka_mock_partition_t *mpart =
+                                            mtopic
+                                                ? rd_kafka_mock_partition_find(
+                                                      mtopic, rktpar->partition)
+                                                : NULL;
+                                        rd_kafka_resp_err_t part_err;
+
+                                        if (!mpart)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        else if (mpart->leader !=
+                                                 mconn->broker)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
+                                        else
+                                                part_err =
+                                                    rd_kafka_mock_sgrp_ack_error_for_partition(
+                                                        &ack_entries, topic_id,
+                                                        rktpar->partition);
 
                                         /* PartitionIndex */
                                         rd_kafka_buf_write_i32(
@@ -4817,10 +4905,20 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_str(
                                                     resp, NULL, -1);
                                         /* CurrentLeader */
-                                        rd_kafka_buf_write_i32(
-                                            resp, -1); /* LeaderId */
-                                        rd_kafka_buf_write_i32(
-                                            resp, -1); /* LeaderEpoch */
+                                        if (mpart && mpart->leader)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader->id);
+                                        else
+                                                rd_kafka_buf_write_i32(
+                                                    resp, -1); /* LeaderId */
+                                        if (mpart)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader_epoch);
+                                        else
+                                                rd_kafka_buf_write_i32(
+                                                    resp, -1); /* LeaderEpoch */
                                         /* CurrentLeader tags */
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Partition tags */

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3799,8 +3799,8 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                         if (offset < pmeta->spso)
                                 continue;
 
-                        state = rd_kafka_mock_sgrp_record_state_find(pmeta,
-                                                                     offset);
+                        state =
+                            rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
                         if (!state)
                                 continue;
 
@@ -4460,8 +4460,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                         if (!mpart)
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
-                                        else if (mpart->leader !=
-                                                 mconn->broker)
+                                        else if (mpart->leader != mconn->broker)
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
                                         else
@@ -4502,16 +4501,16 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                         /* Response: CurrentLeader */
                                         if (mpart && mpart->leader)
                                                 rd_kafka_buf_write_i32(
-                                                    resp,
-                                                    mpart->leader->id);
+                                                    resp, mpart->leader->id);
                                         else
-                                                rd_kafka_buf_write_i32(resp, -1);
-                                        if (mpart)
+                                                rd_kafka_buf_write_i32(resp,
+                                                                       -1);
+                                        if (mpart && mpart->leader)
                                                 rd_kafka_buf_write_i32(
-                                                    resp,
-                                                    mpart->leader_epoch);
+                                                    resp, mpart->leader_epoch);
                                         else
-                                                rd_kafka_buf_write_i32(resp, -1);
+                                                rd_kafka_buf_write_i32(resp,
+                                                                       -1);
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Response: Records (all acquired
                                          * batches concatenated) */
@@ -4880,8 +4879,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         if (!mpart)
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
-                                        else if (mpart->leader !=
-                                                 mconn->broker)
+                                        else if (mpart->leader != mconn->broker)
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
                                         else
@@ -4907,15 +4905,13 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         /* CurrentLeader */
                                         if (mpart && mpart->leader)
                                                 rd_kafka_buf_write_i32(
-                                                    resp,
-                                                    mpart->leader->id);
+                                                    resp, mpart->leader->id);
                                         else
                                                 rd_kafka_buf_write_i32(
                                                     resp, -1); /* LeaderId */
-                                        if (mpart)
+                                        if (mpart && mpart->leader)
                                                 rd_kafka_buf_write_i32(
-                                                    resp,
-                                                    mpart->leader_epoch);
+                                                    resp, mpart->leader_epoch);
                                         else
                                                 rd_kafka_buf_write_i32(
                                                     resp, -1); /* LeaderEpoch */

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -3741,9 +3741,21 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
         if (!pmeta)
                 return RD_KAFKA_RESP_ERR_NO_ERROR;
 
+        /* Pass 1: Validate all offsets in the range.
+         * Acks for a partition in a single request are atomic —
+         * all succeed or all fail together. */
         for (offset = first_offset; offset <= last_offset; offset++) {
-                rd_kafka_mock_sgrp_record_state_t *state =
-                    rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
+                rd_kafka_mock_sgrp_record_state_t *state;
+
+                /* Offsets below SPSO are already logically archived
+                 * (e.g. due to log retention).  Acks for such
+                 * records are silently accepted — no error is
+                 * thrown for a record that is about to become
+                 * Archived. */
+                if (offset < pmeta->spso)
+                        continue;
+
+                state = rd_kafka_mock_sgrp_record_state_find(pmeta, offset);
                 if (!state)
                         continue;
 
@@ -3756,30 +3768,48 @@ rd_kafka_mock_sgrp_apply_ack(rd_kafka_mock_sharegroup_t *sgrp,
                     !state->owner_member_id ||
                     rd_kafkap_str_cmp_str(member_id, state->owner_member_id)) {
                         err = RD_KAFKA_RESP_ERR_INVALID_RECORD_STATE;
-                        continue;
+                        break;
                 }
+        }
 
-                switch (ack_type) {
-                case 1: /* ACCEPT -> Acknowledged */
-                        pmeta->acquired_cnt--;
-                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
-                        rd_free(state->owner_member_id);
-                        state->owner_member_id = NULL;
-                        state->lock_expiry_ts  = 0;
-                        break;
-                case 0: /* GAP -> Archived */
-                case 3: /* REJECT -> Archived */
-                        pmeta->acquired_cnt--;
-                        state->state = RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
-                        rd_free(state->owner_member_id);
-                        state->owner_member_id = NULL;
-                        state->lock_expiry_ts  = 0;
-                        break;
-                case 2: /* RELEASE */
-                        rd_kafka_mock_sgrp_record_release(sgrp, pmeta, state);
-                        break;
-                default:
-                        break;
+        /* Pass 2: Apply state transitions only if validation passed. */
+        if (!err) {
+                for (offset = first_offset; offset <= last_offset; offset++) {
+                        rd_kafka_mock_sgrp_record_state_t *state;
+
+                        if (offset < pmeta->spso)
+                                continue;
+
+                        state = rd_kafka_mock_sgrp_record_state_find(pmeta,
+                                                                     offset);
+                        if (!state)
+                                continue;
+
+                        switch (ack_type) {
+                        case 1: /* ACCEPT -> Acknowledged */
+                                pmeta->acquired_cnt--;
+                                state->state =
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ACKNOWLEDGED;
+                                rd_free(state->owner_member_id);
+                                state->owner_member_id = NULL;
+                                state->lock_expiry_ts  = 0;
+                                break;
+                        case 0: /* GAP -> Archived */
+                        case 3: /* REJECT -> Archived */
+                                pmeta->acquired_cnt--;
+                                state->state =
+                                    RD_KAFKA_MOCK_SGRP_RECORD_ARCHIVED;
+                                rd_free(state->owner_member_id);
+                                state->owner_member_id = NULL;
+                                state->lock_expiry_ts  = 0;
+                                break;
+                        case 2: /* RELEASE */
+                                rd_kafka_mock_sgrp_record_release(sgrp, pmeta,
+                                                                  state);
+                                break;
+                        default:
+                                break;
+                        }
                 }
         }
 
@@ -4183,8 +4213,9 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 }
 
                 /* epoch=-1 (final fetch / close session) must not
-                 * contain ForgottenTopicsData.  Acks in the Topics
-                 * array ARE allowed. */
+                 * contain ForgottenTopicsData.  Partitions
+                 * in the Topics array ARE allowed — they carry
+                 * piggybacked acks for the final request. */
                 if (!err && SessionEpoch == -1 &&
                     (forgotten_partitions && forgotten_partitions->cnt > 0)) {
                         rd_kafka_dbg(
@@ -4276,8 +4307,10 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                         }
                 }
 
-                if (!err && sgrp && session && session->partitions &&
-                    session->partitions->cnt > 0) {
+                /* epoch=-1 is a final fetch: no new records are
+                 * acquired ("No data will be fetched"). */
+                if (!err && SessionEpoch != -1 && sgrp && session &&
+                    session->partitions && session->partitions->cnt > 0) {
                         int pi, pcnt = session->partitions->cnt;
                         int start = session->partition_start_idx % pcnt;
 
@@ -4302,6 +4335,13 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                          * error via mpart==NULL check. */
                                         continue;
                                 }
+
+                                /* Skip acquisition if this broker is
+                                 * not the partition leader.  The
+                                 * response writer returns
+                                 * NOT_LEADER_OR_FOLLOWER. */
+                                if (mpart->leader != mconn->broker)
+                                        continue;
 
                                 rd_kafka_mock_sgrp_partmeta_t *pmeta =
                                     rd_kafka_mock_sgrp_partmeta_get(
@@ -4419,10 +4459,18 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                       rktpar->partition)
                                                 : NULL;
                                         rd_kafka_resp_err_t ack_err;
-                                        rd_kafka_resp_err_t part_err =
-                                            mpart
-                                                ? RD_KAFKA_RESP_ERR_NO_ERROR
-                                                : RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        rd_kafka_resp_err_t part_err;
+
+                                        if (!mpart)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        else if (mpart->leader !=
+                                                 mconn->broker)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
+                                        else
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NO_ERROR;
 
                                         /* Response: Partition */
                                         rd_kafka_buf_write_i32(
@@ -4456,8 +4504,18 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_str(
                                                     resp, NULL, -1);
                                         /* Response: CurrentLeader */
-                                        rd_kafka_buf_write_i32(resp, -1);
-                                        rd_kafka_buf_write_i32(resp, -1);
+                                        if (mpart && mpart->leader)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader->id);
+                                        else
+                                                rd_kafka_buf_write_i32(resp, -1);
+                                        if (mpart)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader_epoch);
+                                        else
+                                                rd_kafka_buf_write_i32(resp, -1);
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Response: Records (all acquired
                                          * batches concatenated) */
@@ -4825,10 +4883,28 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                 for (j = i; j < i + part_cnt; j++) {
                                         rd_kafka_topic_partition_t *rktpar =
                                             &ack_partitions->elems[j];
-                                        rd_kafka_resp_err_t part_err =
-                                            rd_kafka_mock_sgrp_ack_error_for_partition(
-                                                &ack_entries, topic_id,
-                                                rktpar->partition);
+                                        rd_kafka_mock_topic_t *mtopic =
+                                            rd_kafka_mock_topic_find_by_id(
+                                                mcluster, topic_id);
+                                        rd_kafka_mock_partition_t *mpart =
+                                            mtopic
+                                                ? rd_kafka_mock_partition_find(
+                                                      mtopic, rktpar->partition)
+                                                : NULL;
+                                        rd_kafka_resp_err_t part_err;
+
+                                        if (!mpart)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+                                        else if (mpart->leader !=
+                                                 mconn->broker)
+                                                part_err =
+                                                    RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
+                                        else
+                                                part_err =
+                                                    rd_kafka_mock_sgrp_ack_error_for_partition(
+                                                        &ack_entries, topic_id,
+                                                        rktpar->partition);
 
                                         /* PartitionIndex */
                                         rd_kafka_buf_write_i32(
@@ -4845,10 +4921,20 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_str(
                                                     resp, NULL, -1);
                                         /* CurrentLeader */
-                                        rd_kafka_buf_write_i32(
-                                            resp, -1); /* LeaderId */
-                                        rd_kafka_buf_write_i32(
-                                            resp, -1); /* LeaderEpoch */
+                                        if (mpart && mpart->leader)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader->id);
+                                        else
+                                                rd_kafka_buf_write_i32(
+                                                    resp, -1); /* LeaderId */
+                                        if (mpart)
+                                                rd_kafka_buf_write_i32(
+                                                    resp,
+                                                    mpart->leader_epoch);
+                                        else
+                                                rd_kafka_buf_write_i32(
+                                                    resp, -1); /* LeaderEpoch */
                                         /* CurrentLeader tags */
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Partition tags */

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -86,21 +86,6 @@ static void test_ctx_destroy(test_ctx_t *ctx) {
         memset(ctx, 0, sizeof(*ctx));
 }
 
-static void
-produce_messages(rd_kafka_t *producer, const char *topic, int msgcnt) {
-        for (int i = 0; i < msgcnt; i++) {
-                char payload[64];
-                snprintf(payload, sizeof(payload), "%s-%d", topic, i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
-}
-
 static rd_kafka_share_t *new_share_consumer(const char *bootstraps,
                                             const char *group_id) {
         rd_kafka_conf_t *conf;
@@ -129,46 +114,6 @@ static void subscribe_topics(rd_kafka_share_t *consumer,
         rd_kafka_topic_partition_list_destroy(tpl);
 }
 
-static int
-consume_n(rd_kafka_share_t *consumer, int expected, int max_attempts) {
-        int consumed = 0;
-        int attempts = 0;
-
-        while (consumed < expected && attempts < max_attempts) {
-                rd_kafka_message_t *rkmessages[100];
-                size_t rcvd_msgs = 0;
-                rd_kafka_error_t *error;
-
-                error = rd_kafka_share_consume_batch(consumer, 500, rkmessages,
-                                                     &rcvd_msgs);
-                attempts++;
-
-                if (error) {
-                        TEST_SAY("consume error: %s\n",
-                                 rd_kafka_error_string(error));
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-
-                for (size_t i = 0; i < rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkmsg = rkmessages[i];
-                        if (rkmsg->err) {
-                                TEST_SAY("consume error: %s\n",
-                                         rd_kafka_message_errstr(rkmsg));
-                                rd_kafka_message_destroy(rkmsg);
-                                continue;
-                        }
-                        TEST_SAY("Consumed: %.*s\n", (int)rkmsg->len,
-                                 (const char *)rkmsg->payload);
-                        consumed++;
-                        rd_kafka_message_destroy(rkmsg);
-                }
-        }
-
-        return consumed;
-}
-
-
 static void do_test_basic_consume(void) {
         const char *topic = "kip932_pos_basic";
         const int msgcnt  = 5;
@@ -181,11 +126,12 @@ static void do_test_basic_consume(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-pos-basic");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, msgcnt, 50);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -207,12 +153,12 @@ static void do_test_followup_fetch(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 5);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 5);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-pos-followup");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 3, 30);
-        consumed += consume_n(consumer, 2, 30);
+        consumed = test_share_consume_msgs(consumer, 3, 30, 500, NULL, 0);
+        consumed += test_share_consume_msgs(consumer, 2, 30, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -234,11 +180,12 @@ static void do_test_multi_partition(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 2, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-pos-multipart");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, msgcnt, 60);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 60, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -266,11 +213,13 @@ static void do_test_multi_topic(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic B");
 
-        produce_messages(ctx.producer, topic_a, 2);
-        produce_messages(ctx.producer, topic_b, 2);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 2);
+        test_produce_msgs_simple(ctx.producer, topic_b, RD_KAFKA_PARTITION_UA,
+                                 2);
         consumer = new_share_consumer(ctx.bootstraps, "sg-pos-multitopic");
         subscribe_topics(consumer, topics, 2);
-        consumed = consume_n(consumer, 4, 40);
+        consumed = test_share_consume_msgs(consumer, 4, 40, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -294,7 +243,7 @@ static void do_test_empty_topic_no_records(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-pos-empty");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -313,14 +262,14 @@ static int do_test_negative_sharefetch_error(rd_kafka_resp_err_t err) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 1);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 1);
 
         rd_kafka_mock_push_request_errors(ctx.mcluster, RD_KAFKAP_ShareFetch, 1,
                                           err);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-neg-sharefetch");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 30);
+        consumed = test_share_consume_msgs(consumer, 1, 30, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -354,7 +303,7 @@ static void do_test_sghb_error(rd_kafka_resp_err_t err, int count) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 1);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 1);
 
         /* Build an array of 'count' identical errors and push them all.
          * Using the array variant avoids UB from mismatched varargs count. */
@@ -368,7 +317,7 @@ static void do_test_sghb_error(rd_kafka_resp_err_t err, int count) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-neg-sghb");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -392,12 +341,12 @@ static void do_test_topic_error(rd_kafka_resp_err_t err) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 1);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 1);
         rd_kafka_mock_topic_set_error(ctx.mcluster, topic, err);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-neg-topicerr");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -422,7 +371,7 @@ static void do_test_unknown_topic_subscription(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-neg-unknown-topic");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -446,7 +395,7 @@ static void do_test_empty_fetch_no_records(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-neg-empty");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -483,13 +432,14 @@ static void do_test_member_validation(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-member-val");
         subscribe_topics(consumer, &topic, 1);
 
         /* Phase 1: Consume normally -- member is registered via SGHB. */
-        consumed_p1 = consume_n(consumer, 2, 30);
+        consumed_p1 = test_share_consume_msgs(consumer, 2, 30, 500, NULL, 0);
         TEST_SAY("member_validation: phase1 consumed %d/2\n", consumed_p1);
 
         /* Phase 2: Block SGHB so heartbeats fail.
@@ -525,7 +475,7 @@ static void do_test_member_validation(void) {
         /* Phase 3: SGHB errors will eventually drain. Once a SGHB
          * succeeds, the member re-joins and the remaining records
          * become fetchable again. */
-        consumed_p3 = consume_n(consumer, 2, 50);
+        consumed_p3 = test_share_consume_msgs(consumer, 2, 50, 500, NULL, 0);
         TEST_SAY("member_validation: phase3 consumed %d/2\n", consumed_p3);
 
         test_share_consumer_close(consumer);
@@ -555,14 +505,14 @@ static void do_test_sharefetch_session_expiry_rtt(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
         /* Produce only 1 message so a single batch cannot over-consume
-         * past the requested count in consume_n(). */
-        produce_messages(ctx.producer, topic, 1);
+         * past the requested count in test_share_consume_msgs(). */
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 1);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-rtt-expiry");
         subscribe_topics(consumer, &topic, 1);
 
         /* Phase 1: consume one message with normal RTT (no injection). */
-        consumed = consume_n(consumer, 1, 20);
+        consumed = test_share_consume_msgs(consumer, 1, 20, 500, NULL, 0);
         TEST_SAY("rtt_expiry: phase1 consumed %d/1\n", consumed);
 
         /* Phase 2: inject RTT >> session timeout to force session expiry.
@@ -576,7 +526,7 @@ static void do_test_sharefetch_session_expiry_rtt(void) {
         /* Phase 3: clear RTT and let the consumer recover.
          * The same record should be re-delivered after session expiry. */
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 0);
-        consumed += consume_n(consumer, 1, 30);
+        consumed += test_share_consume_msgs(consumer, 1, 30, 500, NULL, 0);
         TEST_SAY("rtt_expiry: phase3 consumed %d/2 total\n", consumed);
 
         test_share_consumer_close(consumer);
@@ -605,13 +555,15 @@ static void do_test_forgotten_topics(void) {
                     "Failed to create mock topic B");
 
         /* Produce 2 messages to each topic */
-        produce_messages(ctx.producer, topic_a, 2);
-        produce_messages(ctx.producer, topic_b, 2);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 2);
+        test_produce_msgs_simple(ctx.producer, topic_b, RD_KAFKA_PARTITION_UA,
+                                 2);
 
         /* Subscribe to both topics and consume all 4 messages */
         consumer = new_share_consumer(ctx.bootstraps, "sg-forgotten");
         subscribe_topics(consumer, both, 2);
-        consumed = consume_n(consumer, 4, 40);
+        consumed = test_share_consume_msgs(consumer, 4, 40, 500, NULL, 0);
         TEST_SAY("forgotten_topics: consumed %d/4 from both topics\n",
                  consumed);
 
@@ -619,10 +571,11 @@ static void do_test_forgotten_topics(void) {
         subscribe_topics(consumer, &topic_a, 1);
 
         /* Produce 2 more messages to topic_a */
-        produce_messages(ctx.producer, topic_a, 2);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 2);
 
         /* Consume the 2 new messages -- only topic_a should deliver */
-        consumed += consume_n(consumer, 2, 30);
+        consumed += test_share_consume_msgs(consumer, 2, 30, 500, NULL, 0);
         TEST_SAY("forgotten_topics: consumed %d/6 total after forget\n",
                  consumed);
 
@@ -673,7 +626,7 @@ static void do_test_multi_batch_consume(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-multi-batch");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, msgcnt, 50);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("multi_batch: consumed %d/%d\n", consumed, msgcnt);
 
         test_share_consumer_close(consumer);
@@ -710,12 +663,14 @@ static void do_test_max_delivery_attempts(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Delivery 1: Consumer A acquires and "crashes" (no ack). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-max-delivery");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("max_delivery: A consumed %d/%d (delivery 1)\n", consumed_a,
                  msgcnt);
         test_share_destroy(consumer);
@@ -725,7 +680,8 @@ static void do_test_max_delivery_attempts(void) {
          * reaches 2 = limit) and "crashes". */
         consumer = new_share_consumer(ctx.bootstraps, "sg-max-delivery");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("max_delivery: B consumed %d/%d (delivery 2)\n", consumed_b,
                  msgcnt);
         test_share_destroy(consumer);
@@ -735,7 +691,7 @@ static void do_test_max_delivery_attempts(void) {
          * all records have been archived (delivery_count >= max). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-max-delivery");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, 1, 10);
+        consumed_c = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("max_delivery: C consumed %d/0 (should be archived)\n",
                  consumed_c);
 
@@ -775,12 +731,14 @@ static void do_test_record_lock_duration(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires records, then crashes (no close). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-lock-duration");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("lock_duration: A consumed %d/%d\n", consumed_a, msgcnt);
         test_share_destroy(consumer);
 
@@ -796,7 +754,8 @@ static void do_test_record_lock_duration(void) {
          * SGHB LEAVE->rejoin cycle delay. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-lock-duration");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 100);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 100, 500, NULL, 0);
         TEST_SAY("lock_duration: B consumed %d/%d\n", consumed_b, msgcnt);
 
         test_share_consumer_close(consumer);
@@ -832,13 +791,15 @@ static void do_test_multi_consumer_lock_expiry(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: subscribe and consume all records (acquires locks). */
         consumer_a =
             new_share_consumer(ctx.bootstraps, "sg-multi-consumer-lock");
         subscribe_topics(consumer_a, &topic, 1);
-        consumed_a = consume_n(consumer_a, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer_a, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("multi_consumer: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Simulate crash: destroy consumer A without calling close.
@@ -856,7 +817,8 @@ static void do_test_multi_consumer_lock_expiry(void) {
         consumer_b =
             new_share_consumer(ctx.bootstraps, "sg-multi-consumer-lock");
         subscribe_topics(consumer_b, &topic, 1);
-        consumed_b = consume_n(consumer_b, msgcnt, 100);
+        consumed_b =
+            test_share_consume_msgs(consumer_b, msgcnt, 100, 500, NULL, 0);
         TEST_SAY("multi_consumer: B consumed %d/%d\n", consumed_b, msgcnt);
 
         test_share_consumer_close(consumer_b);
@@ -888,7 +850,7 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 3);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 3);
 
         /* Push a single error */
         rd_kafka_mock_push_request_errors(ctx.mcluster, RD_KAFKAP_ShareFetch, 1,
@@ -999,7 +961,7 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 3);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 3);
 
         /* Inject a single ShareFetch error to verify that a fetch failure
          * returns 0 records for the affected poll call.
@@ -1052,13 +1014,14 @@ static void do_test_sharefetch_fetch_and_close_implicit(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-fetch-close");
         subscribe_topics(consumer, &topic, 1);
 
         /* Fetch records */
-        consumed = consume_n(consumer, msgcnt, 50);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("fetch_and_close: consumed %d/%d\n", consumed, msgcnt);
 
         /* Close — sends ShareAcknowledge/ShareFetch with epoch=-1 */
@@ -1097,12 +1060,14 @@ static void do_test_session_limit_reached(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer 1 opens a session successfully */
         consumer1 = new_share_consumer(ctx.bootstraps, "sg-session-limit");
         subscribe_topics(consumer1, &topic, 1);
-        consumed1 = consume_n(consumer1, msgcnt, 30);
+        consumed1 =
+            test_share_consume_msgs(consumer1, msgcnt, 30, 500, NULL, 0);
         TEST_ASSERT(consumed1 == msgcnt,
                     "Consumer 1: expected %d consumed, got %d", msgcnt,
                     consumed1);
@@ -1110,7 +1075,7 @@ static void do_test_session_limit_reached(void) {
         /* Consumer 2 tries to open a session — cache is full */
         consumer2 = new_share_consumer(ctx.bootstraps, "sg-session-limit");
         subscribe_topics(consumer2, &topic, 1);
-        consumed2 = consume_n(consumer2, 1, 5);
+        consumed2 = test_share_consume_msgs(consumer2, 1, 5, 500, NULL, 0);
         TEST_ASSERT(consumed2 == 0,
                     "Consumer 2: expected 0 consumed (session limit), got %d",
                     consumed2);
@@ -1159,8 +1124,10 @@ static void do_test_session_limit_per_broker(void) {
         rd_kafka_mock_partition_set_leader(ctx.mcluster, topic_a, 0, 1);
         rd_kafka_mock_partition_set_leader(ctx.mcluster, topic_b, 0, 2);
 
-        produce_messages(ctx.producer, topic_a, msgcnt);
-        produce_messages(ctx.producer, topic_b, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic_b, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Limit to 1 session per broker */
         rd_kafka_mock_sharegroup_set_max_fetch_sessions(ctx.mcluster, 1);
@@ -1168,7 +1135,8 @@ static void do_test_session_limit_per_broker(void) {
         /* Consumer 1 subscribes to topic_a -> session on broker 1 */
         consumer1 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer1, &topic_a, 1);
-        consumed1 = consume_n(consumer1, msgcnt, 30);
+        consumed1 =
+            test_share_consume_msgs(consumer1, msgcnt, 30, 500, NULL, 0);
         TEST_ASSERT(consumed1 == msgcnt,
                     "Consumer 1: expected %d consumed, got %d", msgcnt,
                     consumed1);
@@ -1178,7 +1146,8 @@ static void do_test_session_limit_per_broker(void) {
          * Per-broker: broker 2 has 0 sessions, so it succeeds. */
         consumer2 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer2, &topic_b, 1);
-        consumed2 = consume_n(consumer2, msgcnt, 30);
+        consumed2 =
+            test_share_consume_msgs(consumer2, msgcnt, 30, 500, NULL, 0);
         TEST_ASSERT(consumed2 == msgcnt,
                     "Consumer 2: expected %d consumed, got %d", msgcnt,
                     consumed2);
@@ -1187,7 +1156,7 @@ static void do_test_session_limit_per_broker(void) {
          * 1 session (from consumer 1), so this should be rejected. */
         consumer3 = new_share_consumer(ctx.bootstraps, "sg-session-limit-pb");
         subscribe_topics(consumer3, &topic_a, 1);
-        consumed3 = consume_n(consumer3, 1, 5);
+        consumed3 = test_share_consume_msgs(consumer3, 1, 5, 500, NULL, 0);
         TEST_ASSERT(consumed3 == 0,
                     "Consumer 3: expected 0 consumed (broker 1 at limit), "
                     "got %d",
@@ -1226,7 +1195,8 @@ static void do_test_session_limit_recovery(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Push 3 SHARE_SESSION_LIMIT_REACHED errors, then let it succeed */
         rd_kafka_mock_push_request_errors(
@@ -1237,7 +1207,7 @@ static void do_test_session_limit_recovery(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-session-recovery");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, msgcnt, 30);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 30, 500, NULL, 0);
 
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
@@ -1276,7 +1246,8 @@ static void do_test_max_record_locks(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consume in rounds.  Each round can get at most 3 records
          * (the lock limit).  The implicit ack from the next poll
@@ -1285,7 +1256,8 @@ static void do_test_max_record_locks(void) {
         subscribe_topics(consumer, &topic, 1);
 
         while (total_consumed < msgcnt && rounds < 20) {
-                int got = consume_n(consumer, 3, 10);
+                int got =
+                    test_share_consume_msgs(consumer, 3, 10, 500, NULL, 0);
                 if (got == 0)
                         break;
                 total_consumed += got;
@@ -1348,12 +1320,13 @@ static void do_test_max_record_locks_acquired_only(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: acquire first batch (3 records due to lock limit). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-acq-only");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, 3, 30);
+        consumed_a = test_share_consume_msgs(consumer, 3, 30, 500, NULL, 0);
         TEST_SAY("acquired_only: A consumed %d/3\n", consumed_a);
 
         /* Destroy WITHOUT close — avoids implicit ack.
@@ -1371,7 +1344,7 @@ static void do_test_max_record_locks_acquired_only(void) {
          * With inflight_cnt check, the limit would block acquisition. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-acq-only");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, 3, 30);
+        consumed_b = test_share_consume_msgs(consumer, 3, 30, 500, NULL, 0);
         TEST_SAY("acquired_only: B consumed %d/3\n", consumed_b);
 
         rd_kafka_share_consumer_close(consumer);
@@ -1414,12 +1387,13 @@ static void do_test_spso_advances_on_log_retention(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires records 0-4. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-log-retention");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, 5, 30);
+        consumed_a = test_share_consume_msgs(consumer, 5, 30, 500, NULL, 0);
         TEST_SAY("log_retention: A consumed %d/5\n", consumed_a);
 
         rd_kafka_share_consumer_close(consumer);
@@ -1437,7 +1411,7 @@ static void do_test_spso_advances_on_log_retention(void) {
         /* Consumer B should get records 5-9 (SPSO advanced to 5). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-log-retention");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, 5, 30);
+        consumed_b = test_share_consume_msgs(consumer, 5, 30, 500, NULL, 0);
         TEST_SAY("log_retention: B consumed %d/5\n", consumed_b);
 
         rd_kafka_share_consumer_close(consumer);
@@ -1465,6 +1439,8 @@ static void do_test_auto_offset_reset_latest(void) {
         const int msgcnt  = 5;
         test_ctx_t ctx;
         rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        char errstr[512];
         int consumed;
 
         SUB_TEST_QUICK();
@@ -1483,36 +1459,34 @@ static void do_test_auto_offset_reset_latest(void) {
                     "Failed to enable ShareFetch");
         /* Intentionally NOT calling set_auto_offset_reset — default is latest
          */
-        {
-                rd_kafka_conf_t *conf;
-                char errstr[512];
-                test_conf_init(&conf, NULL, 0);
-                test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
-                ctx.producer = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr,
-                                            sizeof(errstr));
-                TEST_ASSERT(ctx.producer != NULL,
-                            "Failed to create producer: %s", errstr);
-        }
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        ctx.producer =
+            rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(ctx.producer != NULL, "Failed to create producer: %s",
+                    errstr);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
 
         /* Produce records BEFORE subscribing */
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Subscribe — SPSO should start at end of log (latest) */
         consumer = new_share_consumer(ctx.bootstraps, "sg-offset-latest");
         subscribe_topics(consumer, &topic, 1);
-        consumed = consume_n(consumer, 1, 5);
+        consumed = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
         TEST_SAY("offset_reset_latest: consumed %d (expected 0)\n", consumed);
         TEST_ASSERT(consumed == 0,
                     "Expected 0 consumed with latest offset reset, got %d",
                     consumed);
 
         /* Produce new records AFTER subscription — these should be visible */
-        produce_messages(ctx.producer, topic, msgcnt);
-        consumed = consume_n(consumer, msgcnt, 30);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 30, 500, NULL, 0);
         TEST_SAY("offset_reset_latest: consumed %d new records (expected %d)\n",
                  consumed, msgcnt);
 

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -69,6 +69,7 @@ static test_ctx_t test_ctx_new(void) {
         /* Create a producer targeting the mock cluster */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
@@ -1461,6 +1462,7 @@ static void do_test_auto_offset_reset_latest(void) {
          */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
         TEST_ASSERT(ctx.producer != NULL, "Failed to create producer: %s",

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -1486,6 +1486,272 @@ static void do_test_ack_success_advances_spso(void) {
         SUB_TEST_PASS();
 }
 
+
+/**
+ * @brief epoch=-1 (final fetch) must not acquire new records.
+ *
+ * Consumer A acquires two batches (max_record_locks=3 caps each),
+ * then closes.  The close sends epoch=-1 which releases A's
+ * un-acked records but must not acquire anything new.
+ * Consumer B picks up the released records; consumer C sees 0.
+ */
+static void do_test_final_fetch_no_acquisition(void) {
+        const char *topic = "kip932_final_fetch_no_acq";
+        const int msgcnt  = 6;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_a2, consumed_b, extra;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        /* Limit acquisition to 3 records at a time. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 3);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        consumer = new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
+        subscribe_topics(consumer, &topic, 1);
+
+        consumed_a = consume_n(consumer, 3, 40);
+        TEST_SAY("final_fetch_no_acq: A batch1 consumed %d/3\n", consumed_a);
+
+        /* Implicit ack for batch1, acquires batch2. */
+        consumed_a2 = consume_n(consumer, 3, 40);
+        TEST_SAY("final_fetch_no_acq: A batch2 consumed %d/3\n", consumed_a2);
+
+        /* Close sends epoch=-1; batch2 records released. */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
+
+        /* B picks up the released batch2 records. */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
+        subscribe_topics(consumer, &topic, 1);
+
+        consumed_b = consume_n(consumer, 3, 40);
+        TEST_SAY("final_fetch_no_acq: B consumed %d/3\n", consumed_b);
+
+        extra = consume_n(consumer, 1, 5); /* ack B's records */
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        /* C should see nothing — everything acked. */
+        {
+                rd_kafka_share_t *consumer_c;
+                int consumed_c;
+
+                consumer_c =
+                    new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
+                subscribe_topics(consumer_c, &topic, 1);
+                consumed_c = consume_n(consumer_c, 1, 10);
+                TEST_SAY("final_fetch_no_acq: C consumed %d/0 (should be 0)\n",
+                         consumed_c);
+                rd_kafka_share_consumer_close(consumer_c);
+                rd_kafka_share_destroy(consumer_c);
+
+                TEST_ASSERT(consumed_c == 0,
+                            "C: expected 0 consumed, got %d", consumed_c);
+        }
+
+        test_ctx_destroy(&ctx);
+
+        (void)extra;
+        TEST_ASSERT(consumed_a == 3 && consumed_a2 == 3 && consumed_b == 3,
+                    "Expected A1=3 A2=3 B=3, got A1=%d A2=%d B=%d", consumed_a,
+                    consumed_a2, consumed_b);
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Ack for records past SPSO (log retention) succeeds silently.
+ *
+ * Consumer A acquires 5 records, then log retention moves
+ * start_offset past the first 3.  The implicit ack covers all 5,
+ * including the 3 that are now below SPSO.  Those must be silently
+ * accepted rather than returning INVALID_RECORD_STATE.
+ * Consumer B should see 0.
+ */
+static void do_test_ack_after_log_retention_silent(void) {
+        const char *topic = "kip932_ack_log_retention_silent";
+        const int msgcnt  = 5;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_b, extra;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        consumer =
+            new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
+        subscribe_topics(consumer, &topic, 1);
+
+        consumed_a = consume_n(consumer, msgcnt, 50);
+        TEST_SAY("ack_log_retention_silent: A consumed %d/%d\n", consumed_a,
+                 msgcnt);
+
+        /* Move start_offset past first 3 records (simulates retention). */
+        rd_kafka_mock_partition_set_follower_wmarks(ctx.mcluster, topic, 0,
+                                                     3, -1);
+
+        /* Implicit ack covers all 5; offsets 0-2 are below SPSO now. */
+        extra = consume_n(consumer, 1, 10);
+        TEST_SAY("ack_log_retention_silent: A extra %d/0\n", extra);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        /* B should see nothing. */
+        consumer =
+            new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_b = consume_n(consumer, 1, 10);
+        TEST_SAY("ack_log_retention_silent: B consumed %d/0 (should be 0)\n",
+                 consumed_b);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == msgcnt && consumed_b == 0,
+                    "Expected A=%d B=0, got A=%d B=%d", msgcnt, consumed_a,
+                    consumed_b);
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Ack atomicity — expired locks cause full batch rejection.
+ *
+ * Consumer A acquires records but its locks expire before the ack
+ * arrives (RTT delay).  Because acks are atomic per partition, the
+ * entire batch is rejected rather than partially applied.
+ * Consumer B re-acquires, acks, and consumer C sees 0.
+ */
+static void do_test_ack_atomicity_lock_expiry(void) {
+        const char *topic = "kip932_ack_atomicity";
+        const int msgcnt  = 3;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed_a, consumed_b, consumed_c;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        /* Very short lock so it expires before A can ack. */
+        rd_kafka_mock_sharegroup_set_record_lock_duration(ctx.mcluster, 200);
+        rd_kafka_mock_sharegroup_set_session_timeout(ctx.mcluster, 10000);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_a = consume_n(consumer, msgcnt, 50);
+        TEST_SAY("ack_atomicity: A consumed %d/%d\n", consumed_a, msgcnt);
+
+        /* Delay A's next ShareFetch past lock expiry. */
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 3000);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 2, 3000);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 3, 3000);
+
+        rd_usleep(800 * 1000, NULL); /* locks expire */
+        rd_kafka_share_destroy(consumer); /* crash */
+
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 0);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 2, 0);
+        rd_kafka_mock_broker_set_rtt(ctx.mcluster, 3, 0);
+
+        /* B re-acquires everything (A's ack was rejected atomically). */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_b = consume_n(consumer, msgcnt, 50);
+        TEST_SAY("ack_atomicity: B consumed %d/%d (re-delivered)\n",
+                 consumed_b, msgcnt);
+
+        consume_n(consumer, 1, 5); /* ack B's records */
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+
+        /* C sees nothing. */
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
+        subscribe_topics(consumer, &topic, 1);
+        consumed_c = consume_n(consumer, 1, 10);
+        TEST_SAY("ack_atomicity: C consumed %d/0 (should be 0)\n", consumed_c);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&
+                        consumed_c == 0,
+                    "Expected A=%d B=%d C=0, got A=%d B=%d C=%d", msgcnt,
+                    msgcnt, consumed_a, consumed_b, consumed_c);
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Leader change mid-session -> client redirects.
+ *
+ * Consumer fetches from broker 1, then we move the partition leader
+ * to broker 2.  The next ShareFetch to broker 1 gets
+ * NOT_LEADER_OR_FOLLOWER; the client refreshes metadata and
+ * continues from broker 2.
+ */
+static void do_test_not_leader_or_follower_redirect(void) {
+        const char *topic = "kip932_not_leader";
+        const int msgcnt  = 6;
+        test_ctx_t ctx;
+        rd_kafka_share_t *consumer;
+        int consumed;
+
+        SUB_TEST();
+        ctx = test_ctx_new();
+
+        /* Two fetch rounds: 3 records each. */
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 3);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Failed to create mock topic");
+
+        rd_kafka_mock_partition_set_leader(ctx.mcluster, topic, 0, 1);
+        produce_messages(ctx.producer, topic, msgcnt);
+
+        consumer = new_share_consumer(ctx.bootstraps, "sg-not-leader");
+        subscribe_topics(consumer, &topic, 1);
+
+        consumed = consume_n(consumer, 3, 40);
+        TEST_SAY("not_leader: consumed %d/3 from broker 1\n", consumed);
+
+        /* Move leader to broker 2 between fetches. */
+        rd_kafka_mock_partition_set_leader(ctx.mcluster, topic, 0, 2);
+        rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
+
+        /* Client should handle the redirect transparently. */
+        consumed += consume_n(consumer, 3, 60);
+        TEST_SAY("not_leader: total consumed %d/6\n", consumed);
+
+        rd_kafka_share_consumer_close(consumer);
+        rd_kafka_share_destroy(consumer);
+        test_ctx_destroy(&ctx);
+
+        TEST_ASSERT(consumed == msgcnt,
+                    "Expected consumed=%d, got %d", msgcnt, consumed);
+        SUB_TEST_PASS();
+}
+
 /* ===================================================================
  *  Test runner
  * =================================================================== */
@@ -1524,6 +1790,12 @@ int main_0157_share_consumer_ack_mock(int argc, char **argv) {
         /* Ack validation */
         do_test_ack_after_lock_expiry_redelivers();
         do_test_ack_success_advances_spso();
+
+        /* Mock broker fix tests */
+        do_test_final_fetch_no_acquisition();
+        do_test_ack_after_log_retention_silent();
+        do_test_ack_atomicity_lock_expiry();
+        do_test_not_leader_or_follower_redirect();
 
         return 0;
 }

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -69,6 +69,7 @@ static test_ctx_t test_ctx_new(void) {
         /* Create a producer targeting the mock cluster */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
@@ -84,21 +85,6 @@ static void test_ctx_destroy(test_ctx_t *ctx) {
         if (ctx->mcluster)
                 test_mock_cluster_destroy(ctx->mcluster);
         memset(ctx, 0, sizeof(*ctx));
-}
-
-static void
-produce_messages(rd_kafka_t *producer, const char *topic, int msgcnt) {
-        for (int i = 0; i < msgcnt; i++) {
-                char payload[64];
-                snprintf(payload, sizeof(payload), "%s-%d", topic, i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
 }
 
 static rd_kafka_share_t *new_share_consumer(const char *bootstraps,
@@ -129,44 +115,7 @@ static void subscribe_topics(rd_kafka_share_t *consumer,
         rd_kafka_topic_partition_list_destroy(tpl);
 }
 
-static int
-consume_n(rd_kafka_share_t *consumer, int expected, int max_attempts) {
-        int consumed = 0;
-        int attempts = 0;
 
-        while (consumed < expected && attempts < max_attempts) {
-                rd_kafka_message_t *rkmessages[100];
-                size_t rcvd_msgs = 0;
-                rd_kafka_error_t *error;
-
-                error = rd_kafka_share_consume_batch(consumer, 500, rkmessages,
-                                                     &rcvd_msgs);
-                attempts++;
-
-                if (error) {
-                        TEST_SAY("consume error: %s\n",
-                                 rd_kafka_error_string(error));
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-
-                for (size_t i = 0; i < rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkmsg = rkmessages[i];
-                        if (rkmsg->err) {
-                                TEST_SAY("consume error: %s\n",
-                                         rd_kafka_message_errstr(rkmsg));
-                                rd_kafka_message_destroy(rkmsg);
-                                continue;
-                        }
-                        TEST_SAY("Consumed: %.*s\n", (int)rkmsg->len,
-                                 (const char *)rkmsg->payload);
-                        consumed++;
-                        rd_kafka_message_destroy(rkmsg);
-                }
-        }
-
-        return consumed;
-}
 
 /* ===================================================================
  *  Positive test scenarios
@@ -194,18 +143,19 @@ static void do_test_implicit_ack_no_redelivery(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-noredeliver");
         subscribe_topics(consumer, &topic, 1);
 
         /* Consume all records. */
-        consumed = consume_n(consumer, msgcnt, 50);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_no_redelivery: consumed %d/%d\n", consumed, msgcnt);
 
         /* Poll again to trigger the implicit ack (piggybacked on the
          * next ShareFetch).  Expect 0 new records. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_no_redelivery: extra %d/0 (should be 0)\n", extra);
 
         test_share_consumer_close(consumer);
@@ -241,30 +191,30 @@ static void do_test_implicit_ack_with_new_records(void) {
                     "Failed to create mock topic");
 
         /* Batch A */
-        produce_messages(ctx.producer, topic, 3);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 3);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-newrecords");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed_a = consume_n(consumer, 3, 40);
+        consumed_a = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("ack_new_records: A consumed %d/3\n", consumed_a);
 
         /* Trigger implicit ack for batch A. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_new_records: A extra %d/0 (ack sent)\n", extra);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
 
         /* Batch B */
-        produce_messages(ctx.producer, topic, 3);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 3);
 
         /* Consumer B: same group — batch A is archived, should get
          * only batch B. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-newrecords");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed_b = consume_n(consumer, 3, 40);
+        consumed_b = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("ack_new_records: B consumed %d/3 (batch B only)\n",
                  consumed_b);
 
@@ -299,17 +249,19 @@ static void do_test_implicit_ack_cross_consumer(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: consume and ack. */
         consumer_a = new_share_consumer(ctx.bootstraps, "sg-ack-cross");
         subscribe_topics(consumer_a, &topic, 1);
 
-        consumed_a = consume_n(consumer_a, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer_a, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_cross_consumer: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer_a, 1, 10);
+        extra = test_share_consume_msgs(consumer_a, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_cross_consumer: A extra %d/0\n", extra);
 
         test_share_consumer_close(consumer_a);
@@ -319,7 +271,7 @@ static void do_test_implicit_ack_cross_consumer(void) {
         consumer_b = new_share_consumer(ctx.bootstraps, "sg-ack-cross");
         subscribe_topics(consumer_b, &topic, 1);
 
-        consumed_b = consume_n(consumer_b, 1, 15);
+        consumed_b = test_share_consume_msgs(consumer_b, 1, 15, 500, NULL, 0);
         TEST_SAY("ack_cross_consumer: B consumed %d/0 (should be 0)\n",
                  consumed_b);
 
@@ -354,16 +306,17 @@ static void do_test_implicit_ack_multi_partition(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 2, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-multipart");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, msgcnt, 60);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 60, 500, NULL, 0);
         TEST_SAY("ack_multi_partition: consumed %d/%d\n", consumed, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_multi_partition: extra %d/0\n", extra);
 
         test_share_consumer_close(consumer);
@@ -407,13 +360,15 @@ static void do_test_implicit_ack_multiple_rounds(void) {
                 rd_kafka_share_t *consumer;
                 int got, extra;
 
-                produce_messages(ctx.producer, topic, per_round);
+                test_produce_msgs_simple(ctx.producer, topic,
+                                         RD_KAFKA_PARTITION_UA, per_round);
 
                 consumer =
                     new_share_consumer(ctx.bootstraps, "sg-ack-multiround");
                 subscribe_topics(consumer, &topic, 1);
 
-                got = consume_n(consumer, per_round, 40);
+                got = test_share_consume_msgs(consumer, per_round, 40, 500,
+                                              NULL, 0);
                 TEST_SAY("ack_multiple_rounds: round %d consumed %d/%d\n",
                          r + 1, got, per_round);
                 total_consumed += got;
@@ -421,7 +376,7 @@ static void do_test_implicit_ack_multiple_rounds(void) {
                         round_ok = 0;
 
                 /* Trigger implicit ack. */
-                extra = consume_n(consumer, 1, 5);
+                extra = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
                 if (extra != 0) {
                         TEST_SAY(
                             "ack_multiple_rounds: round %d extra %d "
@@ -463,16 +418,16 @@ static void do_test_implicit_ack_single_record(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, 1);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 1);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-single");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, 1, 40);
+        consumed = test_share_consume_msgs(consumer, 1, 40, 500, NULL, 0);
         TEST_SAY("ack_single_record: consumed %d/1\n", consumed);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_single_record: extra %d/0 (should be 0)\n", extra);
 
         test_share_consumer_close(consumer);
@@ -505,16 +460,17 @@ static void do_test_implicit_ack_large_batch(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-large");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, msgcnt, 80);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 80, 500, NULL, 0);
         TEST_SAY("ack_large_batch: consumed %d/%d\n", consumed, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_large_batch: extra %d/0 (should be 0)\n", extra);
 
         test_share_consumer_close(consumer);
@@ -554,18 +510,20 @@ static void do_test_implicit_ack_multi_topic(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic B");
 
-        produce_messages(ctx.producer, topic_a, 3);
-        produce_messages(ctx.producer, topic_b, 3);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 3);
+        test_produce_msgs_simple(ctx.producer, topic_b, RD_KAFKA_PARTITION_UA,
+                                 3);
 
         /* Consumer A: subscribe to both, consume all 6, ack. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-mtopic");
         subscribe_topics(consumer, both, 2);
 
-        consumed = consume_n(consumer, 6, 60);
+        consumed = test_share_consume_msgs(consumer, 6, 60, 500, NULL, 0);
         TEST_SAY("ack_multi_topic: consumed %d/6 from both\n", consumed);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_multi_topic: extra %d/0\n", extra);
 
         test_share_consumer_close(consumer);
@@ -575,7 +533,7 @@ static void do_test_implicit_ack_multi_topic(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-mtopic");
         subscribe_topics(consumer, both, 2);
 
-        consumed_b = consume_n(consumer, 1, 15);
+        consumed_b = test_share_consume_msgs(consumer, 1, 15, 500, NULL, 0);
         TEST_SAY("ack_multi_topic: B consumed %d/0 (should be 0)\n",
                  consumed_b);
 
@@ -629,11 +587,11 @@ static void do_test_implicit_ack_multi_msgset(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-multimsgset");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, msgcnt, 60);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 60, 500, NULL, 0);
         TEST_SAY("ack_multi_msgset: consumed %d/%d\n", consumed, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_multi_msgset: extra %d/0 (should be 0)\n", extra);
 
         test_share_consumer_close(consumer);
@@ -674,12 +632,14 @@ static void do_test_crash_before_ack_redelivery(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: acquire records, then crash (no close, no ack). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-redeliver");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("crash_before_ack: A consumed %d/%d\n", consumed_a, msgcnt);
         test_share_destroy(consumer); /* crash — no close */
 
@@ -689,7 +649,8 @@ static void do_test_crash_before_ack_redelivery(void) {
         /* Consumer B: should get the same records (re-delivered). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-redeliver");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("crash_before_ack: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
@@ -727,12 +688,14 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: acquire and crash. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-then-ack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("crash_then_ack: A consumed %d/%d (will crash)\n", consumed_a,
                  msgcnt);
         test_share_destroy(consumer);
@@ -741,12 +704,13 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         /* Consumer B: re-delivery, then ack via next poll. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-then-ack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("crash_then_ack: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("crash_then_ack: B extra %d/0\n", extra);
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -754,7 +718,7 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         /* Consumer C: should see 0 — records were acked by B. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-then-ack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, 1, 15);
+        consumed_c = test_share_consume_msgs(consumer, 1, 15, 500, NULL, 0);
         TEST_SAY("crash_then_ack: C consumed %d/0 (should be 0)\n", consumed_c);
 
         test_share_consumer_close(consumer);
@@ -794,12 +758,14 @@ static void do_test_session_expiry_invalidates_ack(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: consume records (acquires them). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-session-expire");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("session_expiry: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Block SGHB so heartbeats fail -> member evicted. */
@@ -836,7 +802,8 @@ static void do_test_session_expiry_invalidates_ack(void) {
          * when A's membership was evicted). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-session-expire");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("session_expiry: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
@@ -875,12 +842,14 @@ static void do_test_max_delivery_without_ack(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Delivery 1: Consumer A acquires and crashes. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-maxdel-noack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("max_delivery_no_ack: A consumed %d/%d (delivery 1)\n",
                  consumed_a, msgcnt);
         test_share_destroy(consumer);
@@ -889,7 +858,8 @@ static void do_test_max_delivery_without_ack(void) {
         /* Delivery 2 = max: Consumer B acquires and crashes. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-maxdel-noack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("max_delivery_no_ack: B consumed %d/%d (delivery 2)\n",
                  consumed_b, msgcnt);
         test_share_destroy(consumer);
@@ -899,7 +869,7 @@ static void do_test_max_delivery_without_ack(void) {
          * count exhausted). Consumer C sees 0. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-maxdel-noack");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, 1, 10);
+        consumed_c = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("max_delivery_no_ack: C consumed %d/0 (archived)\n",
                  consumed_c);
 
@@ -939,12 +909,14 @@ static void do_test_sharefetch_error_drops_ack(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires records. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-sf-error");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("sf_error_drops_ack: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Inject ShareFetch transport errors — the next ShareFetch
@@ -967,7 +939,8 @@ static void do_test_sharefetch_error_drops_ack(void) {
         /* Consumer B should get re-delivered records. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-sf-error");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("sf_error_drops_ack: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
@@ -1012,14 +985,16 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic B");
 
-        produce_messages(ctx.producer, topic_a, 2);
-        produce_messages(ctx.producer, topic_b, 2);
+        test_produce_msgs_simple(ctx.producer, topic_a, RD_KAFKA_PARTITION_UA,
+                                 2);
+        test_produce_msgs_simple(ctx.producer, topic_b, RD_KAFKA_PARTITION_UA,
+                                 2);
 
         /* Consumer A: subscribe to both, consume all 4, then crash. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-forget");
         subscribe_topics(consumer, both, 2);
 
-        consumed_both = consume_n(consumer, 4, 60);
+        consumed_both = test_share_consume_msgs(consumer, 4, 60, 500, NULL, 0);
         TEST_SAY("forgotten_releases: consumed %d/4 from both\n",
                  consumed_both);
 
@@ -1031,12 +1006,12 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-forget");
         subscribe_topics(consumer, &topic_a, 1);
 
-        consumed_a = consume_n(consumer, 2, 40);
+        consumed_a = test_share_consume_msgs(consumer, 2, 40, 500, NULL, 0);
         TEST_SAY("forgotten_releases: B consumed %d/2 from topic_a\n",
                  consumed_a);
 
         /* Trigger implicit ack for topic_a. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
 
@@ -1045,7 +1020,7 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-forget");
         subscribe_topics(consumer, &topic_b, 1);
 
-        consumed_b = consume_n(consumer, 2, 40);
+        consumed_b = test_share_consume_msgs(consumer, 2, 40, 500, NULL, 0);
         TEST_SAY(
             "forgotten_releases: C consumed %d/2 from topic_b "
             "(should be re-delivered)\n",
@@ -1088,12 +1063,14 @@ static void do_test_multi_consumer_cascade_crash(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A: acquire and crash. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-cascade-crash");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("cascade_crash: A consumed %d/%d\n", consumed_a, msgcnt);
         test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL);
@@ -1101,7 +1078,8 @@ static void do_test_multi_consumer_cascade_crash(void) {
         /* Consumer B: re-acquire and crash. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-cascade-crash");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("cascade_crash: B consumed %d/%d\n", consumed_b, msgcnt);
         test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL);
@@ -1109,7 +1087,8 @@ static void do_test_multi_consumer_cascade_crash(void) {
         /* Consumer C: re-acquire and crash. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-cascade-crash");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, msgcnt, 50);
+        consumed_c =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("cascade_crash: C consumed %d/%d\n", consumed_c, msgcnt);
 
         test_share_consumer_close(consumer);
@@ -1151,12 +1130,14 @@ static void do_test_lock_expiry_before_ack(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires records. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-lockexpire");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("lock_expiry_before_ack: A consumed %d/%d\n", consumed_a,
                  msgcnt);
 
@@ -1179,7 +1160,8 @@ static void do_test_lock_expiry_before_ack(void) {
          * A's ack could be delivered. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-lockexpire");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("lock_expiry_before_ack: B consumed %d/%d\n", consumed_b,
                  msgcnt);
 
@@ -1220,7 +1202,7 @@ static void do_test_empty_topic_no_ack_side_effects(void) {
         subscribe_topics(consumer, &topic, 1);
 
         /* Phase 1: Poll empty topic — no records, no acks. */
-        consumed_empty = consume_n(consumer, 1, 5);
+        consumed_empty = test_share_consume_msgs(consumer, 1, 5, 500, NULL, 0);
         TEST_SAY("empty_topic: phase1 consumed %d/0 (should be 0)\n",
                  consumed_empty);
 
@@ -1229,16 +1211,17 @@ static void do_test_empty_topic_no_ack_side_effects(void) {
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
 
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-empty-topic");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, msgcnt, 50);
+        consumed = test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("empty_topic: phase2 consumed %d/%d\n", consumed, msgcnt);
 
         /* Phase 3: Trigger implicit ack, verify 0. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("empty_topic: phase3 extra %d/0 (should be 0)\n", extra);
 
         test_share_consumer_close(consumer);
@@ -1278,15 +1261,17 @@ static void do_test_coordinator_failover_ack_recovery(void) {
                     "Failed to create mock topic");
 
         /* Phase 1: Consumer A consumes and acks normally. */
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-coord-failover");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("coord_failover: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Trigger implicit ack. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("coord_failover: A extra %d/0\n", extra);
 
         test_share_consumer_close(consumer);
@@ -1309,17 +1294,19 @@ static void do_test_coordinator_failover_ack_recovery(void) {
 
         /* Wait for errors to start draining, then produce new records. */
         rd_usleep(1000 * 1000, NULL);
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Phase 3: Errors drain, new consumer B joins and consumes
          * the newly produced records (A's records are already acked). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-coord-failover");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 60);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 60, 500, NULL, 0);
         TEST_SAY("coord_failover: B consumed %d/%d\n", consumed_b, msgcnt);
 
         /* Trigger implicit ack for B's records. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("coord_failover: B extra %d/0\n", extra);
 
         test_share_consumer_close(consumer);
@@ -1328,7 +1315,7 @@ static void do_test_coordinator_failover_ack_recovery(void) {
         /* Phase 4: Consumer C — everything is acked, should see 0. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-coord-failover");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, 1, 15);
+        consumed_c = test_share_consume_msgs(consumer, 1, 15, 500, NULL, 0);
         TEST_SAY("coord_failover: C consumed %d/0 (should be 0)\n", consumed_c);
 
         test_share_consumer_close(consumer);
@@ -1368,12 +1355,14 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires records. */
         consumer_a = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_a, &topic, 1);
-        consumed_a = consume_n(consumer_a, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer_a, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_invalid_state: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Inject RTT so A's ack is delayed past lock expiry. */
@@ -1397,11 +1386,12 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
          * ShareFetch). */
         consumer_b = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_b, &topic, 1);
-        consumed_b = consume_n(consumer_b, msgcnt, 50);
+        consumed_b =
+            test_share_consume_msgs(consumer_b, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_invalid_state: B consumed %d/%d\n", consumed_b, msgcnt);
 
         /* Second poll triggers implicit ack for B's records. */
-        consume_n(consumer_b, 1, 3);
+        test_share_consume_msgs(consumer_b, 1, 3, 500, NULL, 0);
 
         rd_kafka_share_consumer_close(consumer_b);
         rd_kafka_share_destroy(consumer_b);
@@ -1409,7 +1399,7 @@ static void do_test_ack_after_lock_expiry_redelivers(void) {
         /* Consumer C should get 0 records — B's ack succeeded. */
         consumer_c = new_share_consumer(ctx.bootstraps, "sg-ack-invalid-state");
         subscribe_topics(consumer_c, &topic, 1);
-        consumed_c = consume_n(consumer_c, 1, 5);
+        consumed_c = test_share_consume_msgs(consumer_c, 1, 5, 500, NULL, 0);
         TEST_SAY("ack_invalid_state: C consumed %d (expected 0)\n", consumed_c);
 
         rd_kafka_share_consumer_close(consumer_c);
@@ -1447,7 +1437,8 @@ static void do_test_ack_success_advances_spso(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         /* Consumer A acquires first batch. MaxRecords in the client
          * defaults to a large value, so it will get all 6.  We use
@@ -1456,11 +1447,11 @@ static void do_test_ack_success_advances_spso(void) {
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-spso");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, 3, 30);
+        consumed_a = test_share_consume_msgs(consumer, 3, 30, 500, NULL, 0);
         TEST_SAY("ack_spso: A consumed %d/3\n", consumed_a);
 
         /* Second poll triggers implicit ack for A's records. */
-        consume_n(consumer, 1, 3);
+        test_share_consume_msgs(consumer, 1, 3, 500, NULL, 0);
 
         /* Close A cleanly. */
         rd_kafka_share_consumer_close(consumer);
@@ -1472,7 +1463,7 @@ static void do_test_ack_success_advances_spso(void) {
         /* Consumer B should get records 3-5 (SPSO advanced past 0-2). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-spso");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, 3, 30);
+        consumed_b = test_share_consume_msgs(consumer, 3, 30, 500, NULL, 0);
         TEST_SAY("ack_spso: B consumed %d/3\n", consumed_b);
 
         rd_kafka_share_consumer_close(consumer);
@@ -1499,8 +1490,8 @@ static void do_test_final_fetch_no_acquisition(void) {
         const char *topic = "kip932_final_fetch_no_acq";
         const int msgcnt  = 6;
         test_ctx_t ctx;
-        rd_kafka_share_t *consumer;
-        int consumed_a, consumed_a2, consumed_b, extra;
+        rd_kafka_share_t *consumer, *consumer_c;
+        int consumed_a, consumed_a2, consumed_b, consumed_c, extra;
 
         SUB_TEST();
         ctx = test_ctx_new();
@@ -1511,16 +1502,17 @@ static void do_test_final_fetch_no_acquisition(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed_a = consume_n(consumer, 3, 40);
+        consumed_a = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("final_fetch_no_acq: A batch1 consumed %d/3\n", consumed_a);
 
         /* Implicit ack for batch1, acquires batch2. */
-        consumed_a2 = consume_n(consumer, 3, 40);
+        consumed_a2 = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("final_fetch_no_acq: A batch2 consumed %d/3\n", consumed_a2);
 
         /* Close sends epoch=-1; batch2 records released. */
@@ -1533,31 +1525,26 @@ static void do_test_final_fetch_no_acquisition(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed_b = consume_n(consumer, 3, 40);
+        consumed_b = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("final_fetch_no_acq: B consumed %d/3\n", consumed_b);
 
-        extra = consume_n(consumer, 1, 5); /* ack B's records */
+        extra = test_share_consume_msgs(consumer, 1, 5, 500, NULL,
+                                        0); /* ack B's records */
 
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 
         /* C should see nothing — everything acked. */
-        {
-                rd_kafka_share_t *consumer_c;
-                int consumed_c;
+        consumer_c = new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
+        subscribe_topics(consumer_c, &topic, 1);
+        consumed_c = test_share_consume_msgs(consumer_c, 1, 10, 500, NULL, 0);
+        TEST_SAY("final_fetch_no_acq: C consumed %d/0 (should be 0)\n",
+                 consumed_c);
+        rd_kafka_share_consumer_close(consumer_c);
+        rd_kafka_share_destroy(consumer_c);
 
-                consumer_c =
-                    new_share_consumer(ctx.bootstraps, "sg-final-no-acq");
-                subscribe_topics(consumer_c, &topic, 1);
-                consumed_c = consume_n(consumer_c, 1, 10);
-                TEST_SAY("final_fetch_no_acq: C consumed %d/0 (should be 0)\n",
-                         consumed_c);
-                rd_kafka_share_consumer_close(consumer_c);
-                rd_kafka_share_destroy(consumer_c);
-
-                TEST_ASSERT(consumed_c == 0,
-                            "C: expected 0 consumed, got %d", consumed_c);
-        }
+        TEST_ASSERT(consumed_c == 0, "C: expected 0 consumed, got %d",
+                    consumed_c);
 
         test_ctx_destroy(&ctx);
 
@@ -1590,32 +1577,32 @@ static void do_test_ack_after_log_retention_silent(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
-        consumer =
-            new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_log_retention_silent: A consumed %d/%d\n", consumed_a,
                  msgcnt);
 
         /* Move start_offset past first 3 records (simulates retention). */
-        rd_kafka_mock_partition_set_follower_wmarks(ctx.mcluster, topic, 0,
-                                                     3, -1);
+        rd_kafka_mock_partition_set_follower_wmarks(ctx.mcluster, topic, 0, 3,
+                                                    -1);
 
         /* Implicit ack covers all 5; offsets 0-2 are below SPSO now. */
-        extra = consume_n(consumer, 1, 10);
+        extra = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_log_retention_silent: A extra %d/0\n", extra);
 
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 
         /* B should see nothing. */
-        consumer =
-            new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
+        consumer = new_share_consumer(ctx.bootstraps, "sg-ack-log-ret-silent");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, 1, 10);
+        consumed_b = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_log_retention_silent: B consumed %d/0 (should be 0)\n",
                  consumed_b);
 
@@ -1654,11 +1641,13 @@ static void do_test_ack_atomicity_lock_expiry(void) {
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
         subscribe_topics(consumer, &topic, 1);
-        consumed_a = consume_n(consumer, msgcnt, 50);
+        consumed_a =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
         TEST_SAY("ack_atomicity: A consumed %d/%d\n", consumed_a, msgcnt);
 
         /* Delay A's next ShareFetch past lock expiry. */
@@ -1666,7 +1655,7 @@ static void do_test_ack_atomicity_lock_expiry(void) {
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, 2, 3000);
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, 3, 3000);
 
-        rd_usleep(800 * 1000, NULL); /* locks expire */
+        rd_usleep(800 * 1000, NULL);      /* locks expire */
         rd_kafka_share_destroy(consumer); /* crash */
 
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 0);
@@ -1676,18 +1665,20 @@ static void do_test_ack_atomicity_lock_expiry(void) {
         /* B re-acquires everything (A's ack was rejected atomically). */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
         subscribe_topics(consumer, &topic, 1);
-        consumed_b = consume_n(consumer, msgcnt, 50);
-        TEST_SAY("ack_atomicity: B consumed %d/%d (re-delivered)\n",
-                 consumed_b, msgcnt);
+        consumed_b =
+            test_share_consume_msgs(consumer, msgcnt, 50, 500, NULL, 0);
+        TEST_SAY("ack_atomicity: B consumed %d/%d (re-delivered)\n", consumed_b,
+                 msgcnt);
 
-        consume_n(consumer, 1, 5); /* ack B's records */
+        test_share_consume_msgs(consumer, 1, 5, 500, NULL,
+                                0); /* ack B's records */
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
 
         /* C sees nothing. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-atomicity");
         subscribe_topics(consumer, &topic, 1);
-        consumed_c = consume_n(consumer, 1, 10);
+        consumed_c = test_share_consume_msgs(consumer, 1, 10, 500, NULL, 0);
         TEST_SAY("ack_atomicity: C consumed %d/0 (should be 0)\n", consumed_c);
 
         rd_kafka_share_consumer_close(consumer);
@@ -1727,12 +1718,13 @@ static void do_test_not_leader_or_follower_redirect(void) {
                     "Failed to create mock topic");
 
         rd_kafka_mock_partition_set_leader(ctx.mcluster, topic, 0, 1);
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         consumer = new_share_consumer(ctx.bootstraps, "sg-not-leader");
         subscribe_topics(consumer, &topic, 1);
 
-        consumed = consume_n(consumer, 3, 40);
+        consumed = test_share_consume_msgs(consumer, 3, 40, 500, NULL, 0);
         TEST_SAY("not_leader: consumed %d/3 from broker 1\n", consumed);
 
         /* Move leader to broker 2 between fetches. */
@@ -1740,15 +1732,15 @@ static void do_test_not_leader_or_follower_redirect(void) {
         rd_kafka_mock_sharegroup_set_max_record_locks(ctx.mcluster, 0);
 
         /* Client should handle the redirect transparently. */
-        consumed += consume_n(consumer, 3, 60);
+        consumed += test_share_consume_msgs(consumer, 3, 60, 500, NULL, 0);
         TEST_SAY("not_leader: total consumed %d/6\n", consumed);
 
         rd_kafka_share_consumer_close(consumer);
         rd_kafka_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
-        TEST_ASSERT(consumed == msgcnt,
-                    "Expected consumed=%d, got %d", msgcnt, consumed);
+        TEST_ASSERT(consumed == msgcnt, "Expected consumed=%d, got %d", msgcnt,
+                    consumed);
         SUB_TEST_PASS();
 }
 
@@ -1791,7 +1783,6 @@ int main_0157_share_consumer_ack_mock(int argc, char **argv) {
         do_test_ack_after_lock_expiry_redelivers();
         do_test_ack_success_advances_spso();
 
-        /* Mock broker fix tests */
         do_test_final_fetch_no_acquisition();
         do_test_ack_after_log_retention_silent();
         do_test_ack_atomicity_lock_expiry();

--- a/tests/0158-share_consumer_transactions_mock.c
+++ b/tests/0158-share_consumer_transactions_mock.c
@@ -103,22 +103,6 @@ static void test_ctx_destroy(test_ctx_t *ctx) {
         memset(ctx, 0, sizeof(*ctx));
 }
 
-static void
-produce_messages(rd_kafka_t *producer, const char *topic, int msgcnt) {
-        int i;
-        for (i = 0; i < msgcnt; i++) {
-                char payload[64];
-                snprintf(payload, sizeof(payload), "%s-%d", topic, i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
-}
-
 static void produce_txn_messages(rd_kafka_t *txn_producer,
                                  const char *topic,
                                  int msgcnt,
@@ -177,45 +161,7 @@ static void subscribe_topics(rd_kafka_share_t *share_c,
         rd_kafka_topic_partition_list_destroy(tpl);
 }
 
-/**
- * @brief Consume up to \p expected messages, retrying up to \p max_attempts.
- *        Uses the same pattern as 0156's consume_n.
- */
-static int
-consume_n(rd_kafka_share_t *consumer, int expected, int max_attempts) {
-        int consumed = 0;
-        int attempts = 0;
 
-        while (consumed < expected && attempts < max_attempts) {
-                rd_kafka_message_t *rkmessages[100];
-                size_t rcvd_msgs = 0;
-                rd_kafka_error_t *error;
-                size_t i;
-
-                error = rd_kafka_share_consume_batch(consumer, 500, rkmessages,
-                                                     &rcvd_msgs);
-                attempts++;
-
-                if (error) {
-                        TEST_SAY("consume error: %s\n",
-                                 rd_kafka_error_string(error));
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-
-                for (i = 0; i < rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkmsg = rkmessages[i];
-                        if (rkmsg->err) {
-                                rd_kafka_message_destroy(rkmsg);
-                                continue;
-                        }
-                        consumed++;
-                        rd_kafka_message_destroy(rkmsg);
-                }
-        }
-
-        return consumed;
-}
 
 /**
  * @brief Committed txn data is delivered in read_uncommitted mode.
@@ -235,7 +181,7 @@ static void do_test_txn_committed_read_uncommitted(void) {
 
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-committed-ru");
         subscribe_topics(share_c, &topic, 1);
-        consumed = consume_n(share_c, 3, 50);
+        consumed = test_share_consume_msgs(share_c, 3, 50, 500, NULL, 0);
         TEST_ASSERT(consumed == 3, "Expected 3 consumed, got %d", consumed);
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -265,7 +211,7 @@ static void do_test_txn_aborted_read_uncommitted(void) {
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-aborted-ru");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 3, 50);
+        consumed = test_share_consume_msgs(share_c, 3, 50, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -292,13 +238,13 @@ static void do_test_txn_mixed_read_uncommitted(void) {
 
         TEST_CALL_ERR__(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1));
 
-        produce_messages(ctx.producer, topic, 2);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 2);
         produce_txn_messages(ctx.txn_producer, topic, 3, rd_true);
 
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-mixed-ru");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 5, 50);
+        consumed = test_share_consume_msgs(share_c, 5, 50, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -329,7 +275,7 @@ static void do_test_txn_committed_read_committed(void) {
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-committed-rc");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 3, 50);
+        consumed = test_share_consume_msgs(share_c, 3, 50, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -362,7 +308,7 @@ static void do_test_txn_aborted_read_committed(void) {
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-aborted-rc");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 0, 15);
+        consumed = test_share_consume_msgs(share_c, 0, 15, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -395,15 +341,15 @@ static void do_test_txn_mixed_read_committed(void) {
 
         TEST_CALL_ERR__(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1));
 
-        produce_messages(ctx.producer, topic, 2);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 2);
         produce_txn_messages(ctx.txn_producer, topic, 3, rd_true);
         produce_txn_messages(ctx.txn_producer, topic, 3, rd_false);
-        produce_messages(ctx.producer, topic, 2);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 2);
 
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-mixed-rc");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 7, 60);
+        consumed = test_share_consume_msgs(share_c, 7, 60, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -434,12 +380,12 @@ static void do_test_txn_nontxn_read_committed(void) {
 
         TEST_CALL_ERR__(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1));
 
-        produce_messages(ctx.producer, topic, 5);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA, 5);
 
         share_c = create_share_consumer(ctx.bootstraps, "sg-txn-nontxn-rc");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 5, 50);
+        consumed = test_share_consume_msgs(share_c, 5, 50, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);
@@ -481,7 +427,7 @@ static void do_test_txn_abort_then_commit_read_committed(void) {
             create_share_consumer(ctx.bootstraps, "sg-txn-abort-commit-rc");
         subscribe_topics(share_c, &topic, 1);
 
-        consumed = consume_n(share_c, 3, 50);
+        consumed = test_share_consume_msgs(share_c, 3, 50, 500, NULL, 0);
 
         test_share_consumer_close(share_c);
         test_share_destroy(share_c);

--- a/tests/0158-share_consumer_transactions_mock.c
+++ b/tests/0158-share_consumer_transactions_mock.c
@@ -71,6 +71,7 @@ static test_ctx_t test_ctx_new(const char *txn_id) {
         /* Non-transactional producer */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
         TEST_ASSERT(ctx.producer != NULL, "Failed to create producer: %s",

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -1296,6 +1296,7 @@ static test_ctx_t test_ctx_new(void) {
 
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
@@ -1311,22 +1312,6 @@ static void test_ctx_destroy(test_ctx_t *ctx) {
         if (ctx->mcluster)
                 test_mock_cluster_destroy(ctx->mcluster);
         memset(ctx, 0, sizeof(*ctx));
-}
-
-static void
-produce_messages(rd_kafka_t *producer, const char *topic, int msgcnt) {
-        int i;
-        for (i = 0; i < msgcnt; i++) {
-                char payload[64];
-                snprintf(payload, sizeof(payload), "%s-%d", topic, i);
-                TEST_ASSERT(rd_kafka_producev(
-                                producer, RD_KAFKA_V_TOPIC(topic),
-                                RD_KAFKA_V_VALUE(payload, strlen(payload)),
-                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
-                                RD_KAFKA_V_END) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Produce failed");
-        }
-        rd_kafka_flush(producer, 5000);
 }
 
 static rd_kafka_share_t *new_share_consumer(const char *bootstraps,
@@ -1382,6 +1367,7 @@ static void do_test_mock_inflight_caching(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         const char *topic = "mock-inflight-cache";
+        const char *t     = topic;
         const int msgcnt  = 100;
         int consumed = 0, i = 0;
         int share_fetch_cnt, share_ack_cnt;
@@ -1395,15 +1381,13 @@ static void do_test_mock_inflight_caching(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
 
-        produce_messages(ctx.producer, topic, msgcnt);
+        test_produce_msgs_simple(ctx.producer, topic, RD_KAFKA_PARTITION_UA,
+                                 msgcnt);
 
         rkshare =
             new_share_consumer(ctx.bootstraps, "sg-mock-inflight", "explicit");
 
-        {
-                const char *t = topic;
-                subscribe_consumer(rkshare, &t, 1);
-        }
+        subscribe_consumer(rkshare, &t, 1);
 
         /* Clear and start tracking requests before the consume+ack+commit
          * loop */

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1056,6 +1056,7 @@ static test_ctx_t test_ctx_new(void) {
 
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
 
         ctx.producer =
             rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));


### PR DESCRIPTION
**Summary**
1. `epoch=-1` ShareFetch no longer acquires new records. It only processes piggybacked acks, releases remaining locks, and closes the session.
2. When log retention advances SPSO past acquired records, the consumer's ack for those offsets succeeds instead of returning INVALID_RECORD_STATE.
3. Ack validation uses a two-pass approach (validate all, then apply all). If any record in the batch fails, the entire batch is rejected with no partial application. 
4. ShareFetch and ShareAcknowledge now return NOT_LEADER_OR_FOLLOWER per-partition when the receiving broker isn't the partition leader, with actual leader ID and epoch in CurrentLeader. 