### PR TITLE
[KIP-932] Change toppars_in_session from TAILQ to rd_list_t

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3534,13 +3534,6 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 TAILQ_REMOVE(&rkb->rkb_toppars, rktp, rktp_rkblink);
                 rkb->rkb_toppar_cnt--;
                 rd_kafka_broker_share_session_toppar_remove(rkb, rktp);
-                /* TODO KIP-932: Verify this while working on leader migration.
-                 * Free rktp_rkb_session_link before the new leader broker
-                 * reuses it via TAILQ_INSERT_TAIL on its own
-                 * toppars_in_session; otherwise old broker's list head is
-                 * left dangling and destroy_final asserts. */
-                rd_kafka_broker_session_remove_partition_from_toppars_in_session(
-                    rkb, rktp);
                 rd_kafka_broker_unlock(rkb);
                 rd_kafka_broker_destroy(rktp->rktp_broker);
                 if (rktp->rktp_msgq_wakeup_q) {
@@ -4496,14 +4489,15 @@ static void rd_kafka_broker_producer_serve(rd_kafka_broker_t *rkb,
  * implementation.
  */
 // void rd_kafka_broker_update_share_fetch_session(rd_kafka_broker_t *rkb) {
-//         rd_kafka_toppar_t *rktp, *rktp_tmp;
+//         rd_kafka_toppar_t *rktp;
+//         int i;
 //         rd_bool_t needs_update = rd_false;
-
-//         TAILQ_FOREACH(rktp, &rkb->rkb_share_fetch_session.toppars_in_session,
-//         rktp_rkb_session_link) {
+//
+//         RD_LIST_FOREACH(rktp,
+//                         rkb->rkb_share_fetch_session.toppars_in_session, i) {
 //                 rd_kafka_toppar_is_valid_to_send_for_share_fetch(rktp);
 //         }
-
+//
 //         if (needs_update)
 //                 rd_kafka_toppar_share_fetch_session_update(rkb);
 // }
@@ -5091,14 +5085,15 @@ void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
         rd_assert(TAILQ_EMPTY(&rkb->rkb_waitresps.rkbq_bufs));
         rd_assert(TAILQ_EMPTY(&rkb->rkb_retrybufs.rkbq_bufs));
         rd_assert(TAILQ_EMPTY(&rkb->rkb_toppars));
-        rd_assert(
-            TAILQ_EMPTY(&rkb->rkb_share_fetch_session.toppars_in_session));
         rd_assert(!rkb->rkb_share_fetch_session.toppars_to_add);
         rd_assert(!rkb->rkb_share_fetch_session.toppars_to_forget);
         rd_assert(!rkb->rkb_share_async_ack_details);
         rd_assert(!rkb->rkb_pending_commit_sync.sync_ack_details);
         rd_assert(!rkb->rkb_share_fetch_session.adding_toppars);
         rd_assert(!rkb->rkb_share_fetch_session.forgetting_toppars);
+        rd_assert(
+            rd_list_empty(rkb->rkb_share_fetch_session.toppars_in_session));
+        rd_list_destroy(rkb->rkb_share_fetch_session.toppars_in_session);
 
         if (rkb->rkb_source != RD_KAFKA_INTERNAL &&
             (rkb->rkb_rk->rk_conf.security_protocol ==
@@ -5231,12 +5226,12 @@ rd_kafka_broker_t *rd_kafka_broker_add(rd_kafka_t *rk,
         mtx_init(&rkb->rkb_logname_lock, mtx_plain);
         rkb->rkb_logname = rd_strdup(rkb->rkb_name);
         TAILQ_INIT(&rkb->rkb_toppars);
-        TAILQ_INIT(&rkb->rkb_share_fetch_session.toppars_in_session);
-        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
-        rkb->rkb_share_fetch_session.toppars_to_forget      = NULL;
-        rkb->rkb_share_fetch_session.toppars_to_add         = NULL;
-        rkb->rkb_share_async_ack_details                    = NULL;
-        rkb->rkb_share_fetch_enqueued                       = rd_false;
+        rkb->rkb_share_fetch_session.toppars_in_session =
+            rd_list_new(0, rd_kafka_toppar_destroy_free);
+        rkb->rkb_share_fetch_session.toppars_to_forget = NULL;
+        rkb->rkb_share_fetch_session.toppars_to_add    = NULL;
+        rkb->rkb_share_async_ack_details               = NULL;
+        rkb->rkb_share_fetch_enqueued                  = rd_false;
         CIRCLEQ_INIT(&rkb->rkb_active_toppars);
         TAILQ_INIT(&rkb->rkb_monitors);
         rd_kafka_bufq_init(&rkb->rkb_outbufs);

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -108,29 +108,27 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
         TAILQ_HEAD(, rd_kafka_toppar_s) rkb_toppars;
 
         /**
-         * TODO KIP-932: Check the type again to optimize the performance
-         *               of adding or removing a partition. Maybe use a map
-         *               or linked list instead of rd_list_t in some of the
-         *               cases.
+         * TODO KIP-932: Consider using a map instead of rd_list_t for
+         *               some of the partition lists to optimize
+         *               add/remove performance.
          */
         struct {
-                TAILQ_HEAD(, rd_kafka_toppar_s)
-                toppars_in_session; /* List of toppars
-                            in the current
-                            fetch session.
-                            Any new added toppar in rkb_toppars will be added
-                            here after successful share fetch request. Any
-                            removed toppar from rkb_toppars will be removed from
-                            here after successful share fetch request.*/
-                int toppars_in_session_cnt;
+                rd_list_t *toppars_in_session; /* List of toppars in the current
+                                                * fetch session. Any new added
+                                                * toppar in rkb_toppars will be
+                                                * added here after successful
+                                                * share fetch request. Any
+                                                * removed toppar from
+                                                * rkb_toppars will be removed
+                                                * from here after successful
+                                                * share fetch request. */
                 rd_list_t
-                    *toppars_to_add; /* TODO KIP-932: Move this from `rd_list_t`
-                                      * to `TAILQ_HEAD(, rd_kafka_toppar_s)` for
-                                      * performance improvements. List of
-                                      * toppars that are to be added to the
-                                      * fetch session. `adding_toppars` are
-                                      * removed from this when fetch request is
-                                      * successful */
+                    *toppars_to_add; /* TODO KIP-932: Consider using a map
+                                      * for performance improvements. List
+                                      * of toppars that are to be added to
+                                      * the fetch session. `adding_toppars`
+                                      * are removed from this when fetch
+                                      * request is successful. */
 
                 rd_list_t
                     *adding_toppars; /* List of toppars that are being added to
@@ -142,14 +140,12 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                                       */
 
                 rd_list_t
-                    *toppars_to_forget; /* TODO KIP-932: Move this from
-                                         * `rd_list_t` to `TAILQ_HEAD(,
-                                         * rd_kafka_toppar_s)` for performance
-                                         * improvements. List of toppars that
-                                         * are removed from the session.
-                                         * `forgetting_toppars` are removed from
-                                         * this when fetch request is successful
-                                         */
+                    *toppars_to_forget; /* TODO KIP-932: Consider using a map
+                                         * for performance improvements. List
+                                         * of toppars that are removed from
+                                         * the session. `forgetting_toppars`
+                                         * are removed from this when fetch
+                                         * request is successful. */
 
                 rd_list_t *forgetting_toppars; /* List of toppars that are being
                                                 * removed from the session.

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1598,14 +1598,16 @@ err_parse:
  * @locality broker thread
  */
 static void rd_kafka_broker_session_reset(rd_kafka_broker_t *rkb) {
-        rd_kafka_toppar_t *rktp, *tmp_rktp;
+        rd_kafka_toppar_t *rktp;
+        int i;
 
-        rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
-                   "Resetting share session: epoch %" PRId32
-                   " -> 0, "
-                   "moving %d toppars_in_session to toppars_to_add",
-                   rkb->rkb_share_fetch_session.epoch,
-                   rkb->rkb_share_fetch_session.toppars_in_session_cnt);
+        rd_rkb_dbg(
+            rkb, FETCH, "SHAREFETCH",
+            "Resetting share session: epoch %" PRId32
+            " -> 0, "
+            "moving %d toppars_in_session to toppars_to_add",
+            rkb->rkb_share_fetch_session.epoch,
+            rd_list_cnt(rkb->rkb_share_fetch_session.toppars_in_session));
 
         rkb->rkb_share_fetch_session.epoch = 0;
 
@@ -1614,27 +1616,15 @@ static void rd_kafka_broker_session_reset(rd_kafka_broker_t *rkb) {
          * new session. */
         if (rkb->rkb_share_fetch_session.toppars_to_forget) {
                 rd_kafka_toppar_t *forget_rktp;
-                int i;
 
                 RD_LIST_FOREACH(forget_rktp,
                                 rkb->rkb_share_fetch_session.toppars_to_forget,
                                 i) {
-                        TAILQ_FOREACH_SAFE(
-                            rktp,
-                            &rkb->rkb_share_fetch_session.toppars_in_session,
-                            rktp_rkb_session_link, tmp_rktp) {
-                                if (rktp == forget_rktp) {
-                                        TAILQ_REMOVE(
-                                            &rkb->rkb_share_fetch_session
-                                                 .toppars_in_session,
-                                            rktp, rktp_rkb_session_link);
-                                        rkb->rkb_share_fetch_session
-                                            .toppars_in_session_cnt--;
-                                        rd_kafka_toppar_destroy(
-                                            rktp); /* from session list */
-                                        break;
-                                }
-                        }
+                        rktp = rd_list_remove(
+                            rkb->rkb_share_fetch_session.toppars_in_session,
+                            forget_rktp);
+                        if (rktp)
+                                rd_kafka_toppar_destroy(rktp);
                 }
 
                 rd_list_destroy(rkb->rkb_share_fetch_session.toppars_to_forget);
@@ -1643,23 +1633,23 @@ static void rd_kafka_broker_session_reset(rd_kafka_broker_t *rkb) {
 
         /* Move remaining toppars_in_session to toppars_to_add so they
          * get sent as new additions in the next request (epoch 0). */
-        TAILQ_FOREACH_SAFE(rktp,
-                           &rkb->rkb_share_fetch_session.toppars_in_session,
-                           rktp_rkb_session_link, tmp_rktp) {
-                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
-                             rktp, rktp_rkb_session_link);
-                rkb->rkb_share_fetch_session.toppars_in_session_cnt--;
-
-                if (!rkb->rkb_share_fetch_session.toppars_to_add)
-                        rkb->rkb_share_fetch_session.toppars_to_add =
-                            rd_list_new(1, rd_kafka_toppar_destroy_free);
-
-                if (!rd_list_find(rkb->rkb_share_fetch_session.toppars_to_add,
-                                  rktp, rd_list_cmp_ptr))
-                        rd_list_add(rkb->rkb_share_fetch_session.toppars_to_add,
-                                    rktp); /* transfer ref */
-                else
-                        rd_kafka_toppar_destroy(rktp); /* from session list */
+        if (!rkb->rkb_share_fetch_session.toppars_to_add) {
+                rkb->rkb_share_fetch_session.toppars_to_add =
+                    rkb->rkb_share_fetch_session.toppars_in_session;
+                rkb->rkb_share_fetch_session.toppars_in_session =
+                    rd_list_new(0, rd_kafka_toppar_destroy_free);
+        } else {
+                while ((rktp = rd_list_pop(
+                            rkb->rkb_share_fetch_session.toppars_in_session))) {
+                        if (!rd_list_find(
+                                rkb->rkb_share_fetch_session.toppars_to_add,
+                                rktp, rd_list_cmp_ptr))
+                                rd_list_add(
+                                    rkb->rkb_share_fetch_session.toppars_to_add,
+                                    rktp);
+                        else
+                                rd_kafka_toppar_destroy(rktp);
+                }
         }
 }
 
@@ -1679,53 +1669,39 @@ static void rd_kafka_broker_session_update_epoch(rd_kafka_broker_t *rkb) {
 static void rd_kafka_broker_session_add_partition_to_toppars_in_session(
     rd_kafka_broker_t *rkb,
     rd_kafka_toppar_t *rktp) {
-        rd_kafka_toppar_t *session_rktp, *adding_rktp;
-        TAILQ_FOREACH(session_rktp,
-                      &rkb->rkb_share_fetch_session.toppars_in_session,
-                      rktp_rkb_session_link) {
-                if (rktp == session_rktp) {
-                        rd_kafka_dbg(rkb->rkb_rk, MSG, "SHAREFETCH",
-                                     "%s [%" PRId32
-                                     "]: already in ShareFetch session",
-                                     rktp->rktp_rkt->rkt_topic->str,
-                                     rktp->rktp_partition);
-                        return;
-                }
+        if (rd_list_find(rkb->rkb_share_fetch_session.toppars_in_session, rktp,
+                         rd_list_cmp_ptr)) {
+                rd_kafka_dbg(rkb->rkb_rk, MSG, "SHAREFETCH",
+                             "%s [%" PRId32 "]: already in ShareFetch session",
+                             rktp->rktp_rkt->rkt_topic->str,
+                             rktp->rktp_partition);
+                return;
         }
         rd_kafka_dbg(rkb->rkb_rk, FETCH, "SHAREFETCH",
                      "%s [%" PRId32 "]: adding to ShareFetch session",
                      rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
-        adding_rktp = rd_kafka_toppar_keep(rktp);
-        TAILQ_INSERT_TAIL(&rkb->rkb_share_fetch_session.toppars_in_session,
-                          adding_rktp, rktp_rkb_session_link);
-        rkb->rkb_share_fetch_session.toppars_in_session_cnt++;
+        rd_kafka_toppar_keep(rktp);
+        rd_list_add(rkb->rkb_share_fetch_session.toppars_in_session, rktp);
 }
 
 void rd_kafka_broker_session_remove_partition_from_toppars_in_session(
     rd_kafka_broker_t *rkb,
     rd_kafka_toppar_t *rktp) {
-        rd_kafka_toppar_t *session_rktp, *tmp_rktp;
-        TAILQ_FOREACH_SAFE(session_rktp,
-                           &rkb->rkb_share_fetch_session.toppars_in_session,
-                           rktp_rkb_session_link, tmp_rktp) {
-                if (rktp == session_rktp) {
-                        TAILQ_REMOVE(
-                            &rkb->rkb_share_fetch_session.toppars_in_session,
-                            session_rktp, rktp_rkb_session_link);
-                        rd_kafka_toppar_destroy(
-                            session_rktp);  // from session list
-                        rkb->rkb_share_fetch_session.toppars_in_session_cnt--;
-                        rd_kafka_dbg(rkb->rkb_rk, MSG, "SHAREFETCH",
-                                     "%s [%" PRId32
-                                     "]: removed from ShareFetch session",
-                                     rktp->rktp_rkt->rkt_topic->str,
-                                     rktp->rktp_partition);
-                        return;
-                }
+        rd_kafka_toppar_t *removed_rktp;
+        removed_rktp = rd_list_remove(
+            rkb->rkb_share_fetch_session.toppars_in_session, rktp);
+        if (removed_rktp) {
+                rd_kafka_toppar_destroy(removed_rktp);
+                rd_kafka_dbg(
+                    rkb->rkb_rk, MSG, "SHAREFETCH",
+                    "%s [%" PRId32 "]: removed from ShareFetch session",
+                    rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
+        } else {
+                rd_kafka_dbg(
+                    rkb->rkb_rk, MSG, "SHAREFETCH",
+                    "%s [%" PRId32 "]: not found in ShareFetch session",
+                    rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
         }
-        rd_kafka_dbg(rkb->rkb_rk, MSG, "SHAREFETCH",
-                     "%s [%" PRId32 "]: not found in ShareFetch session",
-                     rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition);
 }
 
 static void
@@ -2846,22 +2822,12 @@ void rd_kafka_ShareAcknowledgeRequest(rd_kafka_broker_t *rkb,
 
 
 void rd_kafka_broker_share_fetch_session_clear(rd_kafka_broker_t *rkb) {
-        rd_kafka_toppar_t *rktp, *tmp_rktp;
-
         /* Clear toppars in session */
-        TAILQ_FOREACH_SAFE(rktp,
-                           &rkb->rkb_share_fetch_session.toppars_in_session,
-                           rktp_rkb_session_link, tmp_rktp) {
-                TAILQ_REMOVE(&rkb->rkb_share_fetch_session.toppars_in_session,
-                             rktp, rktp_rkb_session_link);
-                rd_rkb_dbg(rkb, BROKER, "SHAREFETCH",
-                           "%s [%" PRId32
-                           "]: removed from ShareFetch session on clear",
-                           rktp->rktp_rkt->rkt_topic->str,
-                           rktp->rktp_partition);
-                rd_kafka_toppar_destroy(rktp);  // from session list
-        }
-        rkb->rkb_share_fetch_session.toppars_in_session_cnt = 0;
+        rd_rkb_dbg(
+            rkb, BROKER, "SHAREFETCH",
+            "Clearing %d toppars from ShareFetch session",
+            rd_list_cnt(rkb->rkb_share_fetch_session.toppars_in_session));
+        rd_list_clear(rkb->rkb_share_fetch_session.toppars_in_session);
 
         /* Clear toppars to add */
         if (rkb->rkb_share_fetch_session.toppars_to_add) {

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -143,12 +143,9 @@ struct rd_kafka_toppar_s {                           /* rd_kafka_toppar_t */
         TAILQ_ENTRY(rd_kafka_toppar_s) rktp_rktlink;  /* rd_kafka_topic_t link*/
         TAILQ_ENTRY(rd_kafka_toppar_s) rktp_cgrplink; /* rd_kafka_cgrp_t link */
         TAILQ_ENTRY(rd_kafka_toppar_s)
-        rktp_txnlink; /**< rd_kafka_t.rk_eos.
-                       *   txn_pend_rktps
-                       *   or txn_rktps */
-        TAILQ_ENTRY(rd_kafka_toppar_s)
-        rktp_rkb_session_link;      /* rkb_share_fetch_session
-                                     * toppars_in_session link */
+        rktp_txnlink;               /**< rd_kafka_t.rk_eos.
+                                     *   txn_pend_rktps
+                                     *   or txn_rktps */
         rd_kafka_topic_t *rktp_rkt; /**< This toppar's topic object */
         int32_t rktp_partition;
         // LOCK: toppar_lock() + topic_wrlock()

--- a/tests/0179-share_consumer_destroy.c
+++ b/tests/0179-share_consumer_destroy.c
@@ -1503,9 +1503,8 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
 //                                  "bootstrap.servers", bootstraps, NULL);
 //
 //         /* Round 2: consume from broker 2. The first ShareFetch reply
-//          * from broker 2 will TAILQ_INSERT_TAIL the toppar into broker
-//          * 2's toppars_in_session, reusing the same rktp_rkb_session_link
-//          * field that broker 1 was using. With the fix, broker 1's list
+//          * from broker 2 will add the toppar into broker
+//          * 2's toppars_in_session. With the fix, broker 1's list
 //          * is cleared by PARTITION_LEAVE before this happens. */
 //         TEST_SAY("Round 2: consume from broker 2 (new leader)\n");
 //         attempts = 0;


### PR DESCRIPTION
1) Replace TAILQ_HEAD + manual toppars_in_session_cnt counter with
   rd_list_t pointer in rkb_share_fetch_session, consistent with
   the other four partition lists in the same struct.
2) Remove intrusive rktp_rkb_session_link TAILQ_ENTRY from
   rd_kafka_toppar_s, saving 16 bytes per partition.
3) Rewrite session add/remove/reset/clear functions to use
   rd_list_find, rd_list_add, rd_list_remove, rd_list_pop,
   rd_list_clear APIs.
4) Add O(1) fast-path pointer swap in session_reset when
   toppars_to_add is NULL: directly assign toppars_in_session
   pointer to toppars_to_add and allocate a fresh empty list.
5) Remove rd_kafka_broker_session_remove_partition_from_toppars_
   in_session call from PARTITION_LEAVE path along with its
   stale TODO comment.
6) Update stale TODO comments: replace TAILQ migration hints
   with map-based optimization suggestion.