### PR TITLE
Fix lock-order-inversion in queue refcount operations

### DIFF
--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -68,6 +68,7 @@ void rd_kafka_q_destroy_final(rd_kafka_q_t *rkq) {
         rd_kafka_q_disable0(rkq, 0 /*no-lock*/); /* for the non-devel case */
         rd_kafka_q_fwd_set0(rkq, NULL, 0 /*no-lock*/, 0 /*no-fwd-app*/);
         rd_kafka_q_purge0(rkq, 0 /*no-lock*/);
+        rd_refcnt_destroy(&rkq->rkq_refcnt);
         assert(!rkq->rkq_fwdq);
         mtx_unlock(&rkq->rkq_lock);
         mtx_destroy(&rkq->rkq_lock);
@@ -89,7 +90,7 @@ void rd_kafka_q_init0(rd_kafka_q_t *rkq,
                       int line) {
         rd_kafka_q_reset(rkq);
         rkq->rkq_fwdq = NULL;
-        rd_atomic32_init(&rkq->rkq_refcnt, 1);
+        rd_refcnt_init(&rkq->rkq_refcnt, 1);
         rkq->rkq_flags = RD_KAFKA_Q_F_READY;
         if (for_consume)
                 rkq->rkq_flags |= RD_KAFKA_Q_F_CONSUMER;
@@ -1177,9 +1178,10 @@ void rd_kafka_q_fix_offsets(rd_kafka_q_t *rkq,
 void rd_kafka_q_dump(FILE *fp, rd_kafka_q_t *rkq) {
         mtx_lock(&rkq->rkq_lock);
         fprintf(fp,
-                "Queue %p \"%s\" (refcnt %d, flags 0x%x, %d ops, "
+                "Queue %p \"%s\" (refcnt %" PRId32
+                ", flags 0x%x, %d ops, "
                 "%" PRId64 " bytes)\n",
-                rkq, rkq->rkq_name, rd_atomic32_get(&rkq->rkq_refcnt),
+                rkq, rkq->rkq_name, rd_refcnt_get(&rkq->rkq_refcnt),
                 rkq->rkq_flags, rkq->rkq_qlen, rkq->rkq_qsize);
 
         if (rkq->rkq_qio)

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -88,9 +88,9 @@ void rd_kafka_q_init0(rd_kafka_q_t *rkq,
                       const char *func,
                       int line) {
         rd_kafka_q_reset(rkq);
-        rkq->rkq_fwdq   = NULL;
-        rkq->rkq_refcnt = 1;
-        rkq->rkq_flags  = RD_KAFKA_Q_F_READY;
+        rkq->rkq_fwdq = NULL;
+        rd_atomic32_init(&rkq->rkq_refcnt, 1);
+        rkq->rkq_flags = RD_KAFKA_Q_F_READY;
         if (for_consume)
                 rkq->rkq_flags |= RD_KAFKA_Q_F_CONSUMER;
         rkq->rkq_rk                 = rk;
@@ -1179,8 +1179,8 @@ void rd_kafka_q_dump(FILE *fp, rd_kafka_q_t *rkq) {
         fprintf(fp,
                 "Queue %p \"%s\" (refcnt %d, flags 0x%x, %d ops, "
                 "%" PRId64 " bytes)\n",
-                rkq, rkq->rkq_name, rkq->rkq_refcnt, rkq->rkq_flags,
-                rkq->rkq_qlen, rkq->rkq_qsize);
+                rkq, rkq->rkq_name, rd_atomic32_get(&rkq->rkq_refcnt),
+                rkq->rkq_flags, rkq->rkq_qlen, rkq->rkq_qsize);
 
         if (rkq->rkq_qio)
                 fprintf(fp, " QIO fd %d\n", (int)rkq->rkq_qio->fd);

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -60,7 +60,7 @@ struct rd_kafka_q_s {
         struct rd_kafka_op_tailq rkq_q; /* TAILQ_HEAD(, rd_kafka_op_s) */
         int rkq_qlen;                   /* Number of entries in queue */
         int64_t rkq_qsize;              /* Size of all entries in queue */
-        int rkq_refcnt;
+        rd_atomic32_t rkq_refcnt;
         int rkq_flags;
 #define RD_KAFKA_Q_F_ALLOCATED 0x1 /* Allocated: rd_free on destroy */
 #define RD_KAFKA_Q_F_READY                                                     \
@@ -155,15 +155,7 @@ void rd_kafka_q_destroy_final(rd_kafka_q_t *rkq);
 #define rd_kafka_q_unlock(rkqu) mtx_unlock(&(rkqu)->rkq_lock)
 
 static RD_INLINE RD_UNUSED rd_kafka_q_t *rd_kafka_q_keep(rd_kafka_q_t *rkq) {
-        mtx_lock(&rkq->rkq_lock);
-        rkq->rkq_refcnt++;
-        mtx_unlock(&rkq->rkq_lock);
-        return rkq;
-}
-
-static RD_INLINE RD_UNUSED rd_kafka_q_t *
-rd_kafka_q_keep_nolock(rd_kafka_q_t *rkq) {
-        rkq->rkq_refcnt++;
+        rd_atomic32_add(&rkq->rkq_refcnt, 1);
         return rkq;
 }
 
@@ -218,7 +210,7 @@ void rd_kafka_q_purge_toppar_version(rd_kafka_q_t *rkq,
  */
 static RD_INLINE RD_UNUSED void rd_kafka_q_destroy0(rd_kafka_q_t *rkq,
                                                     int disable) {
-        int do_delete = 0;
+        int32_t refcnt;
 
         if (disable) {
                 /* To avoid recursive locking (from ops being purged
@@ -229,12 +221,10 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_destroy0(rd_kafka_q_t *rkq,
                 rd_kafka_q_purge0(rkq, 1 /*lock*/);
         }
 
-        mtx_lock(&rkq->rkq_lock);
-        rd_kafka_assert(NULL, rkq->rkq_refcnt > 0);
-        do_delete = !--rkq->rkq_refcnt;
-        mtx_unlock(&rkq->rkq_lock);
+        refcnt = rd_atomic32_sub(&rkq->rkq_refcnt, 1);
+        rd_kafka_assert(NULL, refcnt >= 0);
 
-        if (unlikely(do_delete))
+        if (unlikely(refcnt == 0))
                 rd_kafka_q_destroy_final(rkq);
 }
 
@@ -368,7 +358,7 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_yield(rd_kafka_q_t *rkq) {
 
         mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rkq->rkq_refcnt > 0);
+        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled */
@@ -435,7 +425,7 @@ static RD_INLINE RD_UNUSED int rd_kafka_q_enq1(rd_kafka_q_t *rkq,
         if (do_lock)
                 mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rkq->rkq_refcnt > 0);
+        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled, reply to and fail the rko. */

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -60,7 +60,7 @@ struct rd_kafka_q_s {
         struct rd_kafka_op_tailq rkq_q; /* TAILQ_HEAD(, rd_kafka_op_s) */
         int rkq_qlen;                   /* Number of entries in queue */
         int64_t rkq_qsize;              /* Size of all entries in queue */
-        rd_atomic32_t rkq_refcnt;
+        rd_refcnt_t rkq_refcnt;
         int rkq_flags;
 #define RD_KAFKA_Q_F_ALLOCATED 0x1 /* Allocated: rd_free on destroy */
 #define RD_KAFKA_Q_F_READY                                                     \
@@ -155,7 +155,7 @@ void rd_kafka_q_destroy_final(rd_kafka_q_t *rkq);
 #define rd_kafka_q_unlock(rkqu) mtx_unlock(&(rkqu)->rkq_lock)
 
 static RD_INLINE RD_UNUSED rd_kafka_q_t *rd_kafka_q_keep(rd_kafka_q_t *rkq) {
-        rd_atomic32_add(&rkq->rkq_refcnt, 1);
+        rd_refcnt_add(&rkq->rkq_refcnt);
         return rkq;
 }
 
@@ -221,7 +221,7 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_destroy0(rd_kafka_q_t *rkq,
                 rd_kafka_q_purge0(rkq, 1 /*lock*/);
         }
 
-        refcnt = rd_atomic32_sub(&rkq->rkq_refcnt, 1);
+        refcnt = rd_refcnt_sub(&rkq->rkq_refcnt);
         rd_kafka_assert(NULL, refcnt >= 0);
 
         if (unlikely(refcnt == 0))
@@ -358,7 +358,7 @@ static RD_INLINE RD_UNUSED void rd_kafka_q_yield(rd_kafka_q_t *rkq) {
 
         mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
+        rd_dassert(rd_refcnt_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled */
@@ -425,7 +425,7 @@ static RD_INLINE RD_UNUSED int rd_kafka_q_enq1(rd_kafka_q_t *rkq,
         if (do_lock)
                 mtx_lock(&rkq->rkq_lock);
 
-        rd_dassert(rd_atomic32_get(&rkq->rkq_refcnt) > 0);
+        rd_dassert(rd_refcnt_get(&rkq->rkq_refcnt) > 0);
 
         if (unlikely(!(rkq->rkq_flags & RD_KAFKA_Q_F_READY))) {
                 /* Queue has been disabled, reply to and fail the rko. */


### PR DESCRIPTION
Attempt to fix https://github.com/confluentinc/librdkafka/issues/4782

Original PR in our fork: https://github.com/ClickHouse/librdkafka/pull/15

Change queue refcount from mutex-protected `int` to `rd_atomic32_t` to eliminate lock-order-inversion detected by ThreadSanitizer.

The issue occurred when:
- Thread A held queue A's lock and called `rd_kafka_q_fwd_get` which called `rd_kafka_q_keep` on queue B, trying to acquire B's lock
- Thread B held queue B's lock and during op destruction tried to acquire queue A's lock via `rd_kafka_q_disable0`

This created an ABBA deadlock pattern.

The fix makes refcount operations lock-free by using atomic operations, eliminating the need for `rd_kafka_q_keep` to acquire any locks.

Changes:
- Change `int rkq_refcnt` to `rd_atomic32_t rkq_refcnt`
- Use `rd_atomic32_add` in `rd_kafka_q_keep`
- Use `rd_atomic32_sub` in `rd_kafka_q_destroy0`
- Use `rd_atomic32_get` for assertions and debug output
- Use `rd_atomic32_init` for initialization
- Remove redundant `rd_kafka_q_keep_nolock` function