### PR TITLE
[KIP-932] : Add share consumer log queue forwarding. 

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3471,63 +3471,6 @@ rd_kafka_error_t *rd_kafka_share_sasl_set_credentials(rd_kafka_share_t *rkshare,
                                                       const char *username,
                                                       const char *password);
 
-
-/**
- * @brief Redirect the share consumer's main reply queue onto the underlying
- *        consumer-group queue so that main-queue events (errors, throttles,
- *        OAUTHBEARER authentication failures, etc.) are dispatched via the
- *        consumer-group queue returned by rd_kafka_share_queue_get_consumer().
- *
- * Share consumers wrap a regular RD_KAFKA_CONSUMER handle, so this is a
- * thin passthrough to rd_kafka_poll_set_consumer() on the underlying rk.
- *
- * @param rkshare Share consumer instance.
- *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success;
- *          RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare is NULL or uninitialised;
- *          RD_KAFKA_RESP_ERR__UNKNOWN_GROUP if no consumer group is configured.
- *
- * @sa rd_kafka_poll_set_consumer()
- * @sa rd_kafka_share_queue_get_consumer()
- */
-RD_EXPORT
-rd_kafka_resp_err_t
-rd_kafka_share_poll_set_consumer(rd_kafka_share_t *rkshare);
-
-
-/**
- * @brief Returns a reference to this share consumer's underlying consumer-
- *        group queue. Bindings can poll this queue independently of
- *        rd_kafka_share_consume_batch() to drain main-queue events
- *        (errors, throttles, OAUTHBEARER authentication failures, etc.)
- *        without blocking on record consumption.
- *
- * Symmetric with rd_kafka_queue_get_consumer() for regular consumers and
- * intended to be paired with rd_kafka_share_poll_set_consumer() at
- * construction time.
- *
- * Use rd_kafka_queue_destroy() to release the reference.
- *
- * @param rkshare Share consumer instance.
- *
- * @returns A new reference to the consumer-group queue on success,
- *          NULL if rkshare is NULL/uninitialised or no consumer group is
- *          configured.
- *
- * @remark rd_kafka_queue_destroy() MUST be called on this queue prior to
- *         calling rd_kafka_share_destroy().
- * @remark Polling the returned queue counts as a consumer poll for
- *         max.poll.interval.ms purposes, exactly as for the regular
- *         consumer queue.
- *
- * @sa rd_kafka_queue_get_consumer()
- * @sa rd_kafka_share_poll_set_consumer()
- */
-RD_EXPORT
-rd_kafka_queue_t *
-rd_kafka_share_queue_get_consumer(rd_kafka_share_t *rkshare);
-
-
 /**
  * @brief Flags for rd_kafka_destroy_flags()
  */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4033,16 +4033,18 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
  *
  * @remark librdkafka maintains its own reference to the provided queue.
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success;
- *          RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare is NULL or
- *          uninitialized;
- *          RD_KAFKA_RESP_ERR__NOT_CONFIGURED when log.queue is not set to
- *          true.
+ * @returns NULL on success or an error object on failure.
+ *          The error code will be RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare
+ *          is NULL or uninitialized, or RD_KAFKA_RESP_ERR__NOT_CONFIGURED
+ *          when log.queue is not set to true.
+ *
+ *          The returned error object (if any) must be destroyed with
+ *          rd_kafka_error_destroy().
  *
  * @sa rd_kafka_set_log_queue
  */
 RD_EXPORT
-rd_kafka_resp_err_t
+rd_kafka_error_t *
 rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
                              rd_kafka_queue_t *rkqu);
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3471,6 +3471,63 @@ rd_kafka_error_t *rd_kafka_share_sasl_set_credentials(rd_kafka_share_t *rkshare,
                                                       const char *username,
                                                       const char *password);
 
+
+/**
+ * @brief Redirect the share consumer's main reply queue onto the underlying
+ *        consumer-group queue so that main-queue events (errors, throttles,
+ *        OAUTHBEARER authentication failures, etc.) are dispatched via the
+ *        consumer-group queue returned by rd_kafka_share_queue_get_consumer().
+ *
+ * Share consumers wrap a regular RD_KAFKA_CONSUMER handle, so this is a
+ * thin passthrough to rd_kafka_poll_set_consumer() on the underlying rk.
+ *
+ * @param rkshare Share consumer instance.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success;
+ *          RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare is NULL or uninitialised;
+ *          RD_KAFKA_RESP_ERR__UNKNOWN_GROUP if no consumer group is configured.
+ *
+ * @sa rd_kafka_poll_set_consumer()
+ * @sa rd_kafka_share_queue_get_consumer()
+ */
+RD_EXPORT
+rd_kafka_resp_err_t
+rd_kafka_share_poll_set_consumer(rd_kafka_share_t *rkshare);
+
+
+/**
+ * @brief Returns a reference to this share consumer's underlying consumer-
+ *        group queue. Bindings can poll this queue independently of
+ *        rd_kafka_share_consume_batch() to drain main-queue events
+ *        (errors, throttles, OAUTHBEARER authentication failures, etc.)
+ *        without blocking on record consumption.
+ *
+ * Symmetric with rd_kafka_queue_get_consumer() for regular consumers and
+ * intended to be paired with rd_kafka_share_poll_set_consumer() at
+ * construction time.
+ *
+ * Use rd_kafka_queue_destroy() to release the reference.
+ *
+ * @param rkshare Share consumer instance.
+ *
+ * @returns A new reference to the consumer-group queue on success,
+ *          NULL if rkshare is NULL/uninitialised or no consumer group is
+ *          configured.
+ *
+ * @remark rd_kafka_queue_destroy() MUST be called on this queue prior to
+ *         calling rd_kafka_share_destroy().
+ * @remark Polling the returned queue counts as a consumer poll for
+ *         max.poll.interval.ms purposes, exactly as for the regular
+ *         consumer queue.
+ *
+ * @sa rd_kafka_queue_get_consumer()
+ * @sa rd_kafka_share_poll_set_consumer()
+ */
+RD_EXPORT
+rd_kafka_queue_t *
+rd_kafka_share_queue_get_consumer(rd_kafka_share_t *rkshare);
+
+
 /**
  * @brief Flags for rd_kafka_destroy_flags()
  */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4016,11 +4016,11 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
  * @brief Forward a share consumer's internal log queue onto another queue
  *        for serving with one of the ..poll() calls.
  *
- *        Thin wrapper around rd_kafka_set_log_queue() for use with
- *        rd_kafka_share_t handles. Required when `log.queue=true` is
- *        configured on a share consumer — without this call the share
- *        consumer's internal log queue is never drained and log_cb never
- *        fires.
+ * Thin wrapper around rd_kafka_set_log_queue() for use with
+ * rd_kafka_share_t handles. Required when `log.queue=true` is
+ * configured on a share consumer — without this call the share
+ * consumer's internal log queue is never drained and log_cb never
+ * fires.
  *
  * @param rkshare Share consumer instance.
  * @param rkqu    Queue to forward logs to. If NULL the logs are forwarded

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4013,6 +4013,41 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
 
 
 /**
+ * @brief Forward a share consumer's internal log queue onto another queue
+ *        for serving with one of the ..poll() calls.
+ *
+ *        Thin wrapper around rd_kafka_set_log_queue() for use with
+ *        rd_kafka_share_t handles. Required when `log.queue=true` is
+ *        configured on a share consumer — without this call the share
+ *        consumer's internal log queue is never drained and log_cb never
+ *        fires.
+ *
+ * @param rkshare Share consumer instance.
+ * @param rkqu    Queue to forward logs to. If NULL the logs are forwarded
+ *                to the share consumer's internal rk_rep, which is drained
+ *                by rd_kafka_share_consume_batch() /
+ *                rd_kafka_share_commit_sync() / rd_kafka_share_commit_async()
+ *                on the application's poll thread.
+ *
+ * @remark The configuration property `log.queue` MUST also be set to true.
+ *
+ * @remark librdkafka maintains its own reference to the provided queue.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success;
+ *          RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare is NULL or
+ *          uninitialized;
+ *          RD_KAFKA_RESP_ERR__NOT_CONFIGURED when log.queue is not set to
+ *          true.
+ *
+ * @sa rd_kafka_set_log_queue
+ */
+RD_EXPORT
+rd_kafka_resp_err_t
+rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
+                             rd_kafka_queue_t *rkqu);
+
+
+/**
  * @returns the current number of elements in queue.
  */
 RD_EXPORT

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4044,9 +4044,8 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
  * @sa rd_kafka_set_log_queue
  */
 RD_EXPORT
-rd_kafka_error_t *
-rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
-                             rd_kafka_queue_t *rkqu);
+rd_kafka_error_t *rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
+                                               rd_kafka_queue_t *rkqu);
 
 
 /**

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1018,6 +1018,23 @@ rd_kafka_queue_t *rd_kafka_queue_get_consumer(rd_kafka_t *rk) {
         return rd_kafka_queue_new0(rk, rk->rk_cgrp->rkcg_q);
 }
 
+
+rd_kafka_resp_err_t
+rd_kafka_share_poll_set_consumer(rd_kafka_share_t *rkshare) {
+        if (!rkshare || !rkshare->rkshare_rk)
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        return rd_kafka_poll_set_consumer(rkshare->rkshare_rk);
+}
+
+
+rd_kafka_queue_t *
+rd_kafka_share_queue_get_consumer(rd_kafka_share_t *rkshare) {
+        if (!rkshare || !rkshare->rkshare_rk)
+                return NULL;
+        return rd_kafka_queue_get_consumer(rkshare->rkshare_rk);
+}
+
+
 rd_kafka_queue_t *rd_kafka_queue_get_partition(rd_kafka_t *rk,
                                                const char *topic,
                                                int32_t partition) {

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1018,23 +1018,6 @@ rd_kafka_queue_t *rd_kafka_queue_get_consumer(rd_kafka_t *rk) {
         return rd_kafka_queue_new0(rk, rk->rk_cgrp->rkcg_q);
 }
 
-
-rd_kafka_resp_err_t
-rd_kafka_share_poll_set_consumer(rd_kafka_share_t *rkshare) {
-        if (!rkshare || !rkshare->rkshare_rk)
-                return RD_KAFKA_RESP_ERR__INVALID_ARG;
-        return rd_kafka_poll_set_consumer(rkshare->rkshare_rk);
-}
-
-
-rd_kafka_queue_t *
-rd_kafka_share_queue_get_consumer(rd_kafka_share_t *rkshare) {
-        if (!rkshare || !rkshare->rkshare_rk)
-                return NULL;
-        return rd_kafka_queue_get_consumer(rkshare->rkshare_rk);
-}
-
-
 rd_kafka_queue_t *rd_kafka_queue_get_partition(rd_kafka_t *rk,
                                                const char *topic,
                                                int32_t partition) {

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1089,7 +1089,8 @@ rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
 
         err = rd_kafka_set_log_queue(rkshare->rkshare_rk, rkqu);
 
-        return err ? rd_kafka_error_new(err, NULL) : NULL;
+        return err ? rd_kafka_error_new(err, "%s", rd_kafka_err2str(err))
+                   : NULL;
 }
 
 void rd_kafka_queue_forward(rd_kafka_queue_t *src, rd_kafka_queue_t *dst) {

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1077,9 +1077,8 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
-rd_kafka_error_t *
-rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
-                             rd_kafka_queue_t *rkqu) {
+rd_kafka_error_t *rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
+                                               rd_kafka_queue_t *rkqu) {
         rd_kafka_resp_err_t err;
 
         if (!rkshare || !rkshare->rkshare_rk)

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1077,12 +1077,19 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
-rd_kafka_resp_err_t
+rd_kafka_error_t *
 rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
                              rd_kafka_queue_t *rkqu) {
+        rd_kafka_resp_err_t err;
+
         if (!rkshare || !rkshare->rkshare_rk)
-                return RD_KAFKA_RESP_ERR__INVALID_ARG;
-        return rd_kafka_set_log_queue(rkshare->rkshare_rk, rkqu);
+                return rd_kafka_error_new(
+                    RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "Share consumer handle is NULL or uninitialized");
+
+        err = rd_kafka_set_log_queue(rkshare->rkshare_rk, rkqu);
+
+        return err ? rd_kafka_error_new(err, NULL) : NULL;
 }
 
 void rd_kafka_queue_forward(rd_kafka_queue_t *src, rd_kafka_queue_t *dst) {

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -1077,6 +1077,14 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
         return RD_KAFKA_RESP_ERR_NO_ERROR;
 }
 
+rd_kafka_resp_err_t
+rd_kafka_share_set_log_queue(rd_kafka_share_t *rkshare,
+                             rd_kafka_queue_t *rkqu) {
+        if (!rkshare || !rkshare->rkshare_rk)
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        return rd_kafka_set_log_queue(rkshare->rkshare_rk, rkqu);
+}
+
 void rd_kafka_queue_forward(rd_kafka_queue_t *src, rd_kafka_queue_t *dst) {
         rd_kafka_q_fwd_set0(src->rkqu_q, dst ? dst->rkqu_q : NULL,
                             1, /* do_lock */


### PR DESCRIPTION
**Summary**

* Added the `rd_kafka_share_set_log_queue` function to the public API in `rdkafka.h`, enabling applications to forward a share consumer's internal log queue to another queue for use with poll calls. This is required for proper log handling when `log.queue=true` is set on a share consumer.
* Implemented the `rd_kafka_share_set_log_queue` function in `rdkafka_queue.c`, which validates the share consumer handle and delegates to the existing `rd_kafka_set_log_queue` function.