### PR TITLE
Txn: fix rd_kafka_send_offsets_to_transaction() ignoring timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Fixes
+
+### Transactional producer fixes
+
+* Fix `rd_kafka_send_offsets_to_transaction()` ignoring its `timeout_ms` parameter
+  when it can't find or reach the group coordinator, causing it to block
+  indefinitely. Happening since v1.4.0.
+
 # librdkafka v2.14.2
 
 librdkafka v2.14.2 is a maintenance release:

--- a/src/rdkafka_coord.c
+++ b/src/rdkafka_coord.c
@@ -197,7 +197,7 @@ void rd_kafka_coord_cache_init(rd_kafka_coord_cache_t *cc,
 static void rd_kafka_coord_req_fsm(rd_kafka_t *rk, rd_kafka_coord_req_t *creq);
 
 /**
- * @brief Timer callback for delayed coord requests.
+ * @brief Timer callback that re-enters the coord request FSM.
  */
 static void rd_kafka_coord_req_tmr_cb(rd_kafka_timers_t *rkts, void *arg) {
         rd_kafka_coord_req_t *creq = arg;
@@ -217,7 +217,9 @@ static void rd_kafka_coord_req_tmr_cb(rd_kafka_timers_t *rkts, void *arg) {
  *
  * @param delay_ms If non-zero, delay scheduling of the coord request
  *                 for this long. The passed \p timeout_ms is automatically
- *                 adjusted to + \p delay_ms.
+ *                 adjusted to + \p delay_ms unless \p timeout_ms is
+ *                 RD_POLL_INFINITE, in which case the timeout remains
+ *                 infinite.
  *
  * Response, or error, is sent on \p replyq with callback \p rkbuf_cb.
  *
@@ -235,11 +237,15 @@ void rd_kafka_coord_req(rd_kafka_t *rk,
                         rd_kafka_resp_cb_t *resp_cb,
                         void *reply_opaque) {
         rd_kafka_coord_req_t *creq;
+        int total_timeout_ms;
 
+        total_timeout_ms        = timeout_ms == RD_POLL_INFINITE
+                                      ? RD_POLL_INFINITE
+                                      : delay_ms + timeout_ms;
         creq                    = rd_calloc(1, sizeof(*creq));
         creq->creq_coordtype    = coordtype;
         creq->creq_coordkey     = rd_strdup(coordkey);
-        creq->creq_ts_timeout   = rd_timeout_init(delay_ms + timeout_ms);
+        creq->creq_ts_timeout   = rd_timeout_init(total_timeout_ms);
         creq->creq_send_req_cb  = send_req_cb;
         creq->creq_rko          = rko;
         creq->creq_replyq       = replyq;
@@ -250,6 +256,12 @@ void rd_kafka_coord_req(rd_kafka_t *rk,
         rd_interval_init(&creq->creq_query_intvl);
 
         TAILQ_INSERT_TAIL(&rk->rk_coord_reqs, creq, creq_link);
+
+        if (total_timeout_ms > 0)
+                rd_kafka_timer_start_oneshot(&rk->rk_timers,
+                                             &creq->creq_timeout_tmr, rd_true,
+                                             (rd_ts_t)total_timeout_ms * 1000,
+                                             rd_kafka_coord_req_tmr_cb, creq);
 
         if (delay_ms)
                 rd_kafka_timer_start_oneshot(&rk->rk_timers, &creq->creq_tmr,
@@ -283,6 +295,8 @@ static rd_bool_t rd_kafka_coord_req_destroy(rd_kafka_t *rk,
                 creq->creq_done = rd_true;
 
                 rd_kafka_timer_stop(&rk->rk_timers, &creq->creq_tmr,
+                                    RD_DO_LOCK);
+                rd_kafka_timer_stop(&rk->rk_timers, &creq->creq_timeout_tmr,
                                     RD_DO_LOCK);
         }
 
@@ -463,6 +477,12 @@ static void rd_kafka_coord_req_fsm(rd_kafka_t *rk, rd_kafka_coord_req_t *creq) {
 
         if (unlikely(rd_kafka_terminating(rk))) {
                 rd_kafka_coord_req_fail(rk, creq, RD_KAFKA_RESP_ERR__DESTROY);
+                return;
+        }
+
+        /* Check if the request has timed out. */
+        if (rd_timeout_expired(rd_timeout_remains(creq->creq_ts_timeout))) {
+                rd_kafka_coord_req_fail(rk, creq, RD_KAFKA_RESP_ERR__TIMED_OUT);
                 return;
         }
 

--- a/src/rdkafka_coord.h
+++ b/src/rdkafka_coord.h
@@ -79,15 +79,16 @@ typedef struct rd_kafka_coord_req_s {
         rd_kafka_coordtype_t creq_coordtype;         /**< Coordinator type */
         char *creq_coordkey;                         /**< Coordinator key */
 
-        rd_kafka_op_t *creq_rko;        /**< Requester's rko that is
-                                         *   provided to creq_send_req_cb
-                                         *   (optional). */
-        rd_kafka_timer_t creq_tmr;      /**< Delay timer. */
-        rd_ts_t creq_ts_timeout;        /**< Absolute timeout.
-                                         *   Will fail with an error
-                                         *   code pertaining to the
-                                         *   current state */
-        rd_interval_t creq_query_intvl; /**< Coord query interval (1s) */
+        rd_kafka_op_t *creq_rko;           /**< Requester's rko that is
+                                            *   provided to creq_send_req_cb
+                                            *   (optional). */
+        rd_kafka_timer_t creq_tmr;         /**< Delay timer. */
+        rd_kafka_timer_t creq_timeout_tmr; /**< Timeout timer. */
+        rd_ts_t creq_ts_timeout;           /**< Absolute timeout.
+                                            *   Will fail with an error
+                                            *   code pertaining to the
+                                            *   current state */
+        rd_interval_t creq_query_intvl;    /**< Coord query interval (1s) */
 
         rd_kafka_send_req_cb_t *creq_send_req_cb; /**< Sender callback */
 

--- a/tests/0105-transactions_mock.c
+++ b/tests/0105-transactions_mock.c
@@ -3828,6 +3828,71 @@ do_test_txn_offset_commit_doesnt_retry_too_quickly(rd_bool_t times_out) {
 }
 
 
+/**
+ * @brief Test that send_offsets_to_transaction() times out (rather than
+ *        blocking indefinitely) when the group coordinator is down.
+ */
+static void do_test_txn_send_offsets_timeout_coord_down(void) {
+        rd_kafka_t *rk;
+        rd_kafka_mock_cluster_t *mcluster;
+        rd_kafka_topic_partition_list_t *offsets;
+        rd_kafka_consumer_group_metadata_t *cgmetadata;
+        rd_kafka_error_t *error;
+        test_timing_t timing;
+
+        SUB_TEST_QUICK();
+
+        rk = create_txn_producer(&mcluster, "txnid", 3, NULL);
+
+        rd_kafka_mock_topic_create(mcluster, "mytopic", 1, 1);
+        rd_kafka_mock_coordinator_set(mcluster, "transaction", "txnid", 1);
+        rd_kafka_mock_coordinator_set(mcluster, "group", "mygroup", 2);
+        rd_kafka_mock_partition_set_leader(mcluster, "mytopic", 0, 3);
+
+        TEST_CALL_ERROR__(rd_kafka_init_transactions(rk, 5000));
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(rk));
+
+        /* Bring down the group coordinator */
+        rd_kafka_mock_broker_set_down(mcluster, 2);
+
+        offsets = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(offsets, "mytopic", 0)->offset = 1;
+        cgmetadata = rd_kafka_consumer_group_metadata_new("mygroup");
+
+        /* send_offsets_to_transaction() should time out within ~2s,
+         * not block indefinitely. */
+        TIMING_START(&timing, "send_offsets_to_transaction(2000)");
+        error = rd_kafka_send_offsets_to_transaction(rk, offsets, cgmetadata,
+                                                     2000);
+        TIMING_STOP(&timing);
+
+        rd_kafka_consumer_group_metadata_destroy(cgmetadata);
+        rd_kafka_topic_partition_list_destroy(offsets);
+
+        TIMING_ASSERT(&timing, 1500, 5000);
+
+        TEST_ASSERT(error != NULL,
+                    "Expected send_offsets_to_transaction to fail");
+        TEST_ASSERT(
+            rd_kafka_error_code(error) == RD_KAFKA_RESP_ERR__TIMED_OUT,
+            "Expected send_offsets_to_transaction to fail with timeout, "
+            "not %s: %s",
+            rd_kafka_error_name(error), rd_kafka_error_string(error));
+        TEST_ASSERT(rd_kafka_error_txn_requires_abort(error),
+                    "Expected abortable error");
+        TEST_SAY("send_offsets_to_transaction failed as expected: %s\n",
+                 rd_kafka_error_string(error));
+        rd_kafka_error_destroy(error);
+
+        /* Bring coordinator back up for clean shutdown */
+        rd_kafka_mock_broker_set_up(mcluster, 2);
+
+        rd_kafka_destroy(rk);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0105_transactions_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -3868,6 +3933,8 @@ int main_0105_transactions_mock(int argc, char **argv) {
         do_test_txns_send_offsets_concurrent_is_retried();
 
         do_test_txns_send_offsets_non_eligible();
+
+        do_test_txn_send_offsets_timeout_coord_down();
 
         do_test_txn_coord_req_destroy();
 


### PR DESCRIPTION
(fixes #5456 )

## Bug overview

[`creq_ts_timeout`](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_coord.h#L86) is supposed to serve as a timeout for coordinator requests, but it is never checked anywhere. This can manifest in `rd_kafka_send_offsets_to_transaction()` blocking indefinitely past its timeout, as reproduced in the test case in this PR.


## Fix

The changes in this PR fix the bug by:
1. Initializing a timer in `rd_kafka_coord_req()` that fires when the request timeout expires. The timer callback invokes `rd_kafka_coord_req_fsm()`.
2. Checking for timeout expiration in `rd_kafka_coord_req_fsm()` and failing the request with `RD_KAFKA_RESP_ERR__TIMED_OUT` if the timeout has been exceeded.

## Test

The test case verifies that

1. `rd_kafka_send_offsets_to_transaction()` times out within a reasonable amount of time when the group coordinator is held down
4. that the error code is `RD_KAFKA_RESP_ERR__TIMED_OUT `
5. that the error is classified as abortable (due to [existing timeout error handling](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_txnmgr.c#L1622) in the `TxnOffsetCommit` path, which classifies timeouts as abortable errors).

Before the fix, this test hangs until it is killed by the test infrastructure:
```
Test 0105_transactions_mock (do_test_txn_send_offsets_timeout_coord_down:3843) timed out (timeout set to 160 seconds)
Killed
```

After the fix, it succeeds:
```
[0105_transactions_mock      /  2.057s] send_offsets_to_transaction(2000): duration 2000.557ms
[0105_transactions_mock      /  2.058s] [ do_test_txn_send_offsets_timeout_coord_down:3843: PASS (2.06s) ]
```

## Follow-up work

The two improvements described below would likely build meaningfully on this PR. I left them out intentionally to keep the scope small and the review straightforward. If either is considered a prerequisite for merging this PR, let me know and I'm happy to do the work.

### Use state-specific error codes

The changes in this PR return a generic `RD_KAFKA_RESP_ERR__TIMED_OUT` error when the timeout expires. The comment [here](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_coord.h#L87) suggests returning state-specific error codes (for example, perhaps `RD_KAFKA_RESP_ERR_COORDINATOR_NOT_AVAILABLE` when the coordinator is known but is down). The correct mapping of states to error codes could warrant some discussion.

### Improve time reporting in error strings

After the changes in this PR, librdkafka will log the following when the timeout occurs:

> Current transaction failed in state InTransaction: Failed to commit offsets to transaction on broker (none): Local: Timed out (after 0 ms) (_TIMED_OUT)

The "after 0 ms" portion appears because [`rd_kafka_coord_req_fail()` propagates the error using a dummy rkbuf](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_coord.c#L324) with the `rkbuf_ts_sent` field set to 0.

This can be misleading for clients, since they may reasonably expect the reported duration to reflect the timeout value passed to the API. This issue is not specific to this PR — other code paths using `rd_kafka_coord_req_fail()` will also report "(after 0 ms)" — but the string is arguably more confusing in this context.

Possible approaches for errors propagated using a dummy rkbuf include:

1. Replacing "0 ms" with the elapsed time since [the coord req was created](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_coord.c#L237).
2. Omitting timing information entirely.
4. Extending [`rd_kafka_coord_req_fail()`](https://github.com/confluentinc/librdkafka/blob/82585128d4f6e5daee6eb2dc7cb2b4f3a6cc2b3d/src/rdkafka_coord.c#L313) to let callers control whether timing information is included and, if so, which duration should be reported. And then deciding what to pass case-by-case.