### PR TITLE
[KIP-932] Implement client side performance metrics

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -5252,6 +5252,10 @@ void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
                                     .rkb_avg_share_fetch_latency);
                 rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_current
                                     .rkb_avg_share_fetch_latency);
+                rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_rollover
+                                    .rkb_avg_share_fetch_size);
+                rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_current
+                                    .rkb_avg_share_fetch_size);
         }
 
         mtx_lock(&rkb->rkb_logname_lock);
@@ -5402,6 +5406,14 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
                                  .rkb_avg_share_fetch_latency,
                             RD_AVG_GAUGE, 0, 500 * 1000, 2,
                             rk->rk_conf.enable_metrics_push);
+                rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover
+                                 .rkb_avg_share_fetch_size,
+                            RD_AVG_GAUGE, 0, 100 * 1024 * 1024, 2,
+                            rk->rk_conf.enable_metrics_push);
+                rd_avg_init(
+                    &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                    RD_AVG_GAUGE, 0, 100 * 1024 * 1024, 2,
+                    rk->rk_conf.enable_metrics_push);
         }
 
         rd_refcnt_init(&rkb->rkb_refcnt, 0);

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -289,6 +289,10 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                         rd_avg_t rkb_avg_share_fetch_latency; /**< Current share
                                                                *   fetch latency
                                                                *   avg */
+                        rd_avg_t rkb_avg_share_fetch_size;    /**< Current share
+                                                               *   fetch response
+                                                               *   size avg
+                                                               *   (bytes) */
                         rd_avg_t rkb_avg_produce_latency; /**< Current produce
                                                            *   latency avg */
                 } rd_avg_current;
@@ -305,6 +309,10 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                             rkb_avg_share_fetch_latency; /**< Rolled over
                                                           *   share fetch
                                                           *   latency avg */
+                        rd_avg_t
+                            rkb_avg_share_fetch_size; /**< Rolled over
+                                                       *   share fetch response
+                                                       *   size avg (bytes) */
                         rd_avg_t
                             rkb_avg_produce_latency; /**< Rolled over produce
                                                       *   latency avg */

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -1097,6 +1097,10 @@ rd_kafka_cgrp_handle_ShareGroupHeartbeat_leave(rd_kafka_t *rk,
                 goto err;
         }
 
+        /* Count the leave ShareGroupHeartbeat response for
+         * consumer.share.coordinator.heartbeat.{total,rate} */
+        rd_atomic64_add(&rk->rk_telemetry.heartbeat_total, 1);
+
         rd_kafka_buf_read_throttle_time(rkbuf);
 
         rd_kafka_buf_read_i16(rkbuf, &ErrorCode);
@@ -3477,7 +3481,14 @@ void rd_kafka_cgrp_handle_ShareGroupHeartbeat(rd_kafka_t *rk,
         if (err)
                 goto err;
 
+        /* Count this ShareGroupHeartbeat response for
+         * consumer.share.coordinator.heartbeat.{total,rate}.
+         * recorded once the response arrives (transport-level success),
+         * regardless of Broker level errors */
+        rd_atomic64_add(&rk->rk_telemetry.heartbeat_total, 1);
+
         rd_kafka_buf_read_throttle_time(rkbuf);
+
         rd_kafka_buf_read_i16(rkbuf, &error_code);
         rd_kafka_buf_read_str(rkbuf, &error_str);
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1622,6 +1622,9 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         rd_kafka_op_t *rko_orig       = request->rkbuf_opaque;
         rd_kafka_op_t *response_rko   = NULL;
         rd_kafka_resp_err_t err       = RD_KAFKA_RESP_ERR_NO_ERROR;
+        rd_kafka_op_t *fetch_size_rko;
+        int fetch_size_idx;
+        int64_t total_fetch_size_bytes = 0;
 
         rd_kafka_buf_read_throttle_time(rkbuf);
 
@@ -1728,6 +1731,24 @@ rd_kafka_share_fetch_reply_handle(rd_kafka_broker_t *rkb,
         }
 
         rd_kafka_buf_read_NodeEndpoints(rkbuf, &NodeEndpoints);
+
+        /* Sum per-record wire bytes across acquired records for
+         * consumer.share.fetch.manager.fetch.size.{avg,max} and
+         * .bytes.consumed.{total,rate}. */
+        RD_LIST_FOREACH(fetch_size_rko, filtered_msgs, fetch_size_idx) {
+                if (fetch_size_rko->rko_type == RD_KAFKA_OP_FETCH) {
+                        rd_kafka_msg_t *rkm = &fetch_size_rko->rko_u.fetch.rkm;
+                        total_fetch_size_bytes +=
+                            (int64_t)rkm->rkm_u.consumer.wire_size;
+                }
+        }
+        /* Update bytes per fetch metrics */
+        rd_avg_add(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                   total_fetch_size_bytes);
+
+        /* Update total bytes consumed */
+        rd_atomic64_add(&rkb->rkb_rk->rk_telemetry.share_bytes_consumed_total,
+                        total_fetch_size_bytes);
 
         /* Build response rko with messages and inflight_acks */
         response_rko = rd_kafka_share_build_response_rko(rkb, filtered_msgs,

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -813,8 +813,13 @@ struct rd_kafka_s {
                         uint64_t rebalance_latency_total;
                         /** Total share fetch requests up to previous push */
                         int64_t share_fetch_total;
+                        /** Total share bytes consumed up to previous push */
+                        int64_t share_bytes_consumed_total;
                         /** Total acknowledgements sent up to previous push */
                         int64_t acknowledgements_send_total;
+                        /** Total ShareGroupHeartbeat responses up to previous
+                         * push */
+                        int64_t heartbeat_total;
                 } rk_historic_c;
 
                 struct {
@@ -857,8 +862,14 @@ struct rd_kafka_s {
                 /* Share consumer fetch-RPC counter */
                 rd_atomic64_t share_fetch_total;
 
+                /* Share consumer total bytes consumed */
+                rd_atomic64_t share_bytes_consumed_total;
+
                 /* Share consumer record-level acknowledgements sent counter */
                 rd_atomic64_t acknowledgements_send_total;
+
+                /* Share consumer ShareGroupHeartbeat response counter */
+                rd_atomic64_t heartbeat_total;
         } rk_telemetry;
 
         /* Test mocks */

--- a/src/rdkafka_msg.h
+++ b/src/rdkafka_msg.h
@@ -155,6 +155,13 @@ typedef struct rd_kafka_msg_s {
                                                     *   protocol msg */
                         int32_t leader_epoch;      /**< Leader epoch at the time
                                                     *   the message was fetched. */
+                        int32_t wire_size;         /**< wire-format size of this
+                                                    *   record including the
+                                                    *   length-prefix varint and all
+                                                    *   per-record framing.
+                                                    *   Used by share consumer
+                                                    *   fetch.size telemetry.
+                                                    */
                         rd_kafka_share_internal_acknowledgement_type
                             ack_type; /**< Share consumer: acknowledgement
                                        *   type

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -788,7 +788,13 @@ rd_kafka_msgset_reader_msg_v2(rd_kafka_msgset_reader_t *msetr) {
                 ? LOG_DEBUG
                 : 0;
         size_t message_end;
+        size_t record_start_pos;
         rd_kafka_fetch_pos_t msetr_pos;
+
+        /* Capture buffer position before reading length varint so we can
+         * compute the total wire-format size of this record (length varint
+         * size + body bytes) for share consumer fetch.size telemetry. */
+        record_start_pos = rd_slice_offset(&rkbuf->rkbuf_reader);
 
         rd_kafka_buf_read_varint(rkbuf, &hdr.Length);
         message_end =
@@ -1011,6 +1017,12 @@ rd_kafka_msgset_reader_msg_v2(rd_kafka_msgset_reader_t *msetr) {
                     msetr->msetr_v2_hdr->BaseTimestamp + hdr.TimestampDelta;
         }
 
+
+        /* Cache the wire-format size of this record (length varint +
+         * body) on the rkm.
+         * Used by share consumer fetch.size telemetry. */
+        rkm->rkm_u.consumer.wire_size =
+            (int32_t)(message_end - record_start_pos);
 
         /* Enqueue message on temporary queue */
         rd_kafka_q_enq(&msetr->msetr_rkq, rko);

--- a/src/rdkafka_telemetry.c
+++ b/src/rdkafka_telemetry.c
@@ -173,8 +173,9 @@ static void update_matched_metrics(rd_kafka_t *rk, size_t j) {
 static void rd_kafka_match_requested_metrics(rd_kafka_t *rk) {
         size_t metrics_cnt = RD_KAFKA_TELEMETRY_METRIC_CNT(rk), i;
         rd_bool_t is_metric_included[RD_MAX(
-            (int)RD_KAFKA_TELEMETRY_PRODUCER_METRIC__CNT,
-            (int)RD_KAFKA_TELEMETRY_CONSUMER_METRIC__CNT)] = {0};
+            RD_MAX((int)RD_KAFKA_TELEMETRY_PRODUCER_METRIC__CNT,
+                   (int)RD_KAFKA_TELEMETRY_CONSUMER_METRIC__CNT),
+            (int)RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT)] = {0};
         const rd_kafka_telemetry_metric_info_t *info =
             RD_KAFKA_TELEMETRY_METRIC_INFO(rk);
 

--- a/src/rdkafka_telemetry_decode.c
+++ b/src/rdkafka_telemetry_decode.c
@@ -594,6 +594,7 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
 
         rd_atomic64_init(&rk->rk_telemetry.share_fetch_total, 0);
         rd_atomic64_init(&rk->rk_telemetry.acknowledgements_send_total, 0);
+        rd_atomic64_init(&rk->rk_telemetry.heartbeat_total, 0);
 
         rd_strlcpy(rk->rk_name, "unittest", sizeof(rk->rk_name));
         clear_unit_test_data(expected_value_int, expected_value_double);
@@ -625,6 +626,8 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
         rd_avg_init(
             &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency,
             RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
+        rd_avg_init(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                    RD_AVG_GAUGE, 0, 100 * 1024 * 1024, 2, rd_true);
 
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_rtt,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
@@ -637,6 +640,9 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
         rd_avg_init(
             &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_latency,
             RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
+        rd_avg_init(
+            &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_size,
+            RD_AVG_GAUGE, 0, 100 * 1024 * 1024, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_produce_latency,
                     RD_AVG_GAUGE, 0, 500 * 1000, 2, rd_true);
         rd_avg_init(&rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_produce_latency,
@@ -736,6 +742,11 @@ int unit_test_telemetry(rd_kafka_type_t rk_type,
             &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_latency);
         rd_avg_destroy(
             &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_latency);
+
+        rd_avg_destroy(
+            &rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size);
+        rd_avg_destroy(
+            &rkb->rkb_telemetry.rd_avg_rollover.rkb_avg_share_fetch_size);
 
         rd_avg_destroy(&rk->rk_telemetry.rd_avg_current.rk_avg_poll_idle_ratio);
         rd_avg_destroy(
@@ -847,6 +858,16 @@ void unit_test_telemetry_set_share_fetch_latency(rd_kafka_t *rk,
             23000);
 }
 
+void unit_test_telemetry_set_share_fetch_size(rd_kafka_t *rk,
+                                              rd_kafka_broker_t *rkb) {
+        rd_avg_add(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                   1024);
+        rd_avg_add(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                   2048);
+        rd_avg_add(&rkb->rkb_telemetry.rd_avg_current.rkb_avg_share_fetch_size,
+                   3072);
+}
+
 void unit_test_telemetry_set_poll_idle_ratio(rd_kafka_t *rk,
                                              rd_kafka_broker_t *rkb) {
         rd_avg_add(&rk->rk_telemetry.rd_avg_current.rk_avg_poll_idle_ratio,
@@ -896,6 +917,13 @@ void unit_test_telemetry_set_acknowledgements_send_total(
         rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 10);
         rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 15);
         rd_atomic64_add(&rk->rk_telemetry.acknowledgements_send_total, 17);
+}
+
+void unit_test_telemetry_set_heartbeat_total(rd_kafka_t *rk,
+                                             rd_kafka_broker_t *rkb) {
+        rd_atomic64_add(&rk->rk_telemetry.heartbeat_total, 10);
+        rd_atomic64_add(&rk->rk_telemetry.heartbeat_total, 15);
+        rd_atomic64_add(&rk->rk_telemetry.heartbeat_total, 17);
 }
 
 void unit_test_telemetry_set_commit_latency(rd_kafka_t *rk,
@@ -1150,6 +1178,49 @@ int unit_test_telemetry_gauge(void) {
             "The average number of record acknowledgements sent per second.",
             RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
             unit_test_telemetry_set_acknowledgements_send_total, 0, 42.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_AVG,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.throttle.time.avg",
+            "The average throttle time in ms.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_throttle_time, default_expected_value_int,
+            default_expected_value_double);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_MAX,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.throttle.time.max",
+            "The maximum throttle time in ms.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_false, rd_false,
+            unit_test_telemetry_set_throttle_time, default_expected_value_int,
+            default_expected_value_double);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_RATE,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.coordinator.heartbeat.rate",
+            "The number of heartbeats per second.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_heartbeat_total, 0, 42.0);
+        /* Samples (1024 + 2048 + 3072) / 3 = 2048 */
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_AVG,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.size.avg",
+            "The average number of bytes fetched per request.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_true, rd_false,
+            unit_test_telemetry_set_share_fetch_size, 0, 2048.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_MAX,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.fetch.manager.fetch.size.max",
+            "The maximum number of bytes fetched per request.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE, rd_false, rd_false,
+            unit_test_telemetry_set_share_fetch_size, 3072, 0.0);
         return fails;
 }
 
@@ -1217,6 +1288,14 @@ int unit_test_telemetry_sum(void) {
             "The total number of record acknowledgements sent.",
             RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM, rd_false, rd_false,
             unit_test_telemetry_set_acknowledgements_send_total, 42, 0.0);
+        fails += unit_test_telemetry(
+            RD_KAFKA_CONSUMER,
+            RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_TOTAL,
+            RD_KAFKA_TELEMETRY_METRIC_PREFIX
+            "consumer.share.coordinator.heartbeat.total",
+            "The total number of heartbeats.",
+            RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM, rd_false, rd_false,
+            unit_test_telemetry_set_heartbeat_total, 42, 0.0);
         return fails;
 }
 

--- a/src/rdkafka_telemetry_encode.c
+++ b/src/rdkafka_telemetry_encode.c
@@ -360,6 +360,61 @@ calculate_share_fetch_latency_max(rd_kafka_t *rk,
 }
 
 static rd_kafka_telemetry_metric_value_t
+calculate_share_bytes_consumed_total(rd_kafka_t *rk,
+                                     rd_kafka_broker_t *rkb_selected,
+                                     rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t bytes_consumed_total;
+        int64_t current =
+            rd_atomic64_get(&rk->rk_telemetry.share_bytes_consumed_total);
+
+        if (!rk->rk_telemetry.delta_temporality)
+                bytes_consumed_total.int_value = current;
+        else
+                bytes_consumed_total.int_value =
+                    current -
+                    rk->rk_telemetry.rk_historic_c.share_bytes_consumed_total;
+
+        return bytes_consumed_total;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_bytes_consumed_rate(rd_kafka_t *rk,
+                                    rd_kafka_broker_t *rkb_selected,
+                                    rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t bytes_consumed_rate;
+        rd_ts_t ts_last = rk->rk_telemetry.rk_historic_c.ts_last;
+        int64_t delta =
+            rd_atomic64_get(&rk->rk_telemetry.share_bytes_consumed_total) -
+            rk->rk_telemetry.rk_historic_c.share_bytes_consumed_total;
+        double seconds = (now_ns - ts_last) / 1e9;
+
+        if (seconds > 1.0)
+                bytes_consumed_rate.double_value = (double)delta / seconds;
+        else
+                bytes_consumed_rate.double_value = (double)delta;
+
+        return bytes_consumed_rate;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_size_avg(rd_kafka_t *rk,
+                               rd_kafka_broker_t *rkb_selected,
+                               rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t avg_share_fetch_size;
+        brokers_avg(rk, rkb_avg_share_fetch_size, 1, avg_share_fetch_size);
+        return avg_share_fetch_size;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_fetch_size_max(rd_kafka_t *rk,
+                               rd_kafka_broker_t *rkb_selected,
+                               rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t max_share_fetch_size;
+        brokers_max(rk, rkb_avg_share_fetch_size, 1, max_share_fetch_size);
+        return max_share_fetch_size;
+}
+
+static rd_kafka_telemetry_metric_value_t
 calculate_share_fetch_total(rd_kafka_t *rk,
                             rd_kafka_broker_t *rkb_selected,
                             rd_ts_t now_ns) {
@@ -437,6 +492,40 @@ calculate_share_acknowledgements_send_rate(rd_kafka_t *rk,
         return acknowledgements_send_rate;
 }
 
+static rd_kafka_telemetry_metric_value_t
+calculate_share_heartbeat_total(rd_kafka_t *rk,
+                                rd_kafka_broker_t *rkb_selected,
+                                rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t heartbeat_total;
+        int64_t current = rd_atomic64_get(&rk->rk_telemetry.heartbeat_total);
+
+        if (!rk->rk_telemetry.delta_temporality)
+                heartbeat_total.int_value = current;
+        else
+                heartbeat_total.int_value =
+                    current - rk->rk_telemetry.rk_historic_c.heartbeat_total;
+
+        return heartbeat_total;
+}
+
+static rd_kafka_telemetry_metric_value_t
+calculate_share_heartbeat_rate(rd_kafka_t *rk,
+                               rd_kafka_broker_t *rkb_selected,
+                               rd_ts_t now_ns) {
+        rd_kafka_telemetry_metric_value_t heartbeat_rate;
+        rd_ts_t ts_last = rk->rk_telemetry.rk_historic_c.ts_last;
+        int64_t delta   = rd_atomic64_get(&rk->rk_telemetry.heartbeat_total) -
+                        rk->rk_telemetry.rk_historic_c.heartbeat_total;
+        double seconds = (now_ns - ts_last) / 1e9;
+
+        if (seconds > 1.0)
+                heartbeat_rate.double_value = (double)delta / seconds;
+        else
+                heartbeat_rate.double_value = (double)delta;
+
+        return heartbeat_rate;
+}
+
 static void reset_historical_metrics(rd_kafka_t *rk, rd_ts_t now_ns) {
         rd_kafka_broker_t *rkb;
 
@@ -454,9 +543,14 @@ static void reset_historical_metrics(rd_kafka_t *rk, rd_ts_t now_ns) {
         if (RD_KAFKA_IS_SHARE_CONSUMER(rk)) {
                 rk->rk_telemetry.rk_historic_c.share_fetch_total =
                     rd_atomic64_get(&rk->rk_telemetry.share_fetch_total);
+                rk->rk_telemetry.rk_historic_c.share_bytes_consumed_total =
+                    rd_atomic64_get(
+                        &rk->rk_telemetry.share_bytes_consumed_total);
                 rk->rk_telemetry.rk_historic_c.acknowledgements_send_total =
                     rd_atomic64_get(
                         &rk->rk_telemetry.acknowledgements_send_total);
+                rk->rk_telemetry.rk_historic_c.heartbeat_total =
+                    rd_atomic64_get(&rk->rk_telemetry.heartbeat_total);
         }
 }
 
@@ -515,27 +609,42 @@ static const rd_kafka_telemetry_metric_value_calculator_t
             &calculate_consumer_commit_latency_max,
 };
 
-static const rd_kafka_telemetry_metric_value_calculator_t
-    SHARE_CONSUMER_METRIC_VALUE_CALCULATORS
-        [RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT] = {
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_POLL_IDLE_RATIO_AVG] =
-                &calculate_share_consumer_poll_idle_ratio_avg,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_AVG] =
-                &calculate_share_time_between_poll_avg,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX] =
-                &calculate_share_time_between_poll_max,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
-                &calculate_share_fetch_total,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
-                &calculate_share_fetch_rate,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
-                &calculate_share_fetch_latency_avg,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
-                &calculate_share_fetch_latency_max,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
-                &calculate_share_acknowledgements_send_total,
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
-                &calculate_share_acknowledgements_send_rate,
+static const rd_kafka_telemetry_metric_value_calculator_t SHARE_CONSUMER_METRIC_VALUE_CALCULATORS
+    [RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT] = {
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_POLL_IDLE_RATIO_AVG] =
+            &calculate_share_consumer_poll_idle_ratio_avg,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_AVG] =
+            &calculate_share_time_between_poll_avg,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX] =
+            &calculate_share_time_between_poll_max,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
+            &calculate_share_fetch_total,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
+            &calculate_share_fetch_rate,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
+            &calculate_share_fetch_latency_avg,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
+            &calculate_share_fetch_latency_max,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
+            &calculate_share_acknowledgements_send_total,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
+            &calculate_share_acknowledgements_send_rate,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_AVG] =
+            &calculate_throttle_avg,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_MAX] =
+            &calculate_throttle_max,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_TOTAL] =
+            &calculate_share_heartbeat_total,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_RATE] =
+            &calculate_share_heartbeat_rate,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_AVG] =
+            &calculate_share_fetch_size_avg,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_MAX] =
+            &calculate_share_fetch_size_max,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_TOTAL] =
+            &calculate_share_bytes_consumed_total,
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_RATE] =
+            &calculate_share_bytes_consumed_rate,
 };
 
 static const char *get_client_rack(const rd_kafka_t *rk) {
@@ -963,6 +1072,12 @@ rd_buf_t *rd_kafka_telemetry_encode_metrics(rd_kafka_t *rk) {
                                              .rkb_avg_share_fetch_latency,
                                         &rkb->rkb_telemetry.rd_avg_current
                                              .rkb_avg_share_fetch_latency);
+                        rd_avg_destroy(&rkb->rkb_telemetry.rd_avg_rollover
+                                            .rkb_avg_share_fetch_size);
+                        rd_avg_rollover(&rkb->rkb_telemetry.rd_avg_rollover
+                                             .rkb_avg_share_fetch_size,
+                                        &rkb->rkb_telemetry.rd_avg_current
+                                             .rkb_avg_share_fetch_size);
                 }
         }
 

--- a/src/rdkafka_telemetry_encode.h
+++ b/src/rdkafka_telemetry_encode.h
@@ -96,6 +96,14 @@ typedef enum {
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX,
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL,
         RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_AVG,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_MAX,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_TOTAL,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_RATE,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_AVG,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_MAX,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_TOTAL,
+        RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_RATE,
         RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT
 } rd_kafka_telemetry_share_consumer_metric_name_t;
 
@@ -313,82 +321,137 @@ static const rd_kafka_telemetry_metric_info_t RD_KAFKA_TELEMETRY_CONSUMER_METRIC
              .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
 };
 
-static const rd_kafka_telemetry_metric_info_t
-    RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRICS_INFO
-        [RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT] = {
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_POLL_IDLE_RATIO_AVG] =
-                {.name          = "consumer.share.poll.idle.ratio.avg",
-                 .description   = "The average fraction of time the consumer's "
-                                  "poll() is idle as opposed to waiting for the "
-                                  "user code to process records.",
-                 .unit          = "1",
-                 .is_int        = rd_false,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_AVG] =
-                {.name = "consumer.share.time.between.poll.avg",
-                 .description =
-                     "The average delay between invocations of poll() in "
-                     "milliseconds.",
-                 .unit          = "ms",
-                 .is_int        = rd_false,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX] =
-                {.name = "consumer.share.time.between.poll.max",
-                 .description =
-                     "The max delay between invocations of poll() in "
-                     "milliseconds.",
-                 .unit          = "ms",
-                 .is_int        = rd_true,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
-                {.name          = "consumer.share.fetch.manager.fetch.total",
-                 .description   = "The total number of fetch requests.",
-                 .unit          = "1",
-                 .is_int        = rd_true,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
-                {.name          = "consumer.share.fetch.manager.fetch.rate",
-                 .description   = "The number of fetch requests per second.",
-                 .unit          = "1",
-                 .is_int        = rd_false,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
-                {.name = "consumer.share.fetch.manager.fetch.latency.avg",
-                 .description   = "The average time taken for a fetch request.",
-                 .unit          = "ms",
-                 .is_int        = rd_false,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
-                {.name = "consumer.share.fetch.manager.fetch.latency.max",
-                 .description = "The maximum time taken for any fetch request.",
-                 .unit        = "ms",
-                 .is_int      = rd_true,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
-                {.name = "consumer.share.fetch.manager.acknowledgements.send."
-                         "total",
-                 .description   = "The total number of record acknowledgements "
-                                  "sent.",
-                 .unit          = "1",
-                 .is_int        = rd_true,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
-            [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
-                {.name = "consumer.share.fetch.manager.acknowledgements.send."
-                         "rate",
-                 .description = "The average number of record acknowledgements "
-                                "sent per second.",
-                 .unit        = "1",
-                 .is_int      = rd_false,
-                 .is_per_broker = rd_false,
-                 .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+static const rd_kafka_telemetry_metric_info_t RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRICS_INFO
+    [RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRIC__CNT] = {
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_POLL_IDLE_RATIO_AVG] =
+            {.name          = "consumer.share.poll.idle.ratio.avg",
+             .description   = "The average fraction of time the consumer's "
+                              "poll() is idle as opposed to waiting for the "
+                              "user code to process records.",
+             .unit          = "1",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_AVG] =
+            {.name = "consumer.share.time.between.poll.avg",
+             .description =
+                 "The average delay between invocations of poll() in "
+                 "milliseconds.",
+             .unit          = "ms",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_TIME_BETWEEN_POLL_MAX] =
+            {.name          = "consumer.share.time.between.poll.max",
+             .description   = "The max delay between invocations of poll() in "
+                              "milliseconds.",
+             .unit          = "ms",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_TOTAL] =
+            {.name          = "consumer.share.fetch.manager.fetch.total",
+             .description   = "The total number of fetch requests.",
+             .unit          = "1",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_RATE] =
+            {.name          = "consumer.share.fetch.manager.fetch.rate",
+             .description   = "The number of fetch requests per second.",
+             .unit          = "1",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_AVG] =
+            {.name          = "consumer.share.fetch.manager.fetch.latency.avg",
+             .description   = "The average time taken for a fetch request.",
+             .unit          = "ms",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_LATENCY_MAX] =
+            {.name          = "consumer.share.fetch.manager.fetch.latency.max",
+             .description   = "The maximum time taken for any fetch request.",
+             .unit          = "ms",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_TOTAL] =
+            {.name = "consumer.share.fetch.manager.acknowledgements.send."
+                     "total",
+             .description   = "The total number of record acknowledgements "
+                              "sent.",
+             .unit          = "1",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_ACKNOWLEDGEMENTS_SEND_RATE] =
+            {.name = "consumer.share.fetch.manager.acknowledgements.send."
+                     "rate",
+             .description   = "The average number of record acknowledgements "
+                              "sent per second.",
+             .unit          = "1",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_AVG] =
+            {.name = "consumer.share.fetch.manager.fetch.throttle.time.avg",
+             .description   = "The average throttle time in ms.",
+             .unit          = "ms",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_THROTTLE_TIME_MAX] =
+            {.name = "consumer.share.fetch.manager.fetch.throttle.time.max",
+             .description   = "The maximum throttle time in ms.",
+             .unit          = "ms",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_TOTAL] =
+            {.name          = "consumer.share.coordinator.heartbeat.total",
+             .description   = "The total number of heartbeats.",
+             .unit          = "1",
+             .is_int        = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_COORDINATOR_HEARTBEAT_RATE] =
+            {.name          = "consumer.share.coordinator.heartbeat.rate",
+             .description   = "The number of heartbeats per second.",
+             .unit          = "1",
+             .is_int        = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_AVG] =
+            {.name        = "consumer.share.fetch.manager.fetch.size.avg",
+             .description = "The average number of bytes fetched per request.",
+             .unit        = "bytes",
+             .is_int      = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_FETCH_SIZE_MAX] =
+            {.name        = "consumer.share.fetch.manager.fetch.size.max",
+             .description = "The maximum number of bytes fetched per request.",
+             .unit        = "bytes",
+             .is_int      = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_TOTAL] =
+            {.name        = "consumer.share.fetch.manager.bytes.consumed.total",
+             .description = "The total number of bytes fetched.",
+             .unit        = "bytes",
+             .is_int      = rd_true,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_SUM},
+        [RD_KAFKA_TELEMETRY_METRIC_SHARE_CONSUMER_BYTES_CONSUMED_RATE] =
+            {.name        = "consumer.share.fetch.manager.bytes.consumed.rate",
+             .description = "The average number of bytes fetched per "
+                            "second.",
+             .unit        = "bytes",
+             .is_int      = rd_false,
+             .is_per_broker = rd_false,
+             .type          = RD_KAFKA_TELEMETRY_METRIC_TYPE_GAUGE},
 };
 
 rd_buf_t *rd_kafka_telemetry_encode_metrics(rd_kafka_t *rk);


### PR DESCRIPTION
- `org.apache.kafka.consumer.share.fetch.manager.fetch.throttle.time.avg`— average ShareFetch throttle time (ms)
- `org.apache.kafka.consumer.share.fetch.manager.fetch.throttle.time.max` — maximum ShareFetch throttle time (ms)
- `org.apache.kafka.consumer.share.coordinator.heartbeat.total` — total number of ShareGroupHeartbeat responses
- `org.apache.kafka.consumer.share.coordinator.heartbeat.rate` — ShareGroupHeartbeat responses per second
- `org.apache.kafka.consumer.share.fetch.manager.fetch.size.avg` — average bytes fetched per ShareFetch response
- `org.apache.kafka.consumer.share.fetch.manager.fetch.size.max` — maximum bytes fetched per ShareFetch response
- `org.apache.kafka.consumer.share.fetch.manager.bytes.consumed.total` — total bytes fetched
- `org.apache.kafka.consumer.share.fetch.manager.bytes.consumed.rate` — average bytes fetched per second