### PR TITLE
[KIP-932]: Fix 0155 fatal-state test cleanup and 0177 replication factor

### DIFF
--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -546,7 +546,7 @@ static void do_test_share_group_error_injection(void) {
             RD_KAFKA_RESP_ERR_INVALID_REQUEST, 0);
 
         /* Wait for the fatal error to propagate. */
-        fatal_err = wait_fatal_error(share_c, 5000, errstr, sizeof(errstr));
+        fatal_err = wait_fatal_error(share_c, 7000, errstr, sizeof(errstr));
         TEST_ASSERT(fatal_err != RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected consumer to be in fatal state after "
                     "INVALID_REQUEST error");
@@ -554,7 +554,7 @@ static void do_test_share_group_error_injection(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        test_share_consumer_close(share_c);
+        rd_kafka_share_consumer_close(share_c);
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -1279,7 +1279,7 @@ static void do_test_group_authorization_failed_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        test_share_consumer_close(share_c);
+        rd_kafka_share_consumer_close(share_c);
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -1350,7 +1350,7 @@ static void do_test_group_max_size_reached_error(void) {
 
         /* Cleanup */
         test_share_consumer_close(share_c1);
-        test_share_consumer_close(share_c2);
+        rd_kafka_share_consumer_close(share_c2);
         test_share_destroy(share_c1);
         test_share_destroy(share_c2);
 
@@ -2076,7 +2076,7 @@ static void do_test_invalid_request_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        test_share_consumer_close(share_c);
+        rd_kafka_share_consumer_close(share_c);
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -2135,7 +2135,7 @@ static void do_test_unsupported_version_error(void) {
                  rd_kafka_err2str(fatal_err), errstr);
 
         /* Cleanup */
-        test_share_consumer_close(share_c);
+        rd_kafka_share_consumer_close(share_c);
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -2476,7 +2476,7 @@ static void do_test_double_close(void) {
         /* Second close - should handle gracefully without crashing.
          * The Java equivalent tests verify the CompletableFuture
          * completes immediately on double-leave. */
-        test_share_consumer_close(share_c);
+        rd_kafka_share_consumer_close(share_c);
 
         rd_kafka_topic_partition_list_destroy(subscription);
         test_share_destroy(share_c);

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -278,7 +278,7 @@ static void do_test_committed_transaction(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -357,7 +357,7 @@ static void do_test_aborted_transaction(const char *isolation_level) {
         expected_msgs = is_read_committed ? 0 : msg_cnt;
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -453,7 +453,7 @@ static void do_test_mixed_transactions(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -537,7 +537,7 @@ static void do_test_control_records_filtered(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -625,7 +625,7 @@ static void do_test_multi_partition_transactions(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic with multiple partitions */
-        test_create_topic(NULL, topic, partition_cnt, 1);
+        test_create_topic(NULL, topic, partition_cnt, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -711,7 +711,7 @@ static void do_test_interleaved_producers(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create two transactional producers */
         producer1 = create_txn_producer("txn-producer-1");
@@ -800,7 +800,7 @@ static void do_test_mixed_txn_non_txn(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         txn_producer = create_txn_producer(txn_id);
@@ -886,7 +886,7 @@ static void do_test_dynamic_uncommitted_to_committed(void) {
         topic = test_mk_topic_name("0177-dynamic-uc-to-c", 1);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);
@@ -1000,7 +1000,7 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
         SUB_TEST("isolation.level=%s", isolation_level);
 
         /* Create topic */
-        test_create_topic(NULL, topic, 1, 1);
+        test_create_topic(NULL, topic, 1, -1);
 
         /* Create transactional producer */
         producer = create_txn_producer(txn_id);


### PR DESCRIPTION
- 0155: switch fatal-state subtests back to calling
  `rd_kafka_share_consumer_close` directly. The `test_share_consumer_close`
  wrapper TEST_FAILs on any non-zero return, but a consumer that has
  transitioned to fatal state legitimately returns an error from close,
  so the wrapper was failing the test at cleanup time.
- 0155: raise the `wait_fatal_error` timeout in
  `do_test_share_group_error_injection` from 5000 ms to 7000 ms. The mock's
  default ShareGroupHeartbeat interval is 5000 ms, so the next heartbeat
  (carrying the injected INVALID_REQUEST) fires almost exactly when the
  poll deadline elapses — the fatal flag was being set ~ms after the
  poll loop returned NO_ERROR.
- 0177: pass `-1` instead of a hardcoded `1` for the replication factor
  in all `test_create_topic` calls so the tests honor the broker's
  configured default rather than assuming RF=1.