### PR TITLE
[KIP-932] Fix race: SHARE_FETCH __DESTROY reply silently dropped

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3184,6 +3184,23 @@ static void rd_kafka_share_commit_sync_maybe_complete(rd_kafka_t *rk,
                                                       rd_kafka_cgrp_t *rkcg);
 static void rd_kafka_share_enqueue_sync_ack_op(rd_kafka_t *rk,
                                                rd_kafka_broker_t *rkb);
+rd_kafka_op_res_t rd_kafka_share_fetch_reply_op(rd_kafka_t *rk,
+                                                rd_kafka_op_t *rko_orig);
+
+/**
+ * @brief rko_op_cb wrapper for rd_kafka_share_fetch_reply_op.
+ *
+ * Using rko_op_cb causes rd_kafka_op_reply() to stamp RD_KAFKA_OP_CB
+ * instead of RD_KAFKA_OP_REPLY, which bypasses the handle_std
+ * __DESTROY silent-discard path (rdkafka_op.c:987-991).
+ *
+ * @locality main thread
+ */
+static rd_kafka_op_res_t rd_kafka_share_fetch_reply_op_cb(rd_kafka_t *rk,
+                                                          rd_kafka_q_t *rkq,
+                                                          rd_kafka_op_t *rko) {
+        return rd_kafka_share_fetch_reply_op(rk, rko);
+}
 
 /**
  * Handles RD_KAFKA_OP_SHARE_FETCH | RD_KAFKA_OP_REPLY.
@@ -3419,6 +3436,7 @@ void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
         rd_kafka_broker_keep(rkb);
         rko_sf->rko_u.share_fetch.target_broker = rkb;
         rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
+        rko_sf->rko_op_cb  = rd_kafka_share_fetch_reply_op_cb;
 
         /* Set fetch guard flag to prevent multiple in-flight fetches to the
          * same broker.*/
@@ -3939,6 +3957,7 @@ static void rd_kafka_share_enqueue_sync_ack_op(rd_kafka_t *rk,
         rd_kafka_broker_keep(rkb);
         rko_sf->rko_u.share_fetch.target_broker = rkb;
         rko_sf->rko_replyq = RD_KAFKA_REPLYQ(rk->rk_ops, 0);
+        rko_sf->rko_op_cb  = rd_kafka_share_fetch_reply_op_cb;
 
         rkb->rkb_share_fetch_enqueued = rd_true;
 
@@ -5861,9 +5880,6 @@ rd_kafka_op_res_t rd_kafka_poll_cb(rd_kafka_t *rk,
                 res = rd_kafka_metadata_update_op(rk, rko->rko_u.metadata.mdi);
                 break;
 
-        case RD_KAFKA_OP_SHARE_FETCH | RD_KAFKA_OP_REPLY:
-                res = rd_kafka_share_fetch_reply_op(rk, rko);
-                break;
 
         case RD_KAFKA_OP_SHARE_FETCH_FANOUT | RD_KAFKA_OP_REPLY:
                 rd_kafka_assert(rk, thrd_is_current(rk->rk_thread));

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3605,7 +3605,8 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
                                      "Ignoring SHARE_FETCH op: "
                                      "instance or broker is terminating");
-                        rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__DESTROY);
+                        rd_kafka_op_reply(
+                            rko, rd_kafka_broker_destroy_error(rkb->rkb_rk));
                 } else if (rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP) {
                         /* TODO KIP-932: The main thread should check
                          * broker state before enqueuing SHARE_FETCH


### PR DESCRIPTION
When a broker is decommissioned by the main thread (metadata update) between the time terminate0/commit_sync enqueues a SHARE_FETCH op on B.rkb_ops and the time B's broker thread processes it, the broker thread sees or_instance_terminating(B) == true and replies with __DESTROY via rd_kafka_share_fetch_op_reply_with_err.

Without this fix, the reply carried RD_KAFKA_OP_REPLY which makes rd_kafka_op_handle_std take the __DESTROY shortcut at rdkafka_op.c:987-991 and silently destroy the op, so:
  - share_session_leave_remaining_cnt never decremented -> close hangs
  - brokers_awaiting_result_cnt never decremented -> commit_sync hangs until its own timeout, then surfaces __TIMED_OUT instead of the real __DESTROY
  - per-batch errors set on rktpar->err by the helper are lost

Set rko_op_cb on SHARE_FETCH ops at both enqueue sites (rd_kafka_share_enqueue_fetch_op and rd_kafka_share_enqueue_sync_ack_op). rd_kafka_op_reply then stamps RD_KAFKA_OP_CB instead of RD_KAFKA_OP_REPLY, which the handle_std __DESTROY shortcut does not match -> the reply handler runs and the counters/errors propagate.

Drop the now-unreachable RD_KAFKA_OP_SHARE_FETCH | RD_KAFKA_OP_REPLY case from rd_kafka_poll_cb.