### PR TITLE
Fix use-after-free in consumer lag timer

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3701,6 +3701,17 @@ static void rd_kafka_cgrp_partition_del(rd_kafka_cgrp_t *rkcg,
 
         rd_list_remove(&rkcg->rkcg_toppars, rktp);
 
+        /* Stop the consumer lag timer and release its reference before
+         * releasing the cgrp reference. Both this function and the timer
+         * callback run on the KafkaMain thread, so stopping the timer here
+         * guarantees no callback is in flight when we release the references.
+         * Without this, the broker thread can free the toppar between the
+         * timer capturing its arg pointer and the callback actually running,
+         * causing a heap-use-after-free. */
+        if (rd_kafka_timer_stop(&rktp->rktp_rkt->rkt_rk->rk_timers,
+                                &rktp->rktp_consumer_lag_tmr, 1 /*lock*/))
+                rd_kafka_toppar_destroy(rktp); /* refcnt from timer keep */
+
         rd_kafka_toppar_destroy(rktp); /* refcnt from _add above */
 
         rd_kafka_cgrp_try_terminate(rkcg);

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -283,7 +283,8 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0(rd_kafka_topic_t *rkt,
                         intvl = 10 * 1000;
                 rd_kafka_timer_start(
                     &rkt->rkt_rk->rk_timers, &rktp->rktp_consumer_lag_tmr,
-                    intvl * 1000ll, rd_kafka_toppar_consumer_lag_tmr_cb, rktp);
+                    intvl * 1000ll, rd_kafka_toppar_consumer_lag_tmr_cb,
+                    rd_kafka_toppar_keep(rktp));
         }
 
         rktp->rktp_rkt = rd_kafka_topic_keep(rkt);

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1619,6 +1619,17 @@ void rd_kafka_topic_partitions_remove(rd_kafka_topic_t *rkt) {
                 rd_kafka_toppar_purge_and_disable_queues(rktp);
                 rd_kafka_toppar_unlock(rktp);
 
+                /* Stop the consumer lag timer and release its reference.
+                 * For cgrp partitions the timer was already stopped in
+                 * rd_kafka_cgrp_partition_del so timer_stop returns 0.
+                 * This call runs on the main thread after the main loop
+                 * has exited, so no timer callback can be in flight. */
+                if (rd_kafka_timer_stop(&rkt->rkt_rk->rk_timers,
+                                        &rktp->rktp_consumer_lag_tmr,
+                                        1 /*lock*/))
+                        rd_kafka_toppar_destroy(rktp); /* refcnt from
+                                                        * timer keep */
+
                 rd_kafka_toppar_destroy(rktp);
         }
         rd_list_destroy(partitions);


### PR DESCRIPTION
The race is claimed to be here:

https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_timer.c#L357-L364

Before we call the `callback`, the `arg` — a topic partition object may be destroyed, because no additional reference is acquired. And the proposed solution was to acquire an additional reference when starting a timer.

---

The failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97943&sha=d9c41220fc4185d8e330e9af40ca4414cb29589a&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29