### PR TITLE
[KIP-932] Add share consumer telemetry metrics Librdkafka and Java comparison task

### DIFF
--- a/.semaphore/run-share-perf-comparison.yml
+++ b/.semaphore/run-share-perf-comparison.yml
@@ -1,0 +1,34 @@
+version: v1.0
+name: run-share-perf-comparison
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  hours: 4
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
+      - sem-version java 17
+      - sudo apt update
+      - sudo apt install -y wget docker-compose-plugin jq python3 curl
+  env_vars:
+    - name: KAFKA_VERSION
+      value: '4.2.0'
+    - name: CACHE_TAG
+      value: '1'
+
+blocks:
+  - name: 'Share consumer perf comparison'
+    dependencies: []
+    task:
+      jobs:
+        - name: 'Java vs librdkafka share metrics'
+          commands:
+            - cache restore share-perf-cmp-${KAFKA_VERSION}-${CACHE_TAG}
+            - ./packaging/tools/run-share-perf-comparison.sh
+            - cache store share-perf-cmp-${KAFKA_VERSION}-${CACHE_TAG} tests/share_perf_compare/.work

--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1247,6 +1247,11 @@ int main(int argc, char **argv) {
                 exit(1);
         }
 
+        /* Share consumer rejects offset_commit_cb (registered above); clear
+         * it for -S. */
+        if (mode == 'S')
+                rd_kafka_conf_set_offset_commit_cb(conf, NULL);
+
         if (do_conf_dump) {
                 const char **arr;
                 size_t cnt;

--- a/packaging/tools/run-share-perf-comparison.sh
+++ b/packaging/tools/run-share-perf-comparison.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+set -euo pipefail
+
+DURATION_SECONDS=${DURATION_SECONDS:-300}
+KAFKA_VERSION=${KAFKA_VERSION:-4.2.0}
+METRIC_NAMES=${METRIC_NAMES:-*}
+MSG_SIZE=${MSG_SIZE:-1000}
+PRODUCER_RATE=${PRODUCER_RATE:-}
+
+ROOT=$(git rev-parse --show-toplevel)
+WORK_DIR=${ROOT}/tests/share_perf_compare/.work
+TUTORIALS_REPO=${WORK_DIR}/tutorials
+PLUGIN_JAR=${WORK_DIR}/client-telemetry-reporter-plugin.jar
+KAFKA_DIR=${WORK_DIR}/kafka_2.13-${KAFKA_VERSION}
+KAFKA_DATA=${WORK_DIR}/kafka-data
+OTEL_CONFIG=${TUTORIALS_REPO}/client-telemetry-reporter-plugin/kafka/otel-collector-config.yaml
+PROM_CONFIG=${TUTORIALS_REPO}/client-telemetry-reporter-plugin/kafka/prometheus.yml
+
+TOPIC=perf-share
+SUBSCRIPTION_NAME=share-perf-cmp
+LIBRDKAFKA_GROUP=librdkafka-share
+JAVA_GROUP=java-share
+
+mkdir -p ${WORK_DIR}
+
+echo "==> Parameters"
+echo "    DURATION_SECONDS = ${DURATION_SECONDS}"
+echo "    KAFKA_VERSION    = ${KAFKA_VERSION}"
+echo "    METRIC_NAMES     = ${METRIC_NAMES}"
+echo "    MSG_SIZE         = ${MSG_SIZE}"
+echo "    PRODUCER_RATE    = ${PRODUCER_RATE:-unlimited}"
+
+if [ ! -f "${PLUGIN_JAR}" ]; then
+    echo "==> Building OTLP reporter plugin"
+    if [ ! -d "${TUTORIALS_REPO}" ]; then
+        git clone --depth 1 https://github.com/confluentinc/tutorials.git ${TUTORIALS_REPO}
+    fi
+    sed -i.bak \
+        "s|id 'com.github.johnrengelman.shadow' version '8.1.1'|id 'com.gradleup.shadow' version '8.3.6'|" \
+        ${TUTORIALS_REPO}/client-telemetry-reporter-plugin/kafka/build.gradle
+    (cd ${TUTORIALS_REPO} && ./gradlew --no-daemon clean \
+        :client-telemetry-reporter-plugin:kafka:build)
+    cp ${TUTORIALS_REPO}/client-telemetry-reporter-plugin/kafka/build/libs/client-telemetry-reporter-plugin.jar \
+        ${PLUGIN_JAR}
+fi
+
+if [ ! -d "${KAFKA_DIR}" ]; then
+    echo "==> Setting up Kafka broker ${KAFKA_VERSION}"
+    wget -q https://downloads.apache.org/kafka/${KAFKA_VERSION}/kafka_2.13-${KAFKA_VERSION}.tgz \
+        -O ${WORK_DIR}/kafka.tgz
+    tar -C ${WORK_DIR} -xzf ${WORK_DIR}/kafka.tgz
+
+    SP=${KAFKA_DIR}/config/server.properties
+    sed -i.bak \
+        -e "s|^log.dirs=/tmp/kraft-combined-logs|log.dirs=${KAFKA_DATA}|" \
+        ${SP}
+    echo 'metric.reporters=io.confluent.developer.ClientOtlpMetricsReporter' >> ${SP}
+
+    cp ${PLUGIN_JAR} ${KAFKA_DIR}/libs/
+fi
+
+echo "==> Formatting fresh broker storage"
+rm -rf ${KAFKA_DATA}
+mkdir -p ${KAFKA_DATA}
+CLUSTER_ID=$(${KAFKA_DIR}/bin/kafka-storage.sh random-uuid)
+${KAFKA_DIR}/bin/kafka-storage.sh format --standalone \
+    -t ${CLUSTER_ID} -c ${KAFKA_DIR}/config/server.properties
+
+TEST_CONF_BAK=${ROOT}/tests/test.conf.bak.$$
+PRODUCER_PID=""
+LIBRDKAFKA_CONSUMER_PID=""
+JAVA_CONSUMER_PID=""
+
+cleanup() {
+    local rc=$?
+    set +e
+    echo "==> Cleanup"
+    [ -n "${PRODUCER_PID}" ] && kill -TERM ${PRODUCER_PID} 2>/dev/null
+    [ -n "${LIBRDKAFKA_CONSUMER_PID}" ] && kill -TERM ${LIBRDKAFKA_CONSUMER_PID} 2>/dev/null
+    [ -n "${JAVA_CONSUMER_PID}" ] && kill -TERM ${JAVA_CONSUMER_PID} 2>/dev/null
+    sleep 2
+    [ -n "${PRODUCER_PID}" ] && kill -KILL ${PRODUCER_PID} 2>/dev/null
+    [ -n "${LIBRDKAFKA_CONSUMER_PID}" ] && kill -KILL ${LIBRDKAFKA_CONSUMER_PID} 2>/dev/null
+    [ -n "${JAVA_CONSUMER_PID}" ] && kill -KILL ${JAVA_CONSUMER_PID} 2>/dev/null
+    ${KAFKA_DIR}/bin/kafka-server-stop.sh 2>/dev/null
+    docker stop perf-otel-collector perf-prometheus 2>/dev/null
+    docker rm   perf-otel-collector perf-prometheus 2>/dev/null
+    if [ -f "${TEST_CONF_BAK}" ]; then
+        mv ${TEST_CONF_BAK} ${ROOT}/tests/test.conf
+    fi
+    exit ${rc}
+}
+trap cleanup EXIT
+
+echo "==> Starting OpenTelemetry Collector + Prometheus containers"
+docker rm -f perf-otel-collector perf-prometheus 2>/dev/null || true
+docker network create perf-share-net 2>/dev/null || true
+docker run -d --name perf-otel-collector \
+    --network perf-share-net --network-alias otel-collector \
+    --add-host=host.docker.internal:host-gateway \
+    -p 4317:4317 -p 8889:8889 \
+    -v ${OTEL_CONFIG}:/etc/otelcol-contrib/config.yaml \
+    otel/opentelemetry-collector-contrib
+docker run -d --name perf-prometheus \
+    --network perf-share-net \
+    --add-host=host.docker.internal:host-gateway \
+    -p 9090:9090 \
+    -v ${PROM_CONFIG}:/etc/prometheus/prometheus.yml \
+    prom/prometheus
+
+echo "==> Starting Kafka broker"
+OTEL_EXPORTER_OTLP_ENDPOINT=127.0.0.1:4317 \
+    ${KAFKA_DIR}/bin/kafka-server-start.sh -daemon \
+    ${KAFKA_DIR}/config/server.properties
+
+for i in $(seq 1 60); do
+    if ${KAFKA_DIR}/bin/kafka-broker-api-versions.sh \
+        --bootstrap-server localhost:9092 > /dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+echo "==> Creating topic + metrics subscription"
+${KAFKA_DIR}/bin/kafka-topics.sh --bootstrap-server localhost:9092 --create \
+    --topic ${TOPIC} --partitions 3 --replication-factor 1 --if-not-exists
+${KAFKA_DIR}/bin/kafka-client-metrics.sh --bootstrap-server localhost:9092 --alter \
+    --name ${SUBSCRIPTION_NAME} \
+    --metrics "org.apache.kafka.consumer.share." \
+    --interval 5000
+
+echo "==> Building librdkafka"
+(cd ${ROOT} && ./configure --install-deps --enable-devel)
+make -j -C ${ROOT}
+
+if [ -f ${ROOT}/tests/test.conf ]; then
+    cp ${ROOT}/tests/test.conf ${TEST_CONF_BAK}
+fi
+cat > ${ROOT}/tests/test.conf <<'EOF'
+metadata.broker.list=localhost:9092
+security.protocol=plaintext
+enable.metrics.push=true
+EOF
+
+RUN_TAG=$(date +%s)
+LIBRDKAFKA_GROUP_ID=${LIBRDKAFKA_GROUP}-${RUN_TAG}
+JAVA_GROUP_ID=${JAVA_GROUP}-${RUN_TAG}
+
+echo "==> Launching perf clients (duration ${DURATION_SECONDS}s)"
+PERF_BIN=${ROOT}/examples/rdkafka_performance
+
+# (a) librdkafka producer (continuous feed)
+PRODUCER_RATE_FLAG=""
+[ -n "${PRODUCER_RATE}" ] && PRODUCER_RATE_FLAG="-r ${PRODUCER_RATE}"
+${PERF_BIN} -P -t ${TOPIC} \
+    -s ${MSG_SIZE} ${PRODUCER_RATE_FLAG} \
+    -X file=${ROOT}/tests/test.conf \
+    > ${WORK_DIR}/producer.log 2>&1 &
+PRODUCER_PID=$!
+echo "    producer PID=${PRODUCER_PID}"
+
+# (b) librdkafka share consumer
+${PERF_BIN} -S ${LIBRDKAFKA_GROUP_ID} -t ${TOPIC} \
+    -X file=${ROOT}/tests/test.conf \
+    > ${WORK_DIR}/librdkafka-share.log 2>&1 &
+LIBRDKAFKA_CONSUMER_PID=$!
+echo "    librdkafka share PID=${LIBRDKAFKA_CONSUMER_PID}"
+
+# (c) Java share consumer perf
+${KAFKA_DIR}/bin/kafka-share-consumer-perf-test.sh \
+    --bootstrap-server localhost:9092 \
+    --topic ${TOPIC} \
+    --group ${JAVA_GROUP_ID} \
+    --num-records 100000000 \
+    --timeout 30000000 \
+    --reporting-interval 1000 \
+    --show-detailed-stats \
+    > ${WORK_DIR}/java-share.log 2>&1 &
+JAVA_CONSUMER_PID=$!
+echo "    java share PID=${JAVA_CONSUMER_PID}"
+
+sleep ${DURATION_SECONDS}
+
+echo "==> Stopping perf clients, waiting for trailing telemetry push"
+kill -TERM ${PRODUCER_PID} ${LIBRDKAFKA_CONSUMER_PID} ${JAVA_CONSUMER_PID} 2>/dev/null || true
+sleep 10
+for i in $(seq 1 30); do
+    n=$(curl -s 'http://localhost:9090/api/v1/label/__name__/values' \
+        | jq -r '.data | map(select(startswith("kip-714"))) | length' 2>/dev/null)
+    if [ -n "${n}" ] && [ "${n}" -gt 0 ]; then
+        echo "    Prometheus has ${n} kip-714_* metric names (after ${i} polls)"
+        break
+    fi
+    sleep 2
+done
+
+ALL_NAMES=$(
+    tr '\n' ' ' < ${ROOT}/src/rdkafka_telemetry_encode.h \
+        | sed 's/" *"//g' \
+        | grep -oE 'consumer\.share\.[a-z0-9._]+' \
+        | sort -u
+)
+if [ "${METRIC_NAMES}" = "*" ]; then
+    NAMES="${ALL_NAMES}"
+else
+    NAMES=$(echo "${METRIC_NAMES}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+fi
+
+prom_query() {
+    local selector=$1
+    local encoded
+    encoded=$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))" "${selector}")
+    curl -s "http://localhost:9090/api/v1/query?query=${encoded}" \
+        | jq -r '.data.result[0].value[1] // "—"'
+}
+
+echo "==> Building report"
+REPORT_FILE=${ROOT}/REPORT.md
+
+compute_delta() {
+    local l=$1
+    local j=$2
+    awk -v l="${l}" -v j="${j}" 'BEGIN {
+        if (l == "—" || j == "—") { print "—"; exit }
+        if (l + 0 == l && j + 0 == j) {
+            if (j == 0) {
+                if (l == 0) { print "0%" } else { print "—" }
+                exit
+            }
+            printf "%+.2f%%", (l - j) / j * 100
+        } else {
+            print "—"
+        }
+    }'
+}
+
+{
+    echo "# Share consumer perf comparison"
+    echo ""
+    echo "**Duration:** ${DURATION_SECONDS}s  |  **Kafka:** ${KAFKA_VERSION}  |  **Msg size:** ${MSG_SIZE}B  |  **Producer rate:** ${PRODUCER_RATE:+${PRODUCER_RATE}/s}${PRODUCER_RATE:-unlimited}"
+    echo ""
+    echo "Delta = (librdkafka − Java) / Java × 100 %"
+    echo ""
+    echo "| Metric | librdkafka | Java | Δ |"
+    echo "|---|---:|---:|---:|"
+    while IFS= read -r metric; do
+        [ -z "${metric}" ] && continue
+        prom_name="kip-714_org_apache_kafka_$(echo "${metric}" | tr '.' '_')"
+        librdkafka_val=$(prom_query "{__name__=\"${prom_name}\", client_software_name=\"librdkafka\"}")
+        java_val=$(prom_query "{__name__=\"${prom_name}\", client_software_name=\"apache-kafka-java\"}")
+        delta=$(compute_delta "${librdkafka_val}" "${java_val}")
+        printf '| `%s` | %s | %s | %s |\n' "${metric}" "${librdkafka_val}" "${java_val}" "${delta}"
+    done <<< "${NAMES}"
+} > ${REPORT_FILE}
+
+cat ${REPORT_FILE}
+
+if command -v artifact >/dev/null 2>&1; then
+    artifact push job -f -d .semaphore/REPORT.md ${REPORT_FILE} || true
+fi
+
+exit 0

--- a/service.yml
+++ b/service.yml
@@ -179,4 +179,23 @@ semaphore:
           - "x86_64,aarch64"
           - "x86_64"
           - "aarch64"
-      
+
+  - name: run-share-perf-comparison
+    branch: master
+    scheduled: false
+    pipeline_file: .semaphore/run-share-perf-comparison.yml
+    parameters:
+      - name: DURATION_SECONDS
+        required: false
+        default_value: "300"
+        description: "How long to run the perf clients in seconds. Default 300 (5 min)."
+
+      - name: MSG_SIZE
+        required: false
+        default_value: "1000"
+        description: "Producer message size in bytes."
+
+      - name: PRODUCER_RATE
+        required: false
+        description: "Producer rate cap in messages per second. Leave empty for unlimited."
+


### PR DESCRIPTION
- New task `run-share-perf-comparison` in `service.yml`, dispatched to
  `.semaphore/run-share-perf-comparison.yml`.
- Driver script `packaging/tools/run-share-perf-comparison.sh` brings up
  Kafka 4.2 + the upstream OTLP reporter plugin (cloned verbatim from
  `confluentinc/tutorials`) + OTel Collector + Prometheus, runs a
  librdkafka producer, librdkafka share consumer, and Java share consumer
  concurrently, then queries Prometheus and emits a markdown comparison
  table (`librdkafka | Java | Δ%`) as a job artifact.
- Parameters: `DURATION_SECONDS` (default 300), `MSG_SIZE` (default
  1000), `PRODUCER_RATE` (optional — unlimited when blank).
- The metric set is enumerated from
  `RD_KAFKA_TELEMETRY_SHARE_CONSUMER_METRICS_INFO[]` in
  `src/rdkafka_telemetry_encode.h`, so adding new metrics there
  automatically extends the comparison report.