### PR TITLE
[KIP-932] Share subscribe related improvements

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -6937,7 +6937,6 @@ const char *rd_kafka_Uuid_base64str(const rd_kafka_Uuid_t *uuid) {
         rd_chariov_t in_base64;
         char *out_base64_str;
         char *uuid_bytes;
-        char *p;
         uint64_t input_uuid[2];
 
         input_uuid[0]  = htobe64(uuid->most_significant_bits);
@@ -6947,23 +6946,13 @@ const char *rd_kafka_Uuid_base64str(const rd_kafka_Uuid_t *uuid) {
         in_base64.size = sizeof(uuid->most_significant_bits) +
                          sizeof(uuid->least_significant_bits);
 
-        // Standard Base64 encode
         out_base64_str = rd_base64_encode_str(&in_base64);
         if (!out_base64_str)
                 return NULL;
 
-        // Convert to URL-safe Base64
-        for (p = out_base64_str; *p; p++) {
-                if (*p == '+')
-                        *p = '-';
-                else if (*p == '/')
-                        *p = '_';
-        }
-
         rd_strlcpy((char *)uuid->base64str, out_base64_str,
                    23 /* Removing extra ('=') padding */);
         rd_free(out_base64_str);
-
         return uuid->base64str;
 }
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5133,9 +5133,13 @@ RD_EXPORT rd_kafka_error_t *rd_kafka_consumer_group_metadata_read(
  *         an error on unavailable topics.
  *
  * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or
- *          RD_KAFKA_RESP_ERR__INVALID_ARG if list is empty, contains invalid
- *          topics or regexes or duplicate entries,
+ *          RD_KAFKA_RESP_ERR__INVALID_ARG if list is empty, contains empty
+ *          topic names, or duplicate entries,
  *          RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
+ *
+ * @remark Topic names are forwarded verbatim to the broker via the share
+ *         group heartbeat. The broker validates them and rejects invalid
+ *         topic names.
  */
 RD_EXPORT rd_kafka_resp_err_t
 rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5799,23 +5799,39 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
 
         if (rkcg->rkcg_subscription) {
                 rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_SUBSCRIPTION;
-                if (rd_kafka_topic_partition_list_regex_cnt(
-                        rkcg->rkcg_subscription) > 0)
-                        rkcg->rkcg_flags |=
-                            RD_KAFKA_CGRP_F_WILDCARD_SUBSCRIPTION;
 
-                if (rkcg->rkcg_group_protocol ==
-                    RD_KAFKA_GROUP_PROTOCOL_CONSUMER) {
-                        rkcg->rkcg_subscription_regex =
-                            rd_kafka_topic_partition_list_combine_regexes(
-                                rkcg->rkcg_subscription);
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                        /* Share consumer has no regex subscription: feed the
+                         * full subscription list to the heartbeat as
+                         * SubscribedTopicNames; let the broker reject any
+                         * invalid topic names. */
                         rkcg->rkcg_subscription_topics =
-                            rd_kafka_topic_partition_list_remove_regexes(
+                            rd_kafka_topic_partition_list_copy(
                                 rkcg->rkcg_subscription);
                         rkcg->rkcg_consumer_flags |=
                             RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
                             RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
                         rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
+                } else {
+                        if (rd_kafka_topic_partition_list_regex_cnt(
+                                rkcg->rkcg_subscription) > 0)
+                                rkcg->rkcg_flags |=
+                                    RD_KAFKA_CGRP_F_WILDCARD_SUBSCRIPTION;
+
+                        if (rkcg->rkcg_group_protocol ==
+                            RD_KAFKA_GROUP_PROTOCOL_CONSUMER) {
+                                rkcg->rkcg_subscription_regex =
+                                    rd_kafka_topic_partition_list_combine_regexes(
+                                        rkcg->rkcg_subscription);
+                                rkcg->rkcg_subscription_topics =
+                                    rd_kafka_topic_partition_list_remove_regexes(
+                                        rkcg->rkcg_subscription);
+                                rkcg->rkcg_consumer_flags |=
+                                    RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
+                                    RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
+                                rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(
+                                    rkcg);
+                        }
                 }
         } else {
                 rkcg->rkcg_subscription_regex  = NULL;

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5800,19 +5800,7 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
         if (rkcg->rkcg_subscription) {
                 rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_SUBSCRIPTION;
 
-                if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
-                        /* Share consumer has no regex subscription: feed the
-                         * full subscription list to the heartbeat as
-                         * SubscribedTopicNames; let the broker reject any
-                         * invalid topic names. */
-                        rkcg->rkcg_subscription_topics =
-                            rd_kafka_topic_partition_list_copy(
-                                rkcg->rkcg_subscription);
-                        rkcg->rkcg_consumer_flags |=
-                            RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
-                            RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
-                        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
-                } else {
+                if (!RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
                         if (rd_kafka_topic_partition_list_regex_cnt(
                                 rkcg->rkcg_subscription) > 0)
                                 rkcg->rkcg_flags |=
@@ -5832,6 +5820,18 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
                                 rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(
                                     rkcg);
                         }
+                } else {
+                        /* Share consumer has no regex subscription: feed the
+                         * full subscription list to the heartbeat as
+                         * SubscribedTopicNames; let the broker reject any
+                         * invalid topic names. */
+                        rkcg->rkcg_subscription_topics =
+                            rd_kafka_topic_partition_list_copy(
+                                rkcg->rkcg_subscription);
+                        rkcg->rkcg_consumer_flags |=
+                            RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
+                            RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
+                        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
                 }
         } else {
                 rkcg->rkcg_subscription_regex  = NULL;

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5800,7 +5800,19 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
         if (rkcg->rkcg_subscription) {
                 rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_SUBSCRIPTION;
 
-                if (!RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                        /* Share consumer has no regex subscription: feed the
+                         * full subscription list to the heartbeat as
+                         * SubscribedTopicNames; let the broker reject any
+                         * invalid topic names. */
+                        rkcg->rkcg_subscription_topics =
+                            rd_kafka_topic_partition_list_copy(
+                                rkcg->rkcg_subscription);
+                        rkcg->rkcg_consumer_flags |=
+                            RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
+                            RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
+                        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
+                } else {
                         if (rd_kafka_topic_partition_list_regex_cnt(
                                 rkcg->rkcg_subscription) > 0)
                                 rkcg->rkcg_flags |=
@@ -5820,18 +5832,6 @@ rd_kafka_cgrp_subscription_set(rd_kafka_cgrp_t *rkcg,
                                 rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(
                                     rkcg);
                         }
-                } else {
-                        /* Share consumer has no regex subscription: feed the
-                         * full subscription list to the heartbeat as
-                         * SubscribedTopicNames; let the broker reject any
-                         * invalid topic names. */
-                        rkcg->rkcg_subscription_topics =
-                            rd_kafka_topic_partition_list_copy(
-                                rkcg->rkcg_subscription);
-                        rkcg->rkcg_consumer_flags |=
-                            RD_KAFKA_CGRP_CONSUMER_F_SUBSCRIBED_ONCE |
-                            RD_KAFKA_CGRP_CONSUMER_F_SEND_NEW_SUBSCRIPTION;
-                        rd_kafka_cgrp_maybe_clear_heartbeat_failed_err(rkcg);
                 }
         } else {
                 rkcg->rkcg_subscription_regex  = NULL;

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4310,6 +4310,15 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 return "`RD_KAFKA_EVENT_REBALANCE` is not "
                                        "applicable for share consumer";
 
+                        if (conf->stats_cb)
+                                return "`stats_cb` is not applicable "
+                                       "for share consumer";
+
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "statistics.interval.ms"))
+                                return "`statistics.interval.ms` is not "
+                                       "applicable for share consumer";
+
                         if (rd_kafka_conf_is_modified(conf,
                                                       "enable.auto.commit"))
                                 return "`enable.auto.commit` is not "

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4310,10 +4310,11 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 return "`RD_KAFKA_EVENT_REBALANCE` is not "
                                        "applicable for share consumer";
 
-                        if (conf->stats_cb)
-                                return "`stats_cb` is not applicable "
-                                       "for share consumer";
-
+                        /* TODO KIP-932: verify whether stats_cb should also
+                         * be rejected. Today we only reject the interval
+                         * because the test framework sets stats_cb
+                         * defensively; with interval=0 the callback is
+                         * never invoked, so the callback alone is inert. */
                         if (rd_kafka_conf_is_modified(conf,
                                                       "statistics.interval.ms"))
                                 return "`statistics.interval.ms` is not "

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -80,6 +80,18 @@ static size_t _invalid_topic_cb(const rd_kafka_topic_partition_t *rktpar,
 }
 
 
+/** @returns 1 if the topic is empty (invalid for the share consumer),
+ *           else 0. Share consumer does not support regex/wildcard
+ *           subscriptions; entries are forwarded verbatim to the broker. */
+static size_t _share_invalid_topic_cb(const rd_kafka_topic_partition_t *rktpar,
+                                      void *opaque) {
+        if (!*rktpar->topic)
+                return 1;
+
+        return 0;
+}
+
+
 rd_kafka_resp_err_t
 rd_kafka_subscribe(rd_kafka_t *rk,
                    const rd_kafka_topic_partition_list_t *topics) {
@@ -113,6 +125,9 @@ rd_kafka_subscribe(rd_kafka_t *rk,
 rd_kafka_resp_err_t
 rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
                          const rd_kafka_topic_partition_list_t *topics) {
+        rd_kafka_op_t *rko;
+        rd_kafka_cgrp_t *rkcg;
+        rd_kafka_topic_partition_list_t *topics_cpy;
         rd_kafka_resp_err_t err;
 
         /**
@@ -121,7 +136,29 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
          */
         if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
                 return err;
-        return rd_kafka_subscribe(rkshare->rkshare_rk, topics);
+
+        if (!(rkcg = rd_kafka_cgrp_get(rkshare->rkshare_rk)))
+                return RD_KAFKA_RESP_ERR__UNKNOWN_GROUP;
+
+        /* Share consumer subscriptions are literal topic names only:
+         * regex/wildcard entries are not supported. Reject empty entries;
+         * pass everything else through to the broker via the heartbeat. */
+        if (topics->cnt == 0 || rd_kafka_topic_partition_list_sum(
+                                    topics, _share_invalid_topic_cb, NULL) > 0)
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+
+        topics_cpy = rd_kafka_topic_partition_list_copy(topics);
+        if (rd_kafka_topic_partition_list_has_duplicates(
+                topics_cpy, rd_true /*ignore partition field*/)) {
+                rd_kafka_topic_partition_list_destroy(topics_cpy);
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+
+        rko                         = rd_kafka_op_new(RD_KAFKA_OP_SUBSCRIBE);
+        rko->rko_u.subscribe.topics = topics_cpy;
+
+        return rd_kafka_op_err_destroy(
+            rd_kafka_op_req(rkcg->rkcg_ops, rko, RD_POLL_INFINITE));
 }
 
 

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -614,12 +614,7 @@ static void do_test_scenario(const test_scenario_t *scenario) {
         sub_test_state_t state;
         int op_idx;
 
-        TEST_SAY("\n");
-        TEST_SAY(
-            "============================================================\n");
-        TEST_SAY("=== %s ===\n", scenario->name);
-        TEST_SAY(
-            "============================================================\n");
+        SUB_TEST();
 
         state_init(&state, scenario);
 
@@ -677,7 +672,7 @@ static void do_test_scenario(const test_scenario_t *scenario) {
 
         state_cleanup(&state);
 
-        TEST_SAY("=== %s: PASSED ===\n", scenario->name);
+        SUB_TEST_PASS();
 }
 
 
@@ -802,12 +797,7 @@ static void do_test_multi_consumer_overlap(void) {
         int c0_cnt = 0, c1_cnt = 0;
         int attempts;
 
-        TEST_SAY("\n");
-        TEST_SAY(
-            "============================================================\n");
-        TEST_SAY("=== multi-consumer-overlapping-subscriptions ===\n");
-        TEST_SAY(
-            "============================================================\n");
+        SUB_TEST("multi-consumer-overlapping-subscriptions");
 
         /* Create topics */
         test_create_topic_wait_exists(NULL, shared, 1, -1, 30000);
@@ -862,7 +852,7 @@ static void do_test_multi_consumer_overlap(void) {
         rd_free(c0_only);
         rd_free(c1_only);
 
-        TEST_SAY("=== multi-consumer-overlapping-subscriptions: PASSED ===\n");
+        SUB_TEST_PASS();
 }
 
 
@@ -887,14 +877,7 @@ static void do_test_subscribe_15_topics(void) {
         int attempts;
         int t;
 
-        TEST_SAY("\n");
-        TEST_SAY(
-            "============================================================\n");
-        TEST_SAY(
-            "=== subscribe-15-topics (triggers multiple fetch responses) "
-            "===\n");
-        TEST_SAY(
-            "============================================================\n");
+        SUB_TEST("subscribe-15-topics");
 
         /* Create 15 topics */
         for (t = 0; t < topic_cnt; t++) {
@@ -962,8 +945,7 @@ static void do_test_subscribe_15_topics(void) {
                 rd_free(topics[t]);
         }
 
-        TEST_SAY("=== subscribe-15-topics: PASSED (%d messages) ===\n",
-                 consumed);
+        SUB_TEST_PASS();
 }
 
 
@@ -973,7 +955,7 @@ static void do_test_subscribe_15_topics(void) {
  * Verifies that with share.auto.offset.reset = earliest, consumer receives
  * all messages including those produced before subscription.
  */
-static void test_auto_offset_reset_earliest(void) {
+static void do_test_auto_offset_reset_earliest(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
         const char *topic;
@@ -983,12 +965,7 @@ static void test_auto_offset_reset_earliest(void) {
         int attempts;
         const int msg_cnt = 100;
 
-        TEST_SAY("\n");
-        TEST_SAY(
-            "============================================================\n");
-        TEST_SAY("=== share.auto.offset.reset = earliest ===\n");
-        TEST_SAY(
-            "============================================================\n");
+        SUB_TEST("share.auto.offset.reset=earliest");
 
         /* Create topic */
         topic = test_mk_topic_name("0170-offset-earliest", 1);
@@ -1044,6 +1021,8 @@ static void test_auto_offset_reset_earliest(void) {
         /* Cleanup */
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
 }
 
 /**
@@ -1052,7 +1031,7 @@ static void test_auto_offset_reset_earliest(void) {
  * Verifies that with default (latest) offset, consumer only receives
  * messages produced after subscription, not pre-existing messages.
  */
-static void test_auto_offset_reset_default_latest(void) {
+static void do_test_auto_offset_reset_default_latest(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
         const char *topic;
@@ -1063,12 +1042,7 @@ static void test_auto_offset_reset_default_latest(void) {
         const int initial_msgs = 100;
         const int later_msgs   = 50;
 
-        TEST_SAY("\n");
-        TEST_SAY(
-            "============================================================\n");
-        TEST_SAY("=== share.auto.offset.reset default (latest) ===\n");
-        TEST_SAY(
-            "============================================================\n");
+        SUB_TEST("share.auto.offset.reset=latest (default)");
 
         /* Create topic */
         topic = test_mk_topic_name("0170-offset-default", 1);
@@ -1162,6 +1136,194 @@ static void test_auto_offset_reset_default_latest(void) {
         /* Cleanup */
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief rd_kafka_share_subscribe input validation against a real
+ *        broker.
+ *
+ * Covers the share-subscribe API surface contract:
+ *   1. A topic name starting with '^' is treated as a literal — no
+ *      regex compilation, no rejection. The name is forwarded
+ *      verbatim to the broker via
+ *      ShareGroupHeartbeat.SubscribedTopicNames; the broker silently
+ *      drops names it cannot resolve.
+ *   2. Subscription list containing an empty topic name returns
+ *      INVALID_ARG.
+ *   3. Duplicate topic names return INVALID_ARG. (librdkafka enforces
+ *      dedup at the API; Java silently dedupes via Set — divergence
+ *      tracked as A6 in src/share-consumer-java-divergence.md.)
+ *
+ * Empty-list rejection is covered by the mock test
+ * do_test_empty_topic_list_subscription in
+ * 0155-share_group_heartbeat_mock.c.
+ */
+static void do_test_subscribe_input_validation(void) {
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_resp_err_t err;
+        const char *group = "share-subscribe-validation";
+
+        SUB_TEST();
+
+        /* Case 1: '^foo.*' is forwarded as a literal, not interpreted
+         * as a regex. */
+        consumer = test_create_share_consumer(group, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, "^foo.*",
+                                          RD_KAFKA_PARTITION_UA);
+        err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected NO_ERROR for '^foo.*' literal topic, got: %s",
+                    rd_kafka_err2str(err));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        /* Case 2: entry with empty topic name. */
+        consumer = test_create_share_consumer(group, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subs, "valid-topic",
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subs, "", RD_KAFKA_PARTITION_UA);
+        err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected INVALID_ARG for empty topic name, got: %s",
+                    rd_kafka_err2str(err));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        /* Case 3: duplicate topic names. */
+        consumer = test_create_share_consumer(group, NULL);
+
+        subs = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subs, "duplicate-topic",
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subs, "duplicate-topic",
+                                          RD_KAFKA_PARTITION_UA);
+        err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
+                    "expected INVALID_ARG for duplicate topic, got: %s",
+                    rd_kafka_err2str(err));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief End-to-end verification that '^'-prefixed entries are
+ *        forwarded as literals (no regex resolution).
+ *
+ * Creates a real topic, produces records to it, then:
+ *   Phase 1. Subscribes with a regex-shaped string '^<topic>$' that
+ *            would match the topic if treated as a regex. The broker
+ *            cannot resolve the literal name and silently drops it
+ *            from the assignment. The share consumer must receive
+ *            zero records.
+ *   Phase 2. Unsubscribes, resubscribes with the plain topic name.
+ *            The consumer must now receive all produced records.
+ */
+static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        const char *topic;
+        const char *group = "share-caret-literal-e2e";
+        const int msg_cnt = 50;
+        char caret_pattern[512];
+        size_t records_phase1 = 0;
+        size_t records_phase2 = 0;
+        int attempts;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0170-caret-literal", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_produce_msgs_easy(topic, 0, 0, msg_cnt);
+
+        consumer = test_create_share_consumer(group, NULL);
+
+        /* Phase 1: '^<topic>$' as a literal — broker drops, no records. */
+        rd_snprintf(caret_pattern, sizeof(caret_pattern), "^%s$", topic);
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, caret_pattern,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        TEST_SAY("Phase 1: subscribed with '%s' (literal); polling...\n",
+                 caret_pattern);
+        attempts = 10;
+        while (attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err =
+                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                if (err)
+                        rd_kafka_error_destroy(err);
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err)
+                                records_phase1++;
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+        TEST_ASSERT(records_phase1 == 0,
+                    "Phase 1: expected 0 records for '%s' literal "
+                    "subscription, got %zu",
+                    caret_pattern, records_phase1);
+        TEST_SAY("Phase 1: received 0 records as expected\n");
+
+        /* Phase 2: resubscribe with the plain topic name — broker
+         * resolves it, consumer receives records. */
+        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
+
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        TEST_SAY("Phase 2: resubscribed with plain name '%s'; consuming...\n",
+                 topic);
+        attempts = 10;
+        while (records_phase2 < (size_t)msg_cnt && attempts-- > 0) {
+                size_t rcvd = 0;
+                size_t m;
+                rd_kafka_error_t *err;
+
+                err =
+                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                if (err)
+                        rd_kafka_error_destroy(err);
+
+                for (m = 0; m < rcvd; m++) {
+                        if (!batch[m]->err)
+                                records_phase2++;
+                        rd_kafka_message_destroy(batch[m]);
+                }
+        }
+        TEST_ASSERT(records_phase2 == (size_t)msg_cnt,
+                    "Phase 2: expected %d records, got %zu", msg_cnt,
+                    records_phase2);
+        TEST_SAY("Phase 2: received %zu/%d records\n", records_phase2, msg_cnt);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
 }
 
 int main_0170_share_consumer_subscription(int argc, char **argv) {
@@ -1172,8 +1334,8 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
         test_timeout_set(200);
 
         /* Auto offset reset tests */
-        test_auto_offset_reset_earliest();
-        test_auto_offset_reset_default_latest();
+        do_test_auto_offset_reset_earliest();
+        do_test_auto_offset_reset_default_latest();
 
         /* Basic subscription tests */
         do_test_scenario(&test_single_subscribe);
@@ -1209,6 +1371,10 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
 
         /* Scale tests (many topics) */
         do_test_subscribe_15_topics();
+
+        /* Input validation tests */
+        do_test_subscribe_input_validation();
+        do_test_subscribe_caret_treated_as_literal_e2e();
 
         /* Cleanup common handles */
         rd_kafka_destroy(common_admin);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -1152,13 +1152,7 @@ static void do_test_auto_offset_reset_default_latest(void) {
  *      drops names it cannot resolve.
  *   2. Subscription list containing an empty topic name returns
  *      INVALID_ARG.
- *   3. Duplicate topic names return INVALID_ARG. (librdkafka enforces
- *      dedup at the API; Java silently dedupes via Set — divergence
- *      tracked as A6 in src/share-consumer-java-divergence.md.)
- *
- * Empty-list rejection is covered by the mock test
- * do_test_empty_topic_list_subscription in
- * 0155-share_group_heartbeat_mock.c.
+ *   3. Duplicate topic names return INVALID_ARG.
  */
 static void do_test_subscribe_input_validation(void) {
         rd_kafka_share_t *consumer;
@@ -1262,6 +1256,18 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
         TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
         rd_kafka_topic_partition_list_destroy(subs);
 
+        /* rd_kafka_share_subscription must return the subscribed names
+         * verbatim (the '^' prefix is not stripped). */
+        subs = NULL;
+        TEST_CALL_ERR__(rd_kafka_share_subscription(consumer, &subs));
+        TEST_ASSERT(subs && subs->cnt == 1,
+                    "Phase 1: expected subscription cnt 1, got %d",
+                    subs ? subs->cnt : -1);
+        TEST_ASSERT(!strcmp(subs->elems[0].topic, caret_pattern),
+                    "Phase 1: expected subscription[0]='%s', got '%s'",
+                    caret_pattern, subs->elems[0].topic);
+        rd_kafka_topic_partition_list_destroy(subs);
+
         TEST_SAY("Phase 1: subscribed with '%s' (literal); polling...\n",
                  caret_pattern);
         attempts = 10;
@@ -1294,6 +1300,17 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
         subs = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
         TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* rd_kafka_share_subscription must now return the plain name. */
+        subs = NULL;
+        TEST_CALL_ERR__(rd_kafka_share_subscription(consumer, &subs));
+        TEST_ASSERT(subs && subs->cnt == 1,
+                    "Phase 2: expected subscription cnt 1, got %d",
+                    subs ? subs->cnt : -1);
+        TEST_ASSERT(!strcmp(subs->elems[0].topic, topic),
+                    "Phase 2: expected subscription[0]='%s', got '%s'", topic,
+                    subs->elems[0].topic);
         rd_kafka_topic_partition_list_destroy(subs);
 
         TEST_SAY("Phase 2: resubscribed with plain name '%s'; consuming...\n",

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -105,17 +105,6 @@ static void setter_event_rebalance(rd_kafka_conf_t *conf) {
         rd_kafka_conf_set_events(conf, RD_KAFKA_EVENT_REBALANCE);
 }
 
-/* Unused stub used only as a non-NULL function-pointer value for
- * rd_kafka_conf_set_stats_cb in the rejection test. */
-static int
-unused_stats_cb(rd_kafka_t *rk, char *json, size_t json_len, void *opaque) {
-        return 0;
-}
-
-static void setter_stats_cb(rd_kafka_conf_t *conf) {
-        rd_kafka_conf_set_stats_cb(conf, unused_stats_cb);
-}
-
 /**
  * @brief Share consumer has no rebalance callback semantics; the
  *        factory rejects rebalance_cb at construction so an app's
@@ -145,23 +134,11 @@ static void test_event_rebalance_rejected_at_construction(void) {
 }
 
 /**
- * @brief Share consumer does not emit periodic stats; setting a
- *        stats_cb is rejected so an app's handler can never silently
- *        never-fire.
- */
-static void test_stats_cb_rejected_at_construction(void) {
-        SUB_TEST_QUICK();
-
-        verify_share_consumer_conf_set_rejected("stats_cb set", setter_stats_cb,
-                                                "stats_cb");
-
-        SUB_TEST_PASS();
-}
-
-/**
- * @brief Companion to test_stats_cb_rejected_at_construction: the
- *        property-string form is also rejected so the user can't
- *        request periodic stats indirectly.
+ * @brief Share consumer does not emit periodic stats; the
+ *        statistics.interval.ms property is rejected so the user
+ *        cannot enable stats emission. (stats_cb alone is inert with
+ *        interval=0 and is not rejected — see the TODO in
+ *        rdkafka_conf.c.)
  */
 static void test_statistics_interval_ms_rejected_at_construction(void) {
         SUB_TEST_QUICK();
@@ -293,7 +270,6 @@ static void test_heartbeat_interval_ms_rejected_at_construction(void) {
 int main_0180_share_consumer_config(int argc, char **argv) {
         test_rebalance_cb_rejected_at_construction();
         test_event_rebalance_rejected_at_construction();
-        test_stats_cb_rejected_at_construction();
         test_statistics_interval_ms_rejected_at_construction();
         test_enable_auto_commit_rejected_at_construction();
         test_group_protocol_rejected_at_construction();

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -105,6 +105,17 @@ static void setter_event_rebalance(rd_kafka_conf_t *conf) {
         rd_kafka_conf_set_events(conf, RD_KAFKA_EVENT_REBALANCE);
 }
 
+/* Unused stub used only as a non-NULL function-pointer value for
+ * rd_kafka_conf_set_stats_cb in the rejection test. */
+static int
+unused_stats_cb(rd_kafka_t *rk, char *json, size_t json_len, void *opaque) {
+        return 0;
+}
+
+static void setter_stats_cb(rd_kafka_conf_t *conf) {
+        rd_kafka_conf_set_stats_cb(conf, unused_stats_cb);
+}
+
 /**
  * @brief Share consumer has no rebalance callback semantics; the
  *        factory rejects rebalance_cb at construction so an app's
@@ -129,6 +140,34 @@ static void test_event_rebalance_rejected_at_construction(void) {
         verify_share_consumer_conf_set_rejected("RD_KAFKA_EVENT_REBALANCE set",
                                                 setter_event_rebalance,
                                                 "RD_KAFKA_EVENT_REBALANCE");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Share consumer does not emit periodic stats; setting a
+ *        stats_cb is rejected so an app's handler can never silently
+ *        never-fire.
+ */
+static void test_stats_cb_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_set_rejected("stats_cb set", setter_stats_cb,
+                                                "stats_cb");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Companion to test_stats_cb_rejected_at_construction: the
+ *        property-string form is also rejected so the user can't
+ *        request periodic stats indirectly.
+ */
+static void test_statistics_interval_ms_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("statistics.interval.ms",
+                                                 "1000");
 
         SUB_TEST_PASS();
 }
@@ -254,6 +293,8 @@ static void test_heartbeat_interval_ms_rejected_at_construction(void) {
 int main_0180_share_consumer_config(int argc, char **argv) {
         test_rebalance_cb_rejected_at_construction();
         test_event_rebalance_rejected_at_construction();
+        test_stats_cb_rejected_at_construction();
+        test_statistics_interval_ms_rejected_at_construction();
         test_enable_auto_commit_rejected_at_construction();
         test_group_protocol_rejected_at_construction();
         test_socket_max_fails_rejected_at_construction();


### PR DESCRIPTION
## Summary

Improvements and fixes around the share-consumer subscribe path.

- **Drop regex subscription path.** `rd_kafka_share_subscribe` forwards topic names verbatim to the broker as `ShareGroupHeartbeatRequest.SubscribedTopicNames`, matching the wire schema (no regex field) and Java's `ShareConsumer`. Removes regex compile at the API and `combine_regexes`/`remove_regexes` splitting in the share branch of `rd_kafka_cgrp_subscription_set`. Empty list and empty topic-name entries return `INVALID_ARG`; the dedup check is kept.
- **Revert URL-safe Base64 workaround for generated Uuids.** Reverts the `+`/`/` → `-`/`_` substitution in `rd_kafka_Uuid_base64str` (758c5cd64). Broker now accepts the standard Base64 form.
