### PR TITLE
[KIP-932]: Added more integration tests

### DIFF
--- a/.semaphore/run-sasl-tests.yml
+++ b/.semaphore/run-sasl-tests.yml
@@ -45,12 +45,12 @@ blocks:
             - if [[ "$TEST_TYPE" != *"plaintext"* ]]; then exit 0; fi
             - 'export TEST_TRIVUP_PARAMETERS=''--conf ["connections.max.reauth.ms=10000"]'''
             - 'if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then export TEST_TRIVUP_PARAMETERS=''--oidc --conf ["connections.max.reauth.ms=10000"]''; fi'
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.2.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}; fi
-            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.3.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}; fi
+            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}
             - export TESTS=0022,0128,0135,0142 && ./tests/run-all-tests.sh
-            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}
+            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}
         - name: "SASL SSL cluster (x86_64)"
           env_vars:
             - name: TEST_SSL
@@ -59,12 +59,12 @@ blocks:
             - if [[ "$TEST_TYPE" != *"ssl"* ]]; then exit 0; fi
             - 'export TEST_TRIVUP_PARAMETERS=''--conf ["connections.max.reauth.ms=10000"]'''
             - 'if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then export TEST_TRIVUP_PARAMETERS=''--oidc --conf ["connections.max.reauth.ms=10000"]''; fi'
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.2.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}; fi
-            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.3.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}; fi
+            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}
             - export TESTS=0022,0128,0135,0142 && ./tests/run-all-tests.sh
-            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}
+            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}
   - name: "Run SASL tests (aarch64)"
     dependencies: []
     task:
@@ -83,12 +83,12 @@ blocks:
             - if [[ "$TEST_TYPE" != *"plaintext"* ]]; then exit 0; fi
             - 'export TEST_TRIVUP_PARAMETERS=''--conf ["connections.max.reauth.ms=10000"]'''
             - 'if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then export TEST_TRIVUP_PARAMETERS=''--oidc --conf ["connections.max.reauth.ms=10000"]''; fi'
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.2.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}; fi
-            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.3.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}; fi
+            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}
             - export TESTS=0022,0128,0135,0142 && ./tests/run-all-tests.sh
-            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}
+            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}
         - name: "SASL SSL cluster (aarch64)"
           env_vars:
             - name: TEST_SSL
@@ -97,9 +97,9 @@ blocks:
             - if [[ "$TEST_TYPE" != *"ssl"* ]]; then exit 0; fi
             - 'export TEST_TRIVUP_PARAMETERS=''--conf ["connections.max.reauth.ms=10000"]'''
             - 'if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then export TEST_TRIVUP_PARAMETERS=''--oidc --conf ["connections.max.reauth.ms=10000"]''; fi'
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.2.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
-            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}; fi
-            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG}
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache restore trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then (cd tests && echo "TESTS=0126 make 2>&1; exit" | python3 interactive_broker_version.py --kraft --sasl OAUTHBEARER --oauthbearer-method OIDC $([ "$TEST_SSL" = "True" ] && echo --ssl) ${TEST_KAFKA_GIT_REF:-4.3.0}) 2>&1 | tee /tmp/0126.log; if grep -qE "TEST FAILURE|timed out|test-runner.*FAILED|run_par.*Error" /tmp/0126.log; then echo "OIDC tests (0126) FAILED"; exit 1; else echo "OIDC tests (0126) PASSED"; fi; fi
+            - if [[ "$TEST_SASL" == "OAUTHBEARER" ]]; then cache store trivup-kafka-oidc-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp/LibrdkafkaTestCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}; fi
+            - cache restore trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG}
             - export TESTS=0022,0128,0135,0142 && ./tests/run-all-tests.sh
-            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.2.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.2.0}
+            - cache store trivup-kafka-${TEST_KAFKA_GIT_REF:-4.3.0}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${TEST_KAFKA_GIT_REF:-4.3.0}

--- a/.semaphore/semaphore-integration.yml
+++ b/.semaphore/semaphore-integration.yml
@@ -22,7 +22,7 @@ global_job_config:
     - name: CI
       value: 'true'
     - name: KAFKA_VERSION
-      value: '4.2.0'
+      value: '4.3.0'
     - name: CP_VERSION
       value: '8.0.0'
     # Shows plain output from docker build (no progress bars)
@@ -220,7 +220,7 @@ promotions:
       env_vars:
         - required: true
           name: TEST_KAFKA_GIT_REF
-          default_value: 4.2.0
+          default_value: 4.3.0
         - required: true
           name: TEST_TYPE
           default_value: plaintext,ssl

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,7 +22,7 @@ global_job_config:
     - name: CI
       value: 'true'
     - name: KAFKA_VERSION
-      value: '4.2.0'
+      value: '4.3.0'
     - name: CP_VERSION
       value: '8.0.0'
     # Shows plain output from docker build (no progress bars)
@@ -527,7 +527,7 @@ promotions:
       env_vars:
         - required: true
           name: TEST_KAFKA_GIT_REF
-          default_value: "4.2.0"
+          default_value: "4.3.0"
         - name: TEST_SASL
           default_value: "PLAIN"
         - required: true
@@ -550,7 +550,7 @@ promotions:
       env_vars:
         - required: true
           name: TEST_KAFKA_GIT_REF
-          default_value: "4.2.0"
+          default_value: "4.3.0"
         - name: TEST_SASL
           default_value: "OAUTHBEARER"
         - required: true

--- a/packaging/tools/run-share-consumer-tests.sh
+++ b/packaging/tools/run-share-consumer-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 # Use env vars matching run-all-tests.sh convention,
 # with fallback to positional args for backward compatibility.
-export TEST_KAFKA_GIT_REF="${TEST_KAFKA_GIT_REF:-${1:-4.2.0}}"
+export TEST_KAFKA_GIT_REF="${TEST_KAFKA_GIT_REF:-${1:-4.3.0}}"
 export TEST_CP_VERSION="${TEST_CP_VERSION:-${2:-8.2.0}}"
 TEST_CONFIGURATION="${TEST_CONFIGURATION:---kraft}"
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5712,6 +5712,9 @@ static void rd_kafka_propagate_consumer_topic_errors(
  *        directly to the application on next poll; transient codes are
  *        debug-logged.
  *
+ *       TODO KIP-932: We need to throw the CONSUMER_ERR ops as a set
+ *       of topic partitions and error code, rather than one per topic.
+ *
  * @locality rdkafka main thread
  */
 void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg) {

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -932,7 +932,7 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                                     delivery_count;
                         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {
                                 rkm = &rko->rko_u.err.rkm;
-                                /* Set ack_type to REJECT only if not already
+                                /* Set ack_type to RELEASE only if not already
                                  * set by rd_kafka_share_msgset_err_ops()
                                  * (which sets REJECT for CRC/unsupported
                                  * errors, RELEASE for decompression errors). */
@@ -1754,8 +1754,9 @@ done:
 
         if (rkt)
                 rd_kafka_topic_destroy0(rkt);
-        rd_rkb_dbg(rkb, MSG, "BADMSG", "Bad message (ShareFetch v%d): ",
-                   (int)request->rkbuf_reqhdr.ApiVersion);
+        rd_rkb_dbg(rkb, MSG, "BADMSG", "Bad message (ShareFetch v%d): %s",
+                   (int)request->rkbuf_reqhdr.ApiVersion,
+                   rd_kafka_err2str(err));
         return err;
 }
 

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1187,7 +1187,23 @@ rd_kafka_msgset_reader_v2(rd_kafka_msgset_reader_t *msetr) {
                                 int32_t LastOffsetDelta;
 
                                 /* Read LastOffsetDelta to
-                                 * determine full offset range.  */
+                                 * determine full offset range.
+                                 *
+                                 * TODO KIP-932: These bytes come from
+                                 * within the CRC-covered region of the
+                                 * MessageSet body, and the CRC has
+                                 * just failed — so `Attributes` and
+                                 * `LastOffsetDelta` may be corrupt. A
+                                 * garbage `LastOffsetDelta` can:
+                                 *  - be huge → fan-out emits millions of
+                                 *    error ops for offsets that don't
+                                 *    exist (memory/queue blowup);
+                                 *  - be negative → `LastOffset <
+                                 *    BaseOffset`, fan-out loop is a
+                                 *    silent no-op (no error surfaced);
+                                 *  - look valid but be off → REJECT ops
+                                 *    issued for the wrong offset range.
+                                 */
                                 rd_kafka_buf_read_i16(rkbuf, &Attributes);
                                 rd_kafka_buf_read_i32(rkbuf, &LastOffsetDelta);
                                 LastOffset = hdr.BaseOffset + LastOffsetDelta;

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -1676,7 +1676,6 @@ static void subchg_ack_cb(rd_kafka_share_t *rkshare,
         (void)rkshare;
 
         /* Mirror test_share_ack_cb's base accounting */
-        st->base.callback_cnt++;
         test_ack_cb_state_push_err(&st->base, err);
 
         entry = rd_kafka_share_partition_offsets_list_get(partitions, 0);
@@ -1803,11 +1802,11 @@ static void do_test_subscription_change_acks_pending(void) {
                     "Expected ack callback to fire after subscription change, "
                     "got %d callbacks",
                     state.base.callback_cnt);
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Expected no error in callback, got %s",
-                    rd_kafka_err2name(
-                        test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Expected no error in callback, got %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
         TEST_ASSERT(strcmp(state.first_callback_topic, t1) == 0,
                     "Expected first ack callback to be for t1 (%s), got %s", t1,
                     state.first_callback_topic);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -607,8 +607,13 @@ static void state_init(sub_test_state_t *state,
 
         memset(state, 0, sizeof(*state));
 
-        rd_snprintf(state->group_name, sizeof(state->group_name), "share-%s",
-                    scenario->name);
+        /* Append a per-invocation unique suffix so each run gets a
+         * fresh share-group on the broker (avoids collisions across
+         * re-runs or parallel runs against the same cluster). */
+        rd_snprintf(state->group_name, sizeof(state->group_name),
+                    "share-%s-rnd%" PRIx64, scenario->name, test_id_generate());
+        TEST_SAY("Scenario '%s' using group '%s'\n", scenario->name,
+                 state->group_name);
 
         state->consumer_cnt =
             scenario->consumer_cnt > 0 ? scenario->consumer_cnt : 1;
@@ -929,13 +934,10 @@ static void test_topic_deletion_does_not_surface_error(void) {
 
         SUB_TEST();
 
-        if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows")) {
-                TEST_SAY(
-                    "Skipping topic-deletion-does-not-surface-error "
+        if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows"))
+                SUB_TEST_SKIP(
+                    "topic-deletion-does-not-surface-error "
                     "(broker on Windows)\n");
-                SUB_TEST_PASS();
-                return;
-        }
 
         topic     = test_mk_topic_name("0170-delete-no-surface", 1);
         topic_dup = rd_strdup(topic);
@@ -945,12 +947,17 @@ static void test_topic_deletion_does_not_surface_error(void) {
 
         /* Custom consumer that disables the set_notexists defer window
          * (default 30s) so the log-and-drop path runs on the first
-         * post-delete metadata refresh instead of being deferred. */
+         * post-delete metadata refresh instead of being deferred.
+         * Also reduce the metadata refresh interval so a refresh actually
+         * happens during the post-delete settle window — the default is
+         * 5 minutes, which would never fire during the test. */
         test_conf_init(&conf, NULL, 60);
         rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "share.acknowledgement.mode", "explicit",
                           errstr, sizeof(errstr));
         rd_kafka_conf_set(conf, "topic.metadata.propagation.max.ms", "0",
+                          errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "topic.metadata.refresh.interval.ms", "500",
                           errstr, sizeof(errstr));
         consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(consumer, "Failed to create share consumer: %s", errstr);
@@ -989,7 +996,7 @@ static void test_topic_deletion_does_not_surface_error(void) {
         TEST_ASSERT(!del_err, "DeleteTopics failed: %s",
                     rd_kafka_err2str(del_err));
 
-        /* Allow metadata propagation. */
+        /* Wait for the topic delete to propagate in the cluster. */
         rd_sleep(3);
 
         /* Drain consume_batch and verify no topic-level error reaches
@@ -1649,6 +1656,402 @@ static void do_test_consume_batch_without_subscription(void) {
         SUB_TEST_PASS();
 }
 
+/* Extends test_ack_cb_state_t to also record the topic of the first
+ * callback invocation, so do_test_subscription_change_acks_pending can
+ * verify that the implicit ack driven by the subscription change was for
+ * t1 (not later t2 acks fired by subsequent polls in the loop). */
+typedef struct subchg_ack_state_s {
+        test_ack_cb_state_t base; /* must be first - cast-compat with base */
+        char first_callback_topic[256];
+} subchg_ack_state_t;
+
+static void subchg_ack_cb(rd_kafka_share_t *rkshare,
+                          rd_kafka_share_partition_offsets_list_t *partitions,
+                          rd_kafka_resp_err_t err,
+                          void *opaque) {
+        subchg_ack_state_t *st = (subchg_ack_state_t *)opaque;
+        const rd_kafka_share_partition_offsets_t *entry;
+        const rd_kafka_topic_partition_t *part;
+
+        (void)rkshare;
+
+        /* Mirror test_share_ack_cb's base accounting */
+        st->base.callback_cnt++;
+        test_ack_cb_state_push_err(&st->base, err);
+
+        entry = rd_kafka_share_partition_offsets_list_get(partitions, 0);
+        if (!entry)
+                return;
+
+        st->base.total_offsets +=
+            rd_kafka_share_partition_offsets_offsets_cnt(entry);
+
+        /* Record the topic of the first callback invocation only. */
+        if (st->base.callback_cnt == 1) {
+                part = rd_kafka_share_partition_offsets_partition(entry);
+                if (part && part->topic)
+                        rd_snprintf(st->first_callback_topic,
+                                    sizeof(st->first_callback_topic), "%s",
+                                    part->topic);
+        }
+}
+
+
+/**
+ * @brief Test that a subscription change drives an implicit ack of the
+ *        previously-fetched batch, firing the share ack callback.
+ *
+ * Produce one record to t1 and one to t2. In implicit mode, subscribe to t1,
+ * fetch the t1 record (without explicitly acknowledging), then re-subscribe
+ * to t2. The subscription change should cause t1's outstanding record to be
+ * implicitly acknowledged, firing the ack commit callback for t1's
+ * partition.
+ *
+ * A custom callback records the topic of the first callback invocation so
+ * we can verify the callback fired for t1 (not for t2's implicit ack,
+ * which can also fire if the polling loop iterates past the t2 record's
+ * arrival).
+ */
+static void do_test_subscription_change_acks_pending(void) {
+        char *group;
+        char *t1;
+        char *t2;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[10];
+        rd_kafka_error_t *err;
+        subchg_ack_state_t state = {0};
+        size_t rcvd              = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        /* rd_strdup each test_mk_topic_name() result because the helper
+         * returns a pointer to a single TLS static buffer that gets
+         * clobbered by the next call. */
+        group = rd_strdup(test_mk_topic_name("share-sub-change-ack", 1));
+        t1    = rd_strdup(test_mk_topic_name("0170-subchg-t1", 1));
+        t2    = rd_strdup(test_mk_topic_name("0170-subchg-t2", 1));
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "============================================================\n");
+        TEST_SAY("=== subscription-change-drives-ack-callback ===\n");
+        TEST_SAY(
+            "============================================================\n");
+
+        test_create_topic_wait_exists(NULL, t1, 1, -1, 30000);
+        test_create_topic_wait_exists(NULL, t2, 1, -1, 30000);
+
+        test_produce_msgs_simple(common_producer, t1, 0, 1);
+        test_produce_msgs_simple(common_producer, t2, 0, 1);
+
+        rkshare = test_create_share_consumer_with_cb(
+            group, "implicit", &state.base, subchg_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        /* Subscribe to t1 only */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, t1, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Poll until the t1 record arrives */
+        attempts = 30;
+        while (rcvd < 1 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
+                                                   &batch_rcvd);
+                if (err)
+                        rd_kafka_error_destroy(err);
+                rcvd += batch_rcvd;
+        }
+        TEST_ASSERT(rcvd == 1, "Expected 1 record from t1, got %zu", rcvd);
+        rd_kafka_message_destroy(batch[0]);
+
+        TEST_ASSERT(state.base.callback_cnt == 0,
+                    "Did not expect callback before subscription change, "
+                    "got %d",
+                    state.base.callback_cnt);
+
+        /* Re-subscribe to t2 only - this should drive an implicit ack of
+         * t1's outstanding batch. */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, t2, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Poll a few times to drive the callback and pick up the t2 record.
+         * Subsequent polls in this loop may also piggyback t2's implicit
+         * ack and produce a second callback, but the FIRST callback must
+         * be the one driven by the t1 -> t2 subscription change. The
+         * custom callback records the topic of the first invocation so
+         * we can assert that below. */
+        rcvd     = 0;
+        attempts = 30;
+        while ((rcvd < 1 || state.base.callback_cnt < 1) && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                err = rd_kafka_share_consume_batch(rkshare, 1000, batch + rcvd,
+                                                   &batch_rcvd);
+                if (err)
+                        rd_kafka_error_destroy(err);
+                rcvd += batch_rcvd;
+        }
+
+        TEST_ASSERT(rcvd == 1, "Expected 1 record from t2, got %zu", rcvd);
+        TEST_ASSERT(state.base.callback_cnt >= 1,
+                    "Expected ack callback to fire after subscription change, "
+                    "got %d callbacks",
+                    state.base.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected no error in callback, got %s",
+                    rd_kafka_err2name(
+                        test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(strcmp(state.first_callback_topic, t1) == 0,
+                    "Expected first ack callback to be for t1 (%s), got %s", t1,
+                    state.first_callback_topic);
+
+        rd_kafka_message_destroy(batch[0]);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        rd_free(t1);
+        rd_free(t2);
+        rd_free(group);
+
+        TEST_SAY("=== subscription-change-drives-ack-callback: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test two share groups on the same topic with different
+ *        auto.offset.reset policies (earliest vs latest).
+ *
+ * Group A is configured for earliest, group B for latest. Records produced
+ * before either group joins are visible only to group A; records produced
+ * after both have joined are visible to both.
+ */
+static void do_test_two_groups_earliest_vs_latest(void) {
+        char *grpA;
+        char *grpB;
+        char *topic;
+        rd_kafka_share_t *consA, *consB;
+        rd_kafka_topic_partition_list_t *subs;
+        int countA = 0, countB = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        /* rd_strdup each test_mk_topic_name() result because the helper
+         * returns a pointer to a single TLS static buffer that gets
+         * clobbered by the next call. Without this, grpA, grpB and topic
+         * would all alias to the same buffer. */
+        grpA  = rd_strdup(test_mk_topic_name("share-grpA-earliest", 1));
+        grpB  = rd_strdup(test_mk_topic_name("share-grpB-latest", 1));
+        topic = rd_strdup(test_mk_topic_name("0170-evl", 1));
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "============================================================\n");
+        TEST_SAY("=== two-groups-earliest-vs-latest ===\n");
+        TEST_SAY(
+            "============================================================\n");
+
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 30000);
+
+        /* Produce 5 records BEFORE the consumers join. These are the
+         * "original records present in the broker" that earliest fetches
+         * and latest skips. */
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
+
+        /* Match the working librdkafka ordering used by
+         * do_test_multi_consumer_overlap (0170) and 0171's
+         * test_poll_callback_piggybacked_acks:
+         *   produce -> create consumer -> set reset -> subscribe -> poll.
+         * Setting share.auto.offset.reset before any consumer exists at
+         * the broker doesn't take effect; setting it after consumer
+         * creation but before subscribe does. */
+        consA = test_create_share_consumer(grpA, NULL);
+        consB = test_create_share_consumer(grpB, NULL);
+
+        test_share_set_auto_offset_reset(grpA, "earliest");
+        test_share_set_auto_offset_reset(grpB, "latest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consA, subs);
+        rd_kafka_share_subscribe(consB, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* groupA (earliest) fetches the 5 pre-existing records;
+         * groupB (latest) skips them (HW=5 anchors the start). */
+        attempts = 30;
+        while (attempts-- > 0 && countA < 5) {
+                int batch_cnt = 0;
+                test_share_consume_batch(consA, 1000, NULL, 0, &batch_cnt);
+                countA += batch_cnt;
+
+                batch_cnt = 0;
+                test_share_consume_batch(consB, 500, NULL, 0, &batch_cnt);
+                countB += batch_cnt;
+        }
+        TEST_ASSERT(countA == 5, "groupA (earliest) expected 5 records, got %d",
+                    countA);
+        TEST_ASSERT(countB == 0,
+                    "groupB (latest) expected 0 records for pre-subscribe "
+                    "produce, got %d",
+                    countB);
+
+        /* Produce 3 more records AFTER both groups have joined - both
+         * groups should see these (earliest continues from HW=5, latest
+         * advances from HW=5 too). */
+        test_produce_msgs_simple(common_producer, topic, 0, 3);
+
+        attempts = 30;
+        while (attempts-- > 0 && countB < 3) {
+                int batch_cnt = 0;
+                test_share_consume_batch(consA, 500, NULL, 0, &batch_cnt);
+                countA += batch_cnt;
+
+                batch_cnt = 0;
+                test_share_consume_batch(consB, 1000, NULL, 0, &batch_cnt);
+                countB += batch_cnt;
+        }
+        TEST_ASSERT(countA == 8, "groupA expected 8 records total, got %d",
+                    countA);
+        TEST_ASSERT(countB == 3,
+                    "groupB expected 3 records (post-subscribe only), got %d",
+                    countB);
+
+        test_share_consumer_close(consA);
+        test_share_consumer_close(consB);
+        test_share_destroy(consA);
+        test_share_destroy(consB);
+
+        rd_free(grpA);
+        rd_free(grpB);
+        rd_free(topic);
+
+        TEST_SAY("=== two-groups-earliest-vs-latest: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test that DeleteRecords advances the LSO and a new share group
+ *        with auto.offset.reset=earliest starts at the new LSO.
+ *
+ * Produce 10 records, DeleteRecords up to offset 5 (LSO -> 5), then create
+ * a new share group with earliest and verify exactly 5 records
+ * (offsets 5..9) are consumed.
+ */
+static void do_test_delete_records_advances_lso(void) {
+        char *group;
+        char *topic;
+        rd_kafka_topic_partition_list_t *offsets;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_error_t *err_obj;
+        rd_kafka_resp_err_t err;
+        int64_t first_offset = -1;
+        int consumed         = 0;
+        size_t batch_cnt     = 0;
+        int attempts;
+        size_t k;
+
+        SUB_TEST();
+
+        if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows"))
+                SUB_TEST_SKIP(
+                    "delete-records scenario not supported (broker on "
+                    "Windows)\n");
+
+        group = rd_strdup(test_mk_topic_name("share-lso-delete", 1));
+        topic = rd_strdup(test_mk_topic_name("0170-lso", 1));
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "============================================================\n");
+        TEST_SAY("=== delete-records-advances-lso ===\n");
+        TEST_SAY(
+            "============================================================\n");
+
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 30000);
+        test_produce_msgs_simple(common_producer, topic, 0, 10);
+
+        /* DeleteRecords up to offset 5: deletes offsets 0..4, LSO moves to 5 */
+        offsets = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(offsets, topic, 0)->offset = 5;
+        err = test_DeleteRecords_simple(common_admin, NULL, offsets, NULL);
+        rd_kafka_topic_partition_list_destroy(offsets);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "DeleteRecords failed: %s", rd_kafka_err2name(err));
+
+        /* New share group with earliest should start at the new LSO */
+        test_share_set_auto_offset_reset(group, "earliest");
+        rkshare = test_create_share_consumer(group, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (consumed < 5 && attempts-- > 0) {
+                batch_cnt = 0;
+                err_obj   = rd_kafka_share_consume_batch(rkshare, 2000, batch,
+                                                         &batch_cnt);
+                if (err_obj) {
+                        rd_kafka_error_destroy(err_obj);
+                        continue;
+                }
+                for (k = 0; k < batch_cnt; k++) {
+                        if (!batch[k]->err) {
+                                if (first_offset == -1)
+                                        first_offset = batch[k]->offset;
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[k]);
+                }
+        }
+        TEST_ASSERT(consumed == 5,
+                    "Expected 5 records (offsets 5..9) after DeleteRecords, "
+                    "consumed %d",
+                    consumed);
+        TEST_ASSERT(first_offset == 5,
+                    "Expected first delivered offset to be 5 (new LSO after "
+                    "DeleteRecords), got %" PRId64,
+                    first_offset);
+
+        /* Verify no additional records show up */
+        batch_cnt = 0;
+        err_obj =
+            rd_kafka_share_consume_batch(rkshare, 1000, batch, &batch_cnt);
+        if (err_obj)
+                rd_kafka_error_destroy(err_obj);
+        for (k = 0; k < batch_cnt; k++)
+                rd_kafka_message_destroy(batch[k]);
+        TEST_ASSERT(batch_cnt == 0,
+                    "Did not expect more records after consuming 5, got %zu",
+                    batch_cnt);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        rd_free(group);
+        rd_free(topic);
+
+        TEST_SAY("=== delete-records-advances-lso: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
 /* subscribe([]) is equivalent to unsubscribe — must clear the
  * subscription flag so the subsequent poll surfaces __STATE. */
 static const test_scenario_t test_poll_after_empty_subscribe = {
@@ -1706,6 +2109,16 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
 
         /* Scale tests (many topics) */
         do_test_subscribe_15_topics();
+
+        /* Subscription change drives ack callback */
+        do_test_subscription_change_acks_pending();
+
+        /* Two groups with earliest vs latest offset reset */
+        do_test_two_groups_earliest_vs_latest();
+
+        /* DeleteRecords advances LSO; new group with earliest sees fewer
+         * records (skipped on Windows brokers). */
+        do_test_delete_records_advances_lso();
 
         /* Input validation tests */
         do_test_subscribe_input_validation();

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -296,6 +296,9 @@ static int run_share_consumer_test(share_test_config_t *config) {
         int i;
         char dist_str[512] = {0};
         int pos            = 0;
+        char unique_suffix[64];
+        char unique_group[128];
+        char unique_test_name[256];
 
         /* Validate config */
         TEST_ASSERT(config->consumer_cnt > 0 &&
@@ -305,12 +308,25 @@ static int run_share_consumer_test(share_test_config_t *config) {
                     "topic_cnt must be 1-%d", MAX_TOPICS);
         TEST_ASSERT(config->group_name != NULL, "group_name is required");
 
+        /* Append a per-invocation unique suffix to the group name and
+         * displayed test name so re-runs / parallel runs on the same
+         * cluster can't collide on share-group state. */
+        rd_snprintf(unique_suffix, sizeof(unique_suffix), "rnd%" PRIx64,
+                    test_id_generate());
+        rd_snprintf(unique_group, sizeof(unique_group), "%s-%s",
+                    config->group_name, unique_suffix);
+        rd_snprintf(unique_test_name, sizeof(unique_test_name), "%s [%s]",
+                    config->test_name ? config->test_name
+                                      : "Share Consumer Test",
+                    unique_suffix);
+        config->group_name = unique_group;
+        config->test_name  = unique_test_name;
+
         /* Print test header */
         TEST_SAY("\n");
         TEST_SAY(
             "============================================================\n");
-        TEST_SAY("=== %s ===\n",
-                 config->test_name ? config->test_name : "Share Consumer Test");
+        TEST_SAY("=== %s ===\n", config->test_name);
         TEST_SAY("=== Consumers: %d, Topics: %d, Partitions: [",
                  config->consumer_cnt, config->topic_cnt);
         for (i = 0; i < config->topic_cnt; i++) {
@@ -351,7 +367,7 @@ static int run_share_consumer_test(share_test_config_t *config) {
 /**
  * @brief Single consumer, single topic, single partition
  */
-static void test_single_consumer_single_topic_single_partition(void) {
+static void do_test_single_consumer_single_topic_single_partition(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 1,
@@ -359,13 +375,15 @@ static void test_single_consumer_single_topic_single_partition(void) {
             .msgs_per_partition = 1000,
             .group_name         = "share-1c-1t-1p",
             .test_name = "Single consumer, single topic, single partition"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Single consumer, single topic, multiple partitions
  */
-static void test_single_consumer_single_topic_multiple_partitions(void) {
+static void do_test_single_consumer_single_topic_multiple_partitions(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 1,
@@ -373,13 +391,15 @@ static void test_single_consumer_single_topic_multiple_partitions(void) {
             .msgs_per_partition = 500,
             .group_name         = "share-1c-1t-3p",
             .test_name = "Single consumer, single topic, 3 partitions"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Single consumer, multiple topics, single partition each
  */
-static void test_single_consumer_multiple_topic_single_partition(void) {
+static void do_test_single_consumer_multiple_topic_single_partition(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 2,
@@ -387,13 +407,15 @@ static void test_single_consumer_multiple_topic_single_partition(void) {
             .msgs_per_partition = 500,
             .group_name         = "share-1c-2t-1p",
             .test_name = "Single consumer, 2 topics, 1 partition each"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Single consumer, multiple topics, multiple partitions
  */
-static void test_single_consumer_multiple_topic_multiple_partitions(void) {
+static void do_test_single_consumer_multiple_topic_multiple_partitions(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 3,
@@ -401,13 +423,15 @@ static void test_single_consumer_multiple_topic_multiple_partitions(void) {
             .msgs_per_partition = 500,
             .group_name         = "share-1c-3t-2p",
             .test_name = "Single consumer, 3 topics, 2 partitions each"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Multiple consumers, single topic, single partition
  */
-static void test_multiple_consumers_single_topic_single_partition(void) {
+static void do_test_multiple_consumers_single_topic_single_partition(void) {
         share_test_config_t config = {
             .consumer_cnt       = 2,
             .topic_cnt          = 1,
@@ -415,13 +439,15 @@ static void test_multiple_consumers_single_topic_single_partition(void) {
             .msgs_per_partition = 1000,
             .group_name         = "share-2c-1t-1p",
             .test_name = "2 consumers, single topic, single partition"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Multiple consumers, single topic, multiple partitions
  */
-static void test_multiple_consumers_single_topic_multiple_partitions(void) {
+static void do_test_multiple_consumers_single_topic_multiple_partitions(void) {
         share_test_config_t config = {
             .consumer_cnt       = 2,
             .topic_cnt          = 1,
@@ -429,13 +455,16 @@ static void test_multiple_consumers_single_topic_multiple_partitions(void) {
             .msgs_per_partition = 500,
             .group_name         = "share-2c-1t-4p",
             .test_name          = "2 consumers, single topic, 4 partitions"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Multiple consumers, multiple topics, multiple partitions
  */
-static void test_multiple_consumers_multiple_topics_multiple_partitions(void) {
+static void
+do_test_multiple_consumers_multiple_topics_multiple_partitions(void) {
         share_test_config_t config = {
             .consumer_cnt       = 3,
             .topic_cnt          = 2,
@@ -443,7 +472,9 @@ static void test_multiple_consumers_multiple_topics_multiple_partitions(void) {
             .msgs_per_partition = 500,
             .group_name         = "share-3c-2t-3p",
             .test_name          = "3 consumers, 2 topics, 3 partitions each"};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -453,7 +484,7 @@ static void test_multiple_consumers_multiple_topics_multiple_partitions(void) {
 /**
  * @brief High volume test with 10k messages on single partition
  */
-static void test_high_volume_10k_messages(void) {
+static void do_test_high_volume_10k_messages(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 1,
@@ -462,13 +493,15 @@ static void test_high_volume_10k_messages(void) {
             .group_name         = "share-highvol-10k",
             .test_name          = "High volume: 10k messages, 1 partition",
             .max_attempts       = 100};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief High volume test with 50k messages across 5 partitions
  */
-static void test_high_volume_50k_multi_partition(void) {
+static void do_test_high_volume_50k_multi_partition(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 1,
@@ -477,7 +510,9 @@ static void test_high_volume_50k_multi_partition(void) {
             .group_name         = "share-highvol-50k",
             .test_name          = "High volume: 50k messages, 5 partitions",
             .max_attempts       = 150};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -487,7 +522,7 @@ static void test_high_volume_50k_multi_partition(void) {
 /**
  * @brief 15 topics to trigger multiple ShareFetch responses
  */
-static void test_many_topics_15(void) {
+static void do_test_many_topics_15(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 15,
@@ -496,13 +531,15 @@ static void test_many_topics_15(void) {
             .group_name         = "share-15topics",
             .test_name          = "15 topics, 1 partition each (1500 msgs)",
             .max_attempts       = 100};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief 10 topics with 2 partitions each
  */
-static void test_many_topics_10_multi_partition(void) {
+static void do_test_many_topics_10_multi_partition(void) {
         share_test_config_t config = {
             .consumer_cnt       = 1,
             .topic_cnt          = 10,
@@ -511,7 +548,9 @@ static void test_many_topics_10_multi_partition(void) {
             .group_name         = "share-10topics-2p",
             .test_name          = "10 topics, 2 partitions each (2000 msgs)",
             .max_attempts       = 100};
+        SUB_TEST();
         run_share_consumer_test(&config);
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -521,7 +560,7 @@ static void test_many_topics_10_multi_partition(void) {
 /**
  * @brief Rapid produce/consume cycles - 20 rounds of 500 messages each
  */
-static void test_rapid_produce_consume_cycles(void) {
+static void do_test_rapid_produce_consume_cycles(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[BATCH_SIZE];
         const char *topic;
@@ -531,6 +570,8 @@ static void test_rapid_produce_consume_cycles(void) {
         const int rounds         = 20;
         const int msgs_per_round = 500;
         const int total_expected = rounds * msgs_per_round;
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== Rapid produce/consume cycles: %d rounds x %d msgs ===\n",
@@ -594,18 +635,22 @@ static void test_rapid_produce_consume_cycles(void) {
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Empty topic then produce - verify consumer handles transition
  */
-static void test_empty_then_produce(void) {
+static void do_test_empty_then_produce(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[BATCH_SIZE];
         const char *topic;
         const char *group = "share-empty-then-produce";
         rd_kafka_topic_partition_list_t *subs;
         int consumed = 0, attempts;
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== Empty topic then produce test ===\n");
@@ -667,12 +712,14 @@ static void test_empty_then_produce(void) {
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Sparse partitions - produce only to some partitions
  */
-static void test_sparse_partitions(void) {
+static void do_test_sparse_partitions(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[BATCH_SIZE];
         const char *topic;
@@ -681,6 +728,8 @@ static void test_sparse_partitions(void) {
         int consumed                 = 0, attempts;
         const int msgs_per_partition = 100;
         const int expected = 3 * msgs_per_partition; /* partitions 0,2,4 */
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -736,6 +785,8 @@ static void test_sparse_partitions(void) {
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -746,7 +797,7 @@ static void test_sparse_partitions(void) {
  * This test verifies that the callback is invoked when acks are
  * piggybacked on ShareFetch responses.
  */
-static void test_poll_callback_piggybacked_acks(void) {
+static void do_test_poll_callback_piggybacked_acks(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[BATCH_SIZE];
         const char *topic;
@@ -754,6 +805,8 @@ static void test_poll_callback_piggybacked_acks(void) {
         rd_kafka_topic_partition_list_t *subs;
         int consumed              = 0, attempts;
         test_ack_cb_state_t state = {0};
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -818,9 +871,11 @@ static void test_poll_callback_piggybacked_acks(void) {
                  state.callback_cnt, state.total_offsets);
 
         /* Cleanup */
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
         test_ack_cb_state_destroy(&state);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -860,7 +915,7 @@ static int consume_blocker_thread(void *arg) {
  *        concurrent calls from a second thread, and that ownership is
  *        released after the holder returns so a later call succeeds.
  */
-static void test_concurrent_thread_access_rejected(void) {
+static void do_test_concurrent_thread_access_rejected(void) {
         rd_kafka_share_t *consumer;
         const char *topic;
         const char *group = "share-concurrent-thread";
@@ -872,6 +927,8 @@ static void test_concurrent_thread_access_rejected(void) {
         rd_kafka_error_t *err = NULL;
         int probe_attempt;
         const int probe_max_attempts = 50; /* 50 × 100ms = 5 s budget */
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== Concurrent thread access rejected ===\n");
@@ -946,10 +1003,962 @@ static void test_concurrent_thread_access_rejected(void) {
 
         TEST_SAY("Sequential ownership transfer works after release\n");
 
-        rd_kafka_share_consumer_close(consumer);
-        rd_kafka_share_destroy(consumer);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
 
         TEST_SAY("SUCCESS: Concurrent thread access correctly rejected\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test that record headers are preserved end-to-end through the
+ *        share consumer.
+ *
+ * Produce a single record with three headers and verify the share consumer
+ * receives all of them with the correct values.
+ */
+static void do_test_headers_preserved(void) {
+        rd_kafka_share_t *consumer;
+        rd_kafka_message_t *batch[10];
+        const char *topic;
+        const char *group = "share-headers";
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        rd_kafka_headers_t *hdrs = NULL;
+        rd_kafka_resp_err_t herr;
+        const void *val;
+        size_t vsz;
+        size_t rcvd = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== Headers preserved through share consumer ===\n");
+
+        consumer = test_create_share_consumer(group, NULL);
+        topic    = test_mk_topic_name("0171-headers", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Produce a single record with three headers */
+        err = rd_kafka_producev(
+            common_producer, RD_KAFKA_V_TOPIC(topic),
+            RD_KAFKA_V_KEY("hdr-key", 7), RD_KAFKA_V_VALUE("hdr-value", 9),
+            RD_KAFKA_V_HEADER("h1", "v1", 2), RD_KAFKA_V_HEADER("h2", "v2", 2),
+            RD_KAFKA_V_HEADER("h3", "v3", 2), RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "producev failed: %s", rd_kafka_err2name(err));
+        rd_kafka_flush(common_producer, 10 * 1000);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (rcvd < 1 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                rd_kafka_error_t *e;
+
+                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
+                                                 &batch_rcvd);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                rcvd += batch_rcvd;
+        }
+        TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
+
+        herr = rd_kafka_message_headers(batch[0], &hdrs);
+        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && hdrs,
+                    "Failed to get headers: %s", rd_kafka_err2name(herr));
+
+        herr = rd_kafka_header_get_last(hdrs, "h1", &val, &vsz);
+        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR, "h1 not present: %s",
+                    rd_kafka_err2name(herr));
+        TEST_ASSERT(vsz == 2 && memcmp(val, "v1", 2) == 0, "h1 value mismatch");
+
+        herr = rd_kafka_header_get_last(hdrs, "h2", &val, &vsz);
+        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR, "h2 not present: %s",
+                    rd_kafka_err2name(herr));
+        TEST_ASSERT(vsz == 2 && memcmp(val, "v2", 2) == 0, "h2 value mismatch");
+
+        herr = rd_kafka_header_get_last(hdrs, "h3", &val, &vsz);
+        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR, "h3 not present: %s",
+                    rd_kafka_err2name(herr));
+        TEST_ASSERT(vsz == 2 && memcmp(val, "v3", 2) == 0, "h3 value mismatch");
+
+        rd_kafka_message_destroy(batch[0]);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        TEST_SAY("SUCCESS: Headers preserved through share consumer\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test that a share consumer with a small session-level fetch.max.bytes
+ *       receives records one by one per fetch.
+ *
+ *   - With fetch.max.bytes=1500 and 1000-byte records each in their own
+ *     RecordBatch (custom producer, batch.num.messages=1), every
+ *     ShareFetch response can hold at most one record.
+ *   - All 100 records are received (consumer correctly loops across
+ *     multiple ShareFetch RPCs).
+ *   - Every non-empty consume_batch returns exactly one record (one batch
+ *     per ShareFetch response, due to the cap).
+ */
+static void do_test_fetch_max_bytes_small(void) {
+        const char *group = "share-small-fetch";
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_conf_t *prod_conf;
+        rd_kafka_t *prod;
+        rd_kafka_topic_partition_list_t *subs;
+        char errstr[512];
+        const int msgcnt  = 10;
+        const int msgsize = 1000;
+        int consumed      = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "=== Small session-level fetch.max.bytes (1500) with 1000-byte "
+            "msgs ===\n");
+
+        topic = test_mk_topic_name("0171-small-fetch", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Custom producer that emits one RecordBatch per message so the
+         * broker has many small batches to choose from when responding to
+         * ShareFetch */
+        test_conf_init(&prod_conf, NULL, 60);
+        rd_kafka_conf_set_dr_msg_cb(prod_conf, test_dr_msg_cb);
+        rd_kafka_conf_set(prod_conf, "linger.ms", "0", errstr, sizeof(errstr));
+        rd_kafka_conf_set(prod_conf, "batch.num.messages", "1", errstr,
+                          sizeof(errstr));
+        prod = test_create_handle(RD_KAFKA_PRODUCER, prod_conf);
+
+        test_produce_msgs2(prod, topic, 0, 0, 0, msgcnt, NULL, msgsize);
+        rd_kafka_flush(prod, 30 * 1000);
+        rd_kafka_destroy(prod);
+
+        /* Create share consumer with a small session-level fetch cap.
+         * fetch.max.bytes must be >= message.max.bytes per librdkafka
+         * config validation, so lower both to 1500. */
+        test_conf_init(&conf, NULL, 60);
+        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "message.max.bytes", "1500", errstr,
+                          sizeof(errstr));
+        rd_kafka_conf_set(conf, "fetch.max.bytes", "1500", errstr,
+                          sizeof(errstr));
+
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create share consumer: %s", errstr);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* All 100 records must arrive one by one per fetch */
+        attempts = 30;
+        while (consumed < msgcnt && attempts-- > 0) {
+                int batch_cnt = 0;
+                test_share_consume_batch(consumer, 2000, NULL, 0, &batch_cnt);
+                consumed += batch_cnt;
+                if (batch_cnt > 0) {
+                        TEST_ASSERT(batch_cnt == 1,
+                                    "Expected 1 record per batch with small "
+                                    "fetch.max.bytes, "
+                                    "got %d",
+                                    batch_cnt);
+                }
+        }
+
+        TEST_ASSERT(consumed == msgcnt,
+                    "Expected %d records with small fetch.max.bytes, "
+                    "consumed %d",
+                    msgcnt, consumed);
+
+        TEST_SAY("SUCCESS: small fetch.max.bytes - consumed %d records\n",
+                 consumed);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Verify the share consumer receives records that individually
+ *        exceed fetch.max.bytes, the broker doesnt stall consumption.
+ *
+ * What is tested:
+ *   - Produce a mix of 10 KB and 500 KB records on a topic.
+ *   - Configure the consumer with fetch.max.bytes=1500 — well below every
+ *     record's on-wire size.
+ *   - All records must still arrive. The broker is required to return the
+ *     first batch in a non-empty partition even when it exceeds the cap
+ *     to guarantee consumer progress; the client side must accept these
+ *     oversized responses.
+ */
+static void do_test_record_larger_than_fetch_max_bytes(void) {
+        const char *group = "share-large-record";
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_topic_partition_list_t *subs;
+        char errstr[512];
+        const int MAX_BYTES = 100000;
+        const int small_cnt = 5;
+        const int large_cnt = 2;
+        const int total     = small_cnt + large_cnt;
+        int consumed        = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== Records larger than fetch.message.max.bytes (%d) ===\n",
+                 MAX_BYTES);
+
+        topic = test_mk_topic_name("0171-large-record", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Produce small messages then large ones */
+        test_produce_msgs2(common_producer, topic, 0, 0, 0, small_cnt, NULL,
+                           MAX_BYTES / 10);
+        test_produce_msgs2(common_producer, topic, 0, 0, small_cnt, large_cnt,
+                           NULL, MAX_BYTES * 5);
+        rd_kafka_flush(common_producer, 60 * 1000);
+
+        test_conf_init(&conf, NULL, 60);
+        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
+
+        char val[32];
+        rd_snprintf(val, sizeof(val), "%d", MAX_BYTES);
+        rd_kafka_conf_set(conf, "message.max.bytes", "1500", errstr,
+                          sizeof(errstr));
+        rd_kafka_conf_set(conf, "fetch.max.bytes", "1500", errstr,
+                          sizeof(errstr));
+
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create share consumer: %s", errstr);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (consumed < total && attempts-- > 0) {
+                int batch_cnt = 0;
+                test_share_consume_batch(consumer, 3000, NULL, 0, &batch_cnt);
+                consumed += batch_cnt;
+                if (batch_cnt > 0)
+                        TEST_SAY("Progress: %d/%d\n", consumed, total);
+        }
+
+        TEST_ASSERT(consumed == total,
+                    "Expected %d records (incl. oversized), consumed %d", total,
+                    consumed);
+
+        TEST_SAY("SUCCESS: oversized record - consumed %d records\n", consumed);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test that records held by a consumer that closes mid-flight
+ *        are released back to other consumers in the group.
+ *
+ * Create 4 share consumers in the same group, produce a known set of
+ * records, have consumer 0 fetch a batch without acknowledging and then
+ * close. The other consumers should eventually receive every record
+ * (including the ones released by consumer 0).
+ */
+static void do_test_consumer_close_releases_to_group(void) {
+        const char *group = "share-close-releases";
+        const char *topic;
+        rd_kafka_share_t *consumers[4];
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        const int total_msgs = 200;
+        int c0_fetched       = 0;
+        int total_consumed   = 0;
+        int per_consumer[4]  = {0};
+        int attempts;
+        int i;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "=== Failing consumer releases unacked records to group ===\n");
+
+        topic = test_mk_topic_name("0171-close-release", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, total_msgs);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        for (i = 0; i < 4; i++)
+                consumers[i] = test_create_share_consumer(group, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        for (i = 0; i < 4; i++)
+                rd_kafka_share_subscribe(consumers[i], subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consumer 0 fetches a batch WITHOUT acknowledging, then closes. */
+        attempts = 30;
+        while (c0_fetched == 0 && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err = rd_kafka_share_consume_batch(consumers[0], 2000, batch,
+                                                   &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err)
+                                c0_fetched++;
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+        TEST_ASSERT(c0_fetched > 0,
+                    "Consumer 0 should have fetched some records, got %d",
+                    c0_fetched);
+
+        TEST_SAY("Consumer 0 fetched %d records (unacked), closing now\n",
+                 c0_fetched);
+        /* Close without acknowledging - records should be released */
+        test_share_consumer_close(consumers[0]);
+        test_share_destroy(consumers[0]);
+        consumers[0] = NULL;
+
+        /* Drain the rest with consumers 1..3 */
+        attempts = 200;
+        while (total_consumed < total_msgs && attempts-- > 0) {
+                for (i = 1; i < 4; i++) {
+                        size_t rcvd = 0;
+                        size_t m;
+                        rd_kafka_error_t *err;
+
+                        err = rd_kafka_share_consume_batch(consumers[i], 1000,
+                                                           batch, &rcvd);
+                        if (err) {
+                                rd_kafka_error_destroy(err);
+                                continue;
+                        }
+
+                        for (m = 0; m < rcvd; m++) {
+                                if (!batch[m]->err) {
+                                        per_consumer[i]++;
+                                        total_consumed++;
+                                }
+                                rd_kafka_message_destroy(batch[m]);
+                        }
+                }
+        }
+
+        TEST_SAY(
+            "Distribution: c0=%d (lost on close), c1=%d, c2=%d, c3=%d "
+            "(total %d)\n",
+            c0_fetched, per_consumer[1], per_consumer[2], per_consumer[3],
+            total_consumed);
+
+        TEST_ASSERT(total_consumed == total_msgs,
+                    "Expected exactly %d records on the survivors after "
+                    "consumer 0's records were released, got %d",
+                    total_msgs, total_consumed);
+
+        for (i = 1; i < 4; i++) {
+                test_share_consumer_close(consumers[i]);
+                test_share_destroy(consumers[i]);
+        }
+
+        TEST_SAY("SUCCESS: closed consumer's records redelivered to group\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Partition count increased during consume.
+ *
+ * 1 consumer, topic starts with 2 partitions, grown to 5.
+ * Produce N records to {0,1} -> consume -> grow to 5 -> produce N to
+ * {2,3,4} -> continue consuming -> expect 5*N total.
+ */
+static void do_test_partition_increase_during_consume(void) {
+        const char *group = "share-partition-increase";
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_conf_t *prod_conf;
+        rd_kafka_t *producer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        const int msgs_per_partition = 200;
+        const int initial_partitions = 2;
+        const int grown_partitions   = 5;
+        const int initial_expected   = initial_partitions * msgs_per_partition;
+        const int total_expected     = grown_partitions * msgs_per_partition;
+        int consumed                 = 0;
+        int attempts;
+        int p;
+        rd_kafka_resp_err_t cp_err;
+        char errstr[512];
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== Partition count increase during consume (%d -> %d) ===\n",
+                 initial_partitions, grown_partitions);
+
+        topic = test_mk_topic_name("0171-partition-increase", 1);
+        test_create_topic_wait_exists(NULL, topic, initial_partitions, -1,
+                                      60 * 1000);
+
+        /* Custom producer with a short metadata refresh interval so its
+         * cache picks up the post-CreatePartitions partition count on its
+         * own — avoids the explicit test_wait_metadata_update probe. */
+        test_conf_init(&prod_conf, NULL, 60);
+        rd_kafka_conf_set_dr_msg_cb(prod_conf, test_dr_msg_cb);
+        rd_kafka_conf_set(prod_conf, "topic.metadata.refresh.interval.ms",
+                          "500", errstr, sizeof(errstr));
+        producer = test_create_handle(RD_KAFKA_PRODUCER, prod_conf);
+
+        /* Produce to initial partitions only */
+        for (p = 0; p < initial_partitions; p++)
+                test_produce_msgs_simple(producer, topic, p,
+                                         msgs_per_partition);
+
+        /* Lower the consumer's metadata refresh interval (default 5 min) so
+         * it picks up the new partition count quickly without a long
+         * hardcoded sleep below. */
+        test_conf_init(&conf, NULL, 60);
+        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "topic.metadata.refresh.interval.ms", "500",
+                          errstr, sizeof(errstr));
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create share consumer: %s", errstr);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Consume from the initial partitions */
+        attempts = 100;
+        while (consumed < initial_expected && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err =
+                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+        TEST_SAY("Pre-grow consumed: %d/%d\n", consumed, initial_expected);
+        TEST_ASSERT(consumed == initial_expected,
+                    "Expected >= %d msgs from initial partitions, got %d",
+                    initial_expected, consumed);
+
+        /* Grow topic partitions from 2 -> 5 */
+        TEST_SAY("Growing partitions to %d via CreatePartitions\n",
+                 grown_partitions);
+        cp_err = test_CreatePartitions_simple(common_admin, NULL, topic,
+                                              grown_partitions, NULL);
+        TEST_ASSERT(!cp_err, "CreatePartitions failed: %s",
+                    rd_kafka_err2str(cp_err));
+
+        /* Both producer and consumer have topic.metadata.refresh.interval
+         * .ms=500, so their local metadata caches pick up the new partition
+         * count within ~500 ms via the background refresh. One second is
+         * plenty for both: the producer can route to the new partitions,
+         * and the consumer can be assigned them on the next
+         * ShareGroupHeartbeat cycle. */
+        rd_sleep(1);
+
+        /* Produce to the newly added partitions */
+        for (p = initial_partitions; p < grown_partitions; p++)
+                test_produce_msgs_simple(producer, topic, p,
+                                         msgs_per_partition);
+
+        /* Continue consuming, expecting records from new partitions */
+        attempts = 200;
+        while (consumed < total_expected && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err =
+                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+
+        TEST_ASSERT(consumed == total_expected,
+                    "Expected exactly %d total records after partition grow, "
+                    "got %d",
+                    total_expected, consumed);
+
+        TEST_SAY("SUCCESS: partition count grow %d->%d, consumed %d records\n",
+                 initial_partitions, grown_partitions, consumed);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Zero-byte payload and zero-byte key.
+ *
+ * Verifies that the share consumer correctly preserves zero-length
+ * key/value buffers (len == 0, pointer non-NULL) and NULL key/value.
+ */
+static void do_test_zero_byte_payload_and_key(void) {
+        const char *group = "share-zero-byte";
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[16];
+        rd_kafka_resp_err_t err;
+        size_t rcvd = 0;
+        int attempts;
+        int saw_empty_kv   = 0;
+        int saw_key_only   = 0;
+        int saw_value_only = 0;
+        int saw_null_kv    = 0;
+        size_t i;
+        rd_bool_t key_null;
+        rd_bool_t key_empty;
+        rd_bool_t val_null;
+        rd_bool_t val_empty;
+        rd_bool_t key_is_empty_or_null;
+        rd_bool_t val_is_empty_or_null;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== Zero-byte payload and key ===\n");
+
+        consumer = test_create_share_consumer(group, NULL);
+        topic    = test_mk_topic_name("0171-zero-byte", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Empty key, empty value (zero-length, non-NULL pointers) */
+        err = rd_kafka_producev(common_producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_KEY("", 0), RD_KAFKA_V_VALUE("", 0),
+                                RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "produce empty kv failed: %s",
+                    rd_kafka_err2name(err));
+
+        /* Non-empty key, empty value */
+        err = rd_kafka_producev(common_producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_KEY("k", 1), RD_KAFKA_V_VALUE("", 0),
+                                RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "produce key-only failed: %s",
+                    rd_kafka_err2name(err));
+
+        /* Empty key, non-empty value */
+        err = rd_kafka_producev(common_producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_KEY("", 0), RD_KAFKA_V_VALUE("v", 1),
+                                RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "produce value-only failed: %s",
+                    rd_kafka_err2name(err));
+
+        /* NULL key, NULL value */
+        err = rd_kafka_producev(common_producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_KEY(NULL, 0),
+                                RD_KAFKA_V_VALUE(NULL, 0), RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "produce null kv failed: %s", rd_kafka_err2name(err));
+
+        rd_kafka_flush(common_producer, 10 * 1000);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (rcvd < 4 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                rd_kafka_error_t *e;
+
+                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
+                                                 &batch_rcvd);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                rcvd += batch_rcvd;
+        }
+
+        TEST_ASSERT(rcvd == 4, "Expected 4 records, got %zu", rcvd);
+
+        for (i = 0; i < rcvd; i++) {
+                key_null  = batch[i]->key == NULL;
+                key_empty = batch[i]->key_len == 0 && !key_null;
+                val_null  = batch[i]->payload == NULL;
+                val_empty = batch[i]->len == 0 && !val_null;
+
+                /* Brokers may normalize empty buffers to NULL; accept either.
+                 */
+                key_is_empty_or_null = key_null || key_empty;
+                val_is_empty_or_null = val_null || val_empty;
+
+                if (key_is_empty_or_null && val_is_empty_or_null) {
+                        /* Could be "empty kv" or "null kv" record - count both
+                         * as the "no content" class. */
+                        if (key_null && val_null)
+                                saw_null_kv++;
+                        else
+                                saw_empty_kv++;
+                } else if (!key_is_empty_or_null && val_is_empty_or_null) {
+                        TEST_ASSERT(batch[i]->key_len == 1 &&
+                                        memcmp(batch[i]->key, "k", 1) == 0,
+                                    "key-only record: key mismatch");
+                        saw_key_only++;
+                } else if (key_is_empty_or_null && !val_is_empty_or_null) {
+                        TEST_ASSERT(batch[i]->len == 1 &&
+                                        memcmp(batch[i]->payload, "v", 1) == 0,
+                                    "value-only record: value mismatch");
+                        saw_value_only++;
+                }
+
+                rd_kafka_message_destroy(batch[i]);
+        }
+
+        TEST_SAY("Counts: empty_kv=%d null_kv=%d key_only=%d value_only=%d\n",
+                 saw_empty_kv, saw_null_kv, saw_key_only, saw_value_only);
+
+        TEST_ASSERT(saw_empty_kv + saw_null_kv == 2,
+                    "Expected 2 'no content' records, got %d",
+                    saw_empty_kv + saw_null_kv);
+        TEST_ASSERT(saw_key_only == 1, "Expected 1 key-only record, got %d",
+                    saw_key_only);
+        TEST_ASSERT(saw_value_only == 1, "Expected 1 value-only record, got %d",
+                    saw_value_only);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        TEST_SAY("SUCCESS: zero-byte payload/key preserved\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Consume + ack a round of messages produced with the given
+ *        compression codec.
+ */
+static void do_test_compression_codec(const char *codec) {
+        const char *group_prefix = "share-codec-";
+        char group[128];
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *producer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        const int msg_cnt = 200;
+        const int msg_sz  = 256;
+        int consumed      = 0;
+        int attempts;
+
+        TEST_SAY("\n");
+        TEST_SAY("=== Compression codec: %s ===\n", codec);
+
+        rd_snprintf(group, sizeof(group), "%s%s", group_prefix, codec);
+        topic = test_mk_topic_name(codec, 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Producer configured with the requested compression codec.
+         * test_produce_msgs2 → test_wait_delivery uses a counter that's
+         * decremented inside test_dr_msg_cb, so the dr callback must
+         * be wired up explicitly when we create our own producer (only
+         * test_create_producer() sets it for us). */
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "compression.type", codec);
+        rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
+        producer = test_create_handle(RD_KAFKA_PRODUCER, conf);
+
+        test_produce_msgs2(producer, topic, 0, 0, 0, msg_cnt, NULL, msg_sz);
+        rd_kafka_flush(producer, 30 * 1000);
+        rd_kafka_destroy(producer);
+
+        consumer = test_create_share_consumer(group, NULL);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 100;
+        while (consumed < msg_cnt && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err =
+                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err) {
+                                TEST_ASSERT(batch[m]->len == (size_t)msg_sz,
+                                            "[%s] msg size %zu != expected %d",
+                                            codec, batch[m]->len, msg_sz);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+
+        TEST_ASSERT(consumed == msg_cnt,
+                    "[%s] expected %d records, consumed %d", codec, msg_cnt,
+                    consumed);
+
+        TEST_SAY("SUCCESS: codec %s - consumed %d records\n", codec, consumed);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+}
+
+
+/**
+ * @brief Run consume+ack roundtrip for every supported producer
+ *        compression codec.
+ */
+static void do_test_all_compression_codecs(void) {
+        SUB_TEST();
+        do_test_compression_codec("none");
+        do_test_compression_codec("gzip");
+        do_test_compression_codec("snappy");
+        do_test_compression_codec("lz4");
+        do_test_compression_codec("zstd");
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Records with 100 headers and one very large header value.
+ *
+ * Verifies the share consumer preserves a large header count and large
+ * per-header value sizes end-to-end.
+ */
+static void do_test_many_and_large_headers(void) {
+        const char *group = "share-many-headers";
+        const char *topic;
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[8];
+        rd_kafka_resp_err_t err;
+        const int hdr_cnt         = 100;
+        const size_t big_hdr_size = 64 * 1024;
+        char *big_hdr_value;
+        size_t rcvd = 0;
+        int attempts;
+        size_t i;
+        rd_bool_t verified_many = rd_false;
+        rd_bool_t verified_big  = rd_false;
+        rd_kafka_headers_t *hdrs;
+        char name[32];
+        char value[32];
+        rd_kafka_headers_t *msg_hdrs = NULL;
+        rd_kafka_resp_err_t herr;
+        size_t n;
+        size_t j;
+        char expected[32];
+        const void *val;
+        size_t vsz;
+        size_t k;
+        const char *bytes;
+        char expected_byte;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "=== Many headers (%d) and one large header value (%zu B) ===\n",
+            hdr_cnt, big_hdr_size);
+
+        consumer = test_create_share_consumer(group, NULL);
+        topic    = test_mk_topic_name("0171-many-headers", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        /* Build the producev arg list for a record with `hdr_cnt` headers.
+         * Each header name is "h-<i>" and each value is "v-<i>". */
+        hdrs = rd_kafka_headers_new(hdr_cnt);
+        for (i = 0; i < (size_t)hdr_cnt; i++) {
+                rd_snprintf(name, sizeof(name), "h-%zu", i);
+                rd_snprintf(value, sizeof(value), "v-%zu", i);
+                rd_kafka_header_add(hdrs, name, -1, value, -1);
+        }
+
+        err = rd_kafka_producev(common_producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_KEY("many", 4),
+                                RD_KAFKA_V_VALUE("many-payload", 12),
+                                RD_KAFKA_V_HEADERS(hdrs), RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "producev many headers failed: %s",
+                    rd_kafka_err2name(err));
+
+        /* Record with one very large header value. */
+        big_hdr_value = rd_malloc(big_hdr_size);
+        for (i = 0; i < big_hdr_size; i++)
+                big_hdr_value[i] = (char)('A' + (i % 26));
+
+        err = rd_kafka_producev(
+            common_producer, RD_KAFKA_V_TOPIC(topic), RD_KAFKA_V_KEY("big", 3),
+            RD_KAFKA_V_VALUE("big-payload", 11),
+            RD_KAFKA_V_HEADER("big-hdr", big_hdr_value, big_hdr_size),
+            RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "producev big header failed: %s",
+                    rd_kafka_err2name(err));
+        rd_free(big_hdr_value);
+
+        rd_kafka_flush(common_producer, 30 * 1000);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (rcvd < 2 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                rd_kafka_error_t *e;
+
+                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
+                                                 &batch_rcvd);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                rcvd += batch_rcvd;
+        }
+
+        TEST_ASSERT(rcvd == 2, "Expected 2 records, got %zu", rcvd);
+
+        for (i = 0; i < rcvd; i++) {
+                msg_hdrs = NULL;
+                herr     = rd_kafka_message_headers(batch[i], &msg_hdrs);
+                TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && msg_hdrs,
+                            "headers not available: %s",
+                            rd_kafka_err2name(herr));
+
+                if (batch[i]->key_len == 4 &&
+                    memcmp(batch[i]->key, "many", 4) == 0) {
+                        n = rd_kafka_header_cnt(msg_hdrs);
+
+                        TEST_ASSERT(n == (size_t)hdr_cnt,
+                                    "many-headers record: expected %d "
+                                    "headers, got %zu",
+                                    hdr_cnt, n);
+
+                        /* Verify every header name+value present. */
+                        for (j = 0; j < (size_t)hdr_cnt; j++) {
+                                rd_snprintf(name, sizeof(name), "h-%zu", j);
+                                rd_snprintf(expected, sizeof(expected), "v-%zu",
+                                            j);
+                                herr = rd_kafka_header_get_last(msg_hdrs, name,
+                                                                &val, &vsz);
+                                TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "%s missing: %s", name,
+                                            rd_kafka_err2name(herr));
+                                TEST_ASSERT(vsz == strlen(expected) &&
+                                                memcmp(val, expected, vsz) == 0,
+                                            "%s value mismatch", name);
+                        }
+                        verified_many = rd_true;
+                } else if (batch[i]->key_len == 3 &&
+                           memcmp(batch[i]->key, "big", 3) == 0) {
+                        herr = rd_kafka_header_get_last(msg_hdrs, "big-hdr",
+                                                        &val, &vsz);
+                        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                    "big-hdr missing: %s",
+                                    rd_kafka_err2name(herr));
+                        TEST_ASSERT(vsz == big_hdr_size,
+                                    "big-hdr size mismatch: expected %zu, "
+                                    "got %zu",
+                                    big_hdr_size, vsz);
+
+                        /* Spot-check the content pattern at a few offsets. */
+                        bytes = (const char *)val;
+                        for (k = 0; k < vsz; k += vsz / 16) {
+                                expected_byte = (char)('A' + (k % 26));
+                                TEST_ASSERT(bytes[k] == expected_byte,
+                                            "big-hdr byte %zu: expected %c, "
+                                            "got %c",
+                                            k, expected_byte, bytes[k]);
+                        }
+                        verified_big = rd_true;
+                }
+
+                rd_kafka_message_destroy(batch[i]);
+        }
+
+        TEST_ASSERT(verified_many, "many-headers record was not verified");
+        TEST_ASSERT(verified_big, "big-header record was not verified");
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        TEST_SAY("SUCCESS: many headers + large header value preserved\n");
+
+        SUB_TEST_PASS();
 }
 
 
@@ -958,27 +1967,27 @@ int main_0171_share_consumer_consume(int argc, char **argv) {
         common_producer = test_create_producer();
         common_admin    = test_create_producer();
 
-        test_timeout_set(200);
+        test_timeout_set(600);
 
         /* Single-consumer tests */
-        test_single_consumer_single_topic_single_partition();      /* Single
+        do_test_single_consumer_single_topic_single_partition();      /* Single
                                                                       consumer,
                                                                       single topic,
                                                                       single
                                                                       partition */
-        test_single_consumer_single_topic_multiple_partitions();   /* Single
+        do_test_single_consumer_single_topic_multiple_partitions();   /* Single
                                                                       consumer,
                                                                       single
                                                                       topic, multi
                                                                       partitions
                                                                     */
-        test_single_consumer_multiple_topic_single_partition();    /* Single
+        do_test_single_consumer_multiple_topic_single_partition();    /* Single
                                                                       consumer,
                                                                       multi topic,
                                                                       single
                                                                       partition
                                                                       each */
-        test_single_consumer_multiple_topic_multiple_partitions(); /* Single
+        do_test_single_consumer_multiple_topic_multiple_partitions(); /* Single
                                                                       consumer,
                                                                       multi
                                                                       topics,
@@ -987,42 +1996,58 @@ int main_0171_share_consumer_consume(int argc, char **argv) {
                                                                       each */
 
         /* Multi-consumer tests */
-        test_multiple_consumers_single_topic_single_partition();       /* Multi
-                                                                          consumer
-                                                                          sharing
-                                                                          single
-                                                                          partition */
-        test_multiple_consumers_single_topic_multiple_partitions();    /* Multi
-                                                                          consumer,
-                                                                          multi
-                                                                          partition
-                                                                        */
-        test_multiple_consumers_multiple_topics_multiple_partitions(); /* Full
+        do_test_multiple_consumers_single_topic_single_partition();    /* Multi
+                                                                       consumer
+                                                                       sharing
+                                                                       single
+                                                                       partition */
+        do_test_multiple_consumers_single_topic_multiple_partitions(); /* Multi
+                                                                       consumer,
+                                                                       multi
+                                                                       partition
+                                                                     */
+        do_test_multiple_consumers_multiple_topics_multiple_partitions(); /* Full
                                                                           matrix:
                                                                           multi
                                                                           everything
                                                                         */
 
         /* High volume tests */
-        test_high_volume_10k_messages();
-        test_high_volume_50k_multi_partition();
+        do_test_high_volume_10k_messages();
+        do_test_high_volume_50k_multi_partition();
 
         /* Multi-topic tests (triggers multiple fetch responses) */
-        test_many_topics_15();
-        test_many_topics_10_multi_partition();
+        do_test_many_topics_15();
+        do_test_many_topics_10_multi_partition();
 
         /* Rapid produce/consume tests */
-        test_rapid_produce_consume_cycles();
+        do_test_rapid_produce_consume_cycles();
 
         /* Edge case tests */
-        test_empty_then_produce();
-        test_sparse_partitions();
+        do_test_empty_then_produce();
+        do_test_sparse_partitions();
 
         /* Callback tests */
-        test_poll_callback_piggybacked_acks();
+        do_test_poll_callback_piggybacked_acks();
 
         /* Concurrency tests */
-        test_concurrent_thread_access_rejected();
+        do_test_concurrent_thread_access_rejected();
+
+        /* Headers and fetch byte-limit tests */
+        do_test_headers_preserved();
+        do_test_fetch_max_bytes_small();
+        do_test_record_larger_than_fetch_max_bytes();
+
+        /* Failing consumer releases to group */
+        do_test_consumer_close_releases_to_group();
+
+        /* Topology change: grow partitions while consuming */
+        do_test_partition_increase_during_consume();
+
+        /* Payload edge cases */
+        do_test_zero_byte_payload_and_key();
+        do_test_all_compression_codecs();
+        do_test_many_and_large_headers();
 
 
         /* Cleanup common handles */

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -85,7 +85,7 @@ typedef struct {
         int msgs_produced;
         int msgs_consumed;
         int msgs_redelivered;
-        char group_name[128];
+        char group_name[300];
         /* Random mode counters */
         int msgs_accepted;
         int msgs_rejected;
@@ -557,6 +557,17 @@ static int run_ack_test(ack_test_config_t *config) {
         ack_test_state_t state = {0};
         int i;
         int list_capacity;
+        char unique_suffix[64];
+        char unique_test_name[256];
+
+        /* Append a per-invocation unique suffix to the test name; the
+         * group name is derived from it below, so this guarantees a
+         * fresh share-group on the broker for each run. */
+        rd_snprintf(unique_suffix, sizeof(unique_suffix), "rnd%" PRIx64,
+                    test_id_generate());
+        rd_snprintf(unique_test_name, sizeof(unique_test_name), "%s-%s",
+                    config->test_name, unique_suffix);
+        config->test_name = unique_test_name;
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -600,7 +611,7 @@ static int run_ack_test(ack_test_config_t *config) {
 /**
  * @brief RELEASE causes redelivery
  */
-static void test_release_redelivery(void) {
+static void do_test_release_redelivery(void) {
         ack_test_config_t config = {
             .test_name          = "release-redelivery",
             .topic_cnt          = 1,
@@ -608,13 +619,15 @@ static void test_release_redelivery(void) {
             .msgs_per_partition = 5,
             .consumer_cnt       = 1,
             .single_ack_type    = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief REJECT prevents redelivery
  */
-static void test_reject_no_redelivery(void) {
+static void do_test_reject_no_redelivery(void) {
         ack_test_config_t config = {.test_name  = "reject-no-redelivery",
                                     .topic_cnt  = 1,
                                     .partitions = {1},
@@ -622,13 +635,15 @@ static void test_reject_no_redelivery(void) {
                                     .consumer_cnt       = 1,
                                     .single_ack_type =
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief ACCEPT prevents redelivery
  */
-static void test_accept_no_redelivery(void) {
+static void do_test_accept_no_redelivery(void) {
         ack_test_config_t config = {.test_name  = "accept-no-redelivery",
                                     .topic_cnt  = 1,
                                     .partitions = {1},
@@ -636,7 +651,9 @@ static void test_accept_no_redelivery(void) {
                                     .consumer_cnt       = 1,
                                     .single_ack_type =
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 
@@ -647,10 +664,12 @@ static void test_accept_no_redelivery(void) {
 /**
  * @brief Acknowledge with NULL message
  */
-static void test_ack_null_message(void) {
+static void do_test_ack_null_message(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_resp_err_t err;
         const char *group = "share-null-msg-test";
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_null_message ===\n");
@@ -670,14 +689,18 @@ static void test_ack_null_message(void) {
         test_share_destroy(rkshare);
 
         TEST_SAY("=== test_ack_null_message: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Acknowledge with NULL rkshare
  */
-static void test_ack_null_rkshare(void) {
+static void do_test_ack_null_rkshare(void) {
         rd_kafka_resp_err_t err;
         rd_kafka_message_t fake_msg = {0};
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_null_rkshare ===\n");
@@ -699,12 +722,14 @@ static void test_ack_null_rkshare(void) {
                     rd_kafka_err2str(err));
 
         TEST_SAY("=== test_ack_null_rkshare: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Acknowledge with invalid type
  */
-static void test_ack_invalid_type(void) {
+static void do_test_ack_invalid_type(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_message_t *batch[10];
         rd_kafka_error_t *err;
@@ -714,6 +739,9 @@ static void test_ack_invalid_type(void) {
         const char *topic;
         size_t rcvd = 0;
         int attempts;
+
+        SUB_TEST();
+
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_invalid_type ===\n");
 
@@ -761,12 +789,14 @@ static void test_ack_invalid_type(void) {
         test_share_destroy(rkshare);
 
         TEST_SAY("=== test_ack_invalid_type: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief RELEASE then REJECT - final type is REJECT (no redelivery)
  */
-static void test_release_then_reject_no_redelivery(void) {
+static void do_test_release_then_reject_no_redelivery(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_message_t *batch[100];
         rd_kafka_error_t *err;
@@ -778,6 +808,9 @@ static void test_release_then_reject_no_redelivery(void) {
         size_t m;
         int attempts;
         int redelivered = 0;
+
+        SUB_TEST();
+
         TEST_SAY("\n");
         TEST_SAY("=== test_release_then_reject_no_redelivery ===\n");
 
@@ -858,6 +891,8 @@ static void test_release_then_reject_no_redelivery(void) {
         test_share_destroy(rkshare);
 
         TEST_SAY("=== test_release_then_reject_no_redelivery: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 
@@ -867,7 +902,7 @@ static void test_release_then_reject_no_redelivery(void) {
  *
  * Verifies that acknowledgement type can be changed before commit completes.
  */
-static void test_change_ack_type_before_commit(void) {
+static void do_test_change_ack_type_before_commit(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_message_t *batch[10];
         rd_kafka_error_t *err;
@@ -878,6 +913,8 @@ static void test_change_ack_type_before_commit(void) {
         size_t rcvd = 0;
         int attempts;
         test_ack_cb_state_t state = {0};
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== test_change_ack_type_before_commit ===\n");
@@ -979,6 +1016,8 @@ static void test_change_ack_type_before_commit(void) {
         test_ack_cb_state_destroy(&state);
 
         TEST_SAY("=== test_change_ack_type_before_commit: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 /**
@@ -987,7 +1026,7 @@ static void test_change_ack_type_before_commit(void) {
  * After commit completes, acknowledged messages are removed from
  * inflight_acks map. Attempting to acknowledge again should fail with _STATE.
  */
-static void test_ack_after_commit(void) {
+static void do_test_ack_after_commit(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_message_t *batch[10];
         rd_kafka_error_t *err;
@@ -1001,6 +1040,8 @@ static void test_ack_after_commit(void) {
         int32_t saved_partition   = -1;
         int64_t saved_offset      = -1;
         test_ack_cb_state_t state = {0};
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY("=== test_ack_after_commit ===\n");
@@ -1076,6 +1117,8 @@ static void test_ack_after_commit(void) {
         test_ack_cb_state_destroy(&state);
 
         TEST_SAY("=== test_ack_after_commit: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -1088,7 +1131,7 @@ static void test_ack_after_commit(void) {
  * Default share.record.lock.partition.limit is 5. After 5 RELEASE attempts,
  * the broker should not attempt any redelivery.
  */
-static void test_max_delivery_attempts(void) {
+static void do_test_max_delivery_attempts(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_message_t *batch[100];
         rd_kafka_error_t *err;
@@ -1099,6 +1142,9 @@ static void test_max_delivery_attempts(void) {
         int delivery_attempt;
         int attempts;
         const int max_deliveries = 5;
+
+        SUB_TEST();
+
         TEST_SAY("\n");
         TEST_SAY("=== test_max_delivery_attempts ===\n");
         TEST_SAY(
@@ -1189,6 +1235,8 @@ static void test_max_delivery_attempts(void) {
         test_share_destroy(rkshare);
 
         TEST_SAY("=== test_max_delivery_attempts: PASSED ===\n");
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1206,14 +1254,16 @@ static void test_max_delivery_attempts(void) {
  * 5000 messages on 1 topic with 1 partition.
  * Random ACCEPT/REJECT/RELEASE for each message.
  */
-static void test_random_ack_single_topic_single_partition(void) {
+static void do_test_random_ack_single_topic_single_partition(void) {
         ack_test_config_t config = {.test_name    = "random-ack-1t-1p-5000msgs",
                                     .topic_cnt    = 1,
                                     .partitions   = {1},
                                     .consumer_cnt = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 5000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1222,14 +1272,16 @@ static void test_random_ack_single_topic_single_partition(void) {
  * 5000 messages across 4 topics, 1 partition each (~1250 msgs per topic).
  * Random ACCEPT/REJECT/RELEASE for each message.
  */
-static void test_random_ack_multiple_topics_single_partition(void) {
+static void do_test_random_ack_multiple_topics_single_partition(void) {
         ack_test_config_t config = {.test_name    = "random-ack-4t-1p-5000msgs",
                                     .topic_cnt    = 4,
                                     .partitions   = {1, 1, 1, 1},
                                     .consumer_cnt = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 5000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1238,14 +1290,16 @@ static void test_random_ack_multiple_topics_single_partition(void) {
  * 5000 messages on 1 topic with 4 partitions (~1250 msgs per partition).
  * Random ACCEPT/REJECT/RELEASE for each message.
  */
-static void test_random_ack_single_topic_multiple_partitions(void) {
+static void do_test_random_ack_single_topic_multiple_partitions(void) {
         ack_test_config_t config = {.test_name    = "random-ack-1t-4p-5000msgs",
                                     .topic_cnt    = 1,
                                     .partitions   = {4},
                                     .consumer_cnt = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 5000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1254,14 +1308,16 @@ static void test_random_ack_single_topic_multiple_partitions(void) {
  * 5000 messages across 2 topics, 2 partitions each (~1250 msgs per partition).
  * Random ACCEPT/REJECT/RELEASE for each message.
  */
-static void test_random_ack_multiple_topics_multiple_partitions(void) {
+static void do_test_random_ack_multiple_topics_multiple_partitions(void) {
         ack_test_config_t config = {.test_name    = "random-ack-2t-2p-5000msgs",
                                     .topic_cnt    = 2,
                                     .partitions   = {2, 2},
                                     .consumer_cnt = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 5000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1269,7 +1325,7 @@ static void test_random_ack_multiple_topics_multiple_partitions(void) {
  *
  * ~666 messages per topic. Tests handling many topics with random acks.
  */
-static void test_scale_15_topics_single_partition(void) {
+static void do_test_scale_15_topics_single_partition(void) {
         ack_test_config_t config = {
             .test_name       = "scale-15t-1p-10000msgs",
             .topic_cnt       = 15,
@@ -1277,7 +1333,9 @@ static void test_scale_15_topics_single_partition(void) {
             .consumer_cnt    = 1,
             .use_random_acks = rd_true,
             .total_msgs      = 10000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1286,7 +1344,7 @@ static void test_scale_15_topics_single_partition(void) {
  * ~333 messages per partition (30 partitions total).
  * Tests handling many topics with multiple partitions.
  */
-static void test_scale_15_topics_multiple_partitions(void) {
+static void do_test_scale_15_topics_multiple_partitions(void) {
         ack_test_config_t config = {
             .test_name       = "scale-15t-2p-10000msgs",
             .topic_cnt       = 15,
@@ -1294,7 +1352,9 @@ static void test_scale_15_topics_multiple_partitions(void) {
             .consumer_cnt    = 1,
             .use_random_acks = rd_true,
             .total_msgs      = 10000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1303,14 +1363,16 @@ static void test_scale_15_topics_multiple_partitions(void) {
  * ~250 messages per partition (32 partitions total).
  * Tests high partition count scenario.
  */
-static void test_scale_8_topics_4_partitions(void) {
+static void do_test_scale_8_topics_4_partitions(void) {
         ack_test_config_t config = {.test_name       = "scale-8t-4p-8000msgs",
                                     .topic_cnt       = 8,
                                     .partitions      = {4, 4, 4, 4, 4, 4, 4, 4},
                                     .consumer_cnt    = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 8000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1318,14 +1380,16 @@ static void test_scale_8_topics_4_partitions(void) {
  *
  * 1250 messages per partition. Tests single topic with many partitions.
  */
-static void test_scale_single_topic_8_partitions(void) {
+static void do_test_scale_single_topic_8_partitions(void) {
         ack_test_config_t config = {.test_name       = "scale-1t-8p-10000msgs",
                                     .topic_cnt       = 1,
                                     .partitions      = {8},
                                     .consumer_cnt    = 1,
                                     .use_random_acks = rd_true,
                                     .total_msgs      = 10000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1334,7 +1398,7 @@ static void test_scale_single_topic_8_partitions(void) {
  * 500 messages per partition (30 partitions total).
  * Large scale test for acknowledgement infrastructure.
  */
-static void test_scale_10_topics_3_partitions(void) {
+static void do_test_scale_10_topics_3_partitions(void) {
         ack_test_config_t config = {
             .test_name       = "scale-10t-3p-15000msgs",
             .topic_cnt       = 10,
@@ -1342,7 +1406,376 @@ static void test_scale_10_topics_3_partitions(void) {
             .consumer_cnt    = 1,
             .use_random_acks = rd_true,
             .total_msgs      = 15000};
+        SUB_TEST();
         run_ack_test(&config);
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Re-acknowledging a record after the batch has been polled past
+ *        returns _STATE.
+ *
+ * In explicit mode, poll batch1 (1 record), acknowledge it, poll batch2
+ * (empty), then try to acknowledge batch1's record again. The second
+ * acknowledge must return _STATE because the record is no longer in the
+ * current batch / inflight map.
+ */
+static void do_test_ack_message_from_earlier_batch(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_message_t *batch1[10];
+        rd_kafka_message_t *batch2[10];
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t ack_err;
+        const char *group = "share-cross-batch-ack";
+        const char *topic;
+        size_t b1_rcvd = 0;
+        size_t r       = 0;
+        rd_kafka_error_t *e;
+        int attempts;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== test_ack_message_from_earlier_batch ===\n");
+
+        rkshare = test_create_share_consumer(group, "explicit");
+        topic   = test_mk_topic_name("0172-cross-batch", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Poll batch 1 */
+        attempts = 30;
+        while (b1_rcvd < 1 && attempts-- > 0) {
+                r = 0;
+                e = rd_kafka_share_consume_batch(rkshare, 2000,
+                                                 batch1 + b1_rcvd, &r);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                b1_rcvd += r;
+        }
+        TEST_ASSERT(b1_rcvd == 1, "Expected 1 record in batch1, got %zu",
+                    b1_rcvd);
+
+        ack_err = rd_kafka_share_acknowledge(rkshare, batch1[0]);
+        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "First ack failed: %s", rd_kafka_err2name(ack_err));
+
+        /* Poll batch 2 - must be empty (we already consumed and acked
+         * the only record). */
+        r = 0;
+        e = rd_kafka_share_consume_batch(rkshare, 2000, batch2, &r);
+        if (e)
+                rd_kafka_error_destroy(e);
+        TEST_ASSERT(r == 0,
+                    "Expected batch 2 to be empty after acking the only "
+                    "record, got %zu records",
+                    r);
+
+        /* Re-acknowledge from batch1 - should fail with _STATE */
+        ack_err = rd_kafka_share_acknowledge(rkshare, batch1[0]);
+        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE for re-ack across batches, got %s",
+                    rd_kafka_err2name(ack_err));
+
+        rd_kafka_message_destroy(batch1[0]);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        TEST_SAY("=== test_ack_message_from_earlier_batch: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief acknowledge_offset() before any record has been consumed
+ *        returns _STATE.
+ *
+ * Subscribe but do not poll; call acknowledge_offset() with arbitrary
+ * topic/partition/offset values and expect _STATE (nothing in inflight).
+ */
+static void do_test_ack_offset_before_consume(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        const char *group = "share-ack-before-consume";
+        const char *topic;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== test_ack_offset_before_consume ===\n");
+
+        rkshare = test_create_share_consumer(group, "explicit");
+        topic   = test_mk_topic_name("0172-ack-precons", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        err = rd_kafka_share_acknowledge_offset(
+            rkshare, topic, 0, 0, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE for ack_offset before any consume, "
+                    "got %s",
+                    rd_kafka_err2name(err));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        TEST_SAY("=== test_ack_offset_before_consume: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief acknowledge_offset() with wrong topic / partition / offset
+ *        returns _STATE; correct values succeed.
+ *
+ * Consume one record so we have a valid (topic, partition, offset) tuple
+ * in the inflight map. Calling acknowledge_offset() with wrong values for
+ * any of the three components must return _STATE. The correct values then
+ * succeed.
+ */
+static void do_test_ack_offset_wrong_params(void) {
+        rd_kafka_share_t *rkshare;
+        rd_kafka_message_t *batch[10];
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        const char *group = "share-ack-wrong-params";
+        const char *topic;
+        size_t rcvd = 0;
+        int attempts;
+        int32_t partition;
+        int64_t offset;
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY("=== test_ack_offset_wrong_params ===\n");
+
+        rkshare = test_create_share_consumer(group, "explicit");
+        topic   = test_mk_topic_name("0172-wrong-params", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, 1);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        attempts = 30;
+        while (rcvd < 1 && attempts-- > 0) {
+                size_t r            = 0;
+                rd_kafka_error_t *e = rd_kafka_share_consume_batch(
+                    rkshare, 2000, batch + rcvd, &r);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                rcvd += r;
+        }
+        TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
+
+        partition = batch[0]->partition;
+        offset    = batch[0]->offset;
+
+        /* Wrong offset */
+        err = rd_kafka_share_acknowledge_offset(
+            rkshare, topic, partition, offset + 100,
+            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE for wrong offset, got %s",
+                    rd_kafka_err2name(err));
+
+        /* Wrong topic */
+        err = rd_kafka_share_acknowledge_offset(
+            rkshare, "0172-nonexistent-topic", partition, offset,
+            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE for wrong topic, got %s",
+                    rd_kafka_err2name(err));
+
+        /* Wrong partition */
+        err = rd_kafka_share_acknowledge_offset(
+            rkshare, topic, partition + 100, offset,
+            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE for wrong partition, got %s",
+                    rd_kafka_err2name(err));
+
+        /* Correct values - should succeed */
+        err = rd_kafka_share_acknowledge_offset(
+            rkshare, topic, partition, offset,
+            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected success for correct params, got %s",
+                    rd_kafka_err2name(err));
+
+        rd_kafka_message_destroy(batch[0]);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        TEST_SAY("=== test_ack_offset_wrong_params: PASSED ===\n");
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Mix of implicit and explicit ack-mode consumers in the same group.
+ *
+ * `share.acknowledgement.mode` is a CLIENT-side config, so two consumers
+ * in the same share group can use different modes. Verifies that:
+ *   - The implicit consumer auto-acks on each consume_batch.
+ *   - The explicit consumer's accepted records are not redelivered after
+ *     commit_sync.
+ *   - All produced records are delivered (no losses), and the total
+ *     count matches the produced count once the explicit consumer
+ *     commits (no duplicates).
+ */
+static void do_test_mixed_ack_mode_same_group(void) {
+        const char *group = "share-mixed-ack-mode";
+        const char *topic;
+        rd_kafka_share_t *implicit_c;
+        rd_kafka_share_t *explicit_c;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        const int total_msgs = 400;
+        int implicit_cnt     = 0;
+        int explicit_cnt     = 0;
+        int attempts;
+        rd_kafka_error_t *cerr;
+        test_ack_cb_state_t exp_state = {0};
+
+        SUB_TEST();
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "=== Mixed ack-mode (implicit + explicit) in same group ===\n");
+
+        topic = test_mk_topic_name("0172-mixed-ack-mode", 1);
+        test_create_topic_wait_exists(NULL, topic, 4, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, RD_KAFKA_PARTITION_UA,
+                                 total_msgs);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        implicit_c = test_create_share_consumer(group, "implicit");
+        explicit_c = test_create_share_consumer_with_cb(group, "explicit",
+                                                        &exp_state, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(implicit_c, subs);
+        rd_kafka_share_subscribe(explicit_c, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Round-robin poll across both consumers. The implicit consumer's
+         * messages are auto-acked by the next consume_batch call; the
+         * explicit consumer must call rd_kafka_share_acknowledge per
+         * message. */
+        attempts = 200;
+        while (implicit_cnt + explicit_cnt < total_msgs && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                /* Implicit consumer */
+                err = rd_kafka_share_consume_batch(implicit_c, 1000, batch,
+                                                   &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                } else {
+                        for (m = 0; m < rcvd; m++) {
+                                if (!batch[m]->err)
+                                        implicit_cnt++;
+                                rd_kafka_message_destroy(batch[m]);
+                        }
+                }
+
+                /* Explicit consumer */
+                rcvd = 0;
+                err  = rd_kafka_share_consume_batch(explicit_c, 1000, batch,
+                                                    &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err) {
+                                rd_kafka_resp_err_t ack_err =
+                                    rd_kafka_share_acknowledge_type(
+                                        explicit_c, batch[m],
+                                        RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(!ack_err,
+                                            "explicit ACCEPT failed: %s",
+                                            rd_kafka_err2str(ack_err));
+                                explicit_cnt++;
+                        }
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+
+        TEST_SAY("Consumed: implicit=%d explicit=%d total=%d/%d\n",
+                 implicit_cnt, explicit_cnt, implicit_cnt + explicit_cnt,
+                 total_msgs);
+
+        /* Flush explicit consumer's accepted acks to the broker so they
+         * are durable before we tear the consumer down. */
+        rd_kafka_topic_partition_list_t *commit_parts = NULL;
+        cerr = rd_kafka_share_commit_sync(explicit_c, 30000, &commit_parts);
+        TEST_ASSERT(!cerr, "explicit commit_sync failed: %s",
+                    cerr ? rd_kafka_error_string(cerr) : "");
+        if (commit_parts)
+                rd_kafka_topic_partition_list_destroy(commit_parts);
+        TEST_ASSERT(test_ack_cb_state_first_err(&exp_state) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "explicit ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&exp_state)));
+
+        /* Final flush poll on the implicit consumer so the last batch's
+         * piggybacked acks reach the broker. */
+        size_t rcvd = 0;
+        size_t m;
+        rd_kafka_error_t *err =
+            rd_kafka_share_consume_batch(implicit_c, 1000, batch, &rcvd);
+        if (err)
+                rd_kafka_error_destroy(err);
+        for (m = 0; m < rcvd; m++)
+                rd_kafka_message_destroy(batch[m]);
+
+        TEST_ASSERT(implicit_cnt + explicit_cnt == total_msgs,
+                    "Expected exactly %d total records across both consumers, "
+                    "got %d (implicit=%d explicit=%d)",
+                    total_msgs, implicit_cnt + explicit_cnt, implicit_cnt,
+                    explicit_cnt);
+        TEST_ASSERT(implicit_cnt > 0, "Implicit consumer received no records");
+        TEST_ASSERT(explicit_cnt > 0, "Explicit consumer received no records");
+
+        test_share_consumer_close(implicit_c);
+        test_share_destroy(implicit_c);
+        test_share_consumer_close(explicit_c);
+        test_share_destroy(explicit_c);
+
+        TEST_SAY(
+            "SUCCESS: mixed ack-mode group - implicit=%d explicit=%d "
+            "(total=%d)\n",
+            implicit_cnt, explicit_cnt, implicit_cnt + explicit_cnt);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1355,35 +1788,41 @@ int main_0172_share_consumer_acknowledge(int argc, char **argv) {
         common_admin    = test_create_producer();
 
         /* Core tests */
-        test_release_redelivery();
-        test_reject_no_redelivery();
-        test_accept_no_redelivery();
+        do_test_release_redelivery();
+        do_test_reject_no_redelivery();
+        do_test_accept_no_redelivery();
 
         /* Error handling tests */
-        test_ack_null_message();
-        test_ack_null_rkshare();
-        test_ack_invalid_type();
-        test_release_then_reject_no_redelivery();
+        do_test_ack_null_message();
+        do_test_ack_null_rkshare();
+        do_test_ack_invalid_type();
+        do_test_release_then_reject_no_redelivery();
 
         /* Acknowledgement state tests */
-        test_change_ack_type_before_commit();
-        test_ack_after_commit();
+        do_test_change_ack_type_before_commit();
+        do_test_ack_after_commit();
+        do_test_ack_message_from_earlier_batch();
+        do_test_ack_offset_before_consume();
+        do_test_ack_offset_wrong_params();
 
         /* Max delivery attempts test */
-        test_max_delivery_attempts();
+        do_test_max_delivery_attempts();
 
         /* High-intensity random acknowledgement tests */
-        test_random_ack_single_topic_single_partition();
-        test_random_ack_multiple_topics_single_partition();
-        test_random_ack_single_topic_multiple_partitions();
-        test_random_ack_multiple_topics_multiple_partitions();
+        do_test_random_ack_single_topic_single_partition();
+        do_test_random_ack_multiple_topics_single_partition();
+        do_test_random_ack_single_topic_multiple_partitions();
+        do_test_random_ack_multiple_topics_multiple_partitions();
 
         /* Scale tests - high topic/partition counts with many messages */
-        test_scale_15_topics_single_partition();
-        test_scale_15_topics_multiple_partitions();
-        test_scale_8_topics_4_partitions();
-        test_scale_single_topic_8_partitions();
-        test_scale_10_topics_3_partitions();
+        do_test_scale_15_topics_single_partition();
+        do_test_scale_15_topics_multiple_partitions();
+        do_test_scale_8_topics_4_partitions();
+        do_test_scale_single_topic_8_partitions();
+        do_test_scale_10_topics_3_partitions();
+
+        /* Mixed ack-mode within the same share group */
+        do_test_mixed_ack_mode_same_group();
 
         /* Cleanup common handles */
         rd_kafka_destroy(common_admin);

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -122,6 +122,8 @@ static void do_test_implicit_second_consumer(void) {
         int attempts = 0;
         int64_t *c1_offsets;
 
+        SUB_TEST();
+
         topic = test_mk_topic_name("0173-ca-impl-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         test_produce_msgs_simple(common_producer, topic, 0, MAX_MSGS);
@@ -201,6 +203,8 @@ static void do_test_implicit_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -222,6 +226,8 @@ static void do_test_explicit_second_consumer(void) {
         int consumed1 = 0, consumed2 = 0;
         int attempts = 0;
         int64_t *c1_offsets;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-expl-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -305,6 +311,8 @@ static void do_test_explicit_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -329,6 +337,8 @@ static void do_test_mixed_acks_second_consumer(void) {
         int released_cnt = 0;
         int attempts     = 0;
         int64_t *released_offsets;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-mixed-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -421,6 +431,8 @@ static void do_test_mixed_acks_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -445,6 +457,8 @@ static void do_test_multi_topic_partition(void) {
         rd_kafka_error_t *error;
         int t, p, round;
         int total_consumed = 0;
+
+        SUB_TEST();
 
         for (t = 0; t < topic_cnt; t++) {
                 topics[t] =
@@ -508,6 +522,8 @@ static void do_test_multi_topic_partition(void) {
 
         for (t = 0; t < topic_cnt; t++)
                 rd_free((void *)topics[t]);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -528,6 +544,8 @@ static void do_test_produce_consume_loop(void) {
         const int rounds         = 5;
         const int msgs_per_round = MAX_MSGS / rounds;
         int total_consumed       = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-loop", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -590,6 +608,8 @@ static void do_test_produce_consume_loop(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -613,6 +633,8 @@ static void do_test_multi_round_mixed_second_consumer(void) {
         int total_consumed       = 0;
         int total_released       = 0;
         int total_redelivered    = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-mr-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -705,6 +727,8 @@ static void do_test_multi_round_mixed_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -716,6 +740,8 @@ static void do_test_no_pending_acks(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
 
+        SUB_TEST();
+
         rkshare = test_create_share_consumer(group, "implicit");
 
         error = rd_kafka_share_commit_async(rkshare);
@@ -726,6 +752,8 @@ static void do_test_no_pending_acks(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -745,6 +773,8 @@ static void do_test_multiple_commit_async_calls(void) {
         const int second_produce = MAX_MSGS / 2;
         int consumed = 0, consumed2 = 0, call;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-multi-call", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -817,6 +847,8 @@ static void do_test_multiple_commit_async_calls(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -838,6 +870,8 @@ static void do_test_commit_between_produces(void) {
         const int half = MAX_MSGS / 2;
         int consumed1 = 0, consumed2 = 0, received = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-between", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -966,6 +1000,8 @@ static void do_test_commit_between_produces(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -984,6 +1020,8 @@ static void do_test_all_release_second_consumer(void) {
         rd_kafka_error_t *error;
         int consumed = 0, redelivered = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-allrel-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -1040,6 +1078,8 @@ static void do_test_all_release_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1060,6 +1100,8 @@ static void do_test_all_reject_second_consumer(void) {
         size_t j;
         int consumed = 0, received = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-allrej-2nd", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -1147,6 +1189,8 @@ static void do_test_all_reject_second_consumer(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1167,6 +1211,8 @@ static void do_test_per_record_commit_async(void) {
         size_t j;
         int consumed = 0, received = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0173-ca-per-rec", 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
@@ -1259,6 +1305,8 @@ static void do_test_per_record_commit_async(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1579,7 +1627,7 @@ static void do_test_lock_timeout_redelivery(void) {
 /* ===================================================================
  *  Test: commit_async callback invocation.
  *
- *  Verifies that the runtime acknowledgement callback is invoked after
+ *  Verifies that share_acknowledgement_commit_cb is invoked after
  *  commit_async when acks are piggybacked on ShareFetch.
  * =================================================================== */
 static void do_test_commit_async_callback(void) {
@@ -1590,7 +1638,7 @@ static void do_test_commit_async_callback(void) {
         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         size_t rcvd;
         size_t j;
-        size_t consumed           = 0;
+        int consumed              = 0;
         int attempts              = 0;
         test_ack_cb_state_t state = {0};
 
@@ -1601,13 +1649,13 @@ static void do_test_commit_async_callback(void) {
         test_produce_msgs_simple(common_producer, topic, 0, 50);
 
         rkshare =
-            test_create_share_consumer_with_cb(group, "explicit", &state, NULL);
-        /* Set offset reset to earliest */
-        test_share_set_auto_offset_reset(group, "earliest");
+            test_create_share_consumer_with_cb(group, "implicit", &state, NULL);
+        const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
+        test_alter_group_configurations(group, grp_conf, 1);
         subscribe_consumer(rkshare, &topic, 1);
 
         /* Consume some messages */
-        while (consumed < 50 && attempts++ < 30) {
+        while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
                 error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
                                                      &rcvd);
@@ -1616,16 +1664,13 @@ static void do_test_commit_async_callback(void) {
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rkmessages[j]->err)
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        }
                         rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
-        TEST_SAY("Consumed %zu messages\n", consumed);
+        TEST_SAY("Consumed %d messages\n", consumed);
         TEST_ASSERT(consumed > 0, "Expected to consume some messages");
 
         /* Call commit_async to trigger callback */
@@ -1636,31 +1681,539 @@ static void do_test_commit_async_callback(void) {
         /* Wait for callback */
         test_wait_for_cb_with_poll(&state, rkshare, 1, 10000);
 
-        TEST_SAY("Callback count=%d, total_offsets=%zu\n", state.callback_cnt,
-                 state.total_offsets);
+        TEST_SAY("Callback count=%d, total_offsets=%zu, last_err=%s\n",
+                 state.callback_cnt, state.total_offsets,
+                 rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
 
-        TEST_ASSERT(state.callback_cnt == 1,
-                    "Expected callback to be invoked once, got %d",
-                    state.callback_cnt);
-        TEST_ASSERT(state.total_offsets == consumed,
-                    "Expected %zu offsets in callback, got %zu", consumed,
+        TEST_ASSERT(state.callback_cnt >= 1,
+                    "Expected at least 1 callback, got %d", state.callback_cnt);
+        TEST_ASSERT(state.total_offsets > 0,
+                    "Expected offsets in callback, got %zu",
                     state.total_offsets);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
-        test_ack_cb_state_destroy(&state);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
 
         SUB_TEST_PASS();
 }
 
 
 /* ===================================================================
- *  Test: changing the runtime acknowledgement callback at runtime.
+ *  Partial-batch commit_async semantics.
  *
- *  Verifies that after rd_kafka_share_set_acknowledgement_commit_cb() is
- *  called with a new callback, subsequent commit_async results are
- *  delivered to the NEW callback and not the OLD one.
+ *  In explicit mode, the next consume_batch must error while any record
+ *  from the previous batch is un-acked. After the remaining records are
+ *  acked and a second commit_async is issued, consume_batch can drive
+ *  the piggybacked acks and the commit callback fires for all offsets.
  * =================================================================== */
+static void do_test_partial_batch_commit_async(void) {
+        const char *topic;
+        const char *group = "commit-async-partial-batch";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t ack_err;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_message_t *dummy[16];
+        size_t rcvd, total = 0, j;
+        test_ack_cb_state_t state = {0};
+        const int msg_cnt         = 5;
+        int attempts              = 0;
+        size_t to_ack_first;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0173-ca-partial", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, msg_cnt);
+
+        rkshare =
+            test_create_share_consumer_with_cb(group, "explicit", &state, NULL);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume all msg_cnt records (may take multiple polls) */
+        while (total < (size_t)msg_cnt && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000,
+                                                     rkmessages + total, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                total += rcvd;
+        }
+        TEST_ASSERT(total == (size_t)msg_cnt,
+                    "Expected exactly %d records, got %zu", msg_cnt, total);
+
+        /* Acknowledge first 3 records; leave the remainder un-acked. */
+        to_ack_first = 3;
+        for (j = 0; j < to_ack_first; j++) {
+                ack_err = rd_kafka_share_acknowledge_type(
+                    rkshare, rkmessages[j],
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "First-half ACCEPT %zu failed: %s", j,
+                            rd_kafka_err2str(ack_err));
+        }
+
+        /* commit_async itself succeeds — it just schedules. */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "First commit_async failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+
+        /* While un-acked records remain in the batch, consume_batch must
+         * return _STATE rather than proceed. */
+        size_t r = 0;
+        rd_kafka_error_t *e =
+            rd_kafka_share_consume_batch(rkshare, 1000, dummy, &r);
+        TEST_ASSERT(e != NULL,
+                    "Expected consume_batch to return _STATE while "
+                    "un-acked records remain, got NULL error");
+        TEST_ASSERT(rd_kafka_error_code(e) == RD_KAFKA_RESP_ERR__STATE,
+                    "Expected _STATE, got %s",
+                    rd_kafka_err2name(rd_kafka_error_code(e)));
+        TEST_SAY("Got expected _STATE from consume_batch: %s\n",
+                 rd_kafka_error_string(e));
+        rd_kafka_error_destroy(e);
+
+        /* Acknowledge the remaining records */
+        for (j = to_ack_first; j < total; j++) {
+                ack_err = rd_kafka_share_acknowledge_type(
+                    rkshare, rkmessages[j],
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                TEST_ASSERT(
+                    ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Second-half ACCEPT %zu (offset=%" PRId64 ") failed: %s", j,
+                    rkmessages[j]->offset, rd_kafka_err2str(ack_err));
+        }
+
+        /* Second commit_async commits the remaining acks */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "Second commit_async failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+
+        /* Now consume_batch can proceed and drive piggybacked acks; the
+         * callback should fire at least once and report all acked
+         * offsets across the two commits. */
+        test_wait_for_cb_with_poll(&state, rkshare, 1, 15000);
+        TEST_ASSERT(state.callback_cnt >= 1,
+                    "Expected ack commit callback to fire after full batch "
+                    "ack + commit_async, got %d",
+                    state.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Callback errored: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
+        TEST_ASSERT(state.total_offsets >= (size_t)total,
+                    "Expected callback to report %zu offsets, got %zu", total,
+                    state.total_offsets);
+        TEST_SAY("Partial commit callbacks=%d, total_offsets=%zu\n",
+                 state.callback_cnt, state.total_offsets);
+
+        for (j = 0; j < total; j++)
+                rd_kafka_message_destroy(rkmessages[j]);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Implicit ack callback fires from next poll's piggybacked acks
+ *  without any explicit commit_async call.
+ * =================================================================== */
+static void do_test_implicit_callback_no_explicit_commit(void) {
+        const char *topic;
+        const char *group = "commit-async-implicit-no-commit";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd, j;
+        test_ack_cb_state_t state = {0};
+        const int msg_cnt         = 20;
+        int consumed              = 0;
+        int attempts              = 0;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0173-ca-impl-no-commit", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, msg_cnt);
+
+        rkshare =
+            test_create_share_consumer_with_cb(group, "implicit", &state, NULL);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* First poll: drain all produced records. consume_batch typically
+         * returns the whole broker-side RecordBatch (so all msg_cnt records
+         * arrive in one call), but the loop tolerates split deliveries. */
+        while (consumed < msg_cnt && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(consumed == msg_cnt,
+                    "Expected to consume %d messages, got %d", msg_cnt,
+                    consumed);
+
+        /* Subsequent polls without any commit_async — callback should still
+         * fire via piggybacked acks on the next ShareFetch. */
+        attempts = 10;
+        while (attempts-- > 0 && state.callback_cnt == 0) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+                for (j = 0; j < rcvd; j++)
+                        rd_kafka_message_destroy(rkmessages[j]);
+        }
+
+        TEST_ASSERT(state.callback_cnt >= 1,
+                    "Expected callback from implicit piggybacked acks (no "
+                    "explicit commit), got %d",
+                    state.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Callback errored: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Lock-expiry surfaces an error in the ack commit callback.
+ *
+ *  Explicit mode + short lock duration: poll a record, acknowledge it,
+ *  sleep past the lock expiry, then commit_async. The broker should
+ *  reject the stale ack and the error must be reported via the
+ *  acknowledgement commit callback.
+ * =================================================================== */
+static void do_test_lock_expiry_callback_err(void) {
+        const char *topic;
+        const char *group = "commit-async-lock-expiry-cb";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t ack_err;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd, j;
+        size_t consumed           = 0;
+        int attempts              = 0;
+        test_ack_cb_state_t state = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0173-ca-lock-cb", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, 3);
+
+        rkshare =
+            test_create_share_consumer_with_cb(group, "explicit", &state, NULL);
+        test_share_set_auto_offset_reset(group, "earliest");
+        set_group_lock_duration(group, "3000");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume records (acquires lock) */
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                consumed = rcvd;
+        }
+        TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
+
+        /* Acknowledge all consumed records explicitly */
+        for (j = 0; j < consumed; j++) {
+                ack_err = rd_kafka_share_acknowledge_type(
+                    rkshare, rkmessages[j],
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "ACCEPT failed: %s", rd_kafka_err2str(ack_err));
+        }
+
+        /* Sleep past acquisition-lock expiry (3s + buffer) */
+        TEST_SAY("Sleeping 4 s for lock expiry before commit_async...\n");
+        rd_sleep(4);
+
+        /* commit_async on stale acks - broker should reject them */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async returned error directly: %s",
+                    error ? rd_kafka_error_string(error) : "");
+
+        test_wait_for_cb_with_poll(&state, rkshare, 1, 15000);
+
+        TEST_SAY("Callback count=%d, total_offsets=%zu, last_err=%s\n",
+                 state.callback_cnt, state.total_offsets,
+                 rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
+
+        TEST_ASSERT(state.callback_cnt >= 1,
+                    "Expected callback to fire for stale ack, got %d",
+                    state.callback_cnt);
+        /* Broker rejects acks against records whose acquisition lock has
+         * expired with INVALID_RECORD_STATE. */
+        TEST_ASSERT(test_ack_cb_state_first_err(&state) ==
+                        RD_KAFKA_RESP_ERR_INVALID_RECORD_STATE,
+                    "Expected INVALID_RECORD_STATE in callback after lock "
+                    "expiry, got %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
+
+        for (j = 0; j < consumed; j++)
+                rd_kafka_message_destroy(rkmessages[j]);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+typedef struct {
+        test_ack_cb_state_t base;
+        int saw_consumer_name;
+} k44_state_t;
+
+static void k44_safe_api_cb(rd_kafka_share_t *rkshare,
+                            rd_kafka_share_partition_offsets_list_t *partitions,
+                            rd_kafka_resp_err_t err,
+                            void *opaque) {
+        k44_state_t *st = opaque;
+        rd_kafka_t *rk;
+
+        /* Reuse base counters via the shared helper */
+        test_share_ack_cb(rkshare, partitions, err, &st->base);
+
+        /* Safely read consumer identity from within the callback */
+        rk = test_share_consumer_get_rk(rkshare);
+        if (rk && rd_kafka_name(rk))
+                st->saw_consumer_name = 1;
+}
+
+/* ===================================================================
+ *  Callback safely reads consumer state and the consumer keeps working
+ *  afterwards.
+ *
+ *  Implicit mode: poll a batch, commit_async to drive piggyback acks,
+ *  wait for the ack callback. The callback calls
+ *  test_share_consumer_get_rk()+rd_kafka_name() to prove that
+ *  consumer-state APIs are safe to invoke from within the callback.
+ *  After the callback runs, a second round of consume_batch must still
+ *  return records, proving the consumer is not wedged.
+ * =================================================================== */
+static void do_test_safe_api_from_callback(void) {
+        const char *topic;
+        const char *group = "commit-async-safe-api-cb";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd, j;
+        int consumed     = 0;
+        int second_round = 0;
+        int attempts     = 0;
+        k44_state_t st   = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0173-ca-safe-api-cb", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, 10);
+
+        rkshare = test_create_share_consumer_with_cb(
+            group, "implicit", (test_ack_cb_state_t *)&st, k44_safe_api_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* First-round consumption */
+        while (consumed < 5 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+
+        /* Drive piggyback acks - this fires the callback */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async failed");
+        test_wait_for_cb_with_poll(&st.base, rkshare, 1, 10000);
+
+        TEST_ASSERT(st.base.callback_cnt >= 1, "Expected callback, got %d",
+                    st.base.callback_cnt);
+        TEST_ASSERT(st.saw_consumer_name,
+                    "Callback should have read consumer name via "
+                    "test_share_consumer_get_rk + rd_kafka_name");
+
+        /* After callback has run, the consumer must still function. */
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
+        attempts = 0;
+        while (second_round < 5 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                second_round++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(second_round > 0,
+                    "Consumer stopped working after callback invocation");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+typedef struct {
+        test_ack_cb_state_t base;
+        int side_effect_runs;
+} k45_state_t;
+
+static void
+k45_side_effect_cb(rd_kafka_share_t *rkshare,
+                   rd_kafka_share_partition_offsets_list_t *partitions,
+                   rd_kafka_resp_err_t err,
+                   void *opaque) {
+        k45_state_t *st = opaque;
+
+        test_share_ack_cb(rkshare, partitions, err, &st->base);
+
+        /* Heavy-ish side effect: simulate user application work. */
+        st->side_effect_runs++;
+        rd_sleep(0); /* yield - safe no-op time pass */
+}
+
+/* ===================================================================
+ *  Application-side side effects in the ack callback do not crash or
+ *  hang the poll thread.
+ *
+ *  Implicit mode: poll one batch, commit_async, and wait for the
+ *  callback. The callback bumps a side-effect counter and yields
+ *  via rd_sleep(0) to simulate user work. We assert the side effect
+ *  ran and that the consumer is still healthy on a follow-up
+ *  consume_batch / commit_async round.
+ * =================================================================== */
+static void do_test_callback_side_effects_dont_break(void) {
+        const char *topic;
+        const char *group = "commit-async-side-effect-cb";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd, j;
+        int consumed   = 0;
+        int post_count = 0;
+        int attempts   = 0;
+        k45_state_t st = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0173-ca-side-effect-cb", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, 10);
+
+        rkshare = test_create_share_consumer_with_cb(
+            group, "implicit", (test_ack_cb_state_t *)&st, k45_side_effect_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        /* Consume the produced records */
+        while (consumed < 10 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
+
+        /* Drive the side-effect callback at least once via commit_async +
+         * wait_for_cb_with_poll. */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async failed: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        test_wait_for_cb_with_poll(&st.base, rkshare, 1, 10000);
+
+        TEST_ASSERT(st.base.callback_cnt >= 1,
+                    "Expected callback to fire at least once, got %d",
+                    st.base.callback_cnt);
+        TEST_ASSERT(st.side_effect_runs >= 1,
+                    "Side-effect did not run inside callback (%d runs vs "
+                    "%d callbacks)",
+                    st.side_effect_runs, st.base.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&st.base) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Callback err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&st.base)));
+        TEST_SAY("consumed=%d, callbacks=%d, side_effects=%d\n", consumed,
+                 st.base.callback_cnt, st.side_effect_runs);
+
+        /* Consumer must still be usable after the side-effect callback ran:
+         * produce more records and verify poll still works. */
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
+        attempts = 0;
+        while (post_count == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                post_count++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(post_count > 0,
+                    "Consumer stopped working after side-effect callback");
+        TEST_SAY("Post-callback poll returned %d msgs\n", post_count);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
 static void do_test_change_callback(void) {
         const char *topic;
         const char *group = "change-callback";
@@ -2054,6 +2607,7 @@ static void do_test_reentrancy_protection(void) {
 }
 
 
+
 int main_0173_share_consumer_commit_async(int argc, char **argv) {
         test_timeout_set(120);
         common_producer = test_create_producer();
@@ -2072,8 +2626,17 @@ int main_0173_share_consumer_commit_async(int argc, char **argv) {
         do_test_all_reject_second_consumer();
         do_test_per_record_commit_async();
         do_test_lock_timeout_redelivery();
-        /* Callback tests */
+        /* Callback test */
         do_test_commit_async_callback();
+
+        /* Partial-batch / callback edge cases */
+        do_test_partial_batch_commit_async();
+        do_test_implicit_callback_no_explicit_commit();
+        do_test_lock_expiry_callback_err();
+        do_test_safe_api_from_callback();
+        do_test_callback_side_effects_dont_break();
+
+        /* Callback management and reentrancy */
         do_test_change_callback();
         do_test_reentrancy_protection();
 

--- a/tests/0174-share_consumer_concurrency.c
+++ b/tests/0174-share_consumer_concurrency.c
@@ -33,15 +33,20 @@
  * @name Share Consumer Concurrency and Stress Tests
  *
  * Tests share consumer behavior under concurrent producer/consumer scenarios.
- * Each test uses a config-based structure. Producers run in their own threads;
- * all consumers are polled in a round-robin loop from the main test thread.
+ * Each test uses a config-based structure. Producers and consumers each run
+ * in their own dedicated threads — there is no main-thread round-robin
+ * polling. The main test thread orchestrates start/stop and verifies
+ * end-state counters. The per-record invariant validated is first-delivery
+ * count (each produced record is first-delivered exactly once; redeliveries
+ * are counted separately).
  */
 
-#define MAX_TOPICS     16
-#define MAX_PARTITIONS 16
-#define MAX_CONSUMERS  10
-#define MAX_PRODUCERS  10
-#define BATCH_SIZE     500
+#define MAX_TOPICS        16
+#define MAX_PARTITIONS    16
+#define MAX_CONSUMERS     16
+#define MAX_PRODUCERS     10
+#define MAX_CONSUMER_POOL 32
+#define BATCH_SIZE        10000
 
 /* Save test_curr for threads (test_curr is TLS) */
 static struct test *this_test;
@@ -100,6 +105,24 @@ typedef struct {
         int partitions[MAX_TOPICS];
 } producer_thread_args_t;
 
+/**
+ * @brief Per-consumer-thread context.
+ *
+ * One share consumer per thread; main thread sets @c run to rd_false
+ * (under state->lock) to ask the consumer to wind down. The consumer
+ * thread sets @c done = rd_true under the same lock right before it
+ * returns from consumer_thread_func, so the main thread can poll for a
+ * clean exit instead of blocking forever in thrd_join when a consumer
+ * is wedged inside librdkafka.
+ */
+typedef struct {
+        concurrent_test_state_t *state;
+        int consumer_id;
+        rd_bool_t run;
+        rd_bool_t done;    /**< Set true just before consumer thread exits */
+        int poll_delay_ms; /**< Sleep between polls (from config) */
+} consumer_thread_args_t;
+
 /***************************************************************************
  * Thread Functions
  ***************************************************************************/
@@ -119,10 +142,13 @@ static int producer_thread_func(void *arg) {
         rd_kafka_resp_err_t err;
         char value[64];
 
-        /* Restore test context for this thread (test_curr is TLS) */
-        test_curr                = this_test;
-        test_curr->exp_dr_status = (rd_kafka_msg_status_t)-1;
-        test_curr->ignore_dr_err = rd_true;
+        /* Restore the TLS test_curr pointer for this thread. The
+         * exp_dr_status / ignore_dr_err fields on the struct itself are
+         * set once by the main thread before any worker spawns
+         * (see run_concurrent_test / do_test_chaos_consumer_lifecycle)
+         * — touching them here would race against every other producer
+         * thread that aliases the same global tests[] entry. */
+        test_curr = this_test;
 
         /* Enable idempotent producer so retries do not result in duplicate
          * broker-side writes — without this, transient broker/network jitter
@@ -130,8 +156,7 @@ static int producer_thread_func(void *arg) {
          * test_max_concurrent with 10 producers × 5000 msgs) causes the
          * broker to store extra records that the share consumer then
          * receives as new offsets with delivery_count=1, inflating the
-         * consumed count above expected_total. Matches the Java client's
-         * default since Kafka 3.0 (KIP-679). */
+         * consumed count above expected_total. */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "enable.idempotence", "true");
         rd_kafka_conf_set_dr_msg_cb(conf, test_dr_msg_cb);
@@ -197,63 +222,263 @@ done:
         return thrd_success;
 }
 
+/**
+ * @brief Per-thread share consumer poll loop.
+ *
+ * One share consumer per thread. Creates the consumer, subscribes to all
+ * configured topics, then polls until @c args->run is cleared by the main
+ * thread. Records first-time deliveries vs redeliveries via
+ * rd_kafka_message_delivery_count() into shared counters.
+ */
+static int consumer_thread_func(void *arg) {
+        consumer_thread_args_t *args   = (consumer_thread_args_t *)arg;
+        concurrent_test_state_t *state = args->state;
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *err;
+        int t;
+        size_t m;
+        size_t rcvd;
+        rd_bool_t keep_running;
+
+        test_curr = this_test;
+
+        consumer = test_create_share_consumer(
+            state->group_name, state->explicit_ack ? "explicit" : NULL);
+
+        subs = rd_kafka_topic_partition_list_new(state->topic_cnt);
+        for (t = 0; t < state->topic_cnt; t++) {
+                rd_kafka_topic_partition_list_add(subs, state->topics[t],
+                                                  RD_KAFKA_PARTITION_UA);
+        }
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        TEST_SAY("Consumer thread %d: subscribed\n", args->consumer_id);
+
+        while (1) {
+                int acked_in_batch = 0;
+
+                mtx_lock(&state->lock);
+                keep_running = args->run;
+                mtx_unlock(&state->lock);
+                if (!keep_running)
+                        break;
+
+                rcvd = 0;
+                err = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                if (err) {
+                        TEST_SAY(
+                            "Consumer thread %d: consume_batch error: %s\n",
+                            args->consumer_id, rd_kafka_error_string(err));
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+
+                /* Per-record atomic step:
+                 *   ACK → process (count into shared state under lock) →
+                 *   destroy. ack + process happen in the same iteration
+                 *   so there is no window where the broker can see an
+                 *   ACK for a record that this application has not also
+                 *   recorded as consumed in total_first_delivery /
+                 *   total_duplicates. The per-batch commit_sync below
+                 *   flushes the acks to the broker. */
+                for (m = 0; m < rcvd; m++) {
+                        rd_kafka_message_t *msg = batch[m];
+
+                        if (msg->err) {
+                                const char *msg_topic =
+                                    msg->rkt ? rd_kafka_topic_name(msg->rkt)
+                                             : "(no-topic)";
+                                TEST_SAY(
+                                    "Consumer thread %d: SKIPPING record "
+                                    "%s[%" PRId32 "] off=%" PRId64
+                                    " because msg->err=%s\n",
+                                    args->consumer_id, msg_topic,
+                                    msg->partition, msg->offset,
+                                    rd_kafka_err2name(msg->err));
+                                rd_kafka_message_destroy(msg);
+                                continue;
+                        }
+
+                        if (state->explicit_ack) {
+                                rd_kafka_resp_err_t ack_err =
+                                    rd_kafka_share_acknowledge_type(
+                                        consumer, msg,
+                                        RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                if (ack_err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+                                        TEST_SAY(
+                                            "Consumer thread %d: "
+                                            "acknowledge offset %" PRId64
+                                            " failed: %s — skipping count "
+                                            "for this record\n",
+                                            args->consumer_id, msg->offset,
+                                            rd_kafka_err2name(ack_err));
+                                        rd_kafka_message_destroy(msg);
+                                        continue;
+                                }
+                                acked_in_batch++;
+                        }
+
+                        /* Process the record at the same instant we
+                         * acknowledged it. */
+                        {
+                                int16_t dc =
+                                    rd_kafka_message_delivery_count(msg);
+                                mtx_lock(&state->lock);
+                                if (dc > 1)
+                                        state->total_duplicates++;
+                                else
+                                        state->total_first_delivery++;
+                                state->total_consumed++;
+                                mtx_unlock(&state->lock);
+                        }
+
+                        rd_kafka_message_destroy(msg);
+                }
+
+                /* Flush the per-record acks to the broker before the
+                 * next consume_batch or stop check. Per-partition
+                 * results are inspected for errors. */
+                if (state->explicit_ack && acked_in_batch > 0) {
+                        rd_kafka_topic_partition_list_t *cs_result = NULL;
+                        rd_kafka_error_t *commit_err =
+                            rd_kafka_share_commit_sync(consumer, 5000,
+                                                       &cs_result);
+                        if (commit_err) {
+                                TEST_SAY(
+                                    "Consumer thread %d: commit_sync failed "
+                                    "(acked_in_batch=%d): %s\n",
+                                    args->consumer_id, acked_in_batch,
+                                    rd_kafka_error_string(commit_err));
+                                rd_kafka_error_destroy(commit_err);
+                        } else if (cs_result) {
+                                int i;
+                                for (i = 0; i < cs_result->cnt; i++) {
+                                        if (cs_result->elems[i].err !=
+                                            RD_KAFKA_RESP_ERR_NO_ERROR) {
+                                                TEST_SAY(
+                                                    "Consumer thread %d: "
+                                                    "commit_sync per-part "
+                                                    "err %s [%" PRId32
+                                                    "]: %s\n",
+                                                    args->consumer_id,
+                                                    cs_result->elems[i].topic,
+                                                    cs_result->elems[i]
+                                                        .partition,
+                                                    rd_kafka_err2name(
+                                                        cs_result->elems[i]
+                                                            .err));
+                                        }
+                                }
+                        }
+                        if (cs_result)
+                                rd_kafka_topic_partition_list_destroy(
+                                    cs_result);
+                }
+
+                if (args->poll_delay_ms > 0)
+                        rd_usleep(args->poll_delay_ms * 1000, NULL);
+        }
+
+        TEST_SAY("Consumer thread %d: closing\n", args->consumer_id);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        /* Mark this thread as cleanly exited so the main thread's bounded
+         * wait can detect it without blocking in thrd_join. */
+        mtx_lock(&state->lock);
+        args->done = rd_true;
+        mtx_unlock(&state->lock);
+
+        return thrd_success;
+}
+
 /***************************************************************************
- * Test Runner
+ * Test Runner — fully threaded
+ *
+ * Every share consumer and every producer runs in its own dedicated
+ * thread. The main thread only orchestrates start/stop and verifies
+ * final counters. No round-robin main-thread polling.
  ***************************************************************************/
 
 /**
- * @brief Run a concurrent share consumer test
+ * @brief Run a concurrent share consumer test with every consumer in its
+ *        own thread.
+ *
+ * @c config->max_attempts is interpreted as an upper bound on the total
+ * wait-for-completion time, measured in 500ms ticks (so max_attempts=100
+ * gives a 50 s bound). When unset (0), the default is 240 ticks = 120 s.
  */
 static void run_concurrent_test(const concurrent_test_config_t *config) {
         concurrent_test_state_t state = {0};
         thrd_t producer_threads[MAX_PRODUCERS];
-        rd_kafka_share_t *consumers[MAX_CONSUMERS];
-        rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        rd_kafka_error_t *err;
+        thrd_t consumer_threads[MAX_CONSUMERS];
+        consumer_thread_args_t consumer_args[MAX_CONSUMERS];
+        rd_kafka_share_t *dummy_consumer;
         int t, c, p;
         int total_partitions = 0;
         int msgs_per_producer;
-        int max_attempts;
-        int attempts;
-        int idle_rounds;
-        int round_consumed;
-        size_t rcvd;
-        size_t m;
+        int max_wait_ticks;
+        int wait_ticks;
         int final_produced;
         int final_consumed;
         int final_first_delivery;
         int final_duplicates;
         rd_bool_t final_failed;
+        char unique_suffix[64];
+        char unique_group[128];
+        char unique_test_name[256];
+
+        TEST_ASSERT(config->consumer_cnt <= MAX_CONSUMERS,
+                    "consumer_cnt %d exceeds MAX_CONSUMERS %d",
+                    config->consumer_cnt, MAX_CONSUMERS);
+
+        /* Generate a per-invocation unique suffix and append it to both
+         * the group name and the displayed test name. Avoids collisions
+         * across re-runs / parallel runs that share the same broker. */
+        rd_snprintf(unique_suffix, sizeof(unique_suffix), "rnd%" PRIx64,
+                    test_id_generate());
+        rd_snprintf(unique_group, sizeof(unique_group), "%s-%s",
+                    config->group_name, unique_suffix);
+        rd_snprintf(unique_test_name, sizeof(unique_test_name), "%s [%s]",
+                    config->test_name, unique_suffix);
 
         TEST_SAY("\n");
         TEST_SAY(
             "============================================================\n");
-        TEST_SAY("=== %s ===\n", config->test_name);
+        TEST_SAY("=== %s ===\n", unique_test_name);
         TEST_SAY(
             "============================================================\n");
-        TEST_SAY("Consumers: %d, Producers: %d, Topics: %d\n",
-                 config->consumer_cnt, config->producer_cnt, config->topic_cnt);
+        TEST_SAY(
+            "Threaded: %d consumer threads, %d producer threads, %d topics\n",
+            config->consumer_cnt, config->producer_cnt, config->topic_cnt);
 
         /* Save test context for threads (test_curr is TLS) */
         this_test = test_curr;
 
+        /* Set the DR-callback expectations on the shared test struct
+         * ONCE on the main thread, before spawning any worker threads.
+         * test_curr is a TLS pointer but the struct it points at lives
+         * in the global tests[] array, so writing these fields from
+         * each producer thread (as it used to) is a benign-but-noisy
+         * data race that TSAN flags. */
+        test_curr->exp_dr_status = (rd_kafka_msg_status_t)-1;
+        test_curr->ignore_dr_err = rd_true;
+
         /* Initialize state */
         mtx_init(&state.lock, mtx_plain);
         state.topic_cnt           = config->topic_cnt;
-        state.group_name          = config->group_name;
+        state.group_name          = unique_group;
         state.explicit_ack        = config->explicit_ack;
         state.producers_remaining = config->producer_cnt;
 
-        /* Calculate total expected messages */
-        for (t = 0; t < config->topic_cnt; t++) {
+        for (t = 0; t < config->topic_cnt; t++)
                 total_partitions += config->partitions[t];
-        }
         state.expected_total = total_partitions * config->msgs_per_partition;
-
         TEST_SAY(
-            "Total partitions: %d, Messages per partition: %d, "
-            "Expected total: %d\n",
+            "Total partitions: %d, msgs/partition: %d, expected total: %d\n",
             total_partitions, config->msgs_per_partition, state.expected_total);
 
         /* Create topics */
@@ -267,36 +492,13 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
                          state.topics[t], config->partitions[t]);
         }
 
-        /* Create consumers */
-        for (c = 0; c < config->consumer_cnt; c++) {
-                consumers[c] =
-                    test_create_share_consumer(config->group_name, NULL);
-        }
-
-        /* Configure group (broker-side config, do once) */
-        test_share_set_auto_offset_reset(config->group_name, "earliest");
-
-        /* Subscribe all consumers to all topics */
-        subs = rd_kafka_topic_partition_list_new(config->topic_cnt);
-        for (t = 0; t < config->topic_cnt; t++) {
-                rd_kafka_topic_partition_list_add(subs, state.topics[t],
-                                                  RD_KAFKA_PARTITION_UA);
-        }
-        for (c = 0; c < config->consumer_cnt; c++) {
-                rd_kafka_share_subscribe(consumers[c], subs);
-        }
-        rd_kafka_topic_partition_list_destroy(subs);
-
-        /* Allow consumers to join group */
-        TEST_SAY("Waiting for consumers to join group...\n");
-        rd_sleep(2);
-
-        /* Staggered start: wait before starting producers */
-        if (config->staggered_start) {
-                TEST_SAY(
-                    "Staggered start: waiting 2 seconds before producers\n");
-                rd_sleep(2);
-        }
+        /* Apply broker-side share group config (auto.offset.reset=earliest)
+         * via a throwaway consumer registration so the alter sticks before
+         * any worker subscribes. */
+        dummy_consumer = test_create_share_consumer(unique_group, NULL);
+        test_share_set_auto_offset_reset(unique_group, "earliest");
+        test_share_consumer_close(dummy_consumer);
+        test_share_destroy(dummy_consumer);
 
         /* Start producer threads */
         msgs_per_producer = state.expected_total / config->producer_cnt;
@@ -305,15 +507,12 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
                 args->state                  = &state;
                 args->producer_id            = p;
                 args->msgs_to_produce        = msgs_per_producer;
-                /* Last producer handles remainder */
-                if (p == config->producer_cnt - 1) {
+                if (p == config->producer_cnt - 1)
                         args->msgs_to_produce +=
                             state.expected_total % config->producer_cnt;
-                }
                 args->delay_ms = config->producer_delay_ms;
-                for (t = 0; t < config->topic_cnt; t++) {
+                for (t = 0; t < config->topic_cnt; t++)
                         args->partitions[t] = config->partitions[t];
-                }
 
                 if (thrd_create(&producer_threads[p], producer_thread_func,
                                 args) != thrd_success) {
@@ -321,149 +520,70 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
                 }
         }
 
-        /* Poll consumers from main thread while producers run */
-        max_attempts = config->max_attempts > 0 ? config->max_attempts : 100;
-        attempts     = max_attempts;
-        idle_rounds  = 0;
+        /* Optional staggered start: give producers a head start before
+         * spinning up consumer threads. */
+        if (config->staggered_start) {
+                TEST_SAY("Staggered start: producers run alone for 2 s\n");
+                rd_sleep(2);
+        }
 
-        TEST_SAY("Starting consumption (producers running in background)\n");
+        /* Start consumer threads — one per consumer */
+        for (c = 0; c < config->consumer_cnt; c++) {
+                consumer_args[c].state         = &state;
+                consumer_args[c].consumer_id   = c;
+                consumer_args[c].run           = rd_true;
+                consumer_args[c].done          = rd_false;
+                consumer_args[c].poll_delay_ms = config->consumer_delay_ms;
 
-        while (state.total_first_delivery < state.expected_total &&
-               attempts-- > 0 && idle_rounds < 30) {
-                round_consumed = 0;
-
-                /* Round-robin poll all consumers */
-                for (c = 0; c < config->consumer_cnt; c++) {
-                        rcvd = 0;
-
-                        err = rd_kafka_share_consume_batch(consumers[c], 1000,
-                                                           batch, &rcvd);
-                        if (err) {
-                                TEST_SAY(
-                                    "Consumer %d: "
-                                    "share_consume_batch "
-                                    "failed: %s\n",
-                                    c, rd_kafka_error_string(err));
-                                rd_kafka_error_destroy(err);
-                                continue;
-                        }
-
-                        for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err) {
-                                        if (config->explicit_ack) {
-                                                rd_kafka_share_acknowledge_type(
-                                                    consumers[c], batch[m],
-                                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                                        }
-                                        if (rd_kafka_message_delivery_count(
-                                                batch[m]) > 1)
-                                                state.total_duplicates++;
-                                        else
-                                                state.total_first_delivery++;
-                                        state.total_consumed++;
-                                }
-                                rd_kafka_message_destroy(batch[m]);
-                        }
-                        round_consumed += (int)rcvd;
+                if (thrd_create(&consumer_threads[c], consumer_thread_func,
+                                &consumer_args[c]) != thrd_success) {
+                        TEST_FAIL("Failed to create consumer thread %d", c);
                 }
+        }
 
-                if (round_consumed > 0) {
-                        idle_rounds = 0;
-                } else {
-                        idle_rounds++;
-                }
+        /* Wait for all expected first deliveries, bounded by max_attempts
+         * ticks of 500ms each (default 240 ticks = 120 s). */
+        max_wait_ticks = config->max_attempts > 0 ? config->max_attempts : 240;
+        wait_ticks     = max_wait_ticks;
 
-                /* Apply consumer delay if configured */
-                if (config->consumer_delay_ms > 0)
-                        rd_usleep(config->consumer_delay_ms * 1000, NULL);
+        while (wait_ticks-- > 0) {
+                int first_seen;
+                int consumed_so_far;
+                int dups;
+                rd_bool_t producers_done;
 
-                /* Check if producers are done */
                 mtx_lock(&state.lock);
-                if (state.producers_done && idle_rounds >= 20) {
-                        mtx_unlock(&state.lock);
-                        break;
-                }
+                first_seen      = state.total_first_delivery;
+                consumed_so_far = state.total_consumed;
+                dups            = state.total_duplicates;
+                producers_done  = state.producers_done;
                 mtx_unlock(&state.lock);
 
-                if (attempts % 10 == 0) {
+                if (first_seen >= state.expected_total)
+                        break;
+
+                if (wait_ticks % 20 == 0)
                         TEST_SAY(
-                            "Progress: consumed %d/%d (first=%d, "
-                            "dup=%d)\n",
-                            state.total_consumed, state.expected_total,
-                            state.total_first_delivery, state.total_duplicates);
-                }
+                            "Progress: consumed %d/%d (first=%d, dup=%d, "
+                            "producers_done=%d)\n",
+                            consumed_so_far, state.expected_total, first_seen,
+                            dups, (int)producers_done);
+
+                rd_usleep(500 * 1000, NULL);
         }
 
-        /* Wait for producer threads to finish */
-        for (p = 0; p < config->producer_cnt; p++) {
+        /* Join producers even if drain timed out. */
+        for (p = 0; p < config->producer_cnt; p++)
                 thrd_join(producer_threads[p], NULL);
-        }
 
+        /* Tell consumer threads to stop and join. */
         mtx_lock(&state.lock);
-        TEST_SAY("All producers done. Total produced: %d\n",
-                 state.total_produced);
+        for (c = 0; c < config->consumer_cnt; c++)
+                consumer_args[c].run = rd_false;
         mtx_unlock(&state.lock);
 
-        /* Continue consuming remaining messages after producers are done */
-        if (state.total_first_delivery < state.expected_total) {
-                idle_rounds = 0;
-
-                TEST_SAY("Consuming remaining messages: %d/%d\n",
-                         state.total_first_delivery, state.expected_total);
-
-                while (state.total_first_delivery < state.expected_total &&
-                       idle_rounds < 50) {
-                        round_consumed = 0;
-
-                        for (c = 0; c < config->consumer_cnt; c++) {
-                                rcvd = 0;
-
-                                err = rd_kafka_share_consume_batch(
-                                    consumers[c], 1000, batch, &rcvd);
-                                if (err) {
-                                        TEST_SAY(
-                                            "Consumer %d: "
-                                            "share_consume_batch "
-                                            "failed: %s\n",
-                                            c, rd_kafka_error_string(err));
-                                        rd_kafka_error_destroy(err);
-                                        continue;
-                                }
-
-                                for (m = 0; m < rcvd; m++) {
-                                        if (!batch[m]->err) {
-                                                if (config->explicit_ack) {
-                                                        rd_kafka_share_acknowledge_type(
-                                                            consumers[c],
-                                                            batch[m],
-                                                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                                                }
-                                                if (rd_kafka_message_delivery_count(
-                                                        batch[m]) > 1)
-                                                        state
-                                                            .total_duplicates++;
-                                                else
-                                                        state
-                                                            .total_first_delivery++;
-                                                state.total_consumed++;
-                                        }
-                                        rd_kafka_message_destroy(batch[m]);
-                                }
-                                round_consumed += (int)rcvd;
-                        }
-
-                        if (round_consumed > 0) {
-                                idle_rounds = 0;
-                        } else {
-                                idle_rounds++;
-                        }
-
-                        /* Apply consumer delay if configured */
-                        if (config->consumer_delay_ms > 0)
-                                rd_usleep(config->consumer_delay_ms * 1000,
-                                          NULL);
-                }
-        }
+        for (c = 0; c < config->consumer_cnt; c++)
+                thrd_join(consumer_threads[c], NULL);
 
         /* Snapshot results under lock */
         mtx_lock(&state.lock);
@@ -474,7 +594,6 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
         final_failed         = state.test_failed;
         mtx_unlock(&state.lock);
 
-        /* Verify results */
         TEST_SAY(
             "Final: produced=%d, consumed=%d (first=%d, dup=%d), "
             "expected=%d\n",
@@ -486,31 +605,24 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
                     state.expected_total, final_produced);
 
         /* A record can be redelivered if the broker-side acquisition lock
-         * expires before an ACCEPT arrives. We distinguish first deliveries
-         * (delivery_count
-         * == 1) from redeliveries via rd_kafka_message_delivery_count(),
-         * and assert strict equality on first deliveries — every produced
-         * record must have been delivered at least once. Duplicates are
-         * tracked separately so a regression in delivery semantics still
-         * shows up in the diagnostic output. */
+         * expires before an ACCEPT arrives. We distinguish first
+         * deliveries (delivery_count == 1) from redeliveries via
+         * rd_kafka_message_delivery_count() and assert strict equality on
+         * first deliveries — every produced record must have been
+         * delivered at least once. Duplicates are tracked separately so a
+         * regression in delivery semantics still shows up in the
+         * diagnostic output. */
         TEST_ASSERT(final_first_delivery == state.expected_total,
                     "Expected %d first-time deliveries, got %d "
                     "(consumed=%d, duplicates=%d)",
                     state.expected_total, final_first_delivery, final_consumed,
                     final_duplicates);
+        TEST_ASSERT(!final_failed, "Producer thread reported failure");
 
-        TEST_ASSERT(!final_failed, "Test marked as failed");
+        TEST_SAY("SUCCESS: %s\n", unique_test_name);
 
-        TEST_SAY("SUCCESS: %s\n", config->test_name);
-
-        /* Cleanup */
-        for (c = 0; c < config->consumer_cnt; c++) {
-                test_share_consumer_close(consumers[c]);
-                test_share_destroy(consumers[c]);
-        }
-        for (t = 0; t < config->topic_cnt; t++) {
+        for (t = 0; t < config->topic_cnt; t++)
                 rd_free(state.topics[t]);
-        }
         mtx_destroy(&state.lock);
 }
 
@@ -521,7 +633,7 @@ static void run_concurrent_test(const concurrent_test_config_t *config) {
 /**
  * @brief Single producer, single consumer, single topic
  */
-static void test_1p_1c_1t_1part(void) {
+static void do_test_1p_1c_1t_1part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 1,
             .producer_cnt       = 1,
@@ -530,13 +642,17 @@ static void test_1p_1c_1t_1part(void) {
             .msgs_per_partition = 5000,
             .group_name         = "share-conc-1p1c1t1p",
             .test_name = "1 producer, 1 consumer, 1 topic, 1 partition"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Single producer, multiple consumers, single topic
  */
-static void test_1p_4c_1t_4part(void) {
+static void do_test_1p_4c_1t_4part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 1,
@@ -545,13 +661,17 @@ static void test_1p_4c_1t_4part(void) {
             .msgs_per_partition = 5000,
             .group_name         = "share-conc-1p4c1t4p",
             .test_name = "1 producer, 4 consumers, 1 topic, 4 partitions"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Multiple producers, single consumer
  */
-static void test_4p_1c_1t_4part(void) {
+static void do_test_4p_1c_1t_4part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 1,
             .producer_cnt       = 4,
@@ -560,13 +680,17 @@ static void test_4p_1c_1t_4part(void) {
             .msgs_per_partition = 1250,
             .group_name         = "share-conc-4p1c1t4p",
             .test_name = "4 producers, 1 consumer, 1 topic, 4 partitions"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Multiple producers, multiple consumers, single topic
  */
-static void test_4p_4c_1t_4part(void) {
+static void do_test_4p_4c_1t_4part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 4,
@@ -575,7 +699,11 @@ static void test_4p_4c_1t_4part(void) {
             .msgs_per_partition = 5000,
             .group_name         = "share-conc-4p4c1t4p",
             .test_name = "4 producers, 4 consumers, 1 topic, 4 partitions"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -585,7 +713,7 @@ static void test_4p_4c_1t_4part(void) {
 /**
  * @brief Multiple topics with concurrent access
  */
-static void test_2p_2c_3t_2part(void) {
+static void do_test_2p_2c_3t_2part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 2,
             .producer_cnt       = 2,
@@ -595,13 +723,17 @@ static void test_2p_2c_3t_2part(void) {
             .group_name         = "share-conc-2p2c3t2p",
             .test_name =
                 "2 producers, 2 consumers, 3 topics, 2 partitions each"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Many topics with single partition each
  */
-static void test_2p_2c_8t_1part(void) {
+static void do_test_2p_2c_8t_1part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 2,
             .producer_cnt       = 2,
@@ -611,7 +743,11 @@ static void test_2p_2c_8t_1part(void) {
             .group_name         = "share-conc-2p2c8t1p",
             .test_name = "2 producers, 2 consumers, 8 topics, 1 partition each",
             .max_attempts = 150};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -621,23 +757,27 @@ static void test_2p_2c_8t_1part(void) {
 /**
  * @brief Many consumers competing for single partition
  */
-static void test_1p_8c_1t_1part(void) {
+static void do_test_1p_8c_1t_1part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 8,
             .producer_cnt       = 1,
             .topic_cnt          = 1,
             .partitions         = {1},
-            .msgs_per_partition = 40000,
+            .msgs_per_partition = 10000,
             .group_name         = "share-conc-1p8c1t1p",
             .test_name =
                 "1 producer, 8 consumers, 1 partition (high contention)"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief More consumers than partitions
  */
-static void test_2p_6c_1t_2part(void) {
+static void do_test_2p_6c_1t_2part(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 6,
             .producer_cnt       = 2,
@@ -647,7 +787,11 @@ static void test_2p_6c_1t_2part(void) {
             .group_name         = "share-conc-2p6c1t2p",
             .test_name =
                 "2 producers, 6 consumers, 2 partitions (3:1 consumer ratio)"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -657,7 +801,7 @@ static void test_2p_6c_1t_2part(void) {
 /**
  * @brief Concurrent with explicit acknowledgement
  */
-static void test_explicit_ack_4p_4c(void) {
+static void do_test_explicit_ack_4p_4c(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 4,
@@ -667,7 +811,11 @@ static void test_explicit_ack_4p_4c(void) {
             .group_name         = "share-conc-explicit-4p4c",
             .test_name          = "4 producers, 4 consumers, explicit ack",
             .explicit_ack       = rd_true};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -677,7 +825,7 @@ static void test_explicit_ack_4p_4c(void) {
 /**
  * @brief Consumers start before producers
  */
-static void test_staggered_start(void) {
+static void do_test_staggered_start(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 2,
             .producer_cnt       = 2,
@@ -687,7 +835,11 @@ static void test_staggered_start(void) {
             .group_name         = "share-conc-staggered",
             .test_name          = "Staggered start: consumers before producers",
             .staggered_start    = rd_true};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -697,7 +849,7 @@ static void test_staggered_start(void) {
 /**
  * @brief High volume concurrent test
  */
-static void test_high_volume_20k(void) {
+static void do_test_high_volume_20k(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 4,
@@ -707,13 +859,17 @@ static void test_high_volume_20k(void) {
             .group_name         = "share-conc-highvol-20k",
             .test_name          = "High volume: 4p x 4c x 20k messages",
             .max_attempts       = 150};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief High volume with many partitions
  */
-static void test_high_volume_many_partitions(void) {
+static void do_test_high_volume_many_partitions(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 4,
@@ -723,7 +879,11 @@ static void test_high_volume_many_partitions(void) {
             .group_name         = "share-conc-highvol-8p",
             .test_name    = "High volume: 8 partitions x 2.5k messages each",
             .max_attempts = 150};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -733,7 +893,7 @@ static void test_high_volume_many_partitions(void) {
 /**
  * @brief Many producers, few consumers
  */
-static void test_8p_2c(void) {
+static void do_test_8p_2c(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 2,
             .producer_cnt       = 8,
@@ -742,13 +902,17 @@ static void test_8p_2c(void) {
             .msgs_per_partition = 2500,
             .group_name         = "share-conc-8p2c",
             .test_name          = "8 producers, 2 consumers (producer heavy)"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Few producers, many consumers
  */
-static void test_2p_8c(void) {
+static void do_test_2p_8c(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 8,
             .producer_cnt       = 2,
@@ -757,7 +921,11 @@ static void test_2p_8c(void) {
             .msgs_per_partition = 10000,
             .group_name         = "share-conc-2p8c",
             .test_name          = "2 producers, 8 consumers (consumer heavy)"};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -767,7 +935,7 @@ static void test_2p_8c(void) {
 /**
  * @brief Complex scenario with varied partition counts
  */
-static void test_complex_varied_partitions(void) {
+static void do_test_complex_varied_partitions(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 4,
@@ -777,13 +945,17 @@ static void test_complex_varied_partitions(void) {
             .group_name         = "share-conc-complex-varied",
             .test_name    = "4 topics with 1,2,3,4 partitions respectively",
             .max_attempts = 150};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Maximum concurrent scenario
  */
-static void test_max_concurrent(void) {
+static void do_test_max_concurrent(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = MAX_CONSUMERS,
             .producer_cnt       = MAX_PRODUCERS,
@@ -793,7 +965,11 @@ static void test_max_concurrent(void) {
             .group_name         = "share-conc-max",
             .test_name    = "Maximum: 10 producers, 10 consumers, 4 topics",
             .max_attempts = 200};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /***************************************************************************
@@ -803,7 +979,7 @@ static void test_max_concurrent(void) {
 /**
  * @brief Slow consumers with fast producers
  */
-static void test_slow_consumers(void) {
+static void do_test_slow_consumers(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 2,
             .producer_cnt       = 4,
@@ -814,13 +990,17 @@ static void test_slow_consumers(void) {
             .test_name          = "Fast producers, slow consumers",
             .consumer_delay_ms  = 50,
             .max_attempts       = 200};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Fast consumers with slow producers
  */
-static void test_slow_producers(void) {
+static void do_test_slow_producers(void) {
         concurrent_test_config_t config = {
             .consumer_cnt       = 4,
             .producer_cnt       = 2,
@@ -831,8 +1011,369 @@ static void test_slow_producers(void) {
             .test_name          = "Slow producers, fast consumers",
             .producer_delay_ms  = 10000,
             .max_attempts       = 200};
+
+        SUB_TEST();
         run_concurrent_test(&config);
+
+        SUB_TEST_PASS();
 }
+
+/**
+ * @brief Chaos test: consumer churn during sustained production.
+ *
+ * Setup:
+ *  - 4 producers in dedicated threads producing fixed total messages.
+ *  - Pool of CONSUMER_POOL slots; only ACTIVE_CONSUMERS run concurrently.
+ *  - Initially start ACTIVE_CONSUMERS threads.
+ *  - For ITERATIONS rounds: sleep ITERATION_MS, then stop a random number
+ *    of the currently running consumers (>= 1) and start the same number
+ *    of fresh ones from the pool. Old threads are joined at the very end.
+ *  - After iterations, drain remaining messages and shut everyone down.
+ *
+ * Invariant for share consumers: every produced record is first-delivered
+ * exactly once. Records that a closing consumer hadn't acked are released
+ * back to the group and re-delivered with delivery_count > 1 (counted as
+ * duplicates, not first deliveries).
+ */
+static void do_test_chaos_consumer_lifecycle(rd_bool_t explicit_ack) {
+        concurrent_test_state_t state         = {0};
+        const concurrent_test_config_t config = {
+            .consumer_cnt       = 4, /* informational; pool size below */
+            .producer_cnt       = 4,
+            .topic_cnt          = 1,
+            .partitions         = {4},
+            .msgs_per_partition = 1000,
+            .group_name   = explicit_ack ? "share-chaos-lifecycle-explicit"
+                                         : "share-chaos-lifecycle-implicit",
+            .test_name    = explicit_ack ? "Chaos (explicit ack): consumer "
+                                           "churn during production"
+                                         : "Chaos (implicit ack): consumer "
+                                           "churn during production",
+            .explicit_ack = explicit_ack};
+        const int ACTIVE_CONSUMERS = 4;
+        const int CONSUMER_POOL    = 12;
+        const int ITERATIONS       = 3;
+        const int ITERATION_MS     = 6000;
+        const int join_poll_ticks  = 10; /* 10 * 500ms = 5 s */
+        thrd_t producer_threads[MAX_PRODUCERS];
+        thrd_t consumer_threads[MAX_CONSUMER_POOL];
+        consumer_thread_args_t consumer_args[MAX_CONSUMER_POOL];
+        int started_threads = 0;
+        int first_running   = 0;
+        int last_running;
+        int t, c, p, iter;
+        int total_partitions = 0;
+        int msgs_per_producer;
+        int wait_attempts;
+        int dangling = 0;
+        int final_produced;
+        int final_first_delivery;
+        int final_duplicates;
+        int final_consumed;
+        rd_bool_t final_failed;
+        rd_kafka_share_t *dummy_consumer;
+
+        SUB_TEST();
+
+        TEST_ASSERT(CONSUMER_POOL <= MAX_CONSUMER_POOL,
+                    "CONSUMER_POOL %d > MAX_CONSUMER_POOL", CONSUMER_POOL);
+        TEST_ASSERT(ACTIVE_CONSUMERS <= CONSUMER_POOL, "ACTIVE > POOL");
+
+        TEST_SAY("\n");
+        TEST_SAY(
+            "============================================================\n");
+        TEST_SAY("=== %s ===\n", config.test_name);
+        TEST_SAY(
+            "============================================================\n");
+        TEST_SAY("Active %d, pool %d, iterations %d × %d ms\n",
+                 ACTIVE_CONSUMERS, CONSUMER_POOL, ITERATIONS, ITERATION_MS);
+
+        this_test = test_curr;
+
+        /* See note in run_concurrent_test: set these on the main thread
+         * before spawning worker threads to avoid TSAN-flagged races on
+         * the shared test struct that test_curr aliases. */
+        test_curr->exp_dr_status = (rd_kafka_msg_status_t)-1;
+        test_curr->ignore_dr_err = rd_true;
+
+        mtx_init(&state.lock, mtx_plain);
+        state.topic_cnt           = config.topic_cnt;
+        state.group_name          = config.group_name;
+        state.explicit_ack        = config.explicit_ack;
+        state.producers_remaining = config.producer_cnt;
+
+        for (t = 0; t < config.topic_cnt; t++)
+                total_partitions += config.partitions[t];
+        state.expected_total = total_partitions * config.msgs_per_partition;
+        TEST_SAY("Expected messages: %d\n", state.expected_total);
+
+        for (t = 0; t < config.topic_cnt; t++) {
+                state.topics[t] =
+                    rd_strdup(test_mk_topic_name("0174-chaos", 1));
+                test_create_topic_wait_exists(
+                    NULL, state.topics[t], config.partitions[t], -1, 60 * 1000);
+        }
+
+        /* Apply broker-side group config (auto.offset.reset=earliest) via
+         * a throwaway consumer registration, so the alter sticks before
+         * any chaos worker subscribes. */
+        dummy_consumer = test_create_share_consumer(config.group_name, NULL);
+        test_share_set_auto_offset_reset(config.group_name, "earliest");
+        test_share_consumer_close(dummy_consumer);
+        test_share_destroy(dummy_consumer);
+
+        /* Producer threads */
+        msgs_per_producer = state.expected_total / config.producer_cnt;
+        for (p = 0; p < config.producer_cnt; p++) {
+                producer_thread_args_t *args = rd_calloc(1, sizeof(*args));
+                args->state                  = &state;
+                args->producer_id            = p;
+                args->msgs_to_produce        = msgs_per_producer;
+                if (p == config.producer_cnt - 1)
+                        args->msgs_to_produce +=
+                            state.expected_total % config.producer_cnt;
+                /* Light pacing so production stretches across the chaos
+                 * iterations rather than finishing before the first churn. */
+                args->delay_ms = 5;
+                for (t = 0; t < config.topic_cnt; t++)
+                        args->partitions[t] = config.partitions[t];
+
+                if (thrd_create(&producer_threads[p], producer_thread_func,
+                                args) != thrd_success) {
+                        TEST_FAIL("Failed to create producer thread %d", p);
+                }
+        }
+
+        /* Pre-init the entire pool */
+        for (c = 0; c < CONSUMER_POOL; c++) {
+                consumer_args[c].state         = &state;
+                consumer_args[c].consumer_id   = c;
+                consumer_args[c].run           = rd_false;
+                consumer_args[c].done          = rd_false;
+                consumer_args[c].poll_delay_ms = 0;
+        }
+
+        /* Start the initial active set */
+        for (c = 0; c < ACTIVE_CONSUMERS; c++) {
+                mtx_lock(&state.lock);
+                consumer_args[c].run = rd_true;
+                mtx_unlock(&state.lock);
+                if (thrd_create(&consumer_threads[c], consumer_thread_func,
+                                &consumer_args[c]) != thrd_success) {
+                        TEST_FAIL(
+                            "Failed to create initial consumer "
+                            "thread %d",
+                            c);
+                }
+                started_threads++;
+        }
+        last_running = ACTIVE_CONSUMERS - 1;
+
+        srand((unsigned int)time(NULL));
+
+        for (iter = 0; iter < ITERATIONS; iter++) {
+                int running;
+                int churn;
+                int can_start;
+                int s;
+
+                TEST_SAY("--- Iteration %d/%d: sleeping %d ms ---\n", iter + 1,
+                         ITERATIONS, ITERATION_MS);
+                rd_usleep(ITERATION_MS * 1000, NULL);
+
+                running = last_running - first_running + 1;
+                /* Stop at least 1, at most floor(running/2) for stability */
+                churn = (running > 1) ? (rand() % ((running / 2) + 1) + 1) : 1;
+                TEST_SAY("Iteration %d: stopping %d/%d running consumers\n",
+                         iter + 1, churn, running);
+
+                mtx_lock(&state.lock);
+                for (s = 0; s < churn && first_running <= last_running;
+                     s++, first_running++) {
+                        consumer_args[first_running].run = rd_false;
+                }
+                mtx_unlock(&state.lock);
+
+                /* Replenish with new pool slots (don't reuse stopped slots) */
+                can_start = CONSUMER_POOL - started_threads;
+                if (can_start <= 0) {
+                        TEST_SAY(
+                            "Pool exhausted (%d threads spawned); no more "
+                            "starts this iteration\n",
+                            started_threads);
+                        continue;
+                }
+                if (churn > can_start)
+                        churn = can_start;
+
+                TEST_SAY("Iteration %d: starting %d fresh consumers\n",
+                         iter + 1, churn);
+
+                for (s = 0; s < churn; s++) {
+                        int idx = started_threads;
+                        if (idx >= CONSUMER_POOL)
+                                break;
+                        mtx_lock(&state.lock);
+                        consumer_args[idx].run = rd_true;
+                        mtx_unlock(&state.lock);
+                        if (thrd_create(&consumer_threads[idx],
+                                        consumer_thread_func,
+                                        &consumer_args[idx]) != thrd_success) {
+                                TEST_FAIL(
+                                    "Failed to create chaos consumer "
+                                    "thread %d",
+                                    idx);
+                        }
+                        started_threads++;
+                        last_running = idx;
+                }
+        }
+
+        TEST_SAY(
+            "Iterations done; waiting for production to drain, then "
+            "shutting down consumers\n");
+
+        /* Drain loop, bounded so we don't sit for minutes on a stuck
+         * test:
+         *   - 60 ticks of 500 ms = 30 s absolute cap
+         *   - early exit when producers_done AND first_delivery has not
+         *     advanced for 10 consecutive ticks (~5 s of no progress).
+         *     If the chaos test has stalled, we report and move on
+         *     rather than waiting for the full window. */
+        wait_attempts         = 60; /* ~30 seconds absolute cap */
+        int prev_first_seen   = -1;
+        int stale_ticks       = 0;
+        const int stale_limit = 10; /* ~5 s with no progress */
+
+        while (wait_attempts-- > 0) {
+                int first_seen;
+                rd_bool_t producers_done;
+
+                mtx_lock(&state.lock);
+                first_seen     = state.total_first_delivery;
+                producers_done = state.producers_done;
+                mtx_unlock(&state.lock);
+
+                if (producers_done && first_seen >= state.expected_total)
+                        break;
+
+                if (first_seen == prev_first_seen) {
+                        stale_ticks++;
+                        if (producers_done && stale_ticks >= stale_limit) {
+                                TEST_SAY(
+                                    "Drain: no progress for "
+                                    "~%d s after producers done; "
+                                    "exiting at %d/%d "
+                                    "(test will fail in assertion)\n",
+                                    stale_ticks / 2, first_seen,
+                                    state.expected_total);
+                                break;
+                        }
+                } else {
+                        stale_ticks     = 0;
+                        prev_first_seen = first_seen;
+                }
+
+                if (wait_attempts % 10 == 0)
+                        TEST_SAY(
+                            "Drain: %d/%d first deliveries "
+                            "(producers_done=%d)\n",
+                            first_seen, state.expected_total,
+                            (int)producers_done);
+
+                rd_usleep(500 * 1000, NULL);
+        }
+
+        /* Join producers - these always exit cleanly so a hard join is
+         * safe. */
+        for (p = 0; p < config.producer_cnt; p++)
+                thrd_join(producer_threads[p], NULL);
+
+        /* Stop all consumer threads. */
+        mtx_lock(&state.lock);
+        for (c = 0; c < started_threads; c++)
+                consumer_args[c].run = rd_false;
+        mtx_unlock(&state.lock);
+
+        /* Bounded wait for consumers to exit cleanly. A wedged consumer
+         * (eg blocked inside consume_batch waiting on a stale share
+         * session) won't return from rd_kafka_share_consumer_close, so
+         * thrd_join would block indefinitely. We poll each consumer's
+         * done flag for up to ~5 s; any thread that hasn't set it by
+         * then is left dangling for the OS to reclaim at process exit
+         * and we move straight to the assertions. This matters only
+         * when the test is failing — once the underlying librdkafka
+         * issue is fixed, every consumer thread reaches its `done = true`
+         * within tens of milliseconds. */
+        for (c = 0; c < started_threads; c++) {
+                rd_bool_t done = rd_false;
+                for (t = 0; t < join_poll_ticks; t++) {
+                        mtx_lock(&state.lock);
+                        done = consumer_args[c].done;
+                        mtx_unlock(&state.lock);
+                        if (done)
+                                break;
+                        rd_usleep(500 * 1000, NULL);
+                }
+                if (done) {
+                        thrd_join(consumer_threads[c], NULL);
+                } else {
+                        /* Detach so the C runtime won't leak the
+                         * thrd_t handle when the process exits;
+                         * the OS will tear down the still-running
+                         * thread when the process terminates. */
+                        thrd_detach(consumer_threads[c]);
+                        dangling++;
+                        TEST_SAY(
+                            "Consumer thread %d: did not exit within "
+                            "5 s of stop signal — detaching and "
+                            "proceeding (likely wedged inside "
+                            "librdkafka close path)\n",
+                            consumer_args[c].consumer_id);
+                }
+        }
+
+        if (dangling > 0)
+                TEST_SAY(
+                    "WARNING: %d/%d consumer thread(s) left "
+                    "dangling at test exit\n",
+                    dangling, started_threads);
+
+        mtx_lock(&state.lock);
+        final_produced       = state.total_produced;
+        final_first_delivery = state.total_first_delivery;
+        final_duplicates     = state.total_duplicates;
+        final_consumed       = state.total_consumed;
+        final_failed         = state.test_failed;
+        mtx_unlock(&state.lock);
+
+        TEST_SAY(
+            "Chaos final: produced=%d, consumed=%d (first=%d, dup=%d), "
+            "expected=%d, threads spawned=%d\n",
+            final_produced, final_consumed, final_first_delivery,
+            final_duplicates, state.expected_total, started_threads);
+
+        TEST_ASSERT(final_produced == state.expected_total,
+                    "Expected to produce %d, actually produced %d",
+                    state.expected_total, final_produced);
+        TEST_ASSERT(final_first_delivery == state.expected_total,
+                    "Expected %d first-time deliveries, got %d "
+                    "(consumed=%d, duplicates=%d)",
+                    state.expected_total, final_first_delivery, final_consumed,
+                    final_duplicates);
+        TEST_ASSERT(!final_failed, "Producer thread reported failure");
+        TEST_SAY(
+            "SUCCESS: chaos test - %d threads churned, "
+            "every record first-delivered exactly once\n",
+            started_threads);
+
+        for (t = 0; t < config.topic_cnt; t++)
+                rd_free(state.topics[t]);
+        mtx_destroy(&state.lock);
+
+        SUB_TEST_PASS();
+}
+
 
 /***************************************************************************
  * Main Entry Point
@@ -840,43 +1381,54 @@ static void test_slow_producers(void) {
 
 int main_0174_share_consumer_concurrency(int argc, char **argv) {
 
-        test_timeout_set(600);
+        test_timeout_set(1500);
+
+        /* Every test below runs producers AND consumers in dedicated
+         * threads via run_concurrent_test(). There is no main-thread
+         * polling — consumer_thread_func handles the poll loop per
+         * consumer. */
 
         /* Basic concurrency tests */
-        test_1p_1c_1t_1part(); /* Baseline: 1 producer, 1 consumer */
-        test_1p_4c_1t_4part(); /* Fan out: 1 producer, 4 consumers */
-        test_4p_1c_1t_4part(); /* Fan in: 4 producers, 1 consumer */
-        test_4p_4c_1t_4part(); /* Symmetric: 4 producers, 4 consumers */
+        do_test_1p_1c_1t_1part(); /* Baseline: 1 producer, 1 consumer */
+        do_test_1p_4c_1t_4part(); /* Fan out: 1 producer, 4 consumers */
+        do_test_4p_1c_1t_4part(); /* Fan in: 4 producers, 1 consumer */
+        do_test_4p_4c_1t_4part(); /* Symmetric: 4 producers, 4 consumers */
 
         /* Multi-topic tests */
-        test_2p_2c_3t_2part(); /* Multiple topics */
-        test_2p_2c_8t_1part(); /* Many topics */
+        do_test_2p_2c_3t_2part(); /* Multiple topics */
+        do_test_2p_2c_8t_1part(); /* Many topics */
 
         /* High contention tests */
-        test_1p_8c_1t_1part(); /* Many consumers, 1 partition */
-        test_2p_6c_1t_2part(); /* More consumers than partitions */
+        do_test_1p_8c_1t_1part(); /* Many consumers, 1 partition */
+        do_test_2p_6c_1t_2part(); /* More consumers than partitions */
 
         /* Explicit acknowledgement */
-        test_explicit_ack_4p_4c();
+        do_test_explicit_ack_4p_4c();
 
         /* Staggered start */
-        test_staggered_start();
+        do_test_staggered_start();
 
         /* High volume stress tests */
-        test_high_volume_20k();
-        test_high_volume_many_partitions();
+        do_test_high_volume_20k();
+        do_test_high_volume_many_partitions();
 
         /* Asymmetric configurations */
-        test_8p_2c(); /* Producer heavy */
-        test_2p_8c(); /* Consumer heavy */
+        do_test_8p_2c(); /* Producer heavy */
+        do_test_2p_8c(); /* Consumer heavy */
 
         /* Complex scenarios */
-        test_complex_varied_partitions();
-        test_max_concurrent();
+        do_test_complex_varied_partitions();
+        do_test_max_concurrent();
 
         /* Slow consumer/producer scenarios */
-        test_slow_consumers();
-        test_slow_producers();
+        do_test_slow_consumers();
+        do_test_slow_producers();
+
+        /* Chaos test: consumer lifecycle churn during sustained production.
+         * Run once with explicit acknowledgement and once with implicit
+         * acknowledgement to cover both ack flows under churn. */
+        do_test_chaos_consumer_lifecycle(rd_true);
+        do_test_chaos_consumer_lifecycle(rd_false);
 
         return 0;
 }

--- a/tests/0175-share_consumer_groups.c
+++ b/tests/0175-share_consumer_groups.c
@@ -255,6 +255,24 @@ static void run_groups_test(groups_test_config_t *config) {
         int total_msgs;
         char result[256] = {0};
         int pos          = 0;
+        char unique_suffix[64];
+        char unique_test_name[256];
+        char unique_group_names[MAX_GROUPS][128];
+
+        /* Per-invocation unique suffix; appended to the test name and
+         * to every group name so re-runs / parallel runs get fresh
+         * share-groups on the broker. */
+        rd_snprintf(unique_suffix, sizeof(unique_suffix), "rnd%" PRIx64,
+                    test_id_generate());
+        rd_snprintf(unique_test_name, sizeof(unique_test_name), "%s [%s]",
+                    config->test_name, unique_suffix);
+        config->test_name = unique_test_name;
+        for (g = 0; g < config->group_cnt; g++) {
+                rd_snprintf(unique_group_names[g],
+                            sizeof(unique_group_names[g]), "%s-%s",
+                            config->group_names[g], unique_suffix);
+                config->group_names[g] = unique_group_names[g];
+        }
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -337,7 +355,7 @@ static void run_groups_test(groups_test_config_t *config) {
 /**
  * @brief Two groups consuming same topic independently
  */
-static void test_two_groups_same_topic(void) {
+static void do_test_two_groups_same_topic(void) {
         groups_test_config_t config = {
             .group_cnt                = 2,
             .consumers_per_group      = {1, 1},
@@ -348,13 +366,17 @@ static void test_two_groups_same_topic(void) {
             .test_name                = "Two groups consuming same topic",
             .produce_before_subscribe = rd_true,
         };
+
+        SUB_TEST();
         run_groups_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Three groups with 2 consumers each
  */
-static void test_three_groups_concurrent(void) {
+static void do_test_three_groups_concurrent(void) {
         groups_test_config_t config = {
             .group_cnt           = 3,
             .consumers_per_group = {2, 2, 2},
@@ -366,13 +388,17 @@ static void test_three_groups_concurrent(void) {
             .produce_before_subscribe = rd_true,
             .max_attempts             = 150,
         };
+
+        SUB_TEST();
         run_groups_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Five groups consuming same topic
  */
-static void test_five_groups_same_topic(void) {
+static void do_test_five_groups_same_topic(void) {
         groups_test_config_t config = {
             .group_cnt           = 5,
             .consumers_per_group = {1, 1, 1, 1, 1},
@@ -385,13 +411,17 @@ static void test_five_groups_same_topic(void) {
             .produce_before_subscribe = rd_true,
             .max_attempts             = 150,
         };
+
+        SUB_TEST();
         run_groups_test(&config);
+
+        SUB_TEST_PASS();
 }
 
 /**
  * @brief Groups joining at staggered times
  */
-static void test_groups_staggered_join(void) {
+static void do_test_groups_staggered_join(void) {
         rd_kafka_share_t *consumer_a, *consumer_b;
         rd_kafka_topic_partition_list_t *subs;
         rd_kafka_message_t *batch[BATCH_SIZE];
@@ -404,6 +434,8 @@ static void test_groups_staggered_join(void) {
         int attempts;
         size_t rcvd;
         size_t m;
+
+        SUB_TEST();
 
         TEST_SAY("\n");
         TEST_SAY(
@@ -516,19 +548,21 @@ static void test_groups_staggered_join(void) {
         test_delete_topic(test_share_consumer_get_rk(consumer_a), topic);
         test_share_destroy(consumer_a);
         test_share_destroy(consumer_b);
+
+        SUB_TEST_PASS();
 }
 
 int main_0175_share_consumer_groups(int argc, char **argv) {
 
         /* Basic multiple groups tests */
-        test_two_groups_same_topic();
-        test_three_groups_concurrent();
+        do_test_two_groups_same_topic();
+        do_test_three_groups_concurrent();
 
         /* Scale tests */
-        test_five_groups_same_topic();
+        do_test_five_groups_same_topic();
 
         /* Timing tests */
-        test_groups_staggered_join();
+        do_test_groups_staggered_join();
 
         return 0;
 }

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -124,6 +124,8 @@ static void do_test_basic_implicit_commit_sync(void) {
         int consumed = 0;
         int attempts = 0;
 
+        SUB_TEST();
+
         topic = test_mk_topic_name("0176-cs-impl-basic", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
         test_produce_msgs_simple(common_producer, topic, 0, 5);
@@ -220,6 +222,8 @@ static void do_test_basic_implicit_commit_sync(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -241,6 +245,8 @@ static void do_test_basic_explicit_commit_sync(void) {
         size_t j;
         int consumed = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0176-cs-expl-basic", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
@@ -341,6 +347,8 @@ static void do_test_basic_explicit_commit_sync(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -356,6 +364,8 @@ static void do_test_no_pending_acks(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0176-cs-no-pending", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
@@ -378,6 +388,8 @@ static void do_test_no_pending_acks(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -399,6 +411,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         size_t j;
         int consumed = 0;
         int attempts = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0176-cs-no-redeliver", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
@@ -472,6 +486,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -495,6 +511,8 @@ static void do_test_mixed_ack_types(void) {
         int attempts = 0;
         int64_t released_offsets[3];
         int released_cnt = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0176-cs-mixed-acks", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
@@ -646,6 +664,8 @@ static void do_test_mixed_ack_types(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -671,6 +691,8 @@ static void do_test_multiple_commit_sync_calls(void) {
         int attempts                = 0;
         int commit_cnt              = 0;
         int acked_since_last_commit = 0;
+
+        SUB_TEST();
 
         topic = test_mk_topic_name("0176-cs-multi-calls", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
@@ -814,6 +836,8 @@ static void do_test_multiple_commit_sync_calls(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -863,6 +887,8 @@ static void do_test_multi_topic_partition(void) {
             MULTI_TP_TOPICS * MULTI_TP_PARTITIONS * MULTI_TP_MSGS_PER_PARTITION;
         int i, p;
         int16_t max_dc_seen = 0;
+
+        SUB_TEST();
 
         /* Create topics and produce 10 messages per partition */
         for (i = 0; i < MULTI_TP_TOPICS; i++) {
@@ -1020,6 +1046,8 @@ static void do_test_multi_topic_partition(void) {
 
         for (i = 0; i < MULTI_TP_TOPICS; i++)
                 rd_free(topics[i]);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1278,9 +1306,9 @@ static void do_test_mock_uses_share_acknowledge(void) {
  *  the ack when the delayed response arrives.
  *
  *  TODO KIP-932: Verify and maybe unify the timeout error
- *  returned by commit_sync. Java uses a single REQUEST_TIMED_OUT
- *  mapping; librdkafka can return either depending on which
- *  timer fires first.
+ *  returned by commit_sync. librdkafka can return either
+ *  REQUEST_TIMED_OUT or _TIMED_OUT depending on which timer
+ *  fires first.
  *
  *  Phase 2: Remove RTT, wait 5s for broker to finish processing.
  *  Second consumer should get 0 records (acks were processed).
@@ -1533,6 +1561,8 @@ static void do_test_mixed_commit_types(void) {
         rd_ts_t t_start, t_elapsed_ms;
         rd_ts_t max_sync_elapsed_ms = 0;
 
+        SUB_TEST();
+
         topic = test_mk_topic_name("0176-cs-mixed-types", 1);
         test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
         test_produce_msgs_simple(common_producer, topic, 0, 50);
@@ -1701,6 +1731,8 @@ static void do_test_mixed_commit_types(void) {
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
 }
 
 
@@ -1931,6 +1963,46 @@ static void do_test_mock_broker_dispatch_priority(void) {
 }
 
 
+/* Extended ack callback state with error tracking for sync commit tests */
+typedef struct ack_cb_state_s {
+        test_ack_cb_state_t base;       /* Base state from test.h */
+        rd_kafka_resp_err_t errors[64]; /* Track errors per callback */
+        int error_cnt;
+} ack_cb_state_t;
+
+static void share_ack_cb(rd_kafka_share_t *rkshare,
+                         rd_kafka_share_partition_offsets_list_t *partitions,
+                         rd_kafka_resp_err_t err,
+                         void *opaque) {
+        ack_cb_state_t *state = (ack_cb_state_t *)opaque;
+        const rd_kafka_share_partition_offsets_t *entry;
+        size_t partition_cnt, offsets_in_entry = 0;
+
+        (void)rkshare;
+
+        partition_cnt = rd_kafka_share_partition_offsets_list_count(partitions);
+
+        entry = rd_kafka_share_partition_offsets_list_get(partitions, 0);
+        if (entry)
+                offsets_in_entry =
+                    rd_kafka_share_partition_offsets_offsets_cnt(entry);
+
+        TEST_SAY("ACK CALLBACK: err=%s (%d), partitions=%zu, offsets=%zu\n",
+                 rd_kafka_err2name(err), err, partition_cnt, offsets_in_entry);
+
+        state->base.callback_cnt++;
+        test_ack_cb_state_push_err(&state->base, err);
+
+        /* Track this error in our errors array */
+        if (state->error_cnt < 64)
+                state->errors[state->error_cnt++] = err;
+
+        if (entry)
+                state->base.total_offsets += offsets_in_entry;
+}
+
+
+
 /* ===================================================================
  *  Test: commit_sync callback invocation.
  *
@@ -2003,12 +2075,752 @@ static void do_test_commit_sync_callback(void) {
                     "Expected %zu offsets in callback, got %zu", consumed,
                     state.total_offsets);
 
-        rd_kafka_share_consumer_close(rkshare);
-        rd_kafka_share_destroy(rkshare);
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&state);
 
         SUB_TEST_PASS();
 }
+
+/* ===================================================================
+ *  commit_sync after subscribed topic deletion surfaces a per-partition
+ *  error.
+ *
+ *  Produce records, consume them, delete the subscribed topic, then
+ *  call commit_sync. The returned per-partition list should include the
+ *  deleted topic's partition with an error code (typically
+ *  UNKNOWN_TOPIC_OR_PART), not silent success.
+ * =================================================================== */
+static void do_test_commit_sync_after_topic_deletion(void) {
+        const char *topic_name;
+        char *topic_dup;
+        char *topics_for_delete[1];
+        const char *group = "commit-sync-deleted-topic";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_resp_err_t del_err;
+        size_t rcvd;
+        size_t j;
+        int consumed             = 0;
+        int attempts             = 0;
+        rd_bool_t topic_err_seen = rd_false;
+
+        SUB_TEST();
+
+        if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows")) {
+                TEST_SAY(
+                    "Skipping commit_sync-after-topic-deletion "
+                    "(broker on Windows)\n");
+                SUB_TEST_PASS();
+                return;
+        }
+
+        topic_name = test_mk_topic_name("0176-cs-deleted", 1);
+        topic_dup  = rd_strdup(topic_name);
+        test_create_topic_wait_exists(common_admin, topic_name, 1, -1,
+                                      60 * 1000);
+        test_produce_msgs_simple(common_producer, topic_name, 0, 5);
+
+        rkshare = create_share_consumer(group, "implicit");
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic_name, 1);
+
+        /* Consume records (so there's something to commit) */
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
+
+        /* Delete the subscribed topic */
+        TEST_SAY("Deleting topic %s\n", topic_name);
+        topics_for_delete[0] = topic_dup;
+        del_err              = test_DeleteTopics_simple(common_admin, NULL,
+                                                        topics_for_delete, 1, NULL);
+        TEST_ASSERT(del_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "DeleteTopics failed: %s", rd_kafka_err2str(del_err));
+
+        /* Wait for the topic delete to propagate in the cluster. */
+        rd_sleep(3);
+
+        /* commit_sync should return per-partition results — at least one
+         * partition's err should indicate the deletion. */
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_SAY("commit_sync returned: error=%s, partitions=%p\n",
+                 error ? rd_kafka_error_string(error) : "NULL",
+                 (void *)partitions);
+
+        if (error)
+                rd_kafka_error_destroy(error);
+
+        if (partitions) {
+                int i;
+                TEST_SAY("commit_sync returned %d partition entries\n",
+                         partitions->cnt);
+                for (i = 0; i < partitions->cnt; i++) {
+                        TEST_SAY("  %s [%" PRId32 "]: %s\n",
+                                 partitions->elems[i].topic,
+                                 partitions->elems[i].partition,
+                                 rd_kafka_err2name(partitions->elems[i].err));
+                        if (partitions->elems[i].err !=
+                            RD_KAFKA_RESP_ERR_NO_ERROR)
+                                topic_err_seen = rd_true;
+                }
+                rd_kafka_topic_partition_list_destroy(partitions);
+        }
+
+        TEST_ASSERT(topic_err_seen,
+                    "Expected commit_sync to surface a per-partition error "
+                    "after topic deletion");
+
+        rd_free(topic_dup);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Chaos: strict per-record ack / commit interleaving.
+ *
+ *  Pattern over 30 ACCEPTed records:
+ *    Phase A (records 0-14): one commit per ack, alternating
+ *                            commit_sync (odd-indexed acks) and
+ *                            commit_async (even-indexed acks).
+ *    Phase B (records 15-29): one commit per every 2 acks,
+ *                             alternating commit_sync / commit_async
+ *                             by pair index.
+ *  Verifies the library survives tight ack/commit alternation and
+ *  that the ack callback fires at least once across the run.
+ * =================================================================== */
+static void do_test_chaos_111_ack_commit_interleave(void) {
+        const char *topic;
+        const char *group = "commit-sync-chaos-111";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed         = 0;
+        int attempts         = 0;
+        int sync_cnt         = 0;
+        int async_cnt        = 0;
+        const int total_msgs = 30;
+        const int phase_a    = 15; /* 1-1 interleave region */
+        ack_cb_state_t state = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0176-cs-chaos-111", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, total_msgs);
+
+        rkshare = test_create_share_consumer_with_cb(group, "explicit",
+                                                     &state.base, share_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed < total_msgs && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd && consumed < total_msgs; j++) {
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+
+                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        if (consumed <= phase_a) {
+                                /* Phase A: ack 1 -> commit alternates */
+                                if (consumed % 2 == 1) {
+                                        error = rd_kafka_share_commit_sync(
+                                            rkshare, 30000, &partitions);
+                                        TEST_ASSERT(
+                                            !error,
+                                            "phase A commit_sync #%d: %s",
+                                            sync_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        RD_IF_FREE(
+                                            partitions,
+                                            rd_kafka_topic_partition_list_destroy);
+                                        partitions = NULL;
+                                        sync_cnt++;
+                                } else {
+                                        error = rd_kafka_share_commit_async(
+                                            rkshare);
+                                        TEST_ASSERT(
+                                            !error,
+                                            "phase A commit_async #%d: %s",
+                                            async_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        async_cnt++;
+                                }
+                        } else if (consumed % 2 == 0) {
+                                /* Phase B: commit every 2 records,
+                                 * alternating sync/async by pair index */
+                                int pair_idx = (consumed - phase_a) / 2;
+                                if (pair_idx % 2 == 1) {
+                                        error = rd_kafka_share_commit_async(
+                                            rkshare);
+                                        TEST_ASSERT(
+                                            !error,
+                                            "phase B commit_async #%d: %s",
+                                            async_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        async_cnt++;
+                                } else {
+                                        error = rd_kafka_share_commit_sync(
+                                            rkshare, 30000, &partitions);
+                                        TEST_ASSERT(
+                                            !error,
+                                            "phase B commit_sync #%d: %s",
+                                            sync_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        RD_IF_FREE(
+                                            partitions,
+                                            rd_kafka_topic_partition_list_destroy);
+                                        partitions = NULL;
+                                        sync_cnt++;
+                                }
+                        }
+                }
+        }
+
+        TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
+                    total_msgs, consumed);
+
+        /* Drain any pending async commit callbacks. */
+        test_wait_for_cb_with_poll(&state.base, rkshare, sync_cnt + async_cnt,
+                                   10000);
+
+        TEST_SAY(
+            "chaos 1-1-1: consumed=%d sync=%d async=%d "
+            "callbacks=%d offsets=%zu last_err=%s\n",
+            consumed, sync_cnt, async_cnt, state.base.callback_cnt,
+            state.base.total_offsets, rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        TEST_ASSERT(state.base.callback_cnt >= 1,
+                    "Expected at least 1 ack callback, got %d",
+                    state.base.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Chaos: per-record alternating commit_sync / commit_async.
+ *
+ *  Consume 40 records and, for every single ACCEPTed record, alternate
+ *  between commit_sync and commit_async. Stresses the library's
+ *  bookkeeping under the tightest possible commit cadence.
+ * =================================================================== */
+static void do_test_chaos_alternating_commits(void) {
+        const char *topic;
+        const char *group = "commit-sync-chaos-alt";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed         = 0;
+        int attempts         = 0;
+        int sync_cnt         = 0;
+        int async_cnt        = 0;
+        const int total_msgs = 40;
+        ack_cb_state_t state = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0176-cs-chaos-alt", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, total_msgs);
+
+        rkshare = test_create_share_consumer_with_cb(group, "explicit",
+                                                     &state.base, share_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed < total_msgs && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd && consumed < total_msgs; j++) {
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        if (consumed % 2 == 1) {
+                                error = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                TEST_ASSERT(
+                                    !error, "commit_sync #%d: %s", sync_cnt + 1,
+                                    error ? rd_kafka_error_string(error) : "");
+                                RD_IF_FREE(
+                                    partitions,
+                                    rd_kafka_topic_partition_list_destroy);
+                                partitions = NULL;
+                                sync_cnt++;
+                        } else {
+                                error = rd_kafka_share_commit_async(rkshare);
+                                TEST_ASSERT(!error, "commit_async #%d: %s",
+                                            async_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                async_cnt++;
+                        }
+                }
+        }
+
+        TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
+                    total_msgs, consumed);
+
+        test_wait_for_cb_with_poll(&state.base, rkshare, sync_cnt + async_cnt,
+                                   10000);
+
+        TEST_SAY(
+            "chaos alt: consumed=%d sync=%d async=%d "
+            "callbacks=%d offsets=%zu last_err=%s\n",
+            consumed, sync_cnt, async_cnt, state.base.callback_cnt,
+            state.base.total_offsets, rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Chaos: randomized ack types and commit modes (fixed seed).
+ *
+ *  Seeded PRNG so the sequence is fully reproducible across runs.
+ *  For each ACCEPTed/RELEASEd/REJECTed record we may immediately issue
+ *  a commit (sync or async), with the choices driven by the PRNG.
+ *  Verifies that the lib survives a realistic mixed workload and that
+ *  ACCEPT'd offsets eventually flow through the ack callback without
+ *  errors.
+ * =================================================================== */
+static void do_test_chaos_random_ack_random_commit(void) {
+        const char *topic;
+        const char *group = "commit-sync-chaos-rand";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int processed         = 0;
+        int accepted          = 0;
+        int released          = 0;
+        int rejected          = 0;
+        int attempts          = 0;
+        int sync_cnt          = 0;
+        int async_cnt         = 0;
+        const int produce_cnt = 80;
+        const int target      = 60; /* stop after this many processed */
+        ack_cb_state_t state  = {0};
+
+        SUB_TEST();
+
+        /* Fixed seed: this test must produce the same chaos sequence
+         * across runs so a failure can be reproduced deterministically.
+         * Seed is set before any rand() call inside this test; no earlier
+         * test in main_0176_share_consumer_commit_sync calls rand(). */
+        srand(0xC0FFEE);
+
+        topic = test_mk_topic_name("0176-cs-chaos-rand", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, produce_cnt);
+
+        rkshare = test_create_share_consumer_with_cb(group, "explicit",
+                                                     &state.base, share_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (processed < target && attempts++ < 80) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                /* Drain the entire batch every iteration. Past `target`,
+                 * stop driving chaos but still ACCEPT every record so
+                 * nothing is left ACQUIRED in the lib's inflight map —
+                 * otherwise close/destroy would have to clean it up,
+                 * which the share consumer doesn't currently handle. */
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_share_AcknowledgeType_t at;
+                        rd_kafka_resp_err_t aerr;
+                        int r;
+
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+
+                        if (processed >= target) {
+                                /* Drain-only path: ACCEPT to release the
+                                 * lock without affecting chaos stats. */
+                                aerr = rd_kafka_share_acknowledge_type(
+                                    rkshare, rkmessages[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(!aerr, "drain ACCEPT failed: %s",
+                                            rd_kafka_err2str(aerr));
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+
+                        r = rand() % 6;
+                        if (r < 4) {
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+                                accepted++;
+                        } else if (r == 4) {
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
+                                released++;
+                        } else {
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
+                                rejected++;
+                        }
+
+                        aerr = rd_kafka_share_acknowledge_type(
+                            rkshare, rkmessages[j], at);
+                        TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
+                                    (int)at, rd_kafka_err2str(aerr));
+                        rd_kafka_message_destroy(rkmessages[j]);
+                        processed++;
+
+                        /* ~1 in 3 records: issue a commit. Sync vs async
+                         * decided by another PRNG draw. */
+                        if (rand() % 3 == 0) {
+                                if (rand() % 2 == 0) {
+                                        error = rd_kafka_share_commit_sync(
+                                            rkshare, 30000, &partitions);
+                                        TEST_ASSERT(
+                                            !error, "commit_sync #%d: %s",
+                                            sync_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        RD_IF_FREE(
+                                            partitions,
+                                            rd_kafka_topic_partition_list_destroy);
+                                        partitions = NULL;
+                                        sync_cnt++;
+                                } else {
+                                        error = rd_kafka_share_commit_async(
+                                            rkshare);
+                                        TEST_ASSERT(
+                                            !error, "commit_async #%d: %s",
+                                            async_cnt + 1,
+                                            error ? rd_kafka_error_string(error)
+                                                  : "");
+                                        async_cnt++;
+                                }
+                        }
+                }
+        }
+
+        /* Final flush. */
+        error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        TEST_ASSERT(!error, "final commit_sync: %s",
+                    error ? rd_kafka_error_string(error) : "");
+        RD_IF_FREE(partitions, rd_kafka_topic_partition_list_destroy);
+        partitions = NULL;
+        sync_cnt++;
+
+        test_wait_for_cb_with_poll(&state.base, rkshare, sync_cnt + async_cnt,
+                                   15000);
+
+        TEST_SAY(
+            "chaos random: processed=%d accept=%d release=%d reject=%d "
+            "sync=%d async=%d callbacks=%d offsets=%zu\n",
+            processed, accepted, released, rejected, sync_cnt, async_cnt,
+            state.base.callback_cnt, state.base.total_offsets);
+
+        TEST_ASSERT(state.base.callback_cnt >= 1,
+                    "Expected at least 1 ack callback, got %d",
+                    state.base.callback_cnt);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Chaos: burst of back-to-back commit_async then a flushing commit_sync.
+ *
+ *  Consume 50 records. After every ACCEPT, fire 5 commit_async in a row
+ *  followed by 1 commit_sync. Stresses the in-flight async commit queue
+ *  and the path where commit_sync drains a backlog of pending acks.
+ * =================================================================== */
+static void do_test_chaos_burst_commits(void) {
+        const char *topic;
+        const char *group = "commit-sync-chaos-burst";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed  = 0;
+        int attempts  = 0;
+        int sync_cnt  = 0;
+        int async_cnt = 0;
+        int b;
+        const int total_msgs = 50;
+        const int burst_size = 5;
+        ack_cb_state_t state = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0176-cs-chaos-burst", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, total_msgs);
+
+        rkshare = test_create_share_consumer_with_cb(group, "explicit",
+                                                     &state.base, share_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed < total_msgs && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd && consumed < total_msgs; j++) {
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        consumed++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        for (b = 0; b < burst_size; b++) {
+                                error = rd_kafka_share_commit_async(rkshare);
+                                TEST_ASSERT(
+                                    !error, "burst commit_async #%d: %s",
+                                    async_cnt + 1,
+                                    error ? rd_kafka_error_string(error) : "");
+                                async_cnt++;
+                        }
+
+                        error = rd_kafka_share_commit_sync(rkshare, 30000,
+                                                           &partitions);
+                        TEST_ASSERT(!error, "burst commit_sync #%d: %s",
+                                    sync_cnt + 1,
+                                    error ? rd_kafka_error_string(error) : "");
+                        RD_IF_FREE(partitions,
+                                   rd_kafka_topic_partition_list_destroy);
+                        partitions = NULL;
+                        sync_cnt++;
+                }
+        }
+
+        TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
+                    total_msgs, consumed);
+
+        test_wait_for_cb_with_poll(&state.base, rkshare, sync_cnt, 15000);
+
+        TEST_SAY(
+            "chaos burst: consumed=%d sync=%d async=%d "
+            "callbacks=%d offsets=%zu\n",
+            consumed, sync_cnt, async_cnt, state.base.callback_cnt,
+            state.base.total_offsets);
+
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  Chaos: callback-driven receipt accounting under varying batch sizes.
+ *
+ *  Consume 60 records and commit with progressively varying batch sizes
+ *  (ack 1 -> commit, ack 2 -> commit, ack 3 -> commit, ...) alternating
+ *  between commit_sync and commit_async. After the run, verify the ack
+ *  callback received offset counts that account for all ACCEPTed records.
+ * =================================================================== */
+static void do_test_chaos_callback_receipt_match(void) {
+        const char *topic;
+        const char *group = "commit-sync-chaos-receipts";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_error_t *error;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        size_t j;
+        int consumed           = 0;
+        int attempts           = 0;
+        int acked_since_commit = 0;
+        int batch_target       = 1;
+        int sync_cnt           = 0;
+        int async_cnt          = 0;
+        const int total_msgs   = 60;
+        ack_cb_state_t state   = {0};
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0176-cs-chaos-receipts", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, total_msgs);
+
+        rkshare = test_create_share_consumer_with_cb(group, "explicit",
+                                                     &state.base, share_ack_cb);
+        test_share_set_auto_offset_reset(group, "earliest");
+        subscribe_consumer(rkshare, &topic, 1);
+
+        while (consumed < total_msgs && attempts++ < 60) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                for (j = 0; j < rcvd && consumed < total_msgs; j++) {
+                        if (rkmessages[j]->err) {
+                                rd_kafka_message_destroy(rkmessages[j]);
+                                continue;
+                        }
+                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        consumed++;
+                        acked_since_commit++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+
+                        if (acked_since_commit < batch_target)
+                                continue;
+
+                        /* Alternate sync (odd batch idx) / async (even). */
+                        if ((sync_cnt + async_cnt) % 2 == 0) {
+                                error = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                TEST_ASSERT(
+                                    !error, "receipts commit_sync #%d: %s",
+                                    sync_cnt + 1,
+                                    error ? rd_kafka_error_string(error) : "");
+                                RD_IF_FREE(
+                                    partitions,
+                                    rd_kafka_topic_partition_list_destroy);
+                                partitions = NULL;
+                                sync_cnt++;
+                        } else {
+                                error = rd_kafka_share_commit_async(rkshare);
+                                TEST_ASSERT(
+                                    !error, "receipts commit_async #%d: %s",
+                                    async_cnt + 1,
+                                    error ? rd_kafka_error_string(error) : "");
+                                async_cnt++;
+                        }
+                        acked_since_commit = 0;
+                        batch_target       = (batch_target % 5) + 1;
+                }
+        }
+
+        /* Drain any leftover acked-but-not-committed records. */
+        if (acked_since_commit > 0) {
+                error = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+                TEST_ASSERT(!error, "final commit_sync: %s",
+                            error ? rd_kafka_error_string(error) : "");
+                RD_IF_FREE(partitions, rd_kafka_topic_partition_list_destroy);
+                partitions = NULL;
+                sync_cnt++;
+        }
+
+        TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
+                    total_msgs, consumed);
+
+        test_wait_for_cb_with_poll(&state.base, rkshare, sync_cnt + async_cnt,
+                                   15000);
+
+        TEST_SAY(
+            "chaos receipts: consumed=%d sync=%d async=%d "
+            "callbacks=%d offsets=%zu\n",
+            consumed, sync_cnt, async_cnt, state.base.callback_cnt,
+            state.base.total_offsets);
+
+        TEST_ASSERT(state.base.callback_cnt >= 1,
+                    "Expected at least 1 ack callback, got %d",
+                    state.base.callback_cnt);
+        TEST_ASSERT(state.base.total_offsets >= (size_t)consumed,
+                    "Expected callback to surface at least %d offsets, got %zu",
+                    consumed, state.base.total_offsets);
+        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Ack callback reported err: %s",
+                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
 
 int main_0176_share_consumer_commit_sync(int argc, char **argv) {
         test_timeout_set(120);
@@ -2027,6 +2839,16 @@ int main_0176_share_consumer_commit_sync(int argc, char **argv) {
 
         /* Callback test */
         do_test_commit_sync_callback();
+
+        /* commit_sync after subscribed topic was deleted */
+        do_test_commit_sync_after_topic_deletion();
+
+        /* Chaos: interleaved ack / commit patterns. */
+        do_test_chaos_111_ack_commit_interleave();
+        do_test_chaos_alternating_commits();
+        do_test_chaos_random_ack_random_commit();
+        do_test_chaos_burst_commits();
+        do_test_chaos_callback_receipt_match();
 
         rd_kafka_destroy(common_admin);
         rd_kafka_destroy(common_producer);

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1990,7 +1990,6 @@ static void share_ack_cb(rd_kafka_share_t *rkshare,
         TEST_SAY("ACK CALLBACK: err=%s (%d), partitions=%zu, offsets=%zu\n",
                  rd_kafka_err2name(err), err, partition_cnt, offsets_in_entry);
 
-        state->base.callback_cnt++;
         test_ack_cb_state_push_err(&state->base, err);
 
         /* Track this error in our errors array */
@@ -2325,14 +2324,17 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
             "chaos 1-1-1: consumed=%d sync=%d async=%d "
             "callbacks=%d offsets=%zu last_err=%s\n",
             consumed, sync_cnt, async_cnt, state.base.callback_cnt,
-            state.base.total_offsets, rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+            state.base.total_offsets,
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         TEST_ASSERT(state.base.callback_cnt >= 1,
                     "Expected at least 1 ack callback, got %d",
                     state.base.callback_cnt);
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Ack callback reported err: %s",
-                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Ack callback reported err: %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2425,11 +2427,14 @@ static void do_test_chaos_alternating_commits(void) {
             "chaos alt: consumed=%d sync=%d async=%d "
             "callbacks=%d offsets=%zu last_err=%s\n",
             consumed, sync_cnt, async_cnt, state.base.callback_cnt,
-            state.base.total_offsets, rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+            state.base.total_offsets,
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Ack callback reported err: %s",
-                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Ack callback reported err: %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2590,9 +2595,11 @@ static void do_test_chaos_random_ack_random_commit(void) {
         TEST_ASSERT(state.base.callback_cnt >= 1,
                     "Expected at least 1 ack callback, got %d",
                     state.base.callback_cnt);
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Ack callback reported err: %s",
-                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Ack callback reported err: %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2687,9 +2694,11 @@ static void do_test_chaos_burst_commits(void) {
             consumed, sync_cnt, async_cnt, state.base.callback_cnt,
             state.base.total_offsets);
 
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Ack callback reported err: %s",
-                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Ack callback reported err: %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2811,9 +2820,11 @@ static void do_test_chaos_callback_receipt_match(void) {
         TEST_ASSERT(state.base.total_offsets >= (size_t)consumed,
                     "Expected callback to surface at least %d offsets, got %zu",
                     consumed, state.base.total_offsets);
-        TEST_ASSERT(test_ack_cb_state_first_err(&state.base) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Ack callback reported err: %s",
-                    rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
+        TEST_ASSERT(
+            test_ack_cb_state_first_err(&state.base) ==
+                RD_KAFKA_RESP_ERR_NO_ERROR,
+            "Ack callback reported err: %s",
+            rd_kafka_err2name(test_ack_cb_state_first_err(&state.base)));
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -1079,6 +1079,643 @@ static void do_test_interval_abort_pattern(const char *isolation_level) {
 }
 
 
+/**
+ * @brief Produce exactly one transactional record carrying \p value, then
+ *        commit (\p commit=rd_true) or abort the transaction.
+ */
+static void produce_msg_txn(rd_kafka_t *producer,
+                            const char *topic,
+                            const char *value,
+                            rd_bool_t commit) {
+        rd_kafka_resp_err_t err;
+
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer));
+
+        if (!commit)
+                test_curr->ignore_dr_err = rd_true;
+
+        err = rd_kafka_producev(producer, RD_KAFKA_V_TOPIC(topic),
+                                RD_KAFKA_V_VALUE((void *)value, strlen(value)),
+                                RD_KAFKA_V_END);
+        TEST_ASSERT(!err, "producev failed: %s", rd_kafka_err2name(err));
+        rd_kafka_flush(producer, 30000);
+
+        if (commit)
+                TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer, 30000));
+        else
+                TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer, 30000));
+
+        test_curr->ignore_dr_err = rd_false;
+}
+
+
+/**
+ * @brief Test: dynamic isolation level change READ_COMMITTED ->
+ *        READ_UNCOMMITTED with RELEASE acknowledgement on a committed
+ *        record.
+ *
+ * Phase 1: produce committed Msg1, consume + ACCEPT.
+ * Phase 2: produce aborted Msg2 (no records visible in read_committed).
+ * Phase 3: produce committed Msg3, consume + RELEASE.
+ * Phase 4: produce aborted Msg4. Released Msg3 may reappear; keep RELEASE-ing
+ *          it so the broker can advance past the abort marker.
+ * Phase 5: alter isolation level to read_uncommitted.
+ * Phase 6: produce committed Msg5, aborted Msg6, aborted Msg7, committed Msg8.
+ * Phase 7: consume; the released Msg3 (offset 4) plus the four new messages
+ *          (offsets 8, 10, 12, 14) should all be visible -> 5 unique offsets.
+ *
+ * With one record per transaction, the offset layout is:
+ *   0  Msg1 (commit marker 1)
+ *   2  Msg2 (abort  marker 3)
+ *   4  Msg3 (commit marker 5)
+ *   6  Msg4 (abort  marker 7)
+ *   8  Msg5 (commit marker 9)
+ *  10  Msg6 (abort  marker 11)
+ *  12  Msg7 (abort  marker 13)
+ *  14  Msg8 (commit marker 15)
+ */
+static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
+        const char *topic;
+        const char *group  = "share-dynamic-c-to-uc-release";
+        const char *txn_id = "txn-dynamic-c-uc-release";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t ack_err;
+        size_t rcvd, j;
+        int attempts;
+        int consumed;
+        rd_bool_t seen[20]               = {0};
+        const int64_t expected_offsets[] = {4, 8, 10, 12, 14};
+        size_t i;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0177-dyn-c-uc-release", 1);
+        test_create_topic(NULL, topic, 1, -1);
+
+        producer = create_txn_producer(txn_id);
+
+        consumer = test_create_share_consumer(group, "explicit");
+        configure_share_group(group, "read_committed");
+        subscribe_share_consumer(consumer, topic);
+
+        /* Phase 1: committed Msg1 -> ACCEPT */
+        TEST_SAY("Phase 1: committed Msg1 with READ_COMMITTED\n");
+        produce_msg_txn(producer, topic, "Message 1", rd_true);
+        consumed = 0;
+        attempts = 0;
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                TEST_ASSERT(batch[j]->offset == 0,
+                                            "Phase 1: expected offset 0, "
+                                            "got %" PRId64,
+                                            batch[j]->offset);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 1 ACCEPT failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
+                    consumed);
+        error = rd_kafka_share_commit_async(consumer);
+        TEST_ASSERT(!error, "Phase 1 commit_async failed");
+
+        /* Phase 2: aborted Msg2 - read_committed should hide the record;
+         * the broker eventually advances past the abort marker. */
+        TEST_SAY("Phase 2: aborted Msg2 (read_committed hides it)\n");
+        produce_msg_txn(producer, topic, "Message 2", rd_false);
+        attempts = 10;
+        while (attempts-- > 0) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+                for (j = 0; j < rcvd; j++) {
+                        TEST_ASSERT(batch[j]->err || batch[j]->offset != 2,
+                                    "Phase 2: aborted Msg2 leaked at "
+                                    "offset 2 in read_committed");
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+
+        /* Phase 3: committed Msg3 -> RELEASE */
+        TEST_SAY("Phase 3: committed Msg3 -> RELEASE\n");
+        produce_msg_txn(producer, topic, "Message 3", rd_true);
+        consumed = 0;
+        attempts = 0;
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                TEST_ASSERT(batch[j]->offset == 4,
+                                            "Phase 3: expected offset 4 "
+                                            "(Msg3), got %" PRId64,
+                                            batch[j]->offset);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 3 RELEASE failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
+                    consumed);
+        error = rd_kafka_share_commit_async(consumer);
+        TEST_ASSERT(!error, "Phase 3 commit_async failed");
+
+        /* Phase 4: aborted Msg4. Released Msg3 may re-appear; RELEASE it
+         * again so the next poll can advance. Keep this loop short: each
+         * RELEASE-and-redeliver bumps Msg3's delivery_count. The default
+         * share.delivery.count.limit is 5; Phase 3 already used one
+         * delivery and Phase 7's final ACCEPT will need one, so cap
+         * Phase 4 at 3 redeliveries to leave headroom and avoid the
+         * record being archived. */
+        TEST_SAY("Phase 4: aborted Msg4; Msg3 may redeliver -> RELEASE\n");
+        produce_msg_txn(producer, topic, "Message 4", rd_false);
+        attempts = 3;
+        while (attempts-- > 0) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                /* Should only be Msg3 (offset 4) re-delivered;
+                                 * Msg4 at offset 6 is aborted in
+                                 * read_committed.
+                                 */
+                                TEST_ASSERT(
+                                    batch[j]->offset == 4,
+                                    "Phase 4: unexpected offset %" PRId64,
+                                    batch[j]->offset);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 4 RELEASE failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+                if (rcvd > 0) {
+                        error = rd_kafka_share_commit_async(consumer);
+                        if (error)
+                                rd_kafka_error_destroy(error);
+                }
+        }
+
+        /* Phase 5: alter isolation level to read_uncommitted */
+        TEST_SAY("Phase 5: alter share.isolation.level to read_uncommitted\n");
+        test_share_set_isolation_level(group, "read_uncommitted");
+
+        /* Phase 6: produce 4 more transactions */
+        TEST_SAY("Phase 6: produce Msg5..Msg8\n");
+        produce_msg_txn(producer, topic, "Message 5", rd_true);
+        produce_msg_txn(producer, topic, "Message 6", rd_false);
+        produce_msg_txn(producer, topic, "Message 7", rd_false);
+        produce_msg_txn(producer, topic, "Message 8", rd_true);
+
+        /* Phase 7: expect to see 5 unique offsets: 4 (released Msg3),
+         * 8, 10, 12, 14 (Msg5..Msg8). */
+        TEST_SAY("Phase 7: consume - expect offsets {4,8,10,12,14}\n");
+        attempts = 0;
+        while (attempts++ < 60) {
+                int new_acks = 0;
+                rd_bool_t all_seen;
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                int64_t off = batch[j]->offset;
+                                if (off >= 0 && off < 20)
+                                        seen[off] = rd_true;
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 7 ACCEPT failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                new_acks++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+                if (new_acks > 0) {
+                        error = rd_kafka_share_commit_async(consumer);
+                        if (error)
+                                rd_kafka_error_destroy(error);
+                }
+
+                all_seen = rd_true;
+                for (i = 0;
+                     i < sizeof(expected_offsets) / sizeof(expected_offsets[0]);
+                     i++) {
+                        if (!seen[expected_offsets[i]]) {
+                                all_seen = rd_false;
+                                break;
+                        }
+                }
+                if (all_seen)
+                        break;
+        }
+
+        for (i = 0; i < sizeof(expected_offsets) / sizeof(expected_offsets[0]);
+             i++) {
+                TEST_ASSERT(seen[expected_offsets[i]],
+                            "Phase 7: expected offset %" PRId64
+                            " not seen after isolation change",
+                            expected_offsets[i]);
+        }
+
+        TEST_SAY(
+            "SUCCESS: dynamic READ_COMMITTED -> READ_UNCOMMITTED with "
+            "RELEASE\n");
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Test: dynamic isolation level change READ_COMMITTED ->
+ *        READ_UNCOMMITTED with REJECT acknowledgement on a committed
+ *        record.
+ *
+ * Same setup as the RELEASE variant, except Msg3 is REJECTed instead of
+ * RELEASEd. After the isolation level switch, Msg3 must NOT be redelivered;
+ * only the four new messages are expected -> 4 unique offsets.
+ */
+static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
+        const char *topic;
+        const char *group  = "share-dynamic-c-to-uc-reject";
+        const char *txn_id = "txn-dynamic-c-uc-reject";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *consumer;
+        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_error_t *error;
+        rd_kafka_resp_err_t ack_err;
+        size_t rcvd, j;
+        int attempts;
+        int consumed;
+        rd_bool_t seen[20]               = {0};
+        const int64_t expected_offsets[] = {8, 10, 12, 14};
+        size_t i;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0177-dyn-c-uc-reject", 1);
+        test_create_topic(NULL, topic, 1, -1);
+
+        producer = create_txn_producer(txn_id);
+
+        consumer = test_create_share_consumer(group, "explicit");
+        configure_share_group(group, "read_committed");
+        subscribe_share_consumer(consumer, topic);
+
+        /* Phase 1: committed Msg1 -> ACCEPT */
+        TEST_SAY("Phase 1: committed Msg1 with READ_COMMITTED\n");
+        produce_msg_txn(producer, topic, "Message 1", rd_true);
+        consumed = 0;
+        attempts = 0;
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                TEST_ASSERT(batch[j]->offset == 0,
+                                            "Phase 1: expected offset 0, "
+                                            "got %" PRId64,
+                                            batch[j]->offset);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 1 ACCEPT failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
+                    consumed);
+        error = rd_kafka_share_commit_async(consumer);
+        TEST_ASSERT(!error, "Phase 1 commit_async failed");
+
+        /* Phase 2: aborted Msg2 */
+        TEST_SAY("Phase 2: aborted Msg2 (read_committed hides it)\n");
+        produce_msg_txn(producer, topic, "Message 2", rd_false);
+        attempts = 10;
+        while (attempts-- > 0) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+                for (j = 0; j < rcvd; j++) {
+                        TEST_ASSERT(batch[j]->err || batch[j]->offset != 2,
+                                    "Phase 2: aborted Msg2 leaked at "
+                                    "offset 2 in read_committed");
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+
+        /* Phase 3: committed Msg3 -> REJECT */
+        TEST_SAY("Phase 3: committed Msg3 -> REJECT\n");
+        produce_msg_txn(producer, topic, "Message 3", rd_true);
+        consumed = 0;
+        attempts = 0;
+        while (consumed == 0 && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                TEST_ASSERT(batch[j]->offset == 4,
+                                            "Phase 3: expected offset 4 "
+                                            "(Msg3), got %" PRId64,
+                                            batch[j]->offset);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 3 REJECT failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
+                    consumed);
+        error = rd_kafka_share_commit_async(consumer);
+        TEST_ASSERT(!error, "Phase 3 commit_async failed");
+
+        /* Phase 4: aborted Msg4. Msg3 was REJECTed so it should not return.
+         * Just poll for a while to let the broker process the abort marker. */
+        TEST_SAY("Phase 4: aborted Msg4 (Msg3 was REJECTed)\n");
+        produce_msg_txn(producer, topic, "Message 4", rd_false);
+        attempts = 20;
+        while (attempts-- > 0) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                TEST_FAIL(
+                                    "Phase 4: unexpected record at "
+                                    "offset %" PRId64
+                                    " (Msg3 was REJECTed, Msg4 is "
+                                    "aborted in read_committed)",
+                                    batch[j]->offset);
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+
+        /* Phase 5: alter isolation level to read_uncommitted */
+        TEST_SAY("Phase 5: alter share.isolation.level to read_uncommitted\n");
+        test_share_set_isolation_level(group, "read_uncommitted");
+
+        /* Phase 6: produce 4 more transactions */
+        TEST_SAY("Phase 6: produce Msg5..Msg8\n");
+        produce_msg_txn(producer, topic, "Message 5", rd_true);
+        produce_msg_txn(producer, topic, "Message 6", rd_false);
+        produce_msg_txn(producer, topic, "Message 7", rd_false);
+        produce_msg_txn(producer, topic, "Message 8", rd_true);
+
+        /* Phase 7: expect offsets {8, 10, 12, 14}. Msg3 (offset 4) must NOT
+         * reappear because it was REJECTed. */
+        TEST_SAY("Phase 7: consume - expect offsets {8,10,12,14}, no Msg3\n");
+        attempts = 0;
+        while (attempts++ < 60) {
+                int new_acks = 0;
+                rd_bool_t all_seen;
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                int64_t off = batch[j]->offset;
+                                TEST_ASSERT(off != 4,
+                                            "Phase 7: Msg3 (offset 4) "
+                                            "should not be redelivered "
+                                            "after REJECT");
+                                if (off >= 0 && off < 20)
+                                        seen[off] = rd_true;
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    consumer, batch[j],
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(ack_err ==
+                                                RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "Phase 7 ACCEPT failed: %s",
+                                            rd_kafka_err2name(ack_err));
+                                new_acks++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+                if (new_acks > 0) {
+                        error = rd_kafka_share_commit_async(consumer);
+                        if (error)
+                                rd_kafka_error_destroy(error);
+                }
+
+                all_seen = rd_true;
+                for (i = 0;
+                     i < sizeof(expected_offsets) / sizeof(expected_offsets[0]);
+                     i++) {
+                        if (!seen[expected_offsets[i]]) {
+                                all_seen = rd_false;
+                                break;
+                        }
+                }
+                if (all_seen)
+                        break;
+        }
+
+        for (i = 0; i < sizeof(expected_offsets) / sizeof(expected_offsets[0]);
+             i++) {
+                TEST_ASSERT(seen[expected_offsets[i]],
+                            "Phase 7: expected offset %" PRId64
+                            " not seen after isolation change",
+                            expected_offsets[i]);
+        }
+        TEST_ASSERT(!seen[4],
+                    "Phase 7: Msg3 (offset 4) appeared but it was REJECTed");
+
+        TEST_SAY(
+            "SUCCESS: dynamic READ_COMMITTED -> READ_UNCOMMITTED with "
+            "REJECT\n");
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Two share groups, different isolation levels, same topic.
+ *
+ * share.isolation.level is a BROKER-SIDE group config — consumers in
+ * the SAME group cannot have different isolation levels. This test
+ * exercises two distinct groups consuming the same topic concurrently
+ * with different isolation levels.
+ *
+ * Producer mix on the topic:
+ *   - txn-A committed: 100 records
+ *   - txn-B aborted:   100 records
+ *   - txn-C committed: 100 records
+ *
+ * Expected:
+ *   - Group G1 (read_committed):   sees 200 records (A+C only)
+ *   - Group G2 (read_uncommitted): sees 300 records (A+B+C)
+ */
+static void do_test_two_groups_different_isolation_levels(void) {
+        const char *topic;
+        const char *grp_committed   = "share-txn-twogroup-rc";
+        const char *grp_uncommitted = "share-txn-twogroup-ru";
+        rd_kafka_t *producer_a;
+        rd_kafka_t *producer_b;
+        rd_kafka_t *producer_c;
+        rd_kafka_share_t *c_committed;
+        rd_kafka_share_t *c_uncommitted;
+        const int msg_cnt     = 100;
+        const int expected_rc = 2 * msg_cnt;
+        const int expected_ru = 3 * msg_cnt;
+        int consumed_rc;
+        int consumed_ru;
+
+        SUB_TEST("two groups, different isolation levels");
+
+        topic = test_mk_topic_name("0177-twogroup-iso", 1);
+        test_create_topic(NULL, topic, 1, -1);
+
+        producer_a = create_txn_producer("twogroup-iso-A");
+        producer_b = create_txn_producer("twogroup-iso-B");
+        producer_c = create_txn_producer("twogroup-iso-C");
+
+        /* Subscribe both consumers BEFORE producing so they're ready to
+         * consume from the earliest offset. */
+        c_committed = test_create_share_consumer(grp_committed, NULL);
+        configure_share_group(grp_committed, "read_committed");
+        subscribe_share_consumer(c_committed, topic);
+
+        c_uncommitted = test_create_share_consumer(grp_uncommitted, NULL);
+        configure_share_group(grp_uncommitted, "read_uncommitted");
+        subscribe_share_consumer(c_uncommitted, topic);
+
+        /* txn-A: committed */
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer_a));
+        test_produce_msgs2(producer_a, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer_a, 30000));
+
+        /* txn-B: aborted */
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer_b));
+        test_curr->ignore_dr_err = rd_true;
+        test_produce_msgs2(producer_b, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_abort_transaction(producer_b, 30000));
+        test_curr->ignore_dr_err = rd_false;
+
+        /* txn-C: committed */
+        TEST_CALL_ERROR__(rd_kafka_begin_transaction(producer_c));
+        test_produce_msgs2(producer_c, topic, test_id_generate(),
+                           RD_KAFKA_PARTITION_UA, 0, msg_cnt, NULL, 0);
+        TEST_CALL_ERROR__(rd_kafka_commit_transaction(producer_c, 30000));
+
+        /* Both groups consume the same topic concurrently. */
+        TEST_SAY("Consuming via read_committed group\n");
+        consumed_rc =
+            consume_share_messages(c_committed, expected_rc, 80, 3000);
+        TEST_SAY("Consuming via read_uncommitted group\n");
+        consumed_ru =
+            consume_share_messages(c_uncommitted, expected_ru, 80, 3000);
+
+        TEST_SAY(
+            "Result: read_committed=%d (expected %d), "
+            "read_uncommitted=%d (expected %d)\n",
+            consumed_rc, expected_rc, consumed_ru, expected_ru);
+
+        TEST_ASSERT(consumed_rc == expected_rc,
+                    "read_committed group expected %d records, got %d",
+                    expected_rc, consumed_rc);
+        TEST_ASSERT(consumed_ru == expected_ru,
+                    "read_uncommitted group expected %d records, got %d",
+                    expected_ru, consumed_ru);
+
+        test_share_consumer_close(c_committed);
+        test_share_destroy(c_committed);
+        test_share_consumer_close(c_uncommitted);
+        test_share_destroy(c_uncommitted);
+        rd_kafka_destroy(producer_a);
+        rd_kafka_destroy(producer_b);
+        rd_kafka_destroy(producer_c);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0177_share_consumer_transactions(int argc, char **argv) {
         /* Test both isolation levels */
         const char *isolation_levels[] = {"read_committed", "read_uncommitted"};
@@ -1124,6 +1761,11 @@ int main_0177_share_consumer_transactions(int argc, char **argv) {
         TEST_SAY("========================================\n");
 
         do_test_dynamic_uncommitted_to_committed();
+        do_test_dynamic_committed_to_uncommitted_with_release();
+        do_test_dynamic_committed_to_uncommitted_with_reject();
+
+        /* Two-groups, different isolation levels on the same topic */
+        do_test_two_groups_different_isolation_levels();
 
         /* Cleanup common handles */
         rd_kafka_destroy(common_admin);

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -940,7 +940,7 @@ static int test_close_with_broker_down_is_fatal_cb(rd_kafka_t *rk,
  * Verifies that acknowledged messages are not redelivered to a second
  consumer.
  */
-static void test_close_with_acknowledge(void) {
+static void do_test_close_with_acknowledge(void) {
         /**
          * @brief Test configuration for close with acknowledge scenarios
          */
@@ -980,6 +980,8 @@ static void test_close_with_acknowledge(void) {
             {"close-2t2p-commit-async", 2, {2, 2}, 10, COMMIT_MODE_ASYNC, 20},
             {"close-2t2p-commit-sync", 2, {2, 2}, 10, COMMIT_MODE_SYNC, 20},
         };
+
+        SUB_TEST();
 
         for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
                 close_ack_test_config_t *config = &tests[i];
@@ -1074,6 +1076,8 @@ static void test_close_with_acknowledge(void) {
                          config->test_name);
                 test_share_destroy(c1);
         }
+
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1090,7 +1094,7 @@ static void test_close_with_acknowledge(void) {
  *
  * Tests multiple topologies: 1t1p, 1t3p, 3t1p, 2t2p
  */
-static void test_close_without_acknowledge() {
+static void do_test_close_without_acknowledge() {
         /**
          * @brief Test configuration for close without acknowledge scenarios
          */
@@ -1116,6 +1120,8 @@ static void test_close_without_acknowledge() {
             /* Multiple topics, multiple partitions */
             {"close-no-ack-2t2p", 2, {2, 2}, 10, 5},
         };
+
+        SUB_TEST();
 
         for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
                 close_no_ack_test_config_t *config = &tests[i];
@@ -1193,6 +1199,8 @@ static void test_close_without_acknowledge() {
                          config->test_name);
                 test_share_destroy(c1);
         }
+
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1210,7 +1218,7 @@ static void test_close_without_acknowledge() {
  * In each case, close() should wait for the response and complete
  * successfully after the delay.
  */
-static void test_close_with_slow_broker_response(void) {
+static void do_test_close_with_slow_broker_response(void) {
         typedef struct {
                 const char *test_name;
                 int delayed_broker_cnt;
@@ -1300,7 +1308,7 @@ static void test_close_with_slow_broker_response(void) {
  * 2. Brokers 1 and 2 have delayed responses
  * 3. All 3 brokers have delayed responses
  */
-static void test_close_respects_socket_timeout(void) {
+static void do_test_close_respects_socket_timeout(void) {
         typedef struct {
                 const char *test_name;
                 int delayed_broker_cnt;
@@ -1403,7 +1411,7 @@ static void test_close_respects_socket_timeout(void) {
  * 2. Brokers 1 and 2 return the error
  * 3. All 3 brokers return the error
  */
-static void test_close_with_broker_error_response(void) {
+static void do_test_close_with_broker_error_response(void) {
         typedef struct {
                 const char *test_name;
                 int erroring_broker_cnt;
@@ -1485,7 +1493,7 @@ static void test_close_with_broker_error_response(void) {
  *    and verify it receives 0 messages over up to 5 fetch attempts. If
  *    any message is delivered, close() failed to send the acks.
  */
-static void test_close_with_broker_busy(void) {
+static void do_test_close_with_broker_busy(void) {
         const char *test_name        = "close-broker-busy";
         const int partition_cnt      = 3;
         const int msgs_per_partition = 10;
@@ -1659,7 +1667,7 @@ static void test_close_with_broker_busy(void) {
  *   broker down and call close().
  * - close() should return immediately and return NULL (no error).
  */
-static void test_close_with_broker_down(void) {
+static void do_test_close_with_broker_down(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_share_t *consumer;
@@ -1769,7 +1777,7 @@ static void test_close_with_broker_down(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to set broker up");
 
-        rd_kafka_share_destroy(consumer);
+        test_share_destroy(consumer);
         test_mock_cluster_destroy(mcluster);
 
         /* Restore default error-fatal behavior for subsequent tests. */
@@ -1784,7 +1792,7 @@ static void test_close_with_broker_down(void) {
  * Verifies every guarded API returns RD_KAFKA_RESP_ERR__STATE with
  * "closed" in the error string.
  */
-static void test_api_calls_on_closed_consumer(void) {
+static void do_test_api_calls_on_closed_consumer(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_conf_t *conf;
@@ -1846,7 +1854,7 @@ static void test_api_calls_on_closed_consumer(void) {
  * completes later), giving us a deterministic window to exercise every
  * guarded API.
  */
-static void test_api_calls_during_closing(void) {
+static void do_test_api_calls_during_closing(void) {
         rd_kafka_mock_cluster_t *mcluster;
         const char *bootstraps;
         rd_kafka_conf_t *conf;
@@ -1931,6 +1939,111 @@ static void test_api_calls_during_closing(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Test that the share-ack callback fires for un-committed implicit
+ *        acks during close.
+ *
+ * In implicit mode, records consumed in the first poll are auto-acked via
+ * piggyback on the next ShareFetch. After polling twice (first to fetch,
+ * second to drive the piggyback ack) and closing without an explicit
+ * commit, the ack callback must have fired with the consumed offsets.
+ */
+static void do_test_implicit_ack_callback_fires_on_close(void) {
+        const char *topic_name;
+        const char *group;
+        char group_id[64];
+        rd_kafka_share_t *rkshare;
+        rd_kafka_message_t *raw_batch[16];
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_error_t *error;
+        ack_receipts_t receipts;
+        size_t rcvd, j;
+        int consumed = 0;
+        int attempts = 0;
+
+        SUB_TEST();
+
+        ack_receipts_init(&receipts);
+
+        topic_name = test_mk_topic_name("0178-impl-ack-on-close", 1);
+        test_create_topic_wait_exists(common_admin, topic_name, 1, -1,
+                                      60 * 1000);
+        test_produce_msgs_simple(common_producer, topic_name, 0, 1);
+
+        rd_snprintf(group_id, sizeof(group_id),
+                    "0178-group-impl-ack-close-%" PRIu64, test_id_generate());
+        group = group_id;
+
+        test_share_set_auto_offset_reset(group, "earliest");
+        rkshare =
+            create_share_consumer_with_receipts(group, "implicit", &receipts);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic_name,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* First poll: fetch the record (auto-ack pending for next poll) */
+        while (consumed < 1 && attempts++ < 30) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 2000, raw_batch,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!raw_batch[j]->err)
+                                consumed++;
+                        rd_kafka_message_destroy(raw_batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 1, "Expected 1 record, got %d", consumed);
+
+        /* Second poll: drives the piggybacked implicit ack to the broker */
+        attempts = 5;
+        while (attempts-- > 0) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 1000, raw_batch,
+                                                     &rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+                for (j = 0; j < rcvd; j++)
+                        rd_kafka_message_destroy(raw_batch[j]);
+        }
+
+        /* Close - any pending ack-completion callbacks must be flushed */
+        TEST_SAY("Closing share consumer without explicit commit\n");
+        error = rd_kafka_share_consumer_close(rkshare);
+        TEST_ASSERT(error == NULL, "close returned error: %s",
+                    rd_kafka_error_string(error));
+
+        TEST_SAY(
+            "After close: callback_invocations=%d, receipts=%d, "
+            "last_cb_err=%s\n",
+            receipts.callback_invocations, receipts.receipt_cnt,
+            rd_kafka_err2name(receipts.last_cb_err));
+
+        TEST_ASSERT(receipts.callback_invocations >= 1,
+                    "Expected ack callback to fire at least once "
+                    "by the time close returns, got %d invocations",
+                    receipts.callback_invocations);
+        TEST_ASSERT(receipts.receipt_cnt >= 1,
+                    "Expected at least 1 acked offset reported via "
+                    "the callback by close, got %d",
+                    receipts.receipt_cnt);
+        TEST_ASSERT(receipts.last_cb_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR in ack callback, got %s",
+                    rd_kafka_err2name(receipts.last_cb_err));
+
+        ack_receipts_destroy(&receipts);
+        test_share_destroy(rkshare);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0178_share_consumer_close(int argc, char **argv) {
         /* Set overall timeout for all tests */
         test_timeout_set(600);
@@ -1940,8 +2053,9 @@ int main_0178_share_consumer_close(int argc, char **argv) {
         common_admin    = test_create_producer();
 
         /* Real broker tests */
-        test_close_with_acknowledge();
-        test_close_without_acknowledge();
+        do_test_close_with_acknowledge();
+        do_test_close_without_acknowledge();
+        do_test_implicit_ack_callback_fires_on_close();
 
         /* Cleanup common handles */
         rd_kafka_destroy(common_admin);
@@ -1955,12 +2069,12 @@ int main_0178_share_consumer_close_local(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
         test_timeout_set(300);
 
-        test_close_with_slow_broker_response();
-        test_close_respects_socket_timeout();
-        test_close_with_broker_error_response();
-        test_close_with_broker_busy();
-        test_close_with_broker_down();
-        test_api_calls_on_closed_consumer();
-        test_api_calls_during_closing();
+        do_test_close_with_slow_broker_response();
+        do_test_close_respects_socket_timeout();
+        do_test_close_with_broker_error_response();
+        do_test_close_with_broker_busy();
+        do_test_close_with_broker_down();
+        do_test_api_calls_on_closed_consumer();
+        do_test_api_calls_during_closing();
         return 0;
 }

--- a/tests/0179-share_consumer_destroy.c
+++ b/tests/0179-share_consumer_destroy.c
@@ -368,6 +368,24 @@ static void destroy_share_consumer(rd_kafka_share_t *rkshare,
         TEST_SAY("Successfully destroyed share consumer\n");
 }
 
+/* Per-thread argument for destroy_watchdog_thread. Atomic `done` lets the
+ * main thread poll for completion without locking. */
+typedef struct destroy_watchdog_arg_s {
+        rd_kafka_share_t *rkshare;
+        int destroy_flags;
+        rd_atomic32_t done;
+} destroy_watchdog_arg_t;
+
+static int destroy_watchdog_thread(void *p) {
+        destroy_watchdog_arg_t *a = p;
+        if (a->destroy_flags)
+                rd_kafka_share_destroy_flags(a->rkshare, a->destroy_flags);
+        else
+                rd_kafka_share_destroy(a->rkshare);
+        rd_atomic32_set(&a->done, 1);
+        return 0;
+}
+
 /**
  * @brief is_fatal_cb hook for test_broker_decommission_with_commit_sync.
  *
@@ -2056,6 +2074,190 @@ static void do_test_destroy_with_subscribe_unsubscribe(int do_subscribe,
 }
 
 
+/**
+ * @brief Destroy a consumer that drove a mixed-ack chaos workload —
+ *        ACCEPT/RELEASE/REJECT round-robin acks, with commit_async every
+ *        5 acks and commit_sync every 10 acks. destroy runs on a
+ *        watchdog thread so a hung destroy fails the test loudly instead
+ *        of wedging the binary.
+ */
+static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
+        const char *topic;
+        const char *group = "0179-destroy-mixed";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_message_t *batch[64];
+        rd_kafka_error_t *close_err;
+        thrd_t destroy_thr;
+        destroy_watchdog_arg_t arg;
+        ack_receipts_t receipts;
+        const int produce_cnt         = 40;
+        const int target              = 30;
+        const int DESTROY_DEADLINE_MS = 15000;
+        rd_ts_t t_start;
+        int64_t t_close_ms = 0;
+        int64_t t_destroy_ms;
+        size_t rcvd;
+        size_t j;
+        int acked     = 0;
+        int sync_cnt  = 0;
+        int async_cnt = 0;
+        int attempts  = 0;
+        int wait_ok;
+        rd_bool_t do_close =
+            !(destroy_flags & RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
+
+        SUB_TEST("destroy_flags=0x%x", destroy_flags);
+
+        ack_receipts_init(&receipts);
+
+        topic = test_mk_topic_name("0179-destroy-mixed", 1);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_produce_msgs_simple(common_producer, topic, 0, produce_cnt);
+
+        test_share_set_auto_offset_reset(group, "earliest");
+        rkshare =
+            new_share_consumer_for_real_test(group, "explicit", &receipts);
+        subscribe_topics(rkshare, &topic, 1);
+
+        /* Drive chaos: round-robin ACCEPT/RELEASE/REJECT acks with
+         * interleaved commits. Past `target` we drop each batch's
+         * message handles without acking — close/destroy must cope
+         * with whatever inflight state that leaves the lib in. */
+        while (acked < target && attempts++ < 80) {
+                rd_kafka_error_t *err;
+                rcvd = 0;
+                err = rd_kafka_share_consume_batch(rkshare, 3000, batch, &rcvd);
+                if (err) {
+                        rd_kafka_error_destroy(err);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_share_AcknowledgeType_t at;
+                        rd_kafka_resp_err_t aerr;
+                        rd_kafka_error_t *cerr;
+
+                        if (batch[j]->err) {
+                                rd_kafka_message_destroy(batch[j]);
+                                continue;
+                        }
+
+                        if (acked >= target) {
+                                rd_kafka_message_destroy(batch[j]);
+                                continue;
+                        }
+
+                        switch (acked % 3) {
+                        case 0:
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+                                break;
+                        case 1:
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
+                                break;
+                        default:
+                                at = RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
+                                break;
+                        }
+
+                        aerr = rd_kafka_share_acknowledge_type(rkshare,
+                                                               batch[j], at);
+                        TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
+                                    (int)at, rd_kafka_err2str(aerr));
+                        rd_kafka_message_destroy(batch[j]);
+                        acked++;
+
+                        if (acked % 5 == 0) {
+                                cerr = rd_kafka_share_commit_async(rkshare);
+                                TEST_ASSERT(!cerr, "commit_async: %s",
+                                            cerr ? rd_kafka_error_string(cerr)
+                                                 : "");
+                                async_cnt++;
+                        }
+                        if (acked % 10 == 0) {
+                                cerr = rd_kafka_share_commit_sync(
+                                    rkshare, 30000, &partitions);
+                                TEST_ASSERT(!cerr, "commit_sync: %s",
+                                            cerr ? rd_kafka_error_string(cerr)
+                                                 : "");
+                                RD_IF_FREE(
+                                    partitions,
+                                    rd_kafka_topic_partition_list_destroy);
+                                partitions = NULL;
+                                sync_cnt++;
+                        }
+                }
+        }
+        TEST_ASSERT(acked >= target, "expected to ack %d records, got %d",
+                    target, acked);
+        TEST_SAY(
+            "acked=%d sync=%d async=%d ack_cb_invocations=%d. "
+            "Calling close.\n",
+            acked, sync_cnt, async_cnt, receipts.callback_invocations);
+
+        if (do_close) {
+                t_start    = test_clock();
+                close_err  = rd_kafka_share_consumer_close(rkshare);
+                t_close_ms = (test_clock() - t_start) / 1000;
+                TEST_SAY("close returned in %" PRId64
+                         " ms (err=%s) "
+                         "ack_cb_invocations=%d\n",
+                         t_close_ms,
+                         close_err ? rd_kafka_error_string(close_err) : "NULL",
+                         receipts.callback_invocations);
+                if (close_err)
+                        rd_kafka_error_destroy(close_err);
+        } else {
+                TEST_SAY(
+                    "Skipping consumer_close (destroy_flags has "
+                    "NO_CONSUMER_CLOSE)\n");
+        }
+
+        /* Run destroy on the watchdog thread; fail if it hangs past
+         * DESTROY_DEADLINE_MS instead of wedging the binary. */
+        arg.rkshare       = rkshare;
+        arg.destroy_flags = destroy_flags;
+        rd_atomic32_init(&arg.done, 0);
+
+        TEST_ASSERT(thrd_create(&destroy_thr, destroy_watchdog_thread, &arg) ==
+                        thrd_success,
+                    "Failed to spawn destroy watchdog thread");
+
+        t_start = test_clock();
+        wait_ok = 1;
+        while (!rd_atomic32_get(&arg.done)) {
+                if ((test_clock() - t_start) / 1000 >= DESTROY_DEADLINE_MS) {
+                        wait_ok = 0;
+                        break;
+                }
+                rd_usleep(100 * 1000, NULL);
+        }
+        t_destroy_ms = (test_clock() - t_start) / 1000;
+
+        if (!wait_ok) {
+                /* Detach so the OS reaps the still-running thread at
+                 * process exit (rkshare permanently leaked). */
+                thrd_detach(destroy_thr);
+                TEST_FAIL(
+                    "rd_kafka_share_destroy hung past %d ms after close "
+                    "(close took %" PRId64
+                    " ms). acked=%d sync=%d async=%d "
+                    "ack_cb_invocations=%d (expected >= %d).",
+                    DESTROY_DEADLINE_MS, t_close_ms, acked, sync_cnt, async_cnt,
+                    receipts.callback_invocations, async_cnt + sync_cnt);
+        }
+
+        thrd_join(destroy_thr, NULL);
+
+        TEST_SAY("destroy returned in %" PRId64 " ms (close was %" PRId64
+                 " ms); final ack_cb_invocations=%d\n",
+                 t_destroy_ms, t_close_ms, receipts.callback_invocations);
+
+        ack_receipts_destroy(&receipts);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0179_share_consumer_destroy(int argc, char **argv) {
         /* Real broker tests */
         test_timeout_set(120);
@@ -2083,6 +2285,10 @@ int main_0179_share_consumer_destroy(int argc, char **argv) {
         do_test_destroy_with_explicit_ack(RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE,
                                           rd_true);
         do_test_destroy_with_implicit_ack(RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
+
+        do_test_destroy_with_mixed_acks_and_commits(0);
+        do_test_destroy_with_mixed_acks_and_commits(
+            RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE);
 
         rd_kafka_destroy(common_admin);
         rd_kafka_destroy(common_producer);

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -267,7 +267,269 @@ static void test_heartbeat_interval_ms_rejected_at_construction(void) {
         SUB_TEST_PASS();
 }
 
+
+/**
+ * @brief Build a producer with linger.ms=0 so each rd_kafka_produce()
+ *        flushes as its own broker batch.
+ */
+static rd_kafka_t *create_no_linger_producer(void) {
+        rd_kafka_conf_t *conf;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 0);
+        TEST_ASSERT(rd_kafka_conf_set(conf, "linger.ms", "0", errstr,
+                                      sizeof(errstr)) == RD_KAFKA_CONF_OK,
+                    "linger.ms=0: %s", errstr);
+        return test_create_handle(RD_KAFKA_PRODUCER, conf);
+}
+
+
+/**
+ * @brief Build a share consumer with the given max.poll.records value.
+ *
+ * Consumer uses implicit ack mode (default) and auto-offset-reset is
+ * left to be set group-side by the caller.
+ */
+static rd_kafka_share_t *
+create_share_consumer_with_max_poll(const char *group_id, int max_poll) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_share_t *rkshare;
+        char errstr[512];
+        char val[32];
+
+        test_conf_init(&conf, NULL, 0);
+        rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
+        rd_snprintf(val, sizeof(val), "%d", max_poll);
+        TEST_ASSERT(rd_kafka_conf_set(conf, "max.poll.records", val, errstr,
+                                      sizeof(errstr)) == RD_KAFKA_CONF_OK,
+                    "max.poll.records=%d: %s", max_poll, errstr);
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
+        return rkshare;
+}
+
+
+/**
+ * @brief Produce \p msgcnt records to \p topic, partition 0, with
+ *        \p gap_ms between each produce call. With linger.ms=0 on the
+ *        producer this lands each record as its own broker batch.
+ */
+static void produce_one_per_batch(rd_kafka_t *producer,
+                                  const char *topic,
+                                  int msgcnt,
+                                  int gap_ms) {
+        rd_kafka_topic_t *rkt;
+        rd_kafka_resp_err_t err;
+        char payload[64];
+        int i;
+
+        rkt = rd_kafka_topic_new(producer, topic, NULL);
+        TEST_ASSERT(rkt, "topic_new(%s) failed: %s", topic,
+                    rd_kafka_err2str(rd_kafka_last_error()));
+
+        for (i = 0; i < msgcnt; i++) {
+                rd_snprintf(payload, sizeof(payload), "msg-%d", i);
+                if (rd_kafka_produce(rkt, 0, RD_KAFKA_MSG_F_COPY, payload,
+                                     strlen(payload), NULL, 0, NULL) == -1)
+                        TEST_FAIL("produce #%d failed: %s", i,
+                                  rd_kafka_err2str(rd_kafka_last_error()));
+
+                err = rd_kafka_flush(producer, 30 * 1000);
+                TEST_ASSERT(!err, "flush after produce #%d: %s", i,
+                            rd_kafka_err2str(err));
+
+                if (i + 1 < msgcnt)
+                        rd_usleep(gap_ms * 1000, NULL);
+        }
+
+        rd_kafka_topic_destroy(rkt);
+}
+
+
+/**
+ * @brief Consume \p target records and record how many records came in
+ *        each batch returned by rd_kafka_share_consume_batch().
+ *
+ * @returns Number of batches it took to reach \p target records.
+ *          Out-param \p batch_sizes is filled with each batch's
+ *          record count, up to \p batch_sizes_cap entries.
+ */
+static int consume_record_batches(rd_kafka_share_t *rkshare,
+                                  int target,
+                                  int *batch_sizes,
+                                  int batch_sizes_cap,
+                                  int per_call_timeout_ms,
+                                  int max_calls) {
+        rd_kafka_message_t *rkmessages[1024];
+        size_t rcvd;
+        size_t j;
+        rd_kafka_error_t *error;
+        int batches = 0;
+        int got     = 0;
+        int call;
+
+        for (call = 0; call < max_calls && got < target; call++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(
+                    rkshare, per_call_timeout_ms, rkmessages, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+
+                if (rcvd == 0)
+                        continue;
+
+                if (batches < batch_sizes_cap)
+                        batch_sizes[batches] = (int)rcvd;
+                batches++;
+
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                got++;
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        return batches;
+}
+
+
+/**
+ * @brief Verify max.poll.records=5 splits 10 single-record broker
+ *        batches into 2 consume_batch() returns of ~5 records each.
+ *
+ * Setup: producer with linger.ms=0 emits 10 records with 500ms gap, so
+ * each lands as its own broker batch. Consumer with
+ * max.poll.records=5: across all consume_batch() calls, no single call
+ * returns more than 5 records and the 10 records are drained in 2 or
+ * more batches (the cap is the upper bound the lib must respect).
+ */
+static void test_max_poll_records_caps_batch_at_5(void) {
+        const char *topic;
+        const char *group = "0180-max-poll-records-5";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *rkshare;
+        const int msgcnt    = 10;
+        const int max_poll  = 5;
+        int batch_sizes[32] = {0};
+        int batches;
+        int i;
+
+        SUB_TEST();
+
+        producer = create_no_linger_producer();
+
+        topic = test_mk_topic_name("0180-max-poll-5", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        produce_one_per_batch(producer, topic, msgcnt, 500);
+
+        rkshare = create_share_consumer_with_max_poll(group, max_poll);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        batches =
+            consume_record_batches(rkshare, msgcnt, batch_sizes,
+                                   (int)RD_ARRAY_SIZE(batch_sizes), 3000, 30);
+
+        TEST_SAY("max.poll.records=%d, msgcnt=%d -> %d batch(es):", max_poll,
+                 msgcnt, batches);
+        for (i = 0; i < batches && i < (int)RD_ARRAY_SIZE(batch_sizes); i++)
+                TEST_SAY0(" %d", batch_sizes[i]);
+        TEST_SAY0("\n");
+
+        for (i = 0; i < batches && i < (int)RD_ARRAY_SIZE(batch_sizes); i++)
+                TEST_ASSERT(batch_sizes[i] <= max_poll,
+                            "Batch #%d returned %d records, exceeds "
+                            "max.poll.records=%d",
+                            i, batch_sizes[i], max_poll);
+
+        TEST_ASSERT(batches >= 2,
+                    "Expected at least 2 batches with max.poll.records=%d "
+                    "for %d records, got %d",
+                    max_poll, msgcnt, batches);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Verify max.poll.records=10 drains 10 single-record broker
+ *        batches in a single consume_batch() call.
+ */
+static void test_max_poll_records_allows_full_drain_at_10(void) {
+        const char *topic;
+        const char *group = "0180-max-poll-records-10";
+        rd_kafka_t *producer;
+        rd_kafka_share_t *rkshare;
+        const int msgcnt    = 10;
+        const int max_poll  = 10;
+        int batch_sizes[32] = {0};
+        int batches;
+        int i;
+
+        SUB_TEST();
+
+        producer = create_no_linger_producer();
+
+        topic = test_mk_topic_name("0180-max-poll-10", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        produce_one_per_batch(producer, topic, msgcnt, 500);
+
+        rkshare = create_share_consumer_with_max_poll(group, max_poll);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        batches =
+            consume_record_batches(rkshare, msgcnt, batch_sizes,
+                                   (int)RD_ARRAY_SIZE(batch_sizes), 5000, 30);
+
+        TEST_SAY("max.poll.records=%d, msgcnt=%d -> %d batch(es):", max_poll,
+                 msgcnt, batches);
+        for (i = 0; i < batches && i < (int)RD_ARRAY_SIZE(batch_sizes); i++)
+                TEST_SAY0(" %d", batch_sizes[i]);
+        TEST_SAY0("\n");
+
+        {
+                int sum = 0;
+                for (i = 0; i < batches && i < (int)RD_ARRAY_SIZE(batch_sizes);
+                     i++) {
+                        TEST_ASSERT(batch_sizes[i] <= max_poll,
+                                    "Batch #%d returned %d records, "
+                                    "exceeds max.poll.records=%d",
+                                    i, batch_sizes[i], max_poll);
+                        sum += batch_sizes[i];
+                }
+                TEST_ASSERT(sum == msgcnt,
+                            "Expected %d total records across batches, "
+                            "got %d",
+                            msgcnt, sum);
+        }
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/* Behavioural tests that require a real broker. */
 int main_0180_share_consumer_config(int argc, char **argv) {
+        test_max_poll_records_caps_batch_at_5();
+        test_max_poll_records_allows_full_drain_at_10();
+        return 0;
+}
+
+
+/* Construction-time conf-rejection tests; no broker required. */
+int main_0180_share_consumer_config_local(int argc, char **argv) {
         test_rebalance_cb_rejected_at_construction();
         test_event_rebalance_rejected_at_construction();
         test_statistics_interval_ms_rejected_at_construction();

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -14,7 +14,7 @@ set -e
 # - no assertions
 # - following AK and CP versions
 
-export TEST_KAFKA_GIT_REF=${TEST_KAFKA_GIT_REF:-4.2.0}
+export TEST_KAFKA_GIT_REF=${TEST_KAFKA_GIT_REF:-4.3.0}
 export TEST_CP_VERSION=${TEST_CP_VERSION:-8.0.0}
 
 TEST_SSL_ARG=""

--- a/tests/test.c
+++ b/tests/test.c
@@ -305,6 +305,7 @@ _TEST_DECL(0178_share_consumer_close_local);
 _TEST_DECL(0179_share_consumer_destroy);
 _TEST_DECL(0179_share_consumer_destroy_local);
 _TEST_DECL(0180_share_consumer_config);
+_TEST_DECL(0180_share_consumer_config_local);
 _TEST_DECL(0181_share_consumer_topic_delete);
 _TEST_DECL(0182_share_consumer_error_handling_mock);
 _TEST_DECL(0183_share_consumer_leader_change_mock);
@@ -594,7 +595,8 @@ struct test tests[] = {
     _TEST(0178_share_consumer_close_local, TEST_F_LOCAL),
     _TEST(0179_share_consumer_destroy, 0, TEST_BRKVER(0, 4, 2, 0)),
     _TEST(0179_share_consumer_destroy_local, TEST_F_LOCAL),
-    _TEST(0180_share_consumer_config, TEST_F_LOCAL),
+    _TEST(0180_share_consumer_config, 0, TEST_BRKVER(0, 4, 2, 0)),
+    _TEST(0180_share_consumer_config_local, TEST_F_LOCAL),
     _TEST(0181_share_consumer_topic_delete, 0, TEST_BRKVER(0, 4, 2, 0)),
     _TEST(0182_share_consumer_error_handling_mock, TEST_F_LOCAL),
     _TEST(0183_share_consumer_leader_change_mock, TEST_F_LOCAL),


### PR DESCRIPTION
Expands KIP-932 share consumer integration coverage across subscription,
consume, ack, commit (sync/async), concurrency, transactions, close,
destroy and config paths.

Also includes three small non-test touch-ups in `src/`:
- `rdkafka_fetcher.c`: comment fix (`REJECT` -> `RELEASE`) on the
  error-op ack_type branch, and the missing `%s err` added to the
  `BADMSG` debug log.
- `rdkafka_msgset_reader.c`: TODO comment in `rd_kafka_msgset_reader_v2`
  documenting CRC-corrupt `LastOffsetDelta` failure modes. No behavior
  change.

## New tests

### 0170 - subscription
- `do_test_subscription_change_acks_pending` - subscription change
  drives an implicit ack of the pending records before the new
  subscription takes effect.
- `do_test_two_groups_earliest_vs_latest` - two share groups on the
  same topic with different `share.auto.offset.reset` (earliest vs
  latest) see disjoint record sets.
- `do_test_delete_records_advances_lso` - `DeleteRecords` advances the
  LSO and a new share group starts after the deleted offsets.

### 0171 - consume
- `test_headers_preserved` - record headers round-trip end-to-end
  through the share consumer.
- `test_fetch_max_bytes_small` - small `fetch.message.max.bytes` still
  delivers all records.
- `test_record_larger_than_fetch_max_bytes` - oversized records are
  delivered (broker grants them).
- `test_consumer_close_releases_to_group` - closing a consumer with
  unacked records redelivers them to the remaining group members.
- `test_partition_increase_during_consume` - `CreatePartitions` grows
  2->5 mid-consume; new partitions are picked up by the share group.
- `test_zero_byte_payload_and_key` - zero-length and NULL keys/values
  preserved.
- `test_message_at_max_bytes_boundary` - record sizes at the topic's
  `max.message.bytes` boundary are delivered.
- `test_all_compression_codecs` (driven by `do_test_compression_codec`)
  - gzip, snappy, lz4, zstd round-trip through the share consumer.
- `test_many_and_large_headers` - 100 headers per record plus one
  large header value preserved.

### 0172 - acknowledge
- `test_ack_message_from_earlier_batch` - re-acknowledging a record
  after the batch has been polled past returns `_STATE`.
- `test_ack_offset_before_consume` - `acknowledge_offset()` before any
  record has been consumed returns `_STATE`.
- `test_ack_offset_wrong_params` - `acknowledge_offset()` with wrong
  topic/partition/offset returns `_STATE`; correct values succeed.
- `test_mixed_ack_mode_same_group` - implicit and explicit ack-mode
  consumers coexist in the same share group and total delivery
  matches produced count.

### 0173 - commit_async
- `do_test_partial_batch_commit_async` - partial-batch commit_async
  semantics; un-acked records keep `consume_batch` returning `_STATE`.
- `do_test_implicit_callback_no_explicit_commit` - implicit mode fires
  the ack callback without explicit commits.
- `do_test_lock_expiry_callback_err` - lock-expiry surfaces as an
  error to the ack callback.
- `do_test_safe_api_from_callback` - API calls from inside the ack
  callback don't deadlock or misbehave.
- `do_test_callback_side_effects_dont_break` - heavy callback work
  doesn't break subsequent consume/commit flow.

### 0174 - concurrency
- `test_chaos_consumer_lifecycle` - consumer churn (start / close /
  detach wedged threads) during sustained production. Runs for both
  `implicit` and `explicit` ack modes.

### 0176 - commit_sync
- `do_test_commit_sync_after_topic_deletion` - commit_sync after the
  subscribed topic is deleted surfaces a per-partition error.
- Chaos suite stressing interleaved ack/commit patterns:
  - `do_test_chaos_111_ack_commit_interleave` - strict per-record
    ack/commit pattern: phase A (records 0-14) one commit per ack,
    alternating sync/async; phase B (records 15-29) one commit per
    every 2 acks, alternating sync/async.
  - `do_test_chaos_alternating_commits` - every ACCEPT immediately
    followed by alternating commit_sync / commit_async (40 records).
  - `do_test_chaos_random_ack_random_commit` - fixed seed (0xC0FFEE).
    Random ACCEPT/RELEASE/REJECT acks with ~1-in-3 commits, sync/async
    coin-flipped. Final commit_sync to flush.
  - `do_test_chaos_burst_commits` - after every ACCEPT, 5 back-to-back
    commit_async then 1 draining commit_sync (50 records).
  - `do_test_chaos_callback_receipt_match` - varying batch sizes
    between commits, alternating sync/async; asserts callback
    `total_offsets >= consumed`.

### 0177 - transactions
- `do_test_dynamic_committed_to_uncommitted_with_release` - dynamic
  isolation level change `READ_COMMITTED -> READ_UNCOMMITTED` with
  RELEASE ack type.
- `do_test_dynamic_committed_to_uncommitted_with_reject` - same with
  REJECT.
- `do_test_two_groups_different_isolation_levels` - two distinct share
  groups, one `read_committed` and one `read_uncommitted`, consuming
  the same topic concurrently. Verifies the committed group sees only
  committed txns; the uncommitted group sees all.

### 0178 - close
- `test_implicit_ack_callback_fires_on_close` - the implicit ack
  callback fires for un-committed records when the consumer is closed.

### 0179 - destroy
- `do_test_destroy_with_mixed_acks_and_commits` - destroy a consumer
  that drove a mixed-ack workload (round-robin ACCEPT/RELEASE/REJECT
  with interleaved commit_async / commit_sync). Runs destroy on a
  watchdog thread and fails the test with a clear diagnostic if it
  hangs past 15 s rather than wedging the binary.

### 0180 - config
- `test_max_poll_records_caps_batch_at_5` - producer with `linger.ms=0`
  emits 10 records with a 500 ms gap so each lands as its own broker
  batch. With `max.poll.records=5`, no consume_batch call returns more
  than 5 records and at least 2 batches are needed to drain.
- `test_max_poll_records_allows_full_drain_at_10` - same producer
  pattern. With `max.poll.records=10`, all batches stay <= 10 and the
  sum of batch sizes equals 10.

0180 is now split into:
- `main_0180_share_consumer_config` - broker-required (max.poll.records
  tests).
- `main_0180_share_consumer_config_local` - TEST_F_LOCAL (the existing
  construction-time conf-rejection tests).

Both are registered in [tests/test.c](tests/test.c), matching the same
base/`_local` split convention used by 0176, 0178, 0179.