### PR TITLE
[KIP-932] Bypass the version-outdated filter for consumed records

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3496,8 +3496,11 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 }
                 rd_kafka_toppar_unlock(rktp);
 
-                /* Remove from fetcher list */
-                rd_kafka_toppar_fetch_decide(rktp, rkb, 1 /*force remove*/);
+                if (!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                        /* Remove from fetcher list */
+                        rd_kafka_toppar_fetch_decide(rktp, rkb,
+                                                     1 /*force remove*/);
+                }
 
                 if (rkb->rkb_rk->rk_type == RD_KAFKA_PRODUCER) {
                         /* Purge any ProduceRequests for this toppar
@@ -4009,7 +4012,10 @@ static void rd_kafka_broker_internal_serve(rd_kafka_broker_t *rkb,
         if (rkb->rkb_rk->rk_type == RD_KAFKA_CONSUMER) {
                 /* Consumer */
                 do {
-                        rd_kafka_broker_consumer_toppars_serve(rkb);
+
+                        if (!RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk)) {
+                                rd_kafka_broker_consumer_toppars_serve(rkb);
+                        }
 
                         wakeup = rd_kafka_broker_ops_io_serve(rkb, abs_timeout);
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1426,8 +1426,10 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
                 goto done;
         }
 
-        tver.rktp    = rktp;
-        tver.version = rktp->rktp_fetch_version;
+        tver.rktp = rktp;
+        /* There is no versioning/barrier of the records/partitions in
+         * share consumer case. */
+        tver.version = 0;
 
         /* No error, clear any previous fetch error. */
         rktp->rktp_last_error = RD_KAFKA_RESP_ERR_NO_ERROR;

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -263,7 +263,11 @@ rd_kafka_toppar_t *rd_kafka_toppar_new0(rd_kafka_topic_t *rkt,
         rktp->rktp_ops             = rd_kafka_q_new(rkt->rkt_rk);
         rktp->rktp_ops->rkq_serve  = rd_kafka_toppar_op_serve;
         rktp->rktp_ops->rkq_opaque = rktp;
-        rd_atomic32_init(&rktp->rktp_version, 1);
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkt->rkt_rk)) {
+                rd_atomic32_init(&rktp->rktp_version, 0);
+        } else {
+                rd_atomic32_init(&rktp->rktp_version, 1);
+        }
         rktp->rktp_op_version = rd_atomic32_get(&rktp->rktp_version);
 
         rd_atomic32_init(&rktp->rktp_msgs_inflight, 0);


### PR DESCRIPTION
Parsed share-fetch records could be silently dropped by rd_kafka_op_version_outdated due to two interacting issues:

1. broker_op_serve PARTITION_LEAVE and broker_internal_serve both ran rd_kafka_toppar_fetch_decide on share-consumer rktps. That promoted rktp_fetch_version above 0 for partitions transiting the :0/internal pseudo-broker, causing later parsed messages to be stamped with a version the next rktp_version bump then filtered out as outdated.

2. rktp_version was initialised to 1, and rd_kafka_toppar_op_version_bump short-circuits for share consumer. fetch_start bumped rktp_version to 2 while rktp_op_version stayed at 1; any replyq op tagged with that op_version sat at rko_version=1 while rktp_version had advanced to 2, getting filtered out as outdated.

Fix:
- Guard the two fetch_decide call sites with !IS_SHARE_CONSUMER so the regular-consumer fetch-decision path no longer runs on share-consumer rktps.
- Stamp tver.version=0 in the share-fetch per-partition reply handler so parsed messages always short-circuit rd_kafka_op_version_outdated.
- Initialise rktp_version=0 for share-consumer rktps so any replyq stamped from rktp_op_version (=0) likewise short-circuits.

End state: no rko in the share-consumer path carries rko_version > 0, so the filter is transparent there. Regular consumer semantics (SEEK/STOP/PAUSE filtering) are unchanged.