### PR TITLE
[KIP-932]: Adding destroy before destroying common_admin and common_producer destroy

### DIFF
--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -1010,8 +1010,13 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
         do_test_subscribe_15_topics();
 
         /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+
+        TEST_SAY("Destroying common_producer\n");
         rd_kafka_destroy(common_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -807,8 +807,12 @@ int main_0171_share_consumer_consume(int argc, char **argv) {
         TEST_SAY("\nAll share consumer consume tests passed successfully!\n");
 
         /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+        TEST_SAY("Destroying common_producer\n");
         rd_kafka_destroy(common_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -1165,8 +1165,12 @@ int main_0172_share_consumer_acknowledge(int argc, char **argv) {
         test_scale_10_topics_3_partitions();
 
         /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+        TEST_SAY("Destroying common_producer\n");
         rd_kafka_destroy(common_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -1607,8 +1607,14 @@ int main_0173_share_consumer_commit_async(int argc, char **argv) {
         do_test_per_record_commit_async();
         do_test_lock_timeout_redelivery();
 
+        /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+
+        TEST_SAY("Destroying common_producer\n");
         rd_kafka_destroy(common_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1927,8 +1927,14 @@ int main_0176_share_consumer_commit_sync(int argc, char **argv) {
         do_test_multi_topic_partition();
         do_test_mixed_commit_types();
 
+        /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+
+        TEST_SAY("Destroying common_producer\n");
         rd_kafka_destroy(common_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -1126,8 +1126,14 @@ int main_0177_share_consumer_transactions(int argc, char **argv) {
         do_test_dynamic_uncommitted_to_committed();
 
         /* Cleanup common handles */
+        /* Cleanup common handles */
+        TEST_SAY("Destroying common_admin\n");
         rd_kafka_destroy(common_admin);
+        TEST_SAY("Completed destroying common_admin\n");
+
+        TEST_SAY("Destroying common_regular_producer\n");
         rd_kafka_destroy(common_regular_producer);
+        TEST_SAY("Completed destroying common_producer\n");
 
         return 0;
 }


### PR DESCRIPTION
Added debug logs before the destroy handles of common_admin and common_producer to check where the tests are getting stuck