### PR TITLE
[KIP-932] Implement client side fetch and acknowledge metrics

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2834,6 +2834,11 @@ rd_kafka_t *rd_kafka_new(rd_kafka_type_t type,
                                          .rk_avg_rebalance_latency,
                                     RD_AVG_GAUGE, 0, 900000 * 1000, 2,
                                     rk->rk_conf.enable_metrics_push);
+
+                        rd_atomic64_init(&rk->rk_telemetry.share_fetch_total,
+                                         0);
+                        rd_atomic64_init(
+                            &rk->rk_telemetry.acknowledgements_send_total, 0);
                 } else {
                         rd_avg_init(&rk->rk_telemetry.rd_avg_rollover
                                          .rk_avg_poll_idle_ratio,

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -5247,6 +5247,13 @@ void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
                                     .rkb_avg_produce_latency);
         }
 
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk)) {
+                rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_rollover
+                                    .rkb_avg_share_fetch_latency);
+                rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_current
+                                    .rkb_avg_share_fetch_latency);
+        }
+
 
         mtx_lock(&rkb->rkb_logname_lock);
         rd_free(rkb->rkb_logname);
@@ -5385,6 +5392,17 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
                 rd_avg_init(
                     &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_produce_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
+        }
+
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
+                rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover
+                                 .rkb_avg_share_fetch_latency,
+                            RD_AVG_GAUGE, 0, 500 * 1000, 2,
+                            rk->rk_conf.enable_metrics_push);
+                rd_avg_init(&rkb->rkb_telemetry.rd_avg_current
+                                 .rkb_avg_share_fetch_latency,
+                            RD_AVG_GAUGE, 0, 500 * 1000, 2,
+                            rk->rk_conf.enable_metrics_push);
         }
 
         rd_refcnt_init(&rkb->rkb_refcnt, 0);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -5254,7 +5254,6 @@ void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
                                     .rkb_avg_share_fetch_latency);
         }
 
-
         mtx_lock(&rkb->rkb_logname_lock);
         rd_free(rkb->rkb_logname);
         rkb->rkb_logname = NULL;

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -280,12 +280,15 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                         rd_avg_t rkb_avg_rtt;      /* Current RTT avg */
                         rd_avg_t rkb_avg_throttle; /* Current throttle avg */
                         rd_avg_t
-                            rkb_avg_outbuf_latency;       /**< Current latency
-                                                           *   between buf_enq0
-                                                           *   and writing to socket
-                                                           */
-                        rd_avg_t rkb_avg_fetch_latency;   /**< Current fetch
-                                                           *   latency avg */
+                            rkb_avg_outbuf_latency;     /**< Current latency
+                                                         *   between buf_enq0
+                                                         *   and writing to socket
+                                                         */
+                        rd_avg_t rkb_avg_fetch_latency; /**< Current fetch
+                                                         *   latency avg */
+                        rd_avg_t rkb_avg_share_fetch_latency; /**< Current share
+                                                               *   fetch latency
+                                                               *   avg */
                         rd_avg_t rkb_avg_produce_latency; /**< Current produce
                                                            *   latency avg */
                 } rd_avg_current;
@@ -297,6 +300,10 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                         rd_avg_t rkb_avg_outbuf_latency; /**< Rolled over outbuf
                                                           *   latency avg */
                         rd_avg_t rkb_avg_fetch_latency;  /**< Rolled over fetch
+                                                          *   latency avg */
+                        rd_avg_t
+                            rkb_avg_share_fetch_latency; /**< Rolled over
+                                                          *   share fetch
                                                           *   latency avg */
                         rd_avg_t
                             rkb_avg_produce_latency; /**< Rolled over produce

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1641,7 +1641,14 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
 
         /* Count this successful ShareFetch response for
          * consumer.share.fetch.manager.fetch.{total,rate}.
-         * Fires only after top level error handling */
+         * Fires only after top level error handling.
+         *
+         * TODO KIP-932: Revisit this sampling before GA. It fires here,
+         * before the message set is parsed (rd_kafka_share_msgset_parse in
+         * the partition loop below). If that parse fails with
+         * RD_KAFKA_RESP_ERR__BAD_MSG / __UNDERFLOW the caller drops the
+         * whole response, yet fetch.{total,rate} and fetch.latency have
+         * already been counted here. */
         rd_atomic64_add(&rkb->rkb_rk->rk_telemetry.share_fetch_total, 1);
 
         /* rkbuf_ts_sent is already the request RTT here */
@@ -2515,6 +2522,38 @@ static rd_bool_t can_use_topic_ids(rd_kafka_broker_t *rkb) {
 }
 
 
+/**
+ * @brief Sum the total acknowledgement entries and records across all
+ *        per-partition batches in \p ack_details.
+ *
+ * @param ack_details   List of rd_kafka_share_ack_batches_t, or NULL.
+ * @param entries_out   Set to the total number of ack entries (offset ranges).
+ * @param records_out   Set to the total number of acknowledged records
+ *                      (sum of entry->size across all entries).
+ */
+static void rd_kafka_share_ack_details_totals(rd_list_t *ack_details,
+                                              int *entries_out,
+                                              int64_t *records_out) {
+        rd_kafka_share_ack_batches_t *batches;
+        rd_kafka_share_ack_batch_entry_t *entry;
+        int k, j;
+        int entries     = 0;
+        int64_t records = 0;
+
+        if (ack_details) {
+                RD_LIST_FOREACH(batches, ack_details, k) {
+                        entries += rd_list_cnt(&batches->entries);
+                        RD_LIST_FOREACH(entry, &batches->entries, j) {
+                                records += entry->size;
+                        }
+                }
+        }
+
+        *entries_out = entries;
+        *records_out = records;
+}
+
+
 void rd_kafka_ShareFetchRequest(rd_kafka_broker_t *rkb,
                                 const rd_kafkap_str_t *group_id,
                                 const rd_kafkap_str_t *member_id,
@@ -2577,17 +2616,8 @@ void rd_kafka_ShareFetchRequest(rd_kafka_broker_t *rkb,
         rkbuf_size += (ack_details_cnt * (32 + 4));
         /* Sum total ack entries and total records across all
          * ack_details batches. */
-        if (ack_details) {
-                rd_kafka_share_ack_batches_t *batches;
-                rd_kafka_share_ack_batch_entry_t *entry;
-                int k, j;
-                RD_LIST_FOREACH(batches, ack_details, k) {
-                        total_ack_entries += rd_list_cnt(&batches->entries);
-                        RD_LIST_FOREACH(entry, &batches->entries, j) {
-                                total_ack_records += entry->size;
-                        }
-                }
-        }
+        rd_kafka_share_ack_details_totals(ack_details, &total_ack_entries,
+                                          &total_ack_records);
         /* Accumulate piggybacked record-level acknowledgements for
          * consumer.share.fetch.manager.acknowledgements.send.{total,rate}. */
         if (total_ack_records > 0)
@@ -2972,17 +3002,8 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
         rkbuf_size += (ack_details_cnt * (32 + 4));
         /* Sum total ack entries and total records across all
          * ack_details batches. */
-        if (ack_details) {
-                rd_kafka_share_ack_batches_t *batches;
-                rd_kafka_share_ack_batch_entry_t *entry;
-                int k, j;
-                RD_LIST_FOREACH(batches, ack_details, k) {
-                        total_ack_entries += rd_list_cnt(&batches->entries);
-                        RD_LIST_FOREACH(entry, &batches->entries, j) {
-                                total_ack_records += entry->size;
-                        }
-                }
-        }
+        rd_kafka_share_ack_details_totals(ack_details, &total_ack_entries,
+                                          &total_ack_records);
         /* Accumulate standalone record-level acknowledgements for
          * consumer.share.fetch.manager.acknowledgements.send.{total,rate}. */
         if (total_ack_records > 0)

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1639,6 +1639,16 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
                 return ErrorCode;
         }
 
+        /* Count this successful ShareFetch response for
+         * consumer.share.fetch.manager.fetch.{total,rate}.
+         * Fires only after top level error handling */
+        rd_atomic64_add(&rkb->rkb_rk->rk_telemetry.share_fetch_total, 1);
+
+        /* rkbuf_ts_sent is already the request RTT here */
+        rd_avg_add(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
+            request->rkbuf_ts_sent);
+
         rd_kafka_buf_read_i32(rkbuf, &AcquisitionLockTimeoutMs);
 
         rd_kafka_buf_read_arraycnt(rkbuf, &TopicArrayCnt, RD_KAFKAP_TOPICS_MAX);
@@ -2536,7 +2546,8 @@ void rd_kafka_ShareFetchRequest(rd_kafka_broker_t *rkb,
         int ack_details_cnt = ack_details ? rd_list_cnt(ack_details) : 0;
         /* TODO KIP-932: Ensure there is no intersection between toppars_to_add
          * and ack_details. A toppar should not appear in both lists. */
-        int total_ack_entries = 0;
+        int total_ack_entries     = 0;
+        int64_t total_ack_records = 0;
         int toppars_to_forget_cnt =
             toppars_to_forget ? rd_list_cnt(toppars_to_forget) : 0;
         rd_bool_t is_fetching_messages = max_records > 0 ? rd_true : rd_false;
@@ -2564,14 +2575,26 @@ void rd_kafka_ShareFetchRequest(rd_kafka_broker_t *rkb,
          * E x acknowledgement entries */
 
         rkbuf_size += (ack_details_cnt * (32 + 4));
-        /* Count total ack entries across all ack_details batches */
+        /* Sum total ack entries and total records across all
+         * ack_details batches. */
         if (ack_details) {
                 rd_kafka_share_ack_batches_t *batches;
-                int k;
+                rd_kafka_share_ack_batch_entry_t *entry;
+                int k, j;
                 RD_LIST_FOREACH(batches, ack_details, k) {
                         total_ack_entries += rd_list_cnt(&batches->entries);
+                        RD_LIST_FOREACH(entry, &batches->entries, j) {
+                                total_ack_records += entry->size;
+                        }
                 }
         }
+        /* Accumulate piggybacked record-level acknowledgements for
+         * consumer.share.fetch.manager.acknowledgements.send.{total,rate}. */
+        if (total_ack_records > 0)
+                rd_atomic64_add(
+                    &rkb->rkb_rk->rk_telemetry.acknowledgements_send_total,
+                    total_ack_records);
+
         rkbuf_size += (total_ack_entries * acknowledgement_size);
 
         /* F x (topic id + partition id) for topics to forget */
@@ -2928,8 +2951,9 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
         size_t rkbuf_size           = 0;
         rd_list_t *ack_details =
             rko_orig ? rko_orig->rko_u.share_fetch.ack_details : NULL;
-        int ack_details_cnt   = ack_details ? rd_list_cnt(ack_details) : 0;
-        int total_ack_entries = 0;
+        int ack_details_cnt       = ack_details ? rd_list_cnt(ack_details) : 0;
+        int total_ack_entries     = 0;
+        int64_t total_ack_records = 0;
         /* FirstOffset + LastOffset + AcknowledgementType per ack entry */
         size_t acknowledgement_size = 8 + 8 + 1;
 
@@ -2946,14 +2970,26 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
         rkbuf_size += 4 + 4;
         /* N x (topic id + partition id) for ack details */
         rkbuf_size += (ack_details_cnt * (32 + 4));
-        /* Count total ack entries across all ack_details batches */
+        /* Sum total ack entries and total records across all
+         * ack_details batches. */
         if (ack_details) {
                 rd_kafka_share_ack_batches_t *batches;
-                int k;
+                rd_kafka_share_ack_batch_entry_t *entry;
+                int k, j;
                 RD_LIST_FOREACH(batches, ack_details, k) {
                         total_ack_entries += rd_list_cnt(&batches->entries);
+                        RD_LIST_FOREACH(entry, &batches->entries, j) {
+                                total_ack_records += entry->size;
+                        }
                 }
         }
+        /* Accumulate standalone record-level acknowledgements for
+         * consumer.share.fetch.manager.acknowledgements.send.{total,rate}. */
+        if (total_ack_records > 0)
+                rd_atomic64_add(
+                    &rkb->rkb_rk->rk_telemetry.acknowledgements_send_total,
+                    total_ack_records);
+
         rkbuf_size += (total_ack_entries * acknowledgement_size);
 
         rkbuf = rd_kafka_buf_new_flexver_request(

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -811,6 +811,10 @@ struct rd_kafka_s {
                                            *   started */
                         /** Total rebalance latency (ms) up to previous push */
                         uint64_t rebalance_latency_total;
+                        /** Total share fetch requests up to previous push */
+                        int64_t share_fetch_total;
+                        /** Total acknowledgements sent up to previous push */
+                        int64_t acknowledgements_send_total;
                 } rk_historic_c;
 
                 struct {
@@ -850,6 +854,11 @@ struct rd_kafka_s {
                         rd_ts_t time_since_last_poll;
                 } rk_share_poll;
 
+                /* Share consumer fetch-RPC counter */
+                rd_atomic64_t share_fetch_total;
+
+                /* Share consumer record-level acknowledgements sent counter */
+                rd_atomic64_t acknowledgements_send_total;
         } rk_telemetry;
 
         /* Test mocks */

--- a/src/rdkafka_telemetry_decode.c
+++ b/src/rdkafka_telemetry_decode.c
@@ -592,6 +592,9 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
         rd_avg_init(&rk->rk_telemetry.rd_avg_rollover.rk_avg_rebalance_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
 
+        rd_atomic64_init(&rk->rk_telemetry.share_fetch_total, 0);
+        rd_atomic64_init(&rk->rk_telemetry.acknowledgements_send_total, 0);
+
         rd_strlcpy(rk->rk_name, "unittest", sizeof(rk->rk_name));
         clear_unit_test_data(expected_value_int, expected_value_double);
 
@@ -619,6 +622,9 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_fetch_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
+        rd_avg_init(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
+            RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
 
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_rtt,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
@@ -628,6 +634,9 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_fetch_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
+        rd_avg_init(
+            &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_latency,
+            RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_produce_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_produce_latency,
@@ -722,6 +731,11 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
             &rkb->rkb_telemetry.rd_avg_current.rkb_avg_fetch_latency);
         rd_avg_destroy(
             &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_fetch_latency);
+
+        rd_avg_destroy(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency);
+        rd_avg_destroy(
+            &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_latency);
 
         rd_avg_destroy(&rk->rk_telemetry.rd_avg_current.rk_avg_poll_idle_ratio);
         rd_avg_destroy(
@@ -820,6 +834,19 @@ void unit_test_telemetry_set_fetch_latency(rd_kafka_t *rk,
                    1000);
 }
 
+void unit_test_telemetry_set_share_fetch_latency(rd_kafka_t *rk,
+                                                 rd_kafka_broker_t *rkb) {
+        rd_avg_add(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
+            7000);
+        rd_avg_add(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
+            15000);
+        rd_avg_add(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
+            23000);
+}
+
 void unit_test_telemetry_set_poll_idle_ratio(rd_kafka_t *rk,
                                              rd_kafka_broker_t *rkb) {
         rd_avg_add(&rk->rk_telemetry.rd_avg_current.rk_avg_poll_idle_ratio,
@@ -854,6 +881,21 @@ void unit_test_telemetry_set_time_between_poll(rd_kafka_t *rk,
         rd_avg_add(
             &rk->rk_telemetry.rd_avg_current.rk_avg_share_time_between_poll,
             60000);
+}
+
+void unit_test_telemetry_set_share_fetch_total(rd_kafka_t *rk,
+                                               rd_kafka_broker_t *rkb) {
+        rd_atomic64_add(&rk->rk_telemetry.share_fetch_total, 10);
+        rd_atomic64_add(&rk->rk_telemetry.share_fetch_total, 15);
+        rd_atomic64_add(&rk->rk_telemetry.share_fetch_total, 17);
+}
+
+void unit_test_telemetry_set_acknowledgements_send_total(
+    rd_kafka_t *rk,
+    rd_kafka_broker_t *rkb) {
+        rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 10);
+        rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 15);
+        rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 17);
 }
 
 void unit_test_telemetry_set_commit_latency(rd_kafka_t *rk,
@@ -1076,6 +1118,38 @@ int unit_test_telemetry_gauge(void) {
             "The max delay between invocations of poll() in milliseconds.",
             RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_false, rd_false,
             unit_test_telemetry_set_time_between_poll, 60, 0.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.rate",
+            "The number of fetch requests per second.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_share_fetch_total, 0, 42.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.latency.avg",
+            "The average time taken for a fetch request.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_share_fetch_latency, 0, 15.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.latency.max",
+            "The maximum time taken for any fetch request.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_false, rd_false,
+            unit_test_telemetry_set_share_fetch_latency, 23, 0.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.acknowledgements.send.rate",
+            "The average number of record acknowledgements sent per second.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_acknowledgements_send_total, 0, 42.0);
         return fails;
 }
 
@@ -1125,6 +1199,24 @@ int unit_test_telemetry_sum(void) {
             RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM, rd_false, rd_false,
             unit_test_telemetry_set_rebalance_latency,
             default_expected_value_int, default_expected_value_double);
+
+        /* Expected 42 */
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.total",
+            "The total number of fetch requests.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM, rd_false, rd_false,
+            unit_test_telemetry_set_share_fetch_total, 42, 0.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.acknowledgements.send.total",
+            "The total number of record acknowledgements sent.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM, rd_false, rd_false,
+            unit_test_telemetry_set_acknowledgements_send_total, 42, 0.0);
         return fails;
 }
 

--- a/src/rdkafka_telemetry_encode.c
+++ b/src/rdkafka_telemetry_encode.c
@@ -339,6 +339,104 @@ calculate_share_time_between_poll_max(rd_kafka_t *rk,
         return time_between_poll_max;
 }
 
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_latency_avg(rd_kafka_t *rk,
+                                  rd_kafka_broker_t *rkb_selected,
+                                  rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t avg_share_fetch_latency;
+        brokers_avg(rk, rkb_avg_share_fetch_latency, THREE_ORDERS_MAGNITUDE,
+                    avg_share_fetch_latency);
+        return avg_share_fetch_latency;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_latency_max(rd_kafka_t *rk,
+                                  rd_kafka_broker_t *rkb_selected,
+                                  rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t max_share_fetch_latency;
+        brokers_max(rk, rkb_avg_share_fetch_latency, THREE_ORDERS_MAGNITUDE,
+                    max_share_fetch_latency);
+        return max_share_fetch_latency;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_total(rd_kafka_t *rk,
+                            rd_kafka_broker_t *rkb_selected,
+                            rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t share_fetch_total;
+        int64_t current = rd_atomic64_get(&rk->rk_telemetry.share_fetch_total);
+
+        if (!rk->rk_telemetry.delta_temporality)
+                share_fetch_total.int_value = current;
+        else
+                share_fetch_total.int_value =
+                    current - rk->rk_telemetry.rk_historic_c.share_fetch_total;
+
+        return share_fetch_total;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_rate(rd_kafka_t *rk,
+                           rd_kafka_broker_t *rkb_selected,
+                           rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t share_fetch_rate;
+        rd_ts_t ts_last = rk->rk_telemetry.rk_historic_c.ts_last;
+        int64_t delta   = rd_atomic64_get(&rk->rk_telemetry.share_fetch_total) -
+                        rk->rk_telemetry.rk_historic_c.share_fetch_total;
+        double seconds = (now_ns - ts_last) / 1e9;
+
+        /* For sub-second intervals (e.g. the first reading) report the raw
+         * delta instead of dividing, to avoid a tiny denominator massively
+         * overstating the rate. Same logic as the other rate metrics. */
+        if (seconds > 1.0)
+                share_fetch_rate.double_value = (double)delta / seconds;
+        else
+                share_fetch_rate.double_value = (double)delta;
+
+        return share_fetch_rate;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_acknowledgements_send_total(rd_kafka_t *rk,
+                                            rd_kafka_broker_t *rkb_selected,
+                                            rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t acknowledgements_send_total;
+        int64_t current =
+            rd_atomic64_get(&rk->rk_telemetry.acknowledgements_send_total);
+
+        if (!rk->rk_telemetry.delta_temporality)
+                acknowledgements_send_total.int_value = current;
+        else
+                acknowledgements_send_total.int_value =
+                    current -
+                    rk->rk_telemetry.rk_historic_c.acknowledgements_send_total;
+
+        return acknowledgements_send_total;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_acknowledgements_send_rate(rd_kafka_t *rk,
+                                           rd_kafka_broker_t *rkb_selected,
+                                           rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t acknowledgements_send_rate;
+        rd_ts_t ts_last = rk->rk_telemetry.rk_historic_c.ts_last;
+        int64_t delta =
+            rd_atomic64_get(&rk->rk_telemetry.acknowledgements_send_total) -
+            rk->rk_telemetry.rk_historic_c.acknowledgements_send_total;
+        double seconds = (now_ns - ts_last) / 1e9;
+
+        /* For sub-second intervals (e.g. the first reading) report the raw
+         * delta instead of dividing, to avoid a tiny denominator massively
+         * overstating the rate. Same logic as the other rate metrics. */
+        if (seconds > 1.0)
+                acknowledgements_send_rate.double_value =
+                    (double)delta / seconds;
+        else
+                acknowledgements_send_rate.double_value = (double)delta;
+
+        return acknowledgements_send_rate;
+}
+
 static void reset_historical_metrics(rd_kafka_t *rk, rd_ts_t now_ns) {
         rd_kafka_broker_t *rkb;
 
@@ -351,6 +449,14 @@ static void reset_historical_metrics(rd_kafka_t *rk, rd_ts_t now_ns) {
         TAILQ_FOREACH(rkb, &rk->rk_brokers, rkb_link) {
                 rkb->rkb_telemetry.rkb_historic_c.connects =
                     rd_atomic32_get(&rkb->rkb_c.connects);
+        }
+
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
+                rk->rk_telemetry.rk_historic_c.share_fetch_total =
+                    rd_atomic64_get(&rk->rk_telemetry.share_fetch_total);
+                rk->rk_telemetry.rk_historic_c.acknowledgements_send_total =
+                    rd_atomic64_get(
+                        &rk->rk_telemetry.acknowledgements_send_total);
         }
 }
 
@@ -418,6 +524,18 @@ static const rd_kafka_telemetry_metric_value_calculator_t
                 &calculate_share_time_between_poll_avg,
             [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX] =
                 &calculate_share_time_between_poll_max,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
+                &calculate_share_fetch_total,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
+                &calculate_share_fetch_rate,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
+                &calculate_share_fetch_latency_avg,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
+                &calculate_share_fetch_latency_max,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
+                &calculate_share_acknowledgements_send_total,
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
+                &calculate_share_acknowledgements_send_rate,
 };
 
 static const char *get_client_rack(const rd_kafka_t *rk) {
@@ -836,6 +954,15 @@ rd_buf_t *rd_kafka_telemetry_encode_metrics(rd_kafka_t *rk) {
                                              .rkb_avg_produce_latency,
                                         &rkb->rkb_telemetry.rd_avg_current
                                              .rkb_avg_produce_latency);
+                }
+
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
+                        rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_rollover
+                                            .rkb_avg_share_fetch_latency);
+                        rd_avg_rollover(&rkb->rkb_telemetry.rd_avg_rollover
+                                             .rkb_avg_share_fetch_latency,
+                                        &rkb->rkb_telemetry.rd_avg_current
+                                             .rkb_avg_share_fetch_latency);
                 }
         }
 

--- a/src/rdkafka_telemetry_encode.h
+++ b/src/rdkafka_telemetry_encode.h
@@ -90,6 +90,12 @@ typedef enum {
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_POLL_IDLE_RATIO_AVG,
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_AVG,
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE,
         RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT
 } rd_kafka_telemetry_share_consumer_metric_name_t;
 
@@ -335,6 +341,52 @@ static const rd_kafka_telemetry_metric_info_t
                      "milliseconds.",
                  .unit          = "ms",
                  .is_int        = rd_true,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
+                {.name          = "consumer.share.fetch.manager.fetch.total",
+                 .description   = "The total number of fetch requests.",
+                 .unit          = "1",
+                 .is_int        = rd_true,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
+                {.name          = "consumer.share.fetch.manager.fetch.rate",
+                 .description   = "The number of fetch requests per second.",
+                 .unit          = "1",
+                 .is_int        = rd_false,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
+                {.name = "consumer.share.fetch.manager.fetch.latency.avg",
+                 .description   = "The average time taken for a fetch request.",
+                 .unit          = "ms",
+                 .is_int        = rd_false,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
+                {.name = "consumer.share.fetch.manager.fetch.latency.max",
+                 .description = "The maximum time taken for any fetch request.",
+                 .unit        = "ms",
+                 .is_int      = rd_true,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
+                {.name = "consumer.share.fetch.manager.acknowledgements.send."
+                         "total",
+                 .description   = "The total number of record acknowledgements "
+                                  "sent.",
+                 .unit          = "1",
+                 .is_int        = rd_true,
+                 .is_per_broker = rd_false,
+                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
+                {.name = "consumer.share.fetch.manager.acknowledgements.send."
+                         "rate",
+                 .description = "The average number of record acknowledgements "
+                                "sent per second.",
+                 .unit        = "1",
+                 .is_int      = rd_false,
                  .is_per_broker = rd_false,
                  .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
 };


### PR DESCRIPTION
- `org.apache.kafka.consumer.share.fetch.manager.fetch.total` — total number of successful ShareFetch responses
- `org.apache.kafka.consumer.share.fetch.manager.fetch.rate` — successful ShareFetch responses per second
- `org.apache.kafka.consumer.share.fetch.manager.fetch.latency.avg` — average ShareFetch request to response latency (ms)
- `org.apache.kafka.consumer.share.fetch.manager.fetch.latency.max` — maximum ShareFetch request to response latency (ms)
- `org.apache.kafka.consumer.share.fetch.manager.acknowledgements.send.total` — total record-level acknowledgements sent (piggybacked on ShareFetch and standalone ShareAcknowledge requests)