### PR TITLE
[KIP-932]: Create wrappers around close and destroy

### DIFF
--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -161,8 +161,8 @@ static void do_test_share_group_heartbeat_basic(void) {
                     "Expected at least 2 heartbeats, got %d", found_heartbeats);
 
         /* Close consumer (sends leave heartbeat) */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         /* Verify leave heartbeat was sent */
         found_heartbeats = wait_share_heartbeats(mcluster, 3, 1000);
@@ -265,8 +265,8 @@ static void do_test_share_group_assignment_rebalance(void) {
         rd_kafka_topic_partition_list_destroy(share_c2_assignment);
 
         /* C2 leaves - C1 should get all partitions back */
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c2);
 
         cnt = wait_assignment_count(share_c1, 3, 10000);
         TEST_ASSERT(cnt == 3,
@@ -274,8 +274,8 @@ static void do_test_share_group_assignment_rebalance(void) {
                     cnt);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_destroy(share_c1);
+        test_share_consumer_close(share_c1);
+        test_share_destroy(share_c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -436,8 +436,8 @@ static void do_test_share_group_multi_topic_assignment(void) {
 
         /* C1 leaves - C2 should get all orders, C3 all events.
          * Wait until C2 has 4 orders and C3 has 2 events. */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_destroy(share_c1);
+        test_share_consumer_close(share_c1);
+        test_share_destroy(share_c1);
 
         deadline = test_clock() + 15000 * 1000;
         while (test_clock() < deadline) {
@@ -472,8 +472,8 @@ static void do_test_share_group_multi_topic_assignment(void) {
         rd_kafka_topic_partition_list_destroy(share_c3_assign);
 
         /* C2 leaves - C3 should still have events only */
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c2);
 
         /* Wait for C3 to stabilize with 2 events, 0 orders */
         cnt = wait_assignment_count(share_c3, 2, 10000);
@@ -489,8 +489,8 @@ static void do_test_share_group_multi_topic_assignment(void) {
         rd_kafka_topic_partition_list_destroy(share_c3_assign);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c3);
-        rd_kafka_share_destroy(share_c3);
+        test_share_consumer_close(share_c3);
+        test_share_destroy(share_c3);
 
         rd_kafka_topic_partition_list_destroy(sub_both);
         rd_kafka_topic_partition_list_destroy(sub_orders);
@@ -554,8 +554,8 @@ static void do_test_share_group_error_injection(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -643,8 +643,8 @@ static void do_test_share_group_rtt_injection(void) {
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -721,15 +721,15 @@ static void do_test_share_group_session_timeout(void) {
                     "Both consumers should have partitions");
 
         /* Destroy C2 without close to simulate crash */
-        rd_kafka_share_destroy(share_c2);
+        test_share_destroy(share_c2);
 
         /* Wait for C2's session to time out (3s) and C1 to get
          * all partitions back. */
         TEST_ASSERT(wait_assignment_count(share_c1, 4, 10000) == 4,
                     "C1 should have all 4 partitions after C2 timeout");
 
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_destroy(share_c1);
+        test_share_consumer_close(share_c1);
+        test_share_destroy(share_c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -880,10 +880,10 @@ static void do_test_share_group_target_assignment(void) {
         rd_free(member_ids);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c1);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c1);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c1);
+        test_share_destroy(share_c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -952,8 +952,8 @@ static void do_test_share_group_no_spurious_fencing(void) {
         TEST_SAY("No spurious fencing after 5 seconds\n");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();
@@ -1022,8 +1022,8 @@ static void do_test_unknown_member_id_error(void) {
                     "Expected 3 partitions after rejoin");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1088,8 +1088,8 @@ static void do_test_fenced_member_epoch_error(void) {
                     "Expected 3 partitions after rejoin");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1154,8 +1154,8 @@ static void do_test_coordinator_not_available_error(void) {
                     "Expected 3 partitions after retry");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1220,8 +1220,8 @@ static void do_test_not_coordinator_error(void) {
                     "Expected 3 partitions after finding coordinator");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1279,8 +1279,8 @@ static void do_test_group_authorization_failed_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1349,10 +1349,10 @@ static void do_test_group_max_size_reached_error(void) {
         rd_kafka_topic_partition_list_destroy(subscription);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c1);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c1);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c1);
+        test_share_destroy(share_c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1421,8 +1421,8 @@ static void do_test_member_rejoin_with_epoch_zero(void) {
                     "Expected 3 partitions after rejoin");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1489,16 +1489,16 @@ static void do_test_leaving_member_bumps_group_epoch(void) {
         }
 
         /* C2 leaves (sends epoch=-1 leave heartbeat) */
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c2);
 
         /* Wait for C1 to get all partitions after C2 left */
         TEST_ASSERT(wait_assignment_count(share_c1, 4, 10000) == 4,
                     "C1 should have all 4 partitions after C2 left");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_destroy(share_c1);
+        test_share_consumer_close(share_c1);
+        test_share_destroy(share_c1);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1564,8 +1564,8 @@ static void do_test_partition_assignment_with_multiple_topics(void) {
         rd_kafka_topic_partition_list_destroy(assignment);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1672,12 +1672,12 @@ static void do_test_multiple_members_partition_distribution(void) {
         rd_kafka_topic_partition_list_destroy(share_c3_assign);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_consumer_close(share_c3);
-        rd_kafka_share_destroy(share_c1);
-        rd_kafka_share_destroy(share_c2);
-        rd_kafka_share_destroy(share_c3);
+        test_share_consumer_close(share_c1);
+        test_share_consumer_close(share_c2);
+        test_share_consumer_close(share_c3);
+        test_share_destroy(share_c1);
+        test_share_destroy(share_c2);
+        test_share_destroy(share_c3);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1696,7 +1696,6 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-success";
 
@@ -1724,12 +1723,10 @@ static void do_test_leave_heartbeat_completes_successfully(void) {
         /* Leave group - should send leave heartbeat and complete.
          * Note: After close(), we cannot call rd_kafka_assignment() anymore
          * as the broker handle is destroyed. */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         /* Cleanup */
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1748,7 +1745,6 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-leave-error";
 
@@ -1781,15 +1777,10 @@ static void do_test_leave_heartbeat_completes_on_error(void) {
         /* Leave group - should still complete despite error (best effort).
          * The key behavior: close() must not hang even when the leave
          * heartbeat gets an error response. */
-        err = rd_kafka_share_consumer_close(share_c);
-        /* Close completed (didn't hang) - this is the primary assertion.
-         * The return code may vary depending on whether the error was
-         * processed during leave. */
-        TEST_SAY("Leave completed with: %s (didn't hang - correct)\n",
-                 rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         /* Cleanup */
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1880,8 +1871,8 @@ static void do_test_subscription_change(void) {
                     found_topicB);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -1901,7 +1892,7 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err, fatal_err;
+        rd_kafka_resp_err_t fatal_err;
         char errstr[256];
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-id-not-found-unsub";
@@ -1951,11 +1942,10 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
                     rd_kafka_err2str(fatal_err), errstr);
 
         /* Close consumer */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_SAY("Close returned: %s\n", rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         /* Cleanup */
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2027,8 +2017,8 @@ static void do_test_group_id_not_found_while_unsubscribed(void) {
 //                  rd_kafka_err2str(fatal_err), errstr);
 
 //         /* Cleanup */
-//         rd_kafka_share_consumer_close(share_c);
-//         rd_kafka_share_destroy(share_c);
+//         test_share_consumer_close(share_c);
+//         test_share_destroy(share_c);
 
 //         rd_kafka_mock_stop_request_tracking(mcluster);
 //         test_mock_cluster_destroy(mcluster);
@@ -2086,8 +2076,8 @@ static void do_test_invalid_request_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2145,8 +2135,8 @@ static void do_test_unsupported_version_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2210,8 +2200,8 @@ static void do_test_coordinator_load_in_progress_error(void) {
                     "Expected 3 partitions after retry");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2230,7 +2220,6 @@ static void do_test_graceful_shutdown_stable_state(void) {
         const char *bootstraps;
         rd_kafka_topic_partition_list_t *subscription, *assignment;
         rd_kafka_share_t *share_c;
-        rd_kafka_resp_err_t err;
         int found_heartbeats;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "test-share-group-graceful-shutdown";
@@ -2268,16 +2257,14 @@ static void do_test_graceful_shutdown_stable_state(void) {
         rd_kafka_mock_start_request_tracking(mcluster);
 
         /* Close consumer gracefully - should send leave heartbeat */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         /* Verify leave heartbeat was sent */
         found_heartbeats = wait_share_heartbeats(mcluster, 1, 1000);
         TEST_SAY("Found %d heartbeats during shutdown\n", found_heartbeats);
 
         /* Cleanup */
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2347,8 +2334,8 @@ static void do_test_resubscribe_after_unsubscribe(void) {
                     "Expected 3 partitions after resubscribe");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2412,8 +2399,8 @@ static void do_test_consumer_leave_rebalance(void) {
 
         /* share consumer 3 leaves */
         TEST_SAY("Share consumer 3 leaving...\n");
-        rd_kafka_share_consumer_close(share_c3);
-        rd_kafka_share_destroy(share_c3);
+        test_share_consumer_close(share_c3);
+        test_share_destroy(share_c3);
 
         /* Wait for rebalance to propagate to remaining consumers */
         dl = test_clock() + 15000 * 1000;
@@ -2446,10 +2433,10 @@ static void do_test_consumer_leave_rebalance(void) {
                     final_total);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(share_c1);
-        rd_kafka_share_consumer_close(share_c2);
-        rd_kafka_share_destroy(share_c1);
-        rd_kafka_share_destroy(share_c2);
+        test_share_consumer_close(share_c1);
+        test_share_consumer_close(share_c2);
+        test_share_destroy(share_c1);
+        test_share_destroy(share_c2);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2467,7 +2454,6 @@ static void do_test_double_close(void) {
         const char *group_id = topic;
         rd_kafka_share_t *share_c;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_resp_err_t err;
 
         SUB_TEST_QUICK();
 
@@ -2485,19 +2471,15 @@ static void do_test_double_close(void) {
         wait_share_heartbeats(mcluster, 3, 1000);
 
         /* First close - should succeed */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(!err, "Expected first close to succeed, got %s",
-                    rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         /* Second close - should handle gracefully without crashing.
          * The Java equivalent tests verify the CompletableFuture
          * completes immediately on double-leave. */
-        err = rd_kafka_share_consumer_close(share_c);
-        TEST_SAY("Second close returned: %s (no crash - correct)\n",
-                 rd_kafka_err2str(err));
+        test_share_consumer_close(share_c);
 
         rd_kafka_topic_partition_list_destroy(subscription);
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2542,8 +2524,8 @@ static void do_test_empty_topic_subscription(void) {
 
         rd_kafka_topic_partition_list_destroy(subscription);
         rd_kafka_topic_partition_list_destroy(assignment);
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
         test_mock_cluster_destroy(mcluster);
@@ -2583,7 +2565,7 @@ static void do_test_empty_topic_list_subscription(void) {
                  rd_kafka_err2str(err));
 
         rd_kafka_topic_partition_list_destroy(empty_list);
-        rd_kafka_share_destroy(share_c);
+        test_share_destroy(share_c);
 
         test_mock_cluster_destroy(mcluster);
 

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -183,8 +183,8 @@ static void do_test_basic_consume(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, msgcnt, 50);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt, "Expected %d consumed, got %d", msgcnt,
@@ -210,8 +210,8 @@ static void do_test_followup_fetch(void) {
         consumed = consume_n(consumer, 3, 30);
         consumed += consume_n(consumer, 2, 30);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 5, "Expected 5 consumed, got %d", consumed);
@@ -236,8 +236,8 @@ static void do_test_multi_partition(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, msgcnt, 60);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt, "Expected %d consumed, got %d", msgcnt,
@@ -268,8 +268,8 @@ static void do_test_multi_topic(void) {
         subscribe_topics(consumer, topics, 2);
         consumed = consume_n(consumer, 4, 40);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 4, "Expected 4 consumed, got %d", consumed);
@@ -292,8 +292,8 @@ static void do_test_empty_topic_no_records(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 5);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed, got %d", consumed);
@@ -318,8 +318,8 @@ static int do_test_negative_sharefetch_error(rd_kafka_resp_err_t err) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 30);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         return consumed;
@@ -366,8 +366,8 @@ static void do_test_sghb_error(rd_kafka_resp_err_t err, int count) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 5);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed, got %d", consumed);
@@ -395,8 +395,8 @@ static void do_test_topic_error(rd_kafka_resp_err_t err) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 5);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed, got %d", consumed);
@@ -420,8 +420,8 @@ static void do_test_unknown_topic_subscription(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 5);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed, got %d", consumed);
@@ -444,8 +444,8 @@ static void do_test_empty_fetch_no_records(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed = consume_n(consumer, 1, 5);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed, got %d", consumed);
@@ -524,8 +524,8 @@ static void do_test_member_validation(void) {
         consumed_p3 = consume_n(consumer, 2, 50);
         TEST_SAY("member_validation: phase3 consumed %d/2\n", consumed_p3);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_p1 >= 2 && (consumed_p1 + consumed_p3) >= msgcnt,
@@ -575,8 +575,8 @@ static void do_test_sharefetch_session_expiry_rtt(void) {
         consumed += consume_n(consumer, 1, 30);
         TEST_SAY("rtt_expiry: phase3 consumed %d/2 total\n", consumed);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 2, "Expected 2 consumed, got %d", consumed);
@@ -622,8 +622,8 @@ static void do_test_forgotten_topics(void) {
         TEST_SAY("forgotten_topics: consumed %d/6 total after forget\n",
                  consumed);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         /* We expect at least the 4 initial + 2 from topic_a = 6.
@@ -672,8 +672,8 @@ static void do_test_multi_batch_consume(void) {
         consumed = consume_n(consumer, msgcnt, 50);
         TEST_SAY("multi_batch: consumed %d/%d\n", consumed, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt, "Expected %d consumed, got %d", msgcnt,
@@ -714,7 +714,7 @@ static void do_test_max_delivery_attempts(void) {
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("max_delivery: A consumed %d/%d (delivery 1)\n", consumed_a,
                  msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, 0); /* wait for lock expiry */
 
         /* Delivery 2: Consumer B acquires same records again (delivery_count
@@ -724,7 +724,7 @@ static void do_test_max_delivery_attempts(void) {
         consumed_b = consume_n(consumer, msgcnt, 50);
         TEST_SAY("max_delivery: B consumed %d/%d (delivery 2)\n", consumed_b,
                  msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, 0); /* wait for lock expiry */
 
         /* Delivery 3 attempt: Consumer C should get 0 records because
@@ -735,8 +735,8 @@ static void do_test_max_delivery_attempts(void) {
         TEST_SAY("max_delivery: C consumed %d/0 (should be archived)\n",
                  consumed_c);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&
@@ -778,10 +778,10 @@ static void do_test_record_lock_duration(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("lock_duration: A consumed %d/%d\n", consumed_a, msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
 
         /* Wait for record lock to expire (300ms + margin).
-         * rd_kafka_share_destroy sends SGHB LEAVE which releases
+         * test_share_destroy sends SGHB LEAVE which releases
          * locks immediately, but we still need to wait for the
          * client's internal rejoin cycle to settle. */
         rd_usleep(1000 * 1000, 0);
@@ -795,8 +795,8 @@ static void do_test_record_lock_duration(void) {
         consumed_b = consume_n(consumer, msgcnt, 100);
         TEST_SAY("lock_duration: B consumed %d/%d\n", consumed_b, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -840,7 +840,7 @@ static void do_test_multi_consumer_lock_expiry(void) {
         /* Simulate crash: destroy consumer A without calling close.
          * The session will time out and the proactive lock-expiry
          * timer will release A's locks. */
-        rd_kafka_share_destroy(consumer_a);
+        test_share_destroy(consumer_a);
 
         /* Wait for locks to expire (session_timeout=500ms, add margin). */
         rd_usleep(1500 * 1000, 0);
@@ -855,8 +855,8 @@ static void do_test_multi_consumer_lock_expiry(void) {
         consumed_b = consume_n(consumer_b, msgcnt, 100);
         TEST_SAY("multi_consumer: B consumed %d/%d\n", consumed_b, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer_b);
-        rd_kafka_share_destroy(consumer_b);
+        test_share_consumer_close(consumer_b);
+        test_share_destroy(consumer_b);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -904,8 +904,8 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         TEST_SAY("fetch_error(%s): consumed=%d rcvd=%zu\n",
                  rd_kafka_err2name(err), consumed, rcvd);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed with %s, got %d",
@@ -1020,8 +1020,8 @@ static void do_test_sharefetch_fetch_disconnected(void) {
 
         TEST_SAY("fetch_disconnected: consumed=%d rcvd=%zu\n", consumed, rcvd);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0, "Expected 0 consumed on disconnect, got %d",
@@ -1058,8 +1058,8 @@ static void do_test_sharefetch_fetch_and_close_implicit(void) {
         TEST_SAY("fetch_and_close: consumed %d/%d\n", consumed, msgcnt);
 
         /* Close — sends ShareAcknowledge/ShareFetch with epoch=-1 */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt, "Expected %d consumed, got %d", msgcnt,

--- a/tests/0157-share_consumer_ack_mock.c
+++ b/tests/0157-share_consumer_ack_mock.c
@@ -204,8 +204,8 @@ static void do_test_implicit_ack_no_redelivery(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_no_redelivery: extra %d/0 (should be 0)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt && extra == 0,
@@ -249,8 +249,8 @@ static void do_test_implicit_ack_with_new_records(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_new_records: A extra %d/0 (ack sent)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Batch B */
         produce_messages(ctx.producer, topic, 3);
@@ -264,8 +264,8 @@ static void do_test_implicit_ack_with_new_records(void) {
         TEST_SAY("ack_new_records: B consumed %d/3 (batch B only)\n",
                  consumed_b);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == 3 && extra == 0 && consumed_b == 3,
@@ -308,8 +308,8 @@ static void do_test_implicit_ack_cross_consumer(void) {
         extra = consume_n(consumer_a, 1, 10);
         TEST_SAY("ack_cross_consumer: A extra %d/0\n", extra);
 
-        rd_kafka_share_consumer_close(consumer_a);
-        rd_kafka_share_destroy(consumer_a);
+        test_share_consumer_close(consumer_a);
+        test_share_destroy(consumer_a);
 
         /* Consumer B: same group, should see nothing. */
         consumer_b = new_share_consumer(ctx.bootstraps, "sg-ack-cross");
@@ -319,8 +319,8 @@ static void do_test_implicit_ack_cross_consumer(void) {
         TEST_SAY("ack_cross_consumer: B consumed %d/0 (should be 0)\n",
                  consumed_b);
 
-        rd_kafka_share_consumer_close(consumer_b);
-        rd_kafka_share_destroy(consumer_b);
+        test_share_consumer_close(consumer_b);
+        test_share_destroy(consumer_b);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && extra == 0 && consumed_b == 0,
@@ -362,8 +362,8 @@ static void do_test_implicit_ack_multi_partition(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_multi_partition: extra %d/0\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt && extra == 0,
@@ -426,8 +426,8 @@ static void do_test_implicit_ack_multiple_rounds(void) {
                         round_ok = 0;
                 }
 
-                rd_kafka_share_consumer_close(consumer);
-                rd_kafka_share_destroy(consumer);
+                test_share_consumer_close(consumer);
+                test_share_destroy(consumer);
         }
 
         TEST_SAY("ack_multiple_rounds: total %d/%d\n", total_consumed,
@@ -471,8 +471,8 @@ static void do_test_implicit_ack_single_record(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_single_record: extra %d/0 (should be 0)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 1 && extra == 0,
@@ -513,8 +513,8 @@ static void do_test_implicit_ack_large_batch(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_large_batch: extra %d/0 (should be 0)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt && extra == 0,
@@ -564,8 +564,8 @@ static void do_test_implicit_ack_multi_topic(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_multi_topic: extra %d/0\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Consumer B: same group — should see 0 from either topic. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-mtopic");
@@ -575,8 +575,8 @@ static void do_test_implicit_ack_multi_topic(void) {
         TEST_SAY("ack_multi_topic: B consumed %d/0 (should be 0)\n",
                  consumed_b);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 6 && extra == 0 && consumed_b == 0,
@@ -632,8 +632,8 @@ static void do_test_implicit_ack_multi_msgset(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("ack_multi_msgset: extra %d/0 (should be 0)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == msgcnt && extra == 0,
@@ -677,7 +677,7 @@ static void do_test_crash_before_ack_redelivery(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("crash_before_ack: A consumed %d/%d\n", consumed_a, msgcnt);
-        rd_kafka_share_destroy(consumer); /* crash — no close */
+        test_share_destroy(consumer); /* crash — no close */
 
         /* Wait for lock expiry (session_timeout=500ms + margin). */
         rd_usleep(1500 * 1000, NULL);
@@ -689,8 +689,8 @@ static void do_test_crash_before_ack_redelivery(void) {
         TEST_SAY("crash_before_ack: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -731,7 +731,7 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("crash_then_ack: A consumed %d/%d (will crash)\n", consumed_a,
                  msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL); /* wait for lock expiry */
 
         /* Consumer B: re-delivery, then ack via next poll. */
@@ -744,8 +744,8 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         /* Trigger implicit ack. */
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("crash_then_ack: B extra %d/0\n", extra);
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Consumer C: should see 0 — records were acked by B. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-crash-then-ack");
@@ -753,8 +753,8 @@ static void do_test_crash_then_ack_stops_redelivery(void) {
         consumed_c = consume_n(consumer, 1, 15);
         TEST_SAY("crash_then_ack: C consumed %d/0 (should be 0)\n", consumed_c);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&
@@ -826,7 +826,7 @@ static void do_test_session_expiry_invalidates_ack(void) {
         rd_usleep(1500 * 1000, NULL);
 
         /* Crash consumer A without acking. */
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
 
         /* Consumer B: records should be re-delivered (locks released
          * when A's membership was evicted). */
@@ -836,8 +836,8 @@ static void do_test_session_expiry_invalidates_ack(void) {
         TEST_SAY("session_expiry: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -879,7 +879,7 @@ static void do_test_max_delivery_without_ack(void) {
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("max_delivery_no_ack: A consumed %d/%d (delivery 1)\n",
                  consumed_a, msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL); /* wait for lock expiry */
 
         /* Delivery 2 = max: Consumer B acquires and crashes. */
@@ -888,7 +888,7 @@ static void do_test_max_delivery_without_ack(void) {
         consumed_b = consume_n(consumer, msgcnt, 50);
         TEST_SAY("max_delivery_no_ack: B consumed %d/%d (delivery 2)\n",
                  consumed_b, msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL); /* wait for lock expiry + archival */
 
         /* Delivery 3 attempt: records should be archived (delivery
@@ -899,8 +899,8 @@ static void do_test_max_delivery_without_ack(void) {
         TEST_SAY("max_delivery_no_ack: C consumed %d/0 (archived)\n",
                  consumed_c);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&
@@ -954,7 +954,7 @@ static void do_test_sharefetch_error_drops_ack(void) {
             RD_KAFKA_RESP_ERR__TRANSPORT, RD_KAFKA_RESP_ERR__TRANSPORT);
 
         /* Crash consumer A (ack never delivered). */
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL); /* wait for lock expiry */
 
         /* Clear any remaining errors. */
@@ -967,8 +967,8 @@ static void do_test_sharefetch_error_drops_ack(void) {
         TEST_SAY("sf_error_drops_ack: B consumed %d/%d (re-delivered)\n",
                  consumed_b, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -1020,7 +1020,7 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
                  consumed_both);
 
         /* Crash — no ack for either topic. */
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(3000 * 1000, NULL); /* wait for session + lock expiry */
 
         /* Consumer B: subscribe to topic_a only, consume and ack. */
@@ -1033,8 +1033,8 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
 
         /* Trigger implicit ack for topic_a. */
         extra = consume_n(consumer, 1, 10);
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Consumer C: subscribe to topic_b only.
          * Topic_b's records were never acked — should be available. */
@@ -1047,8 +1047,8 @@ static void do_test_forgotten_topic_releases_not_acks(void) {
             "(should be re-delivered)\n",
             consumed_b);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         (void)extra;
@@ -1091,7 +1091,7 @@ static void do_test_multi_consumer_cascade_crash(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed_a = consume_n(consumer, msgcnt, 50);
         TEST_SAY("cascade_crash: A consumed %d/%d\n", consumed_a, msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL);
 
         /* Consumer B: re-acquire and crash. */
@@ -1099,7 +1099,7 @@ static void do_test_multi_consumer_cascade_crash(void) {
         subscribe_topics(consumer, &topic, 1);
         consumed_b = consume_n(consumer, msgcnt, 50);
         TEST_SAY("cascade_crash: B consumed %d/%d\n", consumed_b, msgcnt);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         rd_usleep(1500 * 1000, NULL);
 
         /* Consumer C: re-acquire and crash. */
@@ -1108,8 +1108,8 @@ static void do_test_multi_consumer_cascade_crash(void) {
         consumed_c = consume_n(consumer, msgcnt, 50);
         TEST_SAY("cascade_crash: C consumed %d/%d\n", consumed_c, msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&
@@ -1164,7 +1164,7 @@ static void do_test_lock_expiry_before_ack(void) {
 
         /* Wait for lock to expire (200ms + margin), then crash. */
         rd_usleep(800 * 1000, NULL);
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
 
         /* Clear RTT so consumer B can operate normally. */
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, 1, 0);
@@ -1179,8 +1179,8 @@ static void do_test_lock_expiry_before_ack(void) {
         TEST_SAY("lock_expiry_before_ack: B consumed %d/%d\n", consumed_b,
                  msgcnt);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt,
@@ -1222,8 +1222,8 @@ static void do_test_empty_topic_no_ack_side_effects(void) {
 
         /* Phase 2: Produce messages, then close this consumer and
          * open a new one to avoid incremental session issues. */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         produce_messages(ctx.producer, topic, msgcnt);
 
@@ -1237,8 +1237,8 @@ static void do_test_empty_topic_no_ack_side_effects(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("empty_topic: phase3 extra %d/0 (should be 0)\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_empty == 0 && consumed == msgcnt && extra == 0,
@@ -1285,8 +1285,8 @@ static void do_test_coordinator_failover_ack_recovery(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("coord_failover: A extra %d/0\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Phase 2: Temporarily push SGHB errors (simulating coordinator
          * failover). Any consumer joining now will fail heartbeats. */
@@ -1318,8 +1318,8 @@ static void do_test_coordinator_failover_ack_recovery(void) {
         extra = consume_n(consumer, 1, 10);
         TEST_SAY("coord_failover: B extra %d/0\n", extra);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         /* Phase 4: Consumer C — everything is acked, should see 0. */
         consumer = new_share_consumer(ctx.bootstraps, "sg-ack-coord-failover");
@@ -1327,8 +1327,8 @@ static void do_test_coordinator_failover_ack_recovery(void) {
         consumed_c = consume_n(consumer, 1, 15);
         TEST_SAY("coord_failover: C consumed %d/0 (should be 0)\n", consumed_c);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed_a == msgcnt && consumed_b == msgcnt &&

--- a/tests/0158-share_consumer_transactions_mock.c
+++ b/tests/0158-share_consumer_transactions_mock.c
@@ -233,8 +233,8 @@ static void do_test_txn_committed_read_uncommitted(void) {
         subscribe_topics(share_c, &topic, 1);
         consumed = consume_n(share_c, 3, 50);
         TEST_ASSERT(consumed == 3, "Expected 3 consumed, got %d", consumed);
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();
@@ -263,8 +263,8 @@ static void do_test_txn_aborted_read_uncommitted(void) {
 
         consumed = consume_n(share_c, 3, 50);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 3,
@@ -296,8 +296,8 @@ static void do_test_txn_mixed_read_uncommitted(void) {
 
         consumed = consume_n(share_c, 5, 50);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 5, "Expected 5 consumed, got %d", consumed);
@@ -327,8 +327,8 @@ static void do_test_txn_committed_read_committed(void) {
 
         consumed = consume_n(share_c, 3, 50);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 3, "Expected 3 consumed, got %d", consumed);
@@ -360,8 +360,8 @@ static void do_test_txn_aborted_read_committed(void) {
 
         consumed = consume_n(share_c, 0, 15);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 0,
@@ -401,8 +401,8 @@ static void do_test_txn_mixed_read_committed(void) {
 
         consumed = consume_n(share_c, 7, 60);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 7,
@@ -437,8 +437,8 @@ static void do_test_txn_nontxn_read_committed(void) {
 
         consumed = consume_n(share_c, 5, 50);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 5, "Expected 5 consumed, got %d", consumed);
@@ -479,8 +479,8 @@ static void do_test_txn_abort_then_commit_read_committed(void) {
 
         consumed = consume_n(share_c, 3, 50);
 
-        rd_kafka_share_consumer_close(share_c);
-        rd_kafka_share_destroy(share_c);
+        test_share_consumer_close(share_c);
+        test_share_destroy(share_c);
         test_ctx_destroy(&ctx);
 
         TEST_ASSERT(consumed == 3,

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -601,8 +601,8 @@ static void state_cleanup(sub_test_state_t *state) {
         /* Destroy all consumers */
         for (i = 0; i < MAX_CONSUMERS; i++) {
                 if (state->consumers[i]) {
-                        rd_kafka_share_consumer_close(state->consumers[i]);
-                        rd_kafka_share_destroy(state->consumers[i]);
+                        test_share_consumer_close(state->consumers[i]);
+                        test_share_destroy(state->consumers[i]);
                 }
         }
 }
@@ -853,10 +853,10 @@ static void do_test_multi_consumer_overlap(void) {
         TEST_ASSERT(c0_cnt > 0 || c1_cnt > 0, "no messages received");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(rkshare0);
-        rd_kafka_share_consumer_close(rkshare1);
-        rd_kafka_share_destroy(rkshare0);
-        rd_kafka_share_destroy(rkshare1);
+        test_share_consumer_close(rkshare0);
+        test_share_consumer_close(rkshare1);
+        test_share_destroy(rkshare0);
+        test_share_destroy(rkshare1);
 
         rd_free(shared);
         rd_free(c0_only);
@@ -955,8 +955,8 @@ static void do_test_subscribe_15_topics(void) {
                     consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         for (t = 0; t < topic_cnt; t++) {
                 rd_free(topics[t]);

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -269,8 +269,8 @@ static void cleanup_test(share_test_config_t *config,
         /* Destroy consumers */
         for (i = 0; i < config->consumer_cnt; i++) {
                 if (state->consumers[i]) {
-                        rd_kafka_share_consumer_close(state->consumers[i]);
-                        rd_kafka_share_destroy(state->consumers[i]);
+                        test_share_consumer_close(state->consumers[i]);
+                        test_share_destroy(state->consumers[i]);
                         state->consumers[i] = NULL;
                 }
         }
@@ -592,8 +592,8 @@ static void test_rapid_produce_consume_cycles(void) {
         TEST_SAY("SUCCESS: Rapid cycles completed - %d messages\n",
                  total_consumed);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 }
 
 /**
@@ -665,8 +665,8 @@ static void test_empty_then_produce(void) {
         TEST_SAY("SUCCESS: Empty then produce - consumed %d messages\n",
                  consumed);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 }
 
 /**
@@ -734,8 +734,8 @@ static void test_sparse_partitions(void) {
         TEST_SAY("SUCCESS: Sparse partitions - consumed %d messages\n",
                  consumed);
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 }
 
 

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -535,8 +535,8 @@ static void cleanup_test(ack_test_config_t *config, ack_test_state_t *state) {
 
         for (i = 0; i < config->consumer_cnt; i++) {
                 if (state->consumers[i]) {
-                        rd_kafka_share_consumer_close(state->consumers[i]);
-                        rd_kafka_share_destroy(state->consumers[i]);
+                        test_share_consumer_close(state->consumers[i]);
+                        test_share_destroy(state->consumers[i]);
                         state->consumers[i] = NULL;
                 }
         }
@@ -666,8 +666,8 @@ static void test_ack_null_message(void) {
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG, got %s", rd_kafka_err2str(err));
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         TEST_SAY("=== test_ack_null_message: PASSED ===\n");
 }
@@ -757,8 +757,8 @@ static void test_ack_invalid_type(void) {
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
         rd_kafka_message_destroy(batch[0]);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         TEST_SAY("=== test_ack_invalid_type: PASSED ===\n");
 }
@@ -854,8 +854,8 @@ static void test_release_then_reject_no_redelivery(void) {
                     "Expected 0 redelivered (REJECT overrides RELEASE), got %d",
                     redelivered);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         TEST_SAY("=== test_release_then_reject_no_redelivery: PASSED ===\n");
 }
@@ -968,8 +968,8 @@ static void test_max_delivery_attempts(void) {
         TEST_SAY("SUCCESS: Message not redelivered after %d RELEASE attempts\n",
                  max_deliveries);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         TEST_SAY("=== test_max_delivery_attempts: PASSED ===\n");
 }

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -160,8 +160,8 @@ static void do_test_implicit_second_consumer(void) {
 
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -199,8 +199,8 @@ static void do_test_implicit_second_consumer(void) {
 
         rd_free(c1_offsets);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -264,8 +264,8 @@ static void do_test_explicit_second_consumer(void) {
 
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -303,8 +303,8 @@ static void do_test_explicit_second_consumer(void) {
 
         rd_free(c1_offsets);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -419,8 +419,8 @@ static void do_test_mixed_acks_second_consumer(void) {
 
         rd_free(released_offsets);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -503,8 +503,8 @@ static void do_test_multi_topic_partition(void) {
         TEST_SAY("Total consumed across %d rounds: %d\n", rounds,
                  total_consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         for (t = 0; t < topic_cnt; t++)
                 rd_free((void *)topics[t]);
@@ -588,8 +588,8 @@ static void do_test_produce_consume_loop(void) {
         TEST_SAY("Total consumed across %d rounds: %d\n", rounds,
                  total_consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -703,8 +703,8 @@ static void do_test_multi_round_mixed_second_consumer(void) {
         TEST_SAY("Total: consumed %d, released %d, redelivered %d\n",
                  total_consumed, total_released, total_redelivered);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -724,8 +724,8 @@ static void do_test_no_pending_acks(void) {
         TEST_ASSERT(!error, "Expected NULL when no pending acks, got error: %s",
                     error ? rd_kafka_error_string(error) : "");
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -815,8 +815,8 @@ static void do_test_multiple_commit_async_calls(void) {
                     "Expected %d (second produce), got %d", second_produce,
                     consumed2);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -883,7 +883,7 @@ static void do_test_commit_between_produces(void) {
         TEST_ASSERT(!error, "commit_async failed: %s",
                     error ? rd_kafka_error_string(error) : "");
 
-        /* Wait for acquisition lock timeout (3s) so first half's acks
+        /* Wait for acquisition lock timeout (3 s + buffer) so first half's acks
          * are fully committed or released before producing the second
          * half */
         rd_sleep(4);
@@ -927,8 +927,8 @@ static void do_test_commit_between_produces(void) {
 
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -964,8 +964,8 @@ static void do_test_commit_between_produces(void) {
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
                     received);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1038,8 +1038,8 @@ static void do_test_all_release_second_consumer(void) {
         TEST_ASSERT(redelivered == consumed, "Expected %d redelivered, got %d",
                     consumed, redelivered);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1109,8 +1109,8 @@ static void do_test_all_reject_second_consumer(void) {
 
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -1145,8 +1145,8 @@ static void do_test_all_reject_second_consumer(void) {
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
                     received);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1221,8 +1221,8 @@ static void do_test_per_record_commit_async(void) {
         /* Wait for async commits to propagate */
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -1257,8 +1257,8 @@ static void do_test_per_record_commit_async(void) {
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
                     received);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1467,8 +1467,8 @@ static void do_test_mock_inflight_caching(void) {
                     share_fetch_cnt, share_ack_cnt,
                     share_fetch_cnt + share_ack_cnt, commit_cnt);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();
@@ -1581,8 +1581,8 @@ static void do_test_lock_timeout_redelivery(void) {
                  msg_cnt);
         TEST_ASSERT(consumed2 > 0, "Expected redelivered records, got 0");
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         SUB_TEST_PASS();
 }

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -218,8 +218,8 @@ static void do_test_basic_implicit_commit_sync(void) {
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -339,8 +339,8 @@ static void do_test_basic_explicit_commit_sync(void) {
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -376,8 +376,8 @@ static void do_test_no_pending_acks(void) {
         TEST_SAY(
             "commit_sync with no pending acks returned NULL as expected\n");
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -433,8 +433,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
                     error ? rd_kafka_error_string(error) : "");
         RD_IF_FREE(partitions, rd_kafka_topic_partition_list_destroy);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -470,8 +470,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -587,8 +587,8 @@ static void do_test_mixed_ack_types(void) {
 
         rd_kafka_topic_partition_list_destroy(partitions);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Consumer B: should only get the 3 RELEASE'd records */
         rkshare = create_share_consumer(group, "implicit");
@@ -644,8 +644,8 @@ static void do_test_mixed_ack_types(void) {
                     "Consumer B got %d records, expected 3 RELEASE'd",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -777,8 +777,8 @@ static void do_test_multiple_commit_sync_calls(void) {
         TEST_ASSERT(commit_cnt == 5, "Expected 5 commit_sync calls, got %d",
                     commit_cnt);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -812,8 +812,8 @@ static void do_test_multiple_commit_sync_calls(void) {
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1015,8 +1015,8 @@ static void do_test_multi_topic_partition(void) {
                     "Max delivery_count=%d exceeds limit=%d", (int)max_dc_seen,
                     MAX_REDELIVERY_ROUNDS);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         for (i = 0; i < MULTI_TP_TOPICS; i++)
                 rd_free(topics[i]);
@@ -1254,8 +1254,8 @@ static void do_test_mock_uses_share_acknowledge(void) {
                     "partitions count (%d)",
                     share_ack_cnt, commit_with_partitions);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();
@@ -1385,8 +1385,8 @@ static void do_test_mock_commit_sync_timeout(void) {
         rd_sleep(5);
 
         /* Close first consumer */
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Second consumer: should get 0 records because the broker
          * processed the acks despite client-side timeout */
@@ -1420,8 +1420,8 @@ static void do_test_mock_commit_sync_timeout(void) {
                     "client-side timeout)",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Phase 3: Produce more, consume, commit_sync normally —
          * verify recovery after timeout */
@@ -1476,8 +1476,8 @@ static void do_test_mock_commit_sync_timeout(void) {
 
         rd_kafka_topic_partition_list_destroy(partitions);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();
@@ -1645,8 +1645,8 @@ static void do_test_mixed_commit_types(void) {
          * response. */
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Produce 5 verification records */
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -1680,8 +1680,8 @@ static void do_test_mixed_commit_types(void) {
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 }
 
 
@@ -1871,8 +1871,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
         /* Wait for remaining async to complete */
         rd_sleep(3);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         /* Second consumer: should get 0 records since all acks
          * were processed successfully */
@@ -1904,8 +1904,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
                     "(all acks should have been processed)",
                     consumed);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -316,8 +316,8 @@ static void do_test_committed_transaction(const char *isolation_level) {
             isolation_level, consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -403,8 +403,8 @@ static void do_test_aborted_transaction(const char *isolation_level) {
             isolation_level, consumed, expected_msgs);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -504,8 +504,8 @@ static void do_test_mixed_transactions(const char *isolation_level) {
                  isolation_level, consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -589,8 +589,8 @@ static void do_test_control_records_filtered(const char *isolation_level) {
                                    control_record_offsets, 2, isolation_level);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -679,8 +679,8 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
                  isolation_level, consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -764,8 +764,8 @@ static void do_test_interleaved_producers(const char *isolation_level) {
                  isolation_level, consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer1);
         rd_kafka_destroy(producer2);
 
@@ -853,8 +853,8 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
                  isolation_level, consumed);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(txn_producer);
 
         SUB_TEST_PASS();
@@ -959,8 +959,8 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
             "READ_COMMITTED works correctly\n");
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
@@ -1071,8 +1071,8 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
             isolation_level, consumed, committed_txns, aborted_txns);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();

--- a/tests/test.c
+++ b/tests/test.c
@@ -8203,7 +8203,7 @@ void test_share_set_isolation_level(const char *group_name,
  * @param rkshare The share consumer to close.
  */
 void test_share_consumer_close(rd_kafka_share_t *rkshare) {
-        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t error;
         test_timing_t timing;
 
         TEST_SAY("Calling rd_kafka_share_consumer_close\n");
@@ -8216,8 +8216,7 @@ void test_share_consumer_close(rd_kafka_share_t *rkshare) {
 
         if (error)
                 TEST_FAIL("Failed to close share consumer: %s\n",
-                          rd_kafka_error_string(error));
-        rd_kafka_error_destroy(error);
+                          rd_kafka_err2str(error));
 }
 
 /**
@@ -8226,7 +8225,6 @@ void test_share_consumer_close(rd_kafka_share_t *rkshare) {
  * @param rkshare The share consumer to destroy.
  */
 void test_share_destroy(rd_kafka_share_t *rkshare) {
-        rd_kafka_t *rk;
 
         TEST_SAY("Calling rd_kafka_share_destroy\n");
         rd_kafka_share_destroy(rkshare);

--- a/tests/test.c
+++ b/tests/test.c
@@ -8196,3 +8196,39 @@ void test_share_set_isolation_level(const char *group_name,
         const char *cfg[] = {"share.isolation.level", "SET", isolation_level};
         test_alter_group_configurations(group_name, cfg, 1);
 }
+
+/**
+ * @brief Close a share consumer and verify it succeeds.
+ *
+ * @param rkshare The share consumer to close.
+ */
+void test_share_consumer_close(rd_kafka_share_t *rkshare) {
+        rd_kafka_error_t *error;
+        test_timing_t timing;
+
+        TEST_SAY("Calling rd_kafka_share_consumer_close\n");
+
+        TIMING_START(&timing, "SHARE_CONSUMER.CLOSE");
+        error = rd_kafka_share_consumer_close(rkshare);
+        TIMING_STOP(&timing);
+
+        TEST_SAY("Completed rd_kafka_share_consumer_close\n");
+
+        if (error)
+                TEST_FAIL("Failed to close share consumer: %s\n",
+                          rd_kafka_error_string(error));
+        rd_kafka_error_destroy(error);
+}
+
+/**
+ * @brief Destroy a share consumer.
+ *
+ * @param rkshare The share consumer to destroy.
+ */
+void test_share_destroy(rd_kafka_share_t *rkshare) {
+        rd_kafka_t *rk;
+
+        TEST_SAY("Calling rd_kafka_share_destroy\n");
+        rd_kafka_share_destroy(rkshare);
+        TEST_SAY("Completed rd_kafka_share_destroy\n");
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -8198,20 +8198,15 @@ void test_share_set_isolation_level(const char *group_name,
 }
 
 /**
- * @brief Close a share consumer and verify it succeeds.
+ * @brief Close a share consumer.
  *
  * @param rkshare The share consumer to close.
  */
 void test_share_consumer_close(rd_kafka_share_t *rkshare) {
         rd_kafka_resp_err_t error;
-        test_timing_t timing;
 
         TEST_SAY("Calling rd_kafka_share_consumer_close\n");
-
-        TIMING_START(&timing, "SHARE_CONSUMER.CLOSE");
         error = rd_kafka_share_consumer_close(rkshare);
-        TIMING_STOP(&timing);
-
         TEST_SAY("Completed rd_kafka_share_consumer_close\n");
 
         if (error)

--- a/tests/test.h
+++ b/tests/test.h
@@ -1062,6 +1062,8 @@ void test_share_set_auto_offset_reset(const char *group_name,
 void test_share_set_isolation_level(const char *group_name,
                                     const char *isolation_level);
 
+void test_share_consumer_close(rd_kafka_share_t *rkshare);
+void test_share_destroy(rd_kafka_share_t *rkshare);
 
 /**
  * @name rusage.c


### PR DESCRIPTION
This PR creates wrapper functions around rd_kafka-share_consumer_close and rd_kafka_share_destroy.
Add loggings around the share and close to test on which the tests are hanging
Use the wrappers in all the tests