### PR TITLE
[KIP-932]: Fix for ack callbacks

### DIFF
--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -803,8 +803,9 @@ rd_kafka_share_partition_offsets_new(rd_kafka_topic_partition_t *tp,
         elem = rd_calloc(1, size);
 
         elem->partition = rd_kafka_topic_partition_new_with_id_and_name(
-            rd_kafka_topic_partition_get_topic_id(tp), tp->topic, tp->partition);
-        elem->cnt       = offsets_cnt;
+            rd_kafka_topic_partition_get_topic_id(tp), tp->topic,
+            tp->partition);
+        elem->cnt = offsets_cnt;
 
         return elem;
 }

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -802,7 +802,8 @@ rd_kafka_share_partition_offsets_new(rd_kafka_topic_partition_t *tp,
         size = sizeof(*elem) + (offsets_cnt * sizeof(int64_t));
         elem = rd_calloc(1, size);
 
-        elem->partition = rd_kafka_topic_partition_copy(tp);
+        elem->partition = rd_kafka_topic_partition_new_with_id_and_name(
+            rd_kafka_topic_partition_get_topic_id(tp), tp->topic, tp->partition);
         elem->cnt       = offsets_cnt;
 
         return elem;

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -866,7 +866,6 @@ static void test_release_then_reject_no_redelivery(void) {
  * @brief Test changing acknowledgement type before commit
  *
  * Verifies that acknowledgement type can be changed before commit completes.
- * Tests both implicit commit (via consume_batch) and explicit commit.
  */
 static void test_change_ack_type_before_commit(void) {
         rd_kafka_share_t *rkshare;
@@ -876,15 +875,17 @@ static void test_change_ack_type_before_commit(void) {
         rd_kafka_topic_partition_list_t *subs;
         const char *group = "share-change-ack-type";
         const char *topic;
-        size_t rcvd = 0;
+        size_t rcvd = 0, i;
         int attempts;
+        test_ack_cb_state_t state = {0};
 
         TEST_SAY("\n");
         TEST_SAY("=== test_change_ack_type_before_commit ===\n");
 
-        /* Test 1: Explicit mode with explicit commit */
-        rkshare = test_create_share_consumer(group, "explicit");
-        topic   = test_mk_topic_name("0172-change-ack-explicit", 1);
+        /* Explicit mode with explicit commit and callback */
+        rkshare =
+            test_create_share_consumer_with_cb(group, "explicit", &state, NULL);
+        topic = test_mk_topic_name("0172-change-ack-explicit", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         test_produce_msgs_simple(common_producer, topic, 0, 5);
 
@@ -895,18 +896,20 @@ static void test_change_ack_type_before_commit(void) {
         rd_kafka_share_subscribe(rkshare, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
-        /* Consume one message */
+        /* Consume five messages */
         attempts = 30;
-        while (rcvd < 1 && attempts-- > 0) {
+        while (rcvd < 5 && attempts-- > 0) {
                 size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch,
+                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
                                                    &batch_rcvd);
                 if (err)
                         rd_kafka_error_destroy(err);
                 rcvd += batch_rcvd;
         }
 
-        TEST_ASSERT(rcvd >= 1, "Expected at least 1 message, got %zu", rcvd);
+        TEST_SAY("Consumed %zu messages after first commit\n", rcvd);
+
+        TEST_ASSERT(rcvd >= 5, "Expected at least 5 messages, got %zu", rcvd);
 
         /* First: RELEASE the message */
         ack_err = rd_kafka_share_acknowledge_type(
@@ -914,7 +917,7 @@ static void test_change_ack_type_before_commit(void) {
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "RELEASE failed: %s",
                     rd_kafka_err2str(ack_err));
 
-        /* Second: Change to ACCEPT before commit */
+        /* Second: Change to ACCEPT for first message before commit */
         ack_err = rd_kafka_share_acknowledge_type(
             rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -923,34 +926,22 @@ static void test_change_ack_type_before_commit(void) {
 
         rd_kafka_message_destroy(batch[0]);
 
+        for (i = 1; i < rcvd; i++) {
+                rd_kafka_share_acknowledge_type(
+                    rkshare, batch[i], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                rd_kafka_message_destroy(batch[i]);
+        }
+
         /* Commit async - should succeed with ACCEPT as final ack type */
         err = rd_kafka_share_commit_async(rkshare);
         TEST_ASSERT(!err, "commit_async failed: %s",
                     err ? rd_kafka_error_string(err) : "");
 
-        /* Wait for commit to complete by polling */
-        rd_sleep(2);
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-
-        /* Test 2: Implicit mode (commit happens automatically) */
-        rkshare = test_create_share_consumer(group, "implicit");
-        topic   = test_mk_topic_name("0172-change-ack-implicit", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_simple(common_producer, topic, 0, 5);
-
-        test_share_set_auto_offset_reset(group, "earliest");
-
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        rd_kafka_share_subscribe(rkshare, subs);
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Consume and change ack type */
+        /* Poll to receive the 4 RELEASED messages that were redelivered
+         * This loop also processes the first callback */
         rcvd     = 0;
         attempts = 30;
-        while (rcvd < 1 && attempts-- > 0) {
+        while ((rcvd < 4 || state.callback_cnt < 1) && attempts-- > 0) {
                 size_t batch_rcvd = 0;
                 err = rd_kafka_share_consume_batch(rkshare, 2000, batch,
                                                    &batch_rcvd);
@@ -959,24 +950,37 @@ static void test_change_ack_type_before_commit(void) {
                 rcvd += batch_rcvd;
         }
 
-        TEST_ASSERT(rcvd >= 1, "Expected at least 1 message, got %zu", rcvd);
+        TEST_ASSERT(state.callback_cnt == 1, "Expected 1 callback, got %d",
+                    state.callback_cnt);
+        TEST_ASSERT(state.last_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "First callback failed: %s",
+                    rd_kafka_err2name(state.last_err));
+        TEST_SAY("First commit callback received: offsets=%zu, err=%s\n",
+                 state.total_offsets, rd_kafka_err2name(state.last_err));
+        TEST_SAY("Consumed %zu redelivered messages\n", rcvd);
+        TEST_ASSERT(rcvd >= 4, "Expected 4 redelivered messages, got %zu",
+                    rcvd);
 
-        /* Change from default ACCEPT to RELEASE then back to ACCEPT */
-        ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
-        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "RELEASE failed: %s",
-                    rd_kafka_err2str(ack_err));
+        /* Accept and destroy all received messages */
+        for (i = 0; i < rcvd; i++) {
+                rd_kafka_share_acknowledge(rkshare, batch[i]);
+                rd_kafka_message_destroy(batch[i]);
+        }
 
-        ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "ACCEPT (changing from RELEASE) failed: %s",
-                    rd_kafka_err2str(ack_err));
+        /* Commit async again for the remaining messages */
+        err = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!err, "Second commit_async failed: %s",
+                    err ? rd_kafka_error_string(err) : "");
 
-        rd_kafka_message_destroy(batch[0]);
-
-        /* Implicit commit happens on next consume_batch or close */
-        rd_sleep(2);
+        /* Wait for second callback and verify (expecting 2 total callbacks) */
+        test_wait_for_cb_with_poll(&state, rkshare, 2, 10000);
+        TEST_ASSERT(state.callback_cnt == 2,
+                    "Expected 2 callbacks total, got %d", state.callback_cnt);
+        TEST_ASSERT(state.last_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Second callback failed: %s",
+                    rd_kafka_err2name(state.last_err));
+        TEST_SAY("Second commit callback received: total_offsets=%zu, err=%s\n",
+                 state.total_offsets, rd_kafka_err2name(state.last_err));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -989,7 +993,6 @@ static void test_change_ack_type_before_commit(void) {
  *
  * After commit completes, acknowledged messages are removed from
  * inflight_acks map. Attempting to acknowledge again should fail with _STATE.
- * Tests both explicit and implicit commit modes.
  */
 static void test_ack_after_commit(void) {
         rd_kafka_share_t *rkshare;
@@ -1001,16 +1004,18 @@ static void test_ack_after_commit(void) {
         const char *topic;
         size_t rcvd = 0;
         int attempts;
-        const char *saved_topic = NULL;
-        int32_t saved_partition = -1;
-        int64_t saved_offset    = -1;
+        const char *saved_topic   = NULL;
+        int32_t saved_partition   = -1;
+        int64_t saved_offset      = -1;
+        test_ack_cb_state_t state = {0};
 
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_after_commit ===\n");
 
-        /* Test 1: Explicit mode with explicit commit */
-        rkshare = test_create_share_consumer(group, "explicit");
-        topic   = test_mk_topic_name("0172-ack-after-commit-explicit", 1);
+        /* Test 1: Explicit mode with explicit commit and callback */
+        rkshare =
+            test_create_share_consumer_with_cb(group, "explicit", &state, NULL);
+        topic = test_mk_topic_name("0172-ack-after-commit-explicit", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         test_produce_msgs_simple(common_producer, topic, 0, 5);
 
@@ -1048,8 +1053,14 @@ static void test_ack_after_commit(void) {
         err = rd_kafka_share_commit_async(rkshare);
         TEST_ASSERT(!err, "commit_async failed");
 
-        /* Wait for commit to complete */
-        rd_sleep(3);
+        /* Wait for callback and verify */
+        test_wait_for_cb_with_poll(&state, rkshare, 1, 10000);
+        TEST_ASSERT(state.callback_cnt >= 1,
+                    "Expected at least 1 callback, got %d", state.callback_cnt);
+        TEST_ASSERT(state.last_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Callback failed: %s", rd_kafka_err2name(state.last_err));
+        TEST_SAY("Commit callback received: offsets=%zu, err=%s\n",
+                 state.total_offsets, rd_kafka_err2name(state.last_err));
 
         /* Now try to acknowledge the same message again - should fail */
         ack_err = rd_kafka_share_acknowledge_offset(
@@ -1060,60 +1071,6 @@ static void test_ack_after_commit(void) {
                     rd_kafka_err2str(ack_err));
         TEST_SAY(
             "Explicit mode: Re-ack after commit correctly failed with "
-            "_STATE\n");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-
-        /* Test 2: Implicit mode */
-        rkshare = test_create_share_consumer(group, "implicit");
-        topic   = test_mk_topic_name("0172-ack-after-commit-implicit", 1);
-        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
-        test_produce_msgs_simple(common_producer, topic, 0, 5);
-
-        test_share_set_auto_offset_reset(group, "earliest");
-
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        rd_kafka_share_subscribe(rkshare, subs);
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Consume messages (implicit commit happens automatically) */
-        rcvd     = 0;
-        attempts = 30;
-        while (rcvd < 5 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
-                if (err)
-                        rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
-        }
-
-        TEST_ASSERT(rcvd >= 5, "Expected at least 5 messages, got %zu", rcvd);
-
-        /* Save first message info */
-        saved_topic     = topic;
-        saved_partition = batch[0]->partition;
-        saved_offset    = batch[0]->offset;
-
-        /* Destroy messages (implicit ACCEPT happens) */
-        for (size_t i = 0; i < rcvd; i++) {
-                rd_kafka_message_destroy(batch[i]);
-        }
-
-        /* Wait for implicit commit */
-        rd_sleep(3);
-
-        /* Try to acknowledge again - should fail */
-        ack_err = rd_kafka_share_acknowledge_offset(
-            rkshare, saved_topic, saved_partition, saved_offset,
-            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__STATE,
-                    "Expected _STATE after implicit commit, got %s",
-                    rd_kafka_err2str(ack_err));
-        TEST_SAY(
-            "Implicit mode: Re-ack after commit correctly failed with "
             "_STATE\n");
 
         test_share_consumer_close(rkshare);
@@ -1409,7 +1366,7 @@ int main_0172_share_consumer_acknowledge(int argc, char **argv) {
         test_ack_invalid_type();
         test_release_then_reject_no_redelivery();
 
-        /* Acknowledgement state tests (explicit and implicit commit) */
+        /* Acknowledgement state tests */
         test_change_ack_type_before_commit();
         test_ack_after_commit();
 


### PR DESCRIPTION
Use rd_kafka_topic_partition_new_with_id_and_name instead of rd_kafka_topic_partition_copy so that we dont keep reference of rktp