### PR TITLE
[KIP-932]: Share consumers must not touch regular-consumer offset machinery

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3499,7 +3499,8 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                                     "finish before producing to "
                                     "new leader");
                         }
-                } else if (rkb->rkb_rk->rk_type == RD_KAFKA_CONSUMER) {
+                } else if (rkb->rkb_rk->rk_type == RD_KAFKA_CONSUMER &&
+                           !RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk)) {
                         rktp->rktp_ts_fetch_backoff = 0;
                 }
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -454,9 +454,6 @@ void rd_kafka_cgrp_destroy_final(rd_kafka_cgrp_t *rkcg) {
         rd_list_destroy(&rkcg->rkcg_toppars);
         rd_list_destroy(rkcg->rkcg_subscribed_topics);
         rd_kafka_topic_partition_list_destroy(rkcg->rkcg_errored_topics);
-        if (rkcg->rkcg_share_topic_errored)
-                rd_kafka_topic_partition_list_destroy(
-                    rkcg->rkcg_share_topic_errored);
         if (rkcg->rkcg_assignor && rkcg->rkcg_assignor->rkas_destroy_state_cb &&
             rkcg->rkcg_assignor_state)
                 rkcg->rkcg_assignor->rkas_destroy_state_cb(
@@ -542,9 +539,6 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_next_target_assignment = NULL;
 
         rkcg->rkcg_errored_topics = rd_kafka_topic_partition_list_new(0);
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rkcg->rkcg_share_topic_errored =
-                    rd_kafka_topic_partition_list_new(0);
 
         /* Create a logical group coordinator broker to provide
          * a dedicated connection for group coordination.
@@ -5718,86 +5712,43 @@ static void rd_kafka_propagate_consumer_topic_errors(
 
 
 /**
- * @brief Clear a share-consumer's errored-topic entry by topic_id.
- *
- *        Called from rd_kafka_topic_set_exists on recovery so a
- *        subsequent re-failure with the same code surfaces again,
- *        independent of any wholesale-replace happening in
- *        rd_kafka_propagate_consumer_topic_errors.
- *
- * @locality rdkafka main thread
- */
-void rd_kafka_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
-                                    rd_kafka_Uuid_t topic_id) {
-        int i;
-
-        if (!rkcg || !rkcg->rkcg_errored_topics)
-                return;
-
-        rd_dassert(thrd_is_current(rkcg->rkcg_rk->rk_thread));
-
-        for (i = 0; i < rkcg->rkcg_errored_topics->cnt; i++) {
-                if (rd_kafka_Uuid_cmp(rd_kafka_topic_partition_get_topic_id(
-                                          &rkcg->rkcg_errored_topics->elems[i]),
-                                      topic_id) == 0) {
-                        rd_kafka_topic_partition_list_del_by_idx(
-                            rkcg->rkcg_errored_topics, i);
-                        return;
-                }
-        }
-}
-
-
-/**
  * @brief Share-consumer entry point for end-of-metadata-cycle error
  *        propagation.
  *
  *        Drains the per-cycle pending list: app-facing codes
- *        (TOPIC_EXCEPTION, TOPIC_AUTHORIZATION_FAILED) are handed to
- *        rd_kafka_propagate_consumer_topic_errors for delivery and
- *        cross-cycle dedup; transient codes are debug-logged at most
- *        once per (topic, err) per cycle. Existing rkcg_errored_topics
- *        entries are always merged forward so propagate's wholesale-
- *        replace cannot drop entries for topics absent from this cycle.
- *
- *        After propagate, entries whose rkt has transitioned to
- *        RD_KAFKA_TOPIC_S_NOTEXISTS are pruned from the dedup memo.
- *        Recovery (back to S_EXISTS) is handled separately by
- *        rd_kafka_share_clear_topic_err on set_exists.
- *
- * TODO KIP-932: GA: Refactor this function and maybe use a new function
- *         instead of rd_kafka_propagate_consumer_topic_errors to avoid
- *         the complexity of merging the pending list with existing
- *         error topics.
+ *        (TOPIC_EXCEPTION, TOPIC_AUTHORIZATION_FAILED) are emitted
+ *        directly to the application on next poll; transient codes are
+ *        debug-logged.
  *
  * @locality rdkafka main thread
  */
 void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg) {
         rd_kafka_t *rk = rkcg->rkcg_rk;
-        rd_kafka_topic_partition_list_t *pending;
-        rd_kafka_topic_partition_list_t *to_surface;
-        int i, j;
+        int i;
 
-        if (!rkcg->rkcg_share_topic_errored)
+        if (!rkcg->rkcg_errored_topics)
                 return;
 
-        pending                        = rkcg->rkcg_share_topic_errored;
-        rkcg->rkcg_share_topic_errored = rd_kafka_topic_partition_list_new(0);
-
-        to_surface = rd_kafka_topic_partition_list_new(0);
-        for (i = 0; i < pending->cnt; i++) {
+        for (i = 0; i < rkcg->rkcg_errored_topics->cnt; i++) {
                 const rd_kafka_topic_partition_t *pending_errored_tp =
-                    &pending->elems[i];
+                    &rkcg->rkcg_errored_topics->elems[i];
 
                 switch (pending_errored_tp->err) {
                 case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
                 case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
-                        rd_kafka_topic_partition_list_add_with_topic_name_and_id(
-                            to_surface,
-                            rd_kafka_topic_partition_get_topic_id(
-                                pending_errored_tp),
-                            pending_errored_tp->topic, RD_KAFKA_PARTITION_UA)
-                            ->err = pending_errored_tp->err;
+                        rd_kafka_dbg(rk, CONSUMER | RD_KAFKA_DBG_TOPIC,
+                                     "TOPICERR",
+                                     "Subscribed topic not available: %s: %s",
+                                     pending_errored_tp->topic,
+                                     rd_kafka_err2str(pending_errored_tp->err));
+                        rd_kafka_consumer_err(
+                            rkcg->rkcg_q, RD_KAFKA_NODEID_UA,
+                            pending_errored_tp->err, 0,
+                            pending_errored_tp->topic, NULL,
+                            RD_KAFKA_OFFSET_INVALID,
+                            "Subscribed topic not available: %s: %s",
+                            pending_errored_tp->topic,
+                            rd_kafka_err2str(pending_errored_tp->err));
                         break;
 
                 default:
@@ -5807,30 +5758,10 @@ void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg) {
                         break;
                 }
         }
-        rd_kafka_topic_partition_list_destroy(pending);
 
-        /* Carry previously-known errored entries forward so propagate's
-         * wholesale-replace doesn't drop them. */
-        if (rkcg->rkcg_errored_topics) {
-                for (j = 0; j < rkcg->rkcg_errored_topics->cnt; j++) {
-                        rd_kafka_topic_partition_t *existing =
-                            &rkcg->rkcg_errored_topics->elems[j];
-                        rd_kafka_Uuid_t existing_id =
-                            rd_kafka_topic_partition_get_topic_id(existing);
-
-                        if (rd_kafka_topic_partition_list_find_topic_by_id(
-                                to_surface, existing_id))
-                                continue; /* pending overrides existing */
-
-                        rd_kafka_topic_partition_list_add_with_topic_name_and_id(
-                            to_surface, existing_id, existing->topic,
-                            RD_KAFKA_PARTITION_UA)
-                            ->err = existing->err;
-                }
-        }
-
-        rd_kafka_propagate_consumer_topic_errors(
-            rkcg, to_surface, "Subscribed topic not available");
+        /* Clear the per-cycle accumulator; next cycle starts fresh. */
+        rd_kafka_topic_partition_list_destroy(rkcg->rkcg_errored_topics);
+        rkcg->rkcg_errored_topics = rd_kafka_topic_partition_list_new(0);
 }
 
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5748,25 +5748,22 @@ void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
  *        (TOPIC_EXCEPTION, TOPIC_AUTHORIZATION_FAILED) are handed to
  *        rd_kafka_propagate_consumer_topic_errors for delivery and
  *        cross-cycle dedup; transient codes are debug-logged at most
- *        once per (topic, err) per cycle. propagate is called even on
- *        an empty surface list so recovered or unsubscribed topics
- *        are dropped from the dedup state.
+ *        once per (topic, err) per cycle. Existing rkcg_errored_topics
+ *        entries are always merged forward so propagate's wholesale-
+ *        replace cannot drop entries for topics absent from this cycle.
  *
- * @param should_merge_existing_errored true when this metadata response
- *        is a partial view of the subscription and previously-known
- *        errored topics must be carried forward to survive the
- *        wholesale-replace in propagate. False on a full-subscription
- *        view, where the response is authoritative.
+ *        After propagate, entries whose rkt has transitioned to
+ *        RD_KAFKA_TOPIC_S_NOTEXISTS are pruned from the dedup memo.
+ *        Recovery (back to S_EXISTS) is handled separately by
+ *        rd_kafka_cgrp_share_clear_topic_err on set_exists.
  *
  * @locality rdkafka main thread
  */
-void rd_kafka_cgrp_share_metadata_update_check(
-    rd_kafka_cgrp_t *rkcg,
-    rd_bool_t should_merge_existing_errored) {
+void rd_kafka_share_topic_err_propogate(rd_kafka_cgrp_t *rkcg) {
         rd_kafka_t *rk = rkcg->rkcg_rk;
         rd_kafka_topic_partition_list_t *pending;
         rd_kafka_topic_partition_list_t *to_surface;
-        int i;
+        int i, j;
 
         if (!rkcg->rkcg_share_topic_errored)
                 return;
@@ -5776,31 +5773,32 @@ void rd_kafka_cgrp_share_metadata_update_check(
 
         to_surface = rd_kafka_topic_partition_list_new(0);
         for (i = 0; i < pending->cnt; i++) {
-                const rd_kafka_topic_partition_t *t = &pending->elems[i];
+                const rd_kafka_topic_partition_t *pending_errored_tp =
+                    &pending->elems[i];
 
-                switch (t->err) {
+                switch (pending_errored_tp->err) {
                 case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
                 case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
                         rd_kafka_topic_partition_list_add_with_topic_name_and_id(
                             to_surface,
-                            rd_kafka_topic_partition_get_topic_id(t), t->topic,
-                            RD_KAFKA_PARTITION_UA)
-                            ->err = t->err;
+                            rd_kafka_topic_partition_get_topic_id(
+                                pending_errored_tp),
+                            pending_errored_tp->topic, RD_KAFKA_PARTITION_UA)
+                            ->err = pending_errored_tp->err;
                         break;
 
                 default:
                         rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
-                                     "Topic %s: %s", t->topic,
-                                     rd_kafka_err2str(t->err));
+                                     "Topic %s: %s", pending_errored_tp->topic,
+                                     rd_kafka_err2str(pending_errored_tp->err));
                         break;
                 }
         }
         rd_kafka_topic_partition_list_destroy(pending);
 
-        /* Partial-view drain: carry previously-known errored entries
-         * forward so propagate's wholesale-replace doesn't drop them. */
-        if (should_merge_existing_errored && rkcg->rkcg_errored_topics) {
-                int j;
+        /* Carry previously-known errored entries forward so propagate's
+         * wholesale-replace doesn't drop them. */
+        if (rkcg->rkcg_errored_topics) {
                 for (j = 0; j < rkcg->rkcg_errored_topics->cnt; j++) {
                         rd_kafka_topic_partition_t *existing =
                             &rkcg->rkcg_errored_topics->elems[j];
@@ -5820,6 +5818,34 @@ void rd_kafka_cgrp_share_metadata_update_check(
 
         rd_kafka_propagate_consumer_topic_errors(
             rkcg, to_surface, "Subscribed topic not available");
+
+        /* Post-propagate cleanup: drop memo entries whose rkt has moved
+         * to S_NOTEXISTS. For those topics the client stops re-asking,
+         * so pending won't refill */
+        if (rkcg->rkcg_errored_topics) {
+                j = 0;
+                while (j < rkcg->rkcg_errored_topics->cnt) {
+                        rd_kafka_topic_partition_t *entry =
+                            &rkcg->rkcg_errored_topics->elems[j];
+                        rd_kafka_topic_t *rkt =
+                            rd_kafka_topic_find(rk, entry->topic, 1 /*lock*/);
+                        rd_bool_t drop = rd_false;
+
+                        if (rkt) {
+                                rd_kafka_topic_rdlock(rkt);
+                                drop = rkt->rkt_state ==
+                                       RD_KAFKA_TOPIC_S_NOTEXISTS;
+                                rd_kafka_topic_rdunlock(rkt);
+                                rd_kafka_topic_destroy0(rkt);
+                        }
+
+                        if (drop)
+                                rd_kafka_topic_partition_list_del_by_idx(
+                                    rkcg->rkcg_errored_topics, j);
+                        else
+                                j++;
+                }
+        }
 }
 
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -454,9 +454,9 @@ void rd_kafka_cgrp_destroy_final(rd_kafka_cgrp_t *rkcg) {
         rd_list_destroy(&rkcg->rkcg_toppars);
         rd_list_destroy(rkcg->rkcg_subscribed_topics);
         rd_kafka_topic_partition_list_destroy(rkcg->rkcg_errored_topics);
-        if (rkcg->rkcg_share_pending_errored)
+        if (rkcg->rkcg_share_topic_errored)
                 rd_kafka_topic_partition_list_destroy(
-                    rkcg->rkcg_share_pending_errored);
+                    rkcg->rkcg_share_topic_errored);
         if (rkcg->rkcg_assignor && rkcg->rkcg_assignor->rkas_destroy_state_cb &&
             rkcg->rkcg_assignor_state)
                 rkcg->rkcg_assignor->rkas_destroy_state_cb(
@@ -543,7 +543,7 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
 
         rkcg->rkcg_errored_topics = rd_kafka_topic_partition_list_new(0);
         if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rkcg->rkcg_share_pending_errored =
+                rkcg->rkcg_share_topic_errored =
                     rd_kafka_topic_partition_list_new(0);
 
         /* Create a logical group coordinator broker to provide
@@ -5728,11 +5728,11 @@ static void rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg) {
         rd_kafka_topic_partition_list_t *to_surface;
         int i;
 
-        if (!rkcg->rkcg_share_pending_errored)
+        if (!rkcg->rkcg_share_topic_errored)
                 return;
 
-        pending                          = rkcg->rkcg_share_pending_errored;
-        rkcg->rkcg_share_pending_errored = rd_kafka_topic_partition_list_new(0);
+        pending                        = rkcg->rkcg_share_topic_errored;
+        rkcg->rkcg_share_topic_errored = rd_kafka_topic_partition_list_new(0);
 
         to_surface = rd_kafka_topic_partition_list_new(0);
         for (i = 0; i < pending->cnt; i++) {
@@ -5741,8 +5741,10 @@ static void rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg) {
                 switch (t->err) {
                 case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
                 case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
-                        rd_kafka_topic_partition_list_add(to_surface, t->topic,
-                                                          RD_KAFKA_PARTITION_UA)
+                        rd_kafka_topic_partition_list_add_with_topic_name_and_id(
+                            to_surface,
+                            rd_kafka_topic_partition_get_topic_id(t), t->topic,
+                            RD_KAFKA_PARTITION_UA)
                             ->err = t->err;
                         break;
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5679,18 +5679,10 @@ static void rd_kafka_propagate_consumer_topic_errors(
                 if (topic->err == RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC)
                         topic->err = RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
 
-                /* Check if this topic errored previously. Share consumers
-                 * key the dedup memo by topic_id — the stable identifier the
-                 * share error flow uses throughout — whereas classic
-                 * consumers key by topic name. */
-                if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk))
-                        prev = rd_kafka_topic_partition_list_find_topic_by_id(
-                            rkcg->rkcg_errored_topics,
-                            rd_kafka_topic_partition_get_topic_id(topic));
-                else
-                        prev = rd_kafka_topic_partition_list_find(
-                            rkcg->rkcg_errored_topics, topic->topic,
-                            RD_KAFKA_PARTITION_UA);
+                /* Check if this topic errored previously */
+                prev = rd_kafka_topic_partition_list_find(
+                    rkcg->rkcg_errored_topics, topic->topic,
+                    RD_KAFKA_PARTITION_UA);
 
                 if (prev && prev->err == topic->err)
                         continue; /* This topic already reported same error */

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5741,7 +5741,8 @@ void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
 
 
 /**
- * @brief Share-consumer variant of rd_kafka_cgrp_metadata_update_check.
+ * @brief Share-consumer entry point for end-of-metadata-cycle error
+ *        propagation.
  *
  *        Drains the per-cycle pending list: app-facing codes
  *        (TOPIC_EXCEPTION, TOPIC_AUTHORIZATION_FAILED) are handed to
@@ -5751,11 +5752,17 @@ void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
  *        an empty surface list so recovered or unsubscribed topics
  *        are dropped from the dedup state.
  *
+ * @param should_merge_existing_errored true when this metadata response
+ *        is a partial view of the subscription and previously-known
+ *        errored topics must be carried forward to survive the
+ *        wholesale-replace in propagate. False on a full-subscription
+ *        view, where the response is authoritative.
+ *
  * @locality rdkafka main thread
  */
-static void
-rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg,
-                                     rd_bool_t should_merge_existing_errored) {
+void rd_kafka_cgrp_share_metadata_update_check(
+    rd_kafka_cgrp_t *rkcg,
+    rd_bool_t should_merge_existing_errored) {
         rd_kafka_t *rk = rkcg->rkcg_rk;
         rd_kafka_topic_partition_list_t *pending;
         rd_kafka_topic_partition_list_t *to_surface;
@@ -7558,23 +7565,6 @@ void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
         rd_bool_t changed;
 
         rd_kafka_assert(NULL, thrd_is_current(rkcg->rkcg_rk->rk_thread));
-
-        /* Share consumers handle topic-level errors via the share
-         * variant; the classic rejoin path is not applicable since
-         * membership is driven by ShareGroupHeartbeat.
-         *
-         * For share, the share variant must additively merge previously-
-         * errored topics forward whenever this metadata response is a
-         * PARTIAL view of the subscription (i.e., the IF-branch
-         * gate in parse_Metadata0 was not taken and we entered this
-         * function via the share fallthrough). That gate's truth value
-         * is what `do_join` carries: do_join=true ↔ full-subscription
-         * view (no merge); do_join=false ↔ partial view (merge). */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
-                rd_kafka_share_metadata_update_check(
-                    rkcg, !do_join /*should_merge_existing_errored*/);
-                return;
-        }
 
         if (rkcg->rkcg_group_protocol != RD_KAFKA_GROUP_PROTOCOL_CLASSIC)
                 return;

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5685,10 +5685,18 @@ static void rd_kafka_propagate_consumer_topic_errors(
                 if (topic->err == RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC)
                         topic->err = RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
 
-                /* Check if this topic errored previously */
-                prev = rd_kafka_topic_partition_list_find(
-                    rkcg->rkcg_errored_topics, topic->topic,
-                    RD_KAFKA_PARTITION_UA);
+                /* Check if this topic errored previously. Share consumers
+                 * key the dedup memo by topic_id — the stable identifier the
+                 * share error flow uses throughout — whereas classic
+                 * consumers key by topic name. */
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk))
+                        prev = rd_kafka_topic_partition_list_find_topic_by_id(
+                            rkcg->rkcg_errored_topics,
+                            rd_kafka_topic_partition_get_topic_id(topic));
+                else
+                        prev = rd_kafka_topic_partition_list_find(
+                            rkcg->rkcg_errored_topics, topic->topic,
+                            RD_KAFKA_PARTITION_UA);
 
                 if (prev && prev->err == topic->err)
                         continue; /* This topic already reported same error */
@@ -5719,8 +5727,8 @@ static void rd_kafka_propagate_consumer_topic_errors(
  *
  * @locality rdkafka main thread
  */
-void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
-                                         rd_kafka_Uuid_t topic_id) {
+void rd_kafka_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
+                                    rd_kafka_Uuid_t topic_id) {
         int i;
 
         if (!rkcg || !rkcg->rkcg_errored_topics)
@@ -5755,11 +5763,16 @@ void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
  *        After propagate, entries whose rkt has transitioned to
  *        RD_KAFKA_TOPIC_S_NOTEXISTS are pruned from the dedup memo.
  *        Recovery (back to S_EXISTS) is handled separately by
- *        rd_kafka_cgrp_share_clear_topic_err on set_exists.
+ *        rd_kafka_share_clear_topic_err on set_exists.
+ *
+ * TODO KIP-932: GA: Refactor this function and maybe use a new function
+ *         instead of rd_kafka_propagate_consumer_topic_errors to avoid
+ *         the complexity of merging the pending list with existing
+ *         error topics.
  *
  * @locality rdkafka main thread
  */
-void rd_kafka_share_topic_err_propogate(rd_kafka_cgrp_t *rkcg) {
+void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg) {
         rd_kafka_t *rk = rkcg->rkcg_rk;
         rd_kafka_topic_partition_list_t *pending;
         rd_kafka_topic_partition_list_t *to_surface;
@@ -5818,34 +5831,6 @@ void rd_kafka_share_topic_err_propogate(rd_kafka_cgrp_t *rkcg) {
 
         rd_kafka_propagate_consumer_topic_errors(
             rkcg, to_surface, "Subscribed topic not available");
-
-        /* Post-propagate cleanup: drop memo entries whose rkt has moved
-         * to S_NOTEXISTS. For those topics the client stops re-asking,
-         * so pending won't refill */
-        if (rkcg->rkcg_errored_topics) {
-                j = 0;
-                while (j < rkcg->rkcg_errored_topics->cnt) {
-                        rd_kafka_topic_partition_t *entry =
-                            &rkcg->rkcg_errored_topics->elems[j];
-                        rd_kafka_topic_t *rkt =
-                            rd_kafka_topic_find(rk, entry->topic, 1 /*lock*/);
-                        rd_bool_t drop = rd_false;
-
-                        if (rkt) {
-                                rd_kafka_topic_rdlock(rkt);
-                                drop = rkt->rkt_state ==
-                                       RD_KAFKA_TOPIC_S_NOTEXISTS;
-                                rd_kafka_topic_rdunlock(rkt);
-                                rd_kafka_topic_destroy0(rkt);
-                        }
-
-                        if (drop)
-                                rd_kafka_topic_partition_list_del_by_idx(
-                                    rkcg->rkcg_errored_topics, j);
-                        else
-                                j++;
-                }
-        }
 }
 
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5710,6 +5710,37 @@ static void rd_kafka_propagate_consumer_topic_errors(
 
 
 /**
+ * @brief Clear a share-consumer's errored-topic entry by topic_id.
+ *
+ *        Called from rd_kafka_topic_set_exists on recovery so a
+ *        subsequent re-failure with the same code surfaces again,
+ *        independent of any wholesale-replace happening in
+ *        rd_kafka_propagate_consumer_topic_errors.
+ *
+ * @locality rdkafka main thread
+ */
+void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
+                                         rd_kafka_Uuid_t topic_id) {
+        int i;
+
+        if (!rkcg || !rkcg->rkcg_errored_topics)
+                return;
+
+        rd_dassert(thrd_is_current(rkcg->rkcg_rk->rk_thread));
+
+        for (i = 0; i < rkcg->rkcg_errored_topics->cnt; i++) {
+                if (rd_kafka_Uuid_cmp(rd_kafka_topic_partition_get_topic_id(
+                                          &rkcg->rkcg_errored_topics->elems[i]),
+                                      topic_id) == 0) {
+                        rd_kafka_topic_partition_list_del_by_idx(
+                            rkcg->rkcg_errored_topics, i);
+                        return;
+                }
+        }
+}
+
+
+/**
  * @brief Share-consumer variant of rd_kafka_cgrp_metadata_update_check.
  *
  *        Drains the per-cycle pending list: app-facing codes
@@ -5722,7 +5753,9 @@ static void rd_kafka_propagate_consumer_topic_errors(
  *
  * @locality rdkafka main thread
  */
-static void rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg) {
+static void
+rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg,
+                                     rd_bool_t should_merge_existing_errored) {
         rd_kafka_t *rk = rkcg->rkcg_rk;
         rd_kafka_topic_partition_list_t *pending;
         rd_kafka_topic_partition_list_t *to_surface;
@@ -5756,6 +5789,27 @@ static void rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg) {
                 }
         }
         rd_kafka_topic_partition_list_destroy(pending);
+
+        /* Partial-view drain: carry previously-known errored entries
+         * forward so propagate's wholesale-replace doesn't drop them. */
+        if (should_merge_existing_errored && rkcg->rkcg_errored_topics) {
+                int j;
+                for (j = 0; j < rkcg->rkcg_errored_topics->cnt; j++) {
+                        rd_kafka_topic_partition_t *existing =
+                            &rkcg->rkcg_errored_topics->elems[j];
+                        rd_kafka_Uuid_t existing_id =
+                            rd_kafka_topic_partition_get_topic_id(existing);
+
+                        if (rd_kafka_topic_partition_list_find_topic_by_id(
+                                to_surface, existing_id))
+                                continue; /* pending overrides existing */
+
+                        rd_kafka_topic_partition_list_add_with_topic_name_and_id(
+                            to_surface, existing_id, existing->topic,
+                            RD_KAFKA_PARTITION_UA)
+                            ->err = existing->err;
+                }
+        }
 
         rd_kafka_propagate_consumer_topic_errors(
             rkcg, to_surface, "Subscribed topic not available");
@@ -7507,9 +7561,18 @@ void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
 
         /* Share consumers handle topic-level errors via the share
          * variant; the classic rejoin path is not applicable since
-         * membership is driven by ShareGroupHeartbeat. */
+         * membership is driven by ShareGroupHeartbeat.
+         *
+         * For share, the share variant must additively merge previously-
+         * errored topics forward whenever this metadata response is a
+         * PARTIAL view of the subscription (i.e., the IF-branch
+         * gate in parse_Metadata0 was not taken and we entered this
+         * function via the share fallthrough). That gate's truth value
+         * is what `do_join` carries: do_join=true ↔ full-subscription
+         * view (no merge); do_join=false ↔ partial view (merge). */
         if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
-                rd_kafka_share_metadata_update_check(rkcg);
+                rd_kafka_share_metadata_update_check(
+                    rkcg, !do_join /*should_merge_existing_errored*/);
                 return;
         }
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -7268,8 +7268,15 @@ static rd_kafka_op_res_t rd_kafka_cgrp_op_serve(rd_kafka_t *rk,
         case RD_KAFKA_OP_PARTITION_JOIN:
                 rd_kafka_cgrp_partition_add(rkcg, rktp);
 
-                /* If terminating tell the partition to leave */
-                if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE)
+                /* If terminating tell the partition to leave.
+                 *
+                 * Skipped for share consumers: op_fetch_stop bumps the
+                 * version barrier, touches rktp_offset_query_tmr, and
+                 * calls offset_store_stop — none of which should fire
+                 * for a share-assigned rktp that never started a
+                 * regular fetch. */
+                if ((rkcg->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) &&
+                    !RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk))
                         rd_kafka_toppar_op_fetch_stop(rktp, RD_KAFKA_NO_REPLYQ);
                 break;
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -454,6 +454,9 @@ void rd_kafka_cgrp_destroy_final(rd_kafka_cgrp_t *rkcg) {
         rd_list_destroy(&rkcg->rkcg_toppars);
         rd_list_destroy(rkcg->rkcg_subscribed_topics);
         rd_kafka_topic_partition_list_destroy(rkcg->rkcg_errored_topics);
+        if (rkcg->rkcg_share_pending_errored)
+                rd_kafka_topic_partition_list_destroy(
+                    rkcg->rkcg_share_pending_errored);
         if (rkcg->rkcg_assignor && rkcg->rkcg_assignor->rkas_destroy_state_cb &&
             rkcg->rkcg_assignor_state)
                 rkcg->rkcg_assignor->rkas_destroy_state_cb(
@@ -539,6 +542,9 @@ rd_kafka_cgrp_t *rd_kafka_cgrp_new(rd_kafka_t *rk,
         rkcg->rkcg_next_target_assignment = NULL;
 
         rkcg->rkcg_errored_topics = rd_kafka_topic_partition_list_new(0);
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                rkcg->rkcg_share_pending_errored =
+                    rd_kafka_topic_partition_list_new(0);
 
         /* Create a logical group coordinator broker to provide
          * a dedicated connection for group coordination.
@@ -5704,6 +5710,57 @@ static void rd_kafka_propagate_consumer_topic_errors(
 
 
 /**
+ * @brief Share-consumer variant of rd_kafka_cgrp_metadata_update_check.
+ *
+ *        Drains the per-cycle pending list: app-facing codes
+ *        (TOPIC_EXCEPTION, TOPIC_AUTHORIZATION_FAILED) are handed to
+ *        rd_kafka_propagate_consumer_topic_errors for delivery and
+ *        cross-cycle dedup; transient codes are debug-logged at most
+ *        once per (topic, err) per cycle. propagate is called even on
+ *        an empty surface list so recovered or unsubscribed topics
+ *        are dropped from the dedup state.
+ *
+ * @locality rdkafka main thread
+ */
+static void rd_kafka_share_metadata_update_check(rd_kafka_cgrp_t *rkcg) {
+        rd_kafka_t *rk = rkcg->rkcg_rk;
+        rd_kafka_topic_partition_list_t *pending;
+        rd_kafka_topic_partition_list_t *to_surface;
+        int i;
+
+        if (!rkcg->rkcg_share_pending_errored)
+                return;
+
+        pending                          = rkcg->rkcg_share_pending_errored;
+        rkcg->rkcg_share_pending_errored = rd_kafka_topic_partition_list_new(0);
+
+        to_surface = rd_kafka_topic_partition_list_new(0);
+        for (i = 0; i < pending->cnt; i++) {
+                const rd_kafka_topic_partition_t *t = &pending->elems[i];
+
+                switch (t->err) {
+                case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
+                case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
+                        rd_kafka_topic_partition_list_add(to_surface, t->topic,
+                                                          RD_KAFKA_PARTITION_UA)
+                            ->err = t->err;
+                        break;
+
+                default:
+                        rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
+                                     "Topic %s: %s", t->topic,
+                                     rd_kafka_err2str(t->err));
+                        break;
+                }
+        }
+        rd_kafka_topic_partition_list_destroy(pending);
+
+        rd_kafka_propagate_consumer_topic_errors(
+            rkcg, to_surface, "Subscribed topic not available");
+}
+
+
+/**
  * @brief Work out the topics currently subscribed to that do not
  *        match any pattern in \p subscription.
  */
@@ -7445,6 +7502,14 @@ void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
         rd_bool_t changed;
 
         rd_kafka_assert(NULL, thrd_is_current(rkcg->rkcg_rk->rk_thread));
+
+        /* Share consumers handle topic-level errors via the share
+         * variant; the classic rejoin path is not applicable since
+         * membership is driven by ShareGroupHeartbeat. */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkcg->rkcg_rk)) {
+                rd_kafka_share_metadata_update_check(rkcg);
+                return;
+        }
 
         if (rkcg->rkcg_group_protocol != RD_KAFKA_GROUP_PROTOCOL_CLASSIC)
                 return;

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -231,7 +231,7 @@ typedef struct rd_kafka_cgrp_s {
         /** Share-consumer per-metadata-cycle (topic, err) accumulator.
          *  Populated by rd_kafka_share_toppar_enq_error and drained
          *  by rd_kafka_share_metadata_update_check at cycle end. */
-        rd_kafka_topic_partition_list_t *rkcg_share_pending_errored;
+        rd_kafka_topic_partition_list_t *rkcg_share_topic_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
          *  completes. The waiting subscription is stored here. */

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -230,7 +230,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_topic_partition_list_t *rkcg_errored_topics;
         /** Share-consumer per-metadata-cycle (topic, err) accumulator.
          *  Populated by rd_kafka_share_toppar_enq_error and drained
-         *  by rd_kafka_share_metadata_update_check at cycle end. */
+         *  by rd_kafka_cgrp_share_metadata_update_check at cycle end. */
         rd_kafka_topic_partition_list_t *rkcg_share_topic_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
@@ -508,6 +508,10 @@ void rd_kafka_cgrp_coord_dead(rd_kafka_cgrp_t *rkcg,
                               const char *reason);
 void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
                                          rd_bool_t do_join);
+
+void rd_kafka_cgrp_share_metadata_update_check(
+    rd_kafka_cgrp_t *rkcg,
+    rd_bool_t should_merge_existing_errored);
 
 void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
                                          rd_kafka_Uuid_t topic_id);

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -226,12 +226,19 @@ typedef struct rd_kafka_cgrp_s {
         /** The actual topics subscribed (after metadata+wildcard matching).
          *  Sorted. */
         rd_list_t *rkcg_subscribed_topics; /**< (rd_kafka_topic_info_t *) */
-        /** Subscribed topics that are errored/not available. */
+        /** Subscribed topics that are errored/not available.
+         *
+         *  Two roles share this field, exclusively per cgrp protocol:
+         *
+         *  - Classic consumer: cross-cycle dedup memo.
+         *    rd_kafka_propagate_consumer_topic_errors wholesale-replaces
+         *    it with the current cycle's errored set after emitting.
+         *
+         *  - Share consumer (KIP-932): per-metadata-cycle (topic, err)
+         *    accumulator. Populated by rd_kafka_share_toppar_enq_error
+         *    and drained (then re-emptied) by
+         *    rd_kafka_share_topic_err_propagate at cycle end. */
         rd_kafka_topic_partition_list_t *rkcg_errored_topics;
-        /** Share-consumer per-metadata-cycle (topic, err) accumulator.
-         *  Populated by rd_kafka_share_toppar_enq_error and drained
-         *  by rd_kafka_share_topic_err_propagate at cycle end. */
-        rd_kafka_topic_partition_list_t *rkcg_share_topic_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
          *  completes. The waiting subscription is stored here. */
@@ -510,13 +517,9 @@ void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
                                          rd_bool_t do_join);
 
 /**
- * TODO KIP-932: Think of correct placing for these two functions
- *               when correcting this field.
+ * TODO KIP-932: Think of correct placing for this function.
  */
 void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg);
-
-void rd_kafka_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
-                                    rd_kafka_Uuid_t topic_id);
 
 #define rd_kafka_cgrp_get(rk) ((rk)->rk_cgrp)
 

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -230,7 +230,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_topic_partition_list_t *rkcg_errored_topics;
         /** Share-consumer per-metadata-cycle (topic, err) accumulator.
          *  Populated by rd_kafka_share_toppar_enq_error and drained
-         *  by rd_kafka_cgrp_share_metadata_update_check at cycle end. */
+         *  by rd_kafka_share_topic_err_propogate at cycle end. */
         rd_kafka_topic_partition_list_t *rkcg_share_topic_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
@@ -509,9 +509,7 @@ void rd_kafka_cgrp_coord_dead(rd_kafka_cgrp_t *rkcg,
 void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
                                          rd_bool_t do_join);
 
-void rd_kafka_cgrp_share_metadata_update_check(
-    rd_kafka_cgrp_t *rkcg,
-    rd_bool_t should_merge_existing_errored);
+void rd_kafka_share_topic_err_propogate(rd_kafka_cgrp_t *rkcg);
 
 void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
                                          rd_kafka_Uuid_t topic_id);

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -230,7 +230,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_topic_partition_list_t *rkcg_errored_topics;
         /** Share-consumer per-metadata-cycle (topic, err) accumulator.
          *  Populated by rd_kafka_share_toppar_enq_error and drained
-         *  by rd_kafka_share_topic_err_propogate at cycle end. */
+         *  by rd_kafka_share_topic_err_propagate at cycle end. */
         rd_kafka_topic_partition_list_t *rkcg_share_topic_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
@@ -509,10 +509,14 @@ void rd_kafka_cgrp_coord_dead(rd_kafka_cgrp_t *rkcg,
 void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
                                          rd_bool_t do_join);
 
-void rd_kafka_share_topic_err_propogate(rd_kafka_cgrp_t *rkcg);
+/**
+ * TODO KIP-932: Think of correct placing for these two functions
+ *               when correcting this field.
+ */
+void rd_kafka_share_topic_err_propagate(rd_kafka_cgrp_t *rkcg);
 
-void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
-                                         rd_kafka_Uuid_t topic_id);
+void rd_kafka_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
+                                    rd_kafka_Uuid_t topic_id);
 
 #define rd_kafka_cgrp_get(rk) ((rk)->rk_cgrp)
 

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -228,6 +228,10 @@ typedef struct rd_kafka_cgrp_s {
         rd_list_t *rkcg_subscribed_topics; /**< (rd_kafka_topic_info_t *) */
         /** Subscribed topics that are errored/not available. */
         rd_kafka_topic_partition_list_t *rkcg_errored_topics;
+        /** Share-consumer per-metadata-cycle (topic, err) accumulator.
+         *  Populated by rd_kafka_share_toppar_enq_error and drained
+         *  by rd_kafka_share_metadata_update_check at cycle end. */
+        rd_kafka_topic_partition_list_t *rkcg_share_pending_errored;
         /** If a SUBSCRIBE op is received during a COOPERATIVE rebalance,
          *  actioning this will be postponed until after the rebalance
          *  completes. The waiting subscription is stored here. */

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -508,6 +508,10 @@ void rd_kafka_cgrp_coord_dead(rd_kafka_cgrp_t *rkcg,
                               const char *reason);
 void rd_kafka_cgrp_metadata_update_check(rd_kafka_cgrp_t *rkcg,
                                          rd_bool_t do_join);
+
+void rd_kafka_cgrp_share_clear_topic_err(rd_kafka_cgrp_t *rkcg,
+                                         rd_kafka_Uuid_t topic_id);
+
 #define rd_kafka_cgrp_get(rk) ((rk)->rk_cgrp)
 
 #define rd_kafka_cgrp_same_subscription_version(rk_cgrp,                       \

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1106,22 +1106,21 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
          * For share consumers, the same predicate also gates whether the
          * share variant should merge pre-existing rkcg_errored_topics
          * forward into this cycle's surface list (merge on partial view;
-         * skip on authoritative). Share goes through its dedicated entry
-         * point, not rd_kafka_cgrp_metadata_update_check. */
-        rd_bool_t cgrp_update_full_metadata_refresh =
+         * skip on full view). */
+        rd_bool_t cgrp_update_covers_subscription =
             cgrp_update &&
             (all_topics ||
              ((requested_topics || requested_topic_ids) &&
               rd_kafka_cgrp_same_subscription_version(
                   rkb->rkb_rk->rk_cgrp, cgrp_subscription_version)));
 
-        if (cgrp_update_full_metadata_refresh)
+        if (cgrp_update_covers_subscription)
                 rd_kafka_cgrp_metadata_update_check(rkb->rkb_rk->rk_cgrp,
                                                     rd_true /*do join*/);
 
         if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
                 rd_kafka_cgrp_share_metadata_update_check(
-                    rk->rk_cgrp, !cgrp_update_full_metadata_refresh
+                    rk->rk_cgrp, !cgrp_update_covers_subscription
                     /*should_merge_existing_errored*/);
 
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp &&

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1111,7 +1111,7 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                                                     rd_true /*do join*/);
 
         if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rd_kafka_share_topic_err_propogate(rk->rk_cgrp);
+                rd_kafka_share_topic_err_propagate(rk->rk_cgrp);
 
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp &&
             rk->rk_cgrp->rkcg_group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC)

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1109,6 +1109,17 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
                   rkb->rkb_rk->rk_cgrp, cgrp_subscription_version))))
                 rd_kafka_cgrp_metadata_update_check(rkb->rkb_rk->rk_cgrp,
                                                     rd_true /*do join*/);
+        else if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                /* Share consumers: drain on every metadata response,
+                 * regardless of cgrp_update, so the heartbeat-driven
+                 * metadata-by-id path and other cgrp_update=false
+                 * responses surface errors promptly. The share variant
+                 * treats this as a "partial view" (do_join=rd_false)
+                 * and merges existing rkcg_errored_topics entries
+                 * forward, so previously-known errored topics are not
+                 * wiped by responses that didn't cover them. */
+                rd_kafka_cgrp_metadata_update_check(rk->rk_cgrp,
+                                                    rd_false /*do join*/);
 
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp &&
             rk->rk_cgrp->rkcg_group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC)

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1101,25 +1101,28 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
          * the request was from the partition assignor (!cgrp_update)
          * which may contain only a sub-set of the subscribed topics (namely
          * the effective subscription of available topics) as to not
-         * propagate non-included topics as non-existent. */
-        if (cgrp_update &&
+         * propagate non-included topics as non-existent.
+         *
+         * For share consumers, the same predicate also gates whether the
+         * share variant should merge pre-existing rkcg_errored_topics
+         * forward into this cycle's surface list (merge on partial view;
+         * skip on authoritative). Share goes through its dedicated entry
+         * point, not rd_kafka_cgrp_metadata_update_check. */
+        rd_bool_t cgrp_update_full_metadata_refresh =
+            cgrp_update &&
             (all_topics ||
              ((requested_topics || requested_topic_ids) &&
               rd_kafka_cgrp_same_subscription_version(
-                  rkb->rkb_rk->rk_cgrp, cgrp_subscription_version))))
+                  rkb->rkb_rk->rk_cgrp, cgrp_subscription_version)));
+
+        if (cgrp_update_full_metadata_refresh)
                 rd_kafka_cgrp_metadata_update_check(rkb->rkb_rk->rk_cgrp,
                                                     rd_true /*do join*/);
-        else if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                /* Share consumers: drain on every metadata response,
-                 * regardless of cgrp_update, so the heartbeat-driven
-                 * metadata-by-id path and other cgrp_update=false
-                 * responses surface errors promptly. The share variant
-                 * treats this as a "partial view" (do_join=rd_false)
-                 * and merges existing rkcg_errored_topics entries
-                 * forward, so previously-known errored topics are not
-                 * wiped by responses that didn't cover them. */
-                rd_kafka_cgrp_metadata_update_check(rk->rk_cgrp,
-                                                    rd_false /*do join*/);
+
+        if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
+                rd_kafka_cgrp_share_metadata_update_check(
+                    rk->rk_cgrp, !cgrp_update_full_metadata_refresh
+                    /*should_merge_existing_errored*/);
 
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp &&
             rk->rk_cgrp->rkcg_group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC)

--- a/src/rdkafka_metadata.c
+++ b/src/rdkafka_metadata.c
@@ -1101,27 +1101,17 @@ rd_kafka_parse_Metadata0(rd_kafka_broker_t *rkb,
          * the request was from the partition assignor (!cgrp_update)
          * which may contain only a sub-set of the subscribed topics (namely
          * the effective subscription of available topics) as to not
-         * propagate non-included topics as non-existent.
-         *
-         * For share consumers, the same predicate also gates whether the
-         * share variant should merge pre-existing rkcg_errored_topics
-         * forward into this cycle's surface list (merge on partial view;
-         * skip on full view). */
-        rd_bool_t cgrp_update_covers_subscription =
-            cgrp_update &&
+         * propagate non-included topics as non-existent. */
+        if (cgrp_update &&
             (all_topics ||
              ((requested_topics || requested_topic_ids) &&
               rd_kafka_cgrp_same_subscription_version(
-                  rkb->rkb_rk->rk_cgrp, cgrp_subscription_version)));
-
-        if (cgrp_update_covers_subscription)
+                  rkb->rkb_rk->rk_cgrp, cgrp_subscription_version))))
                 rd_kafka_cgrp_metadata_update_check(rkb->rkb_rk->rk_cgrp,
                                                     rd_true /*do join*/);
 
         if (rk->rk_cgrp && RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                rd_kafka_cgrp_share_metadata_update_check(
-                    rk->rk_cgrp, !cgrp_update_covers_subscription
-                    /*should_merge_existing_errored*/);
+                rd_kafka_share_topic_err_propogate(rk->rk_cgrp);
 
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp &&
             rk->rk_cgrp->rkcg_group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC)

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1632,20 +1632,38 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                         err = RD_KAFKA_RESP_ERR_NO_ERROR;
         }
 
-        rd_rkb_dbg(msetr->msetr_rkb, MSG | RD_KAFKA_DBG_FETCH, "CONSUME",
-                   "Enqueue %i %smessage(s) (%" PRId64
-                   " bytes, %d ops) on %s [%" PRId32
-                   "] fetch queue (qlen %d, v%d, last_offset %" PRId64
-                   ", %d ctrl msgs, %d aborted msgsets, %s)",
-                   msetr->msetr_msgcnt, msetr->msetr_srcname,
-                   msetr->msetr_msg_bytes, rd_kafka_q_len(&msetr->msetr_rkq),
-                   rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
-                   rd_kafka_q_len(msetr->msetr_par_rkq),
-                   msetr->msetr_tver->version, last_offset,
-                   msetr->msetr_ctrl_cnt, msetr->msetr_aborted_cnt,
-                   msetr->msetr_compression
-                       ? rd_kafka_compression2str(msetr->msetr_compression)
-                       : "uncompressed");
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(msetr->msetr_rkb->rkb_rk)) {
+                rd_rkb_dbg(
+                    msetr->msetr_rkb, MSG | RD_KAFKA_DBG_FETCH, "CONSUME",
+                    "Enqueue %i %smessage(s) (%" PRId64
+                    " bytes, %d ops) on %s [%" PRId32
+                    "] fetch queue (qlen %d, v%d, last_offset %" PRId64
+                    ", %d ctrl msgs, %d aborted msgsets, %s)",
+                    msetr->msetr_msgcnt, msetr->msetr_srcname,
+                    msetr->msetr_msg_bytes, rd_kafka_q_len(&msetr->msetr_rkq),
+                    rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
+                    rd_kafka_q_len(msetr->msetr_par_rkq),
+                    msetr->msetr_tver->version, last_offset,
+                    msetr->msetr_ctrl_cnt, msetr->msetr_aborted_cnt,
+                    msetr->msetr_compression
+                        ? rd_kafka_compression2str(msetr->msetr_compression)
+                        : "uncompressed");
+        } else {
+                rd_rkb_dbg(
+                    msetr->msetr_rkb, MSG | RD_KAFKA_DBG_FETCH, "CONSUME",
+                    "Enqueue %i %smessage(s) (%" PRId64
+                    " bytes, %d ops) on %s [%" PRId32
+                    "] temp fetchq (qlen %d, last_offset %" PRId64
+                    ", %d ctrl msgs, %s)",
+                    msetr->msetr_msgcnt, msetr->msetr_srcname,
+                    msetr->msetr_msg_bytes, rd_kafka_q_len(&msetr->msetr_rkq),
+                    rktp->rktp_rkt->rkt_topic->str, rktp->rktp_partition,
+                    rd_kafka_q_len(msetr->msetr_par_rkq), last_offset,
+                    msetr->msetr_ctrl_cnt,
+                    msetr->msetr_compression
+                        ? rd_kafka_compression2str(msetr->msetr_compression)
+                        : "uncompressed");
+        }
 
         /* Concat all messages&errors onto the parent's queue
          * (the partition's fetch queue) */

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1143,8 +1143,8 @@ static void rd_kafka_toppar_broker_migrate(rd_kafka_toppar_t *rktp,
          * Share consumers never enter OFFSET_WAIT so this branch is
          * unreachable for them today; guard regardless so the offset
          * machinery stays out of the share leader-change path. */
-        if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_WAIT &&
-            !RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk))
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk) &&
+            rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_WAIT)
                 rd_kafka_toppar_offset_retry(rktp, 500,
                                              "migrating to new broker");
 
@@ -2537,6 +2537,81 @@ rd_kafka_toppars_pause_resume(rd_kafka_t *rk,
 }
 
 
+/**
+ * @brief Enqueue an RD_KAFKA_OP_CONSUMER_ERR on the share consumer's
+ *        cgrp queue so the error surfaces through consume_batch.
+ *
+ * @remark No-op if the share consumer's cgrp hasn't been initialised yet.
+ */
+static void rd_kafka_share_toppar_enq_consumer_err(rd_kafka_toppar_t *rktp,
+                                                   rd_kafka_resp_err_t err,
+                                                   const char *errstr) {
+        rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
+        rd_kafka_op_t *rko;
+
+        if (!rk->rk_cgrp)
+                return;
+
+        rko                   = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
+        rko->rko_err          = err;
+        rko->rko_rktp         = rd_kafka_toppar_keep(rktp);
+        rko->rko_u.err.errstr = rd_strdup(errstr);
+
+        rd_kafka_q_enq(rk->rk_cgrp->rkcg_q, rko);
+}
+
+
+/**
+ * @brief Share-consumer variant of rd_kafka_toppar_enq_error.
+ *
+ * Surfaces TOPIC_EXCEPTION and TOPIC_AUTHORIZATION_FAILED to the
+ * application via the cgrp queue (as RD_KAFKA_OP_CONSUMER_ERR). Other
+ * topic-level errors (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
+ * UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) describe transient metadata
+ * drift that the library recovers from internally; they are logged and
+ * not delivered to the app.
+ */
+static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
+                                            rd_kafka_resp_err_t err,
+                                            const char *reason) {
+        rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
+        char buf[512];
+
+        rd_snprintf(buf, sizeof(buf), "%.*s [%" PRId32 "]: %s (%s)",
+                    RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+                    rktp->rktp_partition, reason, rd_kafka_err2str(err));
+
+        switch (err) {
+        case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
+        case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
+                rd_kafka_share_toppar_enq_consumer_err(rktp, err, buf);
+                return;
+
+        case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
+        case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
+        case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART:
+                rd_kafka_log(rk, LOG_WARNING, "TOPICERR",
+                             "Received unknown topic or partition error "
+                             "for partition %.*s [%" PRId32 "]",
+                             RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+                             rktp->rktp_partition);
+                return;
+
+        case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID:
+                rd_kafka_log(rk, LOG_WARNING, "TOPICERR",
+                             "Received unknown topic ID error "
+                             "for partition %.*s [%" PRId32 "]",
+                             RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+                             rktp->rktp_partition);
+                return;
+
+        default:
+                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
+                             "Unhandled topic-level error: %s", buf);
+                return;
+        }
+}
+
 
 /**
  * Propagate error for toppar
@@ -2546,6 +2621,11 @@ void rd_kafka_toppar_enq_error(rd_kafka_toppar_t *rktp,
                                const char *reason) {
         rd_kafka_op_t *rko;
         char buf[512];
+
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                rd_kafka_share_toppar_enq_error(rktp, err, reason);
+                return;
+        }
 
         rko           = rd_kafka_op_new(RD_KAFKA_OP_ERR);
         rko->rko_err  = err;
@@ -2557,18 +2637,7 @@ void rd_kafka_toppar_enq_error(rd_kafka_toppar_t *rktp,
 
         rko->rko_u.err.errstr = rd_strdup(buf);
 
-        /* Share consumers don't drain rktp_fetchq — route topic-level
-         * errors (UNKNOWN_TOPIC_OR_PART / UNKNOWN_PARTITION etc.
-         * surfaced from the metadata-refresh path in rdkafka_topic.c)
-         * to the cgrp queue so they reach the app via consume_batch. */
-        {
-                rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
-                rd_kafka_q_t *rkq =
-                    RD_KAFKA_IS_SHARE_CONSUMER(rk) && rk->rk_cgrp
-                        ? rk->rk_cgrp->rkcg_q
-                        : rktp->rktp_fetchq;
-                rd_kafka_q_enq(rkq, rko);
-        }
+        rd_kafka_q_enq(rktp->rktp_fetchq, rko);
 }
 
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -1138,8 +1138,13 @@ static void rd_kafka_toppar_broker_migrate(rd_kafka_toppar_t *rktp,
          * prior to leaving the broker to avoid stalling
          * on the new broker waiting for a offset reply from
          * this old broker (that might not come and thus need
-         * to time out..slowly) */
-        if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_WAIT)
+         * to time out..slowly).
+         *
+         * Share consumers never enter OFFSET_WAIT so this branch is
+         * unreachable for them today; guard regardless so the offset
+         * machinery stays out of the share leader-change path. */
+        if (rktp->rktp_fetch_state == RD_KAFKA_TOPPAR_FETCH_OFFSET_WAIT &&
+            !RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk))
                 rd_kafka_toppar_offset_retry(rktp, 500,
                                              "migrating to new broker");
 
@@ -1582,6 +1587,13 @@ static void rd_kafka_toppar_offset_retry(rd_kafka_toppar_t *rktp,
                                          const char *reason) {
         rd_ts_t tmr_next;
         int restart_tmr;
+
+        /* Share consumers never use the offset-query state machine.
+         * Callers must guard; this early-return is belt-and-suspenders
+         * so a stray future call doesn't arm the offset-query timer
+         * for a share-assigned rktp. */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk))
+                return;
 
         /* (Re)start timer if not started or the current timeout
          * is larger than \p backoff_ms. */
@@ -2545,14 +2557,18 @@ void rd_kafka_toppar_enq_error(rd_kafka_toppar_t *rktp,
 
         rko->rko_u.err.errstr = rd_strdup(buf);
 
-        /* TODO KIP-932: share consumer does not forward rktp_fetchq to
-         * rkcg_q, so this OP_ERR gets stranded. Topic-level errors
-         * surfaced through this helper (UNKNOWN_TOPIC_OR_PART /
-         * UNKNOWN_PARTITION etc. from the metadata-refresh path in
-         * rdkafka_topic.c) may still be useful for share-consumer
-         * apps; verify and consider routing to rk_rep for share
-         * consumer instead. */
-        rd_kafka_q_enq(rktp->rktp_fetchq, rko);
+        /* Share consumers don't drain rktp_fetchq — route topic-level
+         * errors (UNKNOWN_TOPIC_OR_PART / UNKNOWN_PARTITION etc.
+         * surfaced from the metadata-refresh path in rdkafka_topic.c)
+         * to the cgrp queue so they reach the app via consume_batch. */
+        {
+                rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
+                rd_kafka_q_t *rkq =
+                    RD_KAFKA_IS_SHARE_CONSUMER(rk) && rk->rk_cgrp
+                        ? rk->rk_cgrp->rkcg_q
+                        : rktp->rktp_fetchq;
+                rd_kafka_q_enq(rkq, rko);
+        }
 }
 
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2555,16 +2555,16 @@ static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
         rd_kafka_Uuid_t topic_id = rkt->rkt_topic_id;
         rd_kafka_topic_partition_t *prev;
 
-        if (!rkcg || !rkcg->rkcg_share_topic_errored)
+        if (!rkcg || !rkcg->rkcg_errored_topics)
                 return;
 
         prev = rd_kafka_topic_partition_list_find_topic_by_id(
-            rkcg->rkcg_share_topic_errored, topic_id);
+            rkcg->rkcg_errored_topics, topic_id);
         if (prev) {
                 prev->err = err;
         } else {
                 rd_kafka_topic_partition_list_add_with_topic_name_and_id(
-                    rkcg->rkcg_share_topic_errored, topic_id, topic,
+                    rkcg->rkcg_errored_topics, topic_id, topic,
                     RD_KAFKA_PARTITION_UA)
                     ->err = err;
         }

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2549,20 +2549,22 @@ rd_kafka_toppars_pause_resume(rd_kafka_t *rk,
  */
 static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
                                             rd_kafka_resp_err_t err) {
-        rd_kafka_cgrp_t *rkcg = rktp->rktp_rkt->rkt_rk->rk_cgrp;
-        const char *topic     = rktp->rktp_rkt->rkt_topic->str;
+        rd_kafka_cgrp_t *rkcg    = rktp->rktp_rkt->rkt_rk->rk_cgrp;
+        rd_kafka_topic_t *rkt    = rktp->rktp_rkt;
+        const char *topic        = rkt->rkt_topic->str;
+        rd_kafka_Uuid_t topic_id = rkt->rkt_topic_id;
         rd_kafka_topic_partition_t *prev;
 
-        if (!rkcg || !rkcg->rkcg_share_pending_errored)
+        if (!rkcg || !rkcg->rkcg_share_topic_errored)
                 return;
 
-        prev = rd_kafka_topic_partition_list_find(
-            rkcg->rkcg_share_pending_errored, topic, RD_KAFKA_PARTITION_UA);
+        prev = rd_kafka_topic_partition_list_find_topic_by_id(
+            rkcg->rkcg_share_topic_errored, topic_id);
         if (prev) {
                 prev->err = err;
         } else {
-                rd_kafka_topic_partition_list_add(
-                    rkcg->rkcg_share_pending_errored, topic,
+                rd_kafka_topic_partition_list_add_with_topic_name_and_id(
+                    rkcg->rkcg_share_topic_errored, topic_id, topic,
                     RD_KAFKA_PARTITION_UA)
                     ->err = err;
         }

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2538,26 +2538,39 @@ rd_kafka_toppars_pause_resume(rd_kafka_t *rk,
 
 
 /**
- * @brief Enqueue an RD_KAFKA_OP_CONSUMER_ERR on the share consumer's
- *        cgrp queue so the error surfaces through consume_batch.
+ * @brief Per-(topic, err) dedup for share-consumer topic-level errors.
  *
- * @remark No-op if the share consumer's cgrp hasn't been initialised yet.
+ * Suppresses repeats of the same (topic, err); allows re-emission when
+ * the err code changes.
+ *
+ * @returns rd_true if (topic, err) was already reported.
+ *          rd_false otherwise — records the (topic, err) for future
+ *          calls.
  */
-static void rd_kafka_share_toppar_enq_consumer_err(rd_kafka_toppar_t *rktp,
-                                                   rd_kafka_resp_err_t err,
-                                                   const char *errstr) {
-        rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
-        rd_kafka_op_t *rko;
+static rd_bool_t
+rd_kafka_share_topic_err_already_reported(rd_kafka_cgrp_t *rkcg,
+                                          const char *topic,
+                                          rd_kafka_resp_err_t err) {
+        rd_kafka_topic_partition_t *prev;
 
-        if (!rk->rk_cgrp)
-                return;
+        prev = rd_kafka_topic_partition_list_find(rkcg->rkcg_errored_topics,
+                                                  topic, RD_KAFKA_PARTITION_UA);
 
-        rko                   = rd_kafka_op_new(RD_KAFKA_OP_CONSUMER_ERR);
-        rko->rko_err          = err;
-        rko->rko_rktp         = rd_kafka_toppar_keep(rktp);
-        rko->rko_u.err.errstr = rd_strdup(errstr);
+        if (prev && prev->err == err)
+                return rd_true;
 
-        rd_kafka_q_enq(rk->rk_cgrp->rkcg_q, rko);
+        if (prev) {
+                /* Different err code for the same topic — refresh. */
+                prev->err = err;
+        } else {
+                rd_kafka_topic_partition_t *rktpar =
+                    rd_kafka_topic_partition_list_add(rkcg->rkcg_errored_topics,
+                                                      topic,
+                                                      RD_KAFKA_PARTITION_UA);
+                rktpar->err = err;
+        }
+
+        return rd_false;
 }
 
 
@@ -2568,8 +2581,11 @@ static void rd_kafka_share_toppar_enq_consumer_err(rd_kafka_toppar_t *rktp,
  * application via the cgrp queue (as RD_KAFKA_OP_CONSUMER_ERR). Other
  * topic-level errors (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
  * UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) describe transient metadata
- * drift that the library recovers from internally; they are logged and
- * not delivered to the app.
+ * drift that the library recovers from internally; they are logged at
+ * debug level only and not delivered to the app.
+ *
+ * Repeats of the same (topic, err) are suppressed via rkcg_errored_topics
+ * so the same error can't spam the queue or the log.
  */
 static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
                                             rd_kafka_resp_err_t err,
@@ -2581,16 +2597,26 @@ static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
                     RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
                     rktp->rktp_partition, reason, rd_kafka_err2str(err));
 
+        if (rk->rk_cgrp &&
+            rd_kafka_share_topic_err_already_reported(
+                rk->rk_cgrp, rktp->rktp_rkt->rkt_topic->str, err))
+                return;
+
         switch (err) {
         case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
         case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
-                rd_kafka_share_toppar_enq_consumer_err(rktp, err, buf);
+                if (rk->rk_cgrp)
+                        rd_kafka_consumer_err(
+                            rk->rk_cgrp->rkcg_q, RD_KAFKA_NODEID_UA, err,
+                            0 /*version*/,
+                            rktp->rktp_rkt->rkt_topic->str /*topic*/,
+                            NULL /*rktp*/, RD_KAFKA_OFFSET_INVALID, "%s", buf);
                 return;
 
         case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
         case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
         case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART:
-                rd_kafka_log(rk, LOG_WARNING, "TOPICERR",
+                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
                              "Received unknown topic or partition error "
                              "for partition %.*s [%" PRId32 "]",
                              RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
@@ -2598,7 +2624,7 @@ static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
                 return;
 
         case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID:
-                rd_kafka_log(rk, LOG_WARNING, "TOPICERR",
+                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
                              "Received unknown topic ID error "
                              "for partition %.*s [%" PRId32 "]",
                              RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2538,103 +2538,33 @@ rd_kafka_toppars_pause_resume(rd_kafka_t *rk,
 
 
 /**
- * @brief Per-(topic, err) dedup for share-consumer topic-level errors.
- *
- * Suppresses repeats of the same (topic, err); allows re-emission when
- * the err code changes.
- *
- * @returns rd_true if (topic, err) was already reported.
- *          rd_false otherwise — records the (topic, err) for future
- *          calls.
- */
-static rd_bool_t
-rd_kafka_share_topic_err_already_reported(rd_kafka_cgrp_t *rkcg,
-                                          const char *topic,
-                                          rd_kafka_resp_err_t err) {
-        rd_kafka_topic_partition_t *prev;
-
-        prev = rd_kafka_topic_partition_list_find(rkcg->rkcg_errored_topics,
-                                                  topic, RD_KAFKA_PARTITION_UA);
-
-        if (prev && prev->err == err)
-                return rd_true;
-
-        if (prev) {
-                /* Different err code for the same topic — refresh. */
-                prev->err = err;
-        } else {
-                rd_kafka_topic_partition_t *rktpar =
-                    rd_kafka_topic_partition_list_add(rkcg->rkcg_errored_topics,
-                                                      topic,
-                                                      RD_KAFKA_PARTITION_UA);
-                rktpar->err = err;
-        }
-
-        return rd_false;
-}
-
-
-/**
  * @brief Share-consumer variant of rd_kafka_toppar_enq_error.
  *
- * Surfaces TOPIC_EXCEPTION and TOPIC_AUTHORIZATION_FAILED to the
- * application via the cgrp queue (as RD_KAFKA_OP_CONSUMER_ERR). Other
- * topic-level errors (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
- * UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) describe transient metadata
- * drift that the library recovers from internally; they are logged at
- * debug level only and not delivered to the app.
+ *        Records the (topic, err) on the cgrp's per-cycle accumulator
+ *        for delivery or logging at the end of the metadata cycle.
+ *        Multiple calls for the same topic in one cycle collapse to
+ *        a single entry.
  *
- * Repeats of the same (topic, err) are suppressed via rkcg_errored_topics
- * so the same error can't spam the queue or the log.
+ * @locality rdkafka main thread
  */
 static void rd_kafka_share_toppar_enq_error(rd_kafka_toppar_t *rktp,
-                                            rd_kafka_resp_err_t err,
-                                            const char *reason) {
-        rd_kafka_t *rk = rktp->rktp_rkt->rkt_rk;
-        char buf[512];
+                                            rd_kafka_resp_err_t err) {
+        rd_kafka_cgrp_t *rkcg = rktp->rktp_rkt->rkt_rk->rk_cgrp;
+        const char *topic     = rktp->rktp_rkt->rkt_topic->str;
+        rd_kafka_topic_partition_t *prev;
 
-        rd_snprintf(buf, sizeof(buf), "%.*s [%" PRId32 "]: %s (%s)",
-                    RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
-                    rktp->rktp_partition, reason, rd_kafka_err2str(err));
-
-        if (rk->rk_cgrp &&
-            rd_kafka_share_topic_err_already_reported(
-                rk->rk_cgrp, rktp->rktp_rkt->rkt_topic->str, err))
+        if (!rkcg || !rkcg->rkcg_share_pending_errored)
                 return;
 
-        switch (err) {
-        case RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION:
-        case RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED:
-                if (rk->rk_cgrp)
-                        rd_kafka_consumer_err(
-                            rk->rk_cgrp->rkcg_q, RD_KAFKA_NODEID_UA, err,
-                            0 /*version*/,
-                            rktp->rktp_rkt->rkt_topic->str /*topic*/,
-                            NULL /*rktp*/, RD_KAFKA_OFFSET_INVALID, "%s", buf);
-                return;
-
-        case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
-        case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
-        case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART:
-                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
-                             "Received unknown topic or partition error "
-                             "for partition %.*s [%" PRId32 "]",
-                             RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
-                             rktp->rktp_partition);
-                return;
-
-        case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID:
-                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
-                             "Received unknown topic ID error "
-                             "for partition %.*s [%" PRId32 "]",
-                             RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
-                             rktp->rktp_partition);
-                return;
-
-        default:
-                rd_kafka_dbg(rk, TOPIC | RD_KAFKA_DBG_CGRP, "TOPICERR",
-                             "Unhandled topic-level error: %s", buf);
-                return;
+        prev = rd_kafka_topic_partition_list_find(
+            rkcg->rkcg_share_pending_errored, topic, RD_KAFKA_PARTITION_UA);
+        if (prev) {
+                prev->err = err;
+        } else {
+                rd_kafka_topic_partition_list_add(
+                    rkcg->rkcg_share_pending_errored, topic,
+                    RD_KAFKA_PARTITION_UA)
+                    ->err = err;
         }
 }
 
@@ -2649,7 +2579,7 @@ void rd_kafka_toppar_enq_error(rd_kafka_toppar_t *rktp,
         char buf[512];
 
         if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
-                rd_kafka_share_toppar_enq_error(rktp, err, reason);
+                rd_kafka_share_toppar_enq_error(rktp, err);
                 return;
         }
 

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -766,10 +766,16 @@ static int rd_kafka_toppar_leader_update(rd_kafka_topic_t *rkt,
                                                   "leader updated");
         }
 
-        if (need_epoch_validation) {
+        if (need_epoch_validation &&
+            !RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
                 /* Set offset validation position,
                  * depending it if should continue with current position or
-                 * with next fetch start position. */
+                 * with next fetch start position.
+                 *
+                 * Skipped for share consumers: the offset-validation flow
+                 * issues OffsetForLeaderEpoch / ListOffsets and pipes
+                 * results into rktp_fetchq, which the share path doesn't
+                 * drain. */
                 rd_kafka_toppar_set_offset_validation_position(
                     rktp,
                     rd_kafka_toppar_fetch_decide_next_fetch_start_pos(rktp));

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1318,14 +1318,6 @@ rd_bool_t rd_kafka_topic_set_exists(rd_kafka_topic_t *rkt,
 
         rd_kafka_topic_set_state(rkt, RD_KAFKA_TOPIC_S_EXISTS);
 
-        /* Share consumers: explicit recovery hook. Clear any prior
-         * (topic, err) dedup entry so a subsequent re-failure with
-         * the same code surfaces afresh, even on metadata responses
-         * that don't trigger the share metadata-cycle drain. */
-        if (RD_KAFKA_IS_SHARE_CONSUMER(rkt->rkt_rk) && rkt->rkt_rk->rk_cgrp)
-                rd_kafka_share_clear_topic_err(rkt->rkt_rk->rk_cgrp,
-                                               rkt->rkt_topic_id);
-
         return rd_true;
 }
 

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1318,6 +1318,14 @@ rd_bool_t rd_kafka_topic_set_exists(rd_kafka_topic_t *rkt,
 
         rd_kafka_topic_set_state(rkt, RD_KAFKA_TOPIC_S_EXISTS);
 
+        /* Share consumers: explicit recovery hook. Clear any prior
+         * (topic, err) dedup entry so a subsequent re-failure with
+         * the same code surfaces afresh, even on metadata responses
+         * that don't trigger the share metadata-cycle drain. */
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rkt->rkt_rk) && rkt->rkt_rk->rk_cgrp)
+                rd_kafka_cgrp_share_clear_topic_err(rkt->rkt_rk->rk_cgrp,
+                                                    rkt->rkt_topic_id);
+
         return rd_true;
 }
 

--- a/src/rdkafka_topic.c
+++ b/src/rdkafka_topic.c
@@ -1323,8 +1323,8 @@ rd_bool_t rd_kafka_topic_set_exists(rd_kafka_topic_t *rkt,
          * the same code surfaces afresh, even on metadata responses
          * that don't trigger the share metadata-cycle drain. */
         if (RD_KAFKA_IS_SHARE_CONSUMER(rkt->rkt_rk) && rkt->rkt_rk->rk_cgrp)
-                rd_kafka_cgrp_share_clear_topic_err(rkt->rkt_rk->rk_cgrp,
-                                                    rkt->rkt_topic_id);
+                rd_kafka_share_clear_topic_err(rkt->rkt_rk->rk_cgrp,
+                                               rkt->rkt_topic_id);
 
         return rd_true;
 }

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -857,6 +857,145 @@ static void do_test_multi_consumer_overlap(void) {
 
 
 /**
+ * @brief Topic-level metadata-error policy: when a subscribed topic is
+ *        deleted mid-stream, the resulting metadata error
+ *        (UNKNOWN_TOPIC_OR_PART / UNKNOWN_TOPIC) is treated as a
+ *        transient code by the share consumer — logged internally and
+ *        not surfaced to the application via consume_batch.
+ *
+ * Subscribe to a valid topic, prime the share assignment so the rktp
+ * is on rkt_desp, delete the topic, allow metadata propagation, and
+ * verify that no topic-level err shows up in subsequent consume_batch
+ * calls.
+ */
+static void test_topic_deletion_does_not_surface_error(void) {
+        const char *topic;
+        const char *group = "share-topic-delete-no-surface";
+        rd_kafka_share_t *consumer;
+        rd_kafka_conf_t *conf;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_error_t *error;
+        char errstr[512];
+        char *topic_dup;
+        char *topics_for_delete[1];
+        rd_kafka_resp_err_t del_err;
+        size_t rcvd;
+        size_t j;
+        int consumed = 0;
+        int attempts = 0;
+        int post_attempts;
+        rd_bool_t surfaced_topic_err = rd_false;
+
+        SUB_TEST();
+
+        if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows")) {
+                TEST_SAY(
+                    "Skipping topic-deletion-does-not-surface-error "
+                    "(broker on Windows)\n");
+                SUB_TEST_PASS();
+                return;
+        }
+
+        topic     = test_mk_topic_name("0170-delete-no-surface", 1);
+        topic_dup = rd_strdup(topic);
+        test_create_topic_wait_exists(common_admin, topic, 1, -1, 60 * 1000);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_produce_msgs_simple(common_producer, topic, 0, 5);
+
+        /* Custom consumer that disables the set_notexists defer window
+         * (default 30s) so the log-and-drop path runs on the first
+         * post-delete metadata refresh instead of being deferred. */
+        test_conf_init(&conf, NULL, 60);
+        rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "share.acknowledgement.mode", "explicit",
+                          errstr, sizeof(errstr));
+        rd_kafka_conf_set(conf, "topic.metadata.propagation.max.ms", "0",
+                          errstr, sizeof(errstr));
+        consumer = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(consumer, "Failed to create share consumer: %s", errstr);
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(consumer, subs);
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        /* Prime the share assignment: consume + ACCEPT at least one
+         * record so the rktp materialises on rkt_desp (precondition
+         * for the metadata-error propagation path to fire). */
+        while (consumed < 1 && attempts++ < 30) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err) {
+                                rd_kafka_share_acknowledge(consumer, batch[j]);
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+        TEST_ASSERT(consumed >= 1,
+                    "Pre-condition: expected to consume + ack at least one "
+                    "record before deleting the topic");
+
+        TEST_SAY("Deleting topic %s\n", topic);
+        topics_for_delete[0] = topic_dup;
+        del_err              = test_DeleteTopics_simple(common_admin, NULL,
+                                                        topics_for_delete, 1, NULL);
+        TEST_ASSERT(!del_err, "DeleteTopics failed: %s",
+                    rd_kafka_err2str(del_err));
+
+        /* Allow metadata propagation. */
+        rd_sleep(3);
+
+        /* Drain consume_batch and verify no topic-level error reaches
+         * the application. _STATE / generic timeouts are expected
+         * (no more records); only the metadata-derived topic codes
+         * must not surface. */
+        for (post_attempts = 0; post_attempts < 30; post_attempts++) {
+                rcvd = 0;
+                error =
+                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        TEST_SAY("Post-delete consume_batch: %s\n",
+                                 rd_kafka_err2name(code));
+                        if (code == RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION ||
+                            code == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART ||
+                            code == RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC ||
+                            code == RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION ||
+                            code == RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID ||
+                            code ==
+                                RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED)
+                                surfaced_topic_err = rd_true;
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!batch[j]->err)
+                                rd_kafka_share_acknowledge(consumer, batch[j]);
+                        rd_kafka_message_destroy(batch[j]);
+                }
+        }
+
+        TEST_ASSERT(!surfaced_topic_err,
+                    "Topic-level metadata errors must not surface to "
+                    "the application after the subscribed topic is "
+                    "deleted (transient codes are log-only)");
+
+        rd_free(topic_dup);
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
  * @brief Test subscribing to 15 topics - triggers multiple fetch responses
  *
  * Creates 15 topics, subscribes to all of them, produces messages to each,
@@ -1379,6 +1518,10 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
                     "(broker on Windows)\n");
         else
                 do_test_scenario(&test_topic_deletion);
+
+        /* Verify that topic deletion does not surface a topic-level
+         * error code to consume_batch (transient codes are log-only). */
+        test_topic_deletion_does_not_surface_error();
 
         /* Stress tests */
         do_test_scenario(&test_rapid_updates);

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -314,10 +314,8 @@ static void test_commit_sync_invalid_share_session_epoch(void) {
             RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH);
 }
 
-/* SHARE_SESSION_LIMIT_REACHED on ShareAcknowledge falls to the
- * default branch (no session reset, no special handling). The
- * top-level err is just propagated to commit_sync results. Matches
- * Java which only checks SHARE_SESSION_LIMIT_REACHED on ShareFetch. */
+/* commit_sync surfaces a top-level SHARE_SESSION_LIMIT_REACHED from
+ * ShareAcknowledge without any client-side special handling. */
 static void test_commit_sync_share_session_limit_reached(void) {
         do_test_commit_sync_top_level_err(
             "session-limit-reached",
@@ -614,14 +612,12 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
 
 /* ===================================================================
  *  Test — commit_sync at session epoch 0 returns
- *         INVALID_SHARE_SESSION_EPOCH without sending the
+ *         INVALID_SHARE_SESSION_EPOCH without sending a
  *         ShareAcknowledge request.
  *
- *  Rationale: when the broker session epoch is 0 (new consumer or
- *  post-reset) the broker has no session state to acknowledge
- *  against. The client must fail acks locally — matches Java's
- *  ShareConsumeRequestManager which raises
- *  InvalidShareSessionEpochException for the same condition.
+ *  When the broker session epoch is 0 (new consumer or post-reset)
+ *  there is no session state to acknowledge against, so the client
+ *  must fail acks locally.
  *
  *  Two-phase test:
  *    Phase 1: Trigger session reset by injecting
@@ -1979,32 +1975,22 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
 /* ===================================================================
  *  Topic-level metadata error tests.
  *
- *  These exercise rd_kafka_share_toppar_enq_error in rdkafka_partition.c:
- *  metadata responses that mark a subscribed topic with an err flow
- *  through set_notexists / set_error / propagate_notexists ->
- *  toppar_enq_error -> share variant. The share variant surfaces
- *  TOPIC_EXCEPTION and TOPIC_AUTHORIZATION_FAILED via consume_batch
- *  (as an rd_kafka_error_t) and dedupes repeats of the same
- *  (topic, err); other codes (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
- *  UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) are dropped silently (debug
- *  log only) and never delivered to the app.
+ *  Verify that a share consumer surfaces topic-level errors from
+ *  metadata responses to the application as rd_kafka_error_t via
+ *  consume_batch. Only TOPIC_EXCEPTION and TOPIC_AUTHORIZATION_FAILED
+ *  reach the app; transient codes (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
+ *  UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) are not delivered. Repeats of
+ *  the same (topic, err) are deduped; recovery, unsubscribe, and
+ *  re-subscribe each have well-defined behaviour exercised below.
  *
- *  Real brokers don't dynamically flip topic-name validity, and the
- *  share-assignment path requires the rktp to exist on rkt_desp before
- *  toppar_enq_error can fire — both make these scenarios hard to
- *  reproduce against a real broker. Mock injection is the deterministic
- *  way to drive the code under test.
+ *  These scenarios are hard to reproduce on a real broker — the mock
+ *  cluster lets us inject the exact per-topic error byte in a metadata
+ *  response on demand.
  * =================================================================== */
 
-/* Prime the share assignment by driving at least one consume_batch so
- * rd_kafka_share_assignment_add materialises the rktp and links it on
- * rkt_desp (precondition for rd_kafka_share_toppar_enq_error to fire).
- *
- * The consumer is in explicit ack mode, so every consumed record is
- * ACCEPTed before returning — otherwise subsequent consume_batch calls
- * would return _STATE ("records from previous poll have not been
- * acknowledged") and never reach the rkcg_q dequeue path where the
- * OP_CONSUMER_ERR lives. */
+/* Drive at least one successful consume_batch so the share assignment
+ * is fully materialised before the test injects an error. Records are
+ * ACKed inline because the consumer is in explicit-ack mode. */
 static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         rd_kafka_error_t *error;
@@ -2181,9 +2167,53 @@ static void test_share_consumer_surfaces_topic_authorization_failed(void) {
 }
 
 
-/* Verify the same (topic, err) is only delivered once. After the first
- * surface, a second metadata refresh with the same injected err must
- * NOT deliver a second error op — dedup via rkcg_errored_topics. */
+/* TOPIC_AUTHORIZATION_FAILED is surfaced once; a second metadata
+ * refresh that sees the same error on the same topic must not surface
+ * a duplicate. */
+static void test_share_consumer_dedupes_repeated_auth_failed(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-dedupe-auth-failed";
+        const char *group = "sg-0182-dedupe-auth-failed";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* First injection: must surface. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(
+            share_topic_err_wait_for_err(
+                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
+            "First AUTH_FAILED must surface");
+
+        /* Same error on the next refresh must not surface again. */
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(rkshare, 10,
+                                      "repeat AUTH_FAILED must be deduped");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* TOPIC_EXCEPTION is surfaced once; a second metadata refresh that
+ * sees the same error on the same topic must not surface a
+ * duplicate. */
 static void test_share_consumer_dedupes_repeated_topic_exception(void) {
         test_ctx_t ctx;
         rd_kafka_share_t *rkshare;
@@ -2203,7 +2233,6 @@ static void test_share_consumer_dedupes_repeated_topic_exception(void) {
         subscribe_one(rkshare, topic);
         share_topic_err_prime_assignment(rkshare);
 
-        /* First injection: must surface. */
         rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
                                       RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
         share_topic_err_force_metadata(rkshare);
@@ -2211,7 +2240,6 @@ static void test_share_consumer_dedupes_repeated_topic_exception(void) {
                         rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
                     "First TOPIC_EXCEPTION must surface");
 
-        /* Second refresh with the same err: must NOT surface again. */
         share_topic_err_force_metadata(rkshare);
         share_topic_err_assert_no_err(rkshare, 10,
                                       "repeat TOPIC_EXCEPTION must be deduped");
@@ -2224,8 +2252,107 @@ static void test_share_consumer_dedupes_repeated_topic_exception(void) {
 }
 
 
-/* Verify the same topic with a NEW err code surfaces again (dedup is
- * keyed on (topic, err), not just topic). */
+/* Two topics fail with the same error in one metadata cycle: both
+ * surface once, and neither re-surfaces on the next refresh while
+ * both stay failing. */
+static void test_share_consumer_two_topics_dedupe_independently(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic_a = "0182-multi-topic-a";
+        const char *topic_b = "0182-multi-topic-b";
+        const char *group   = "sg-0182-multi-topic";
+        rd_kafka_topic_partition_list_t *subscription;
+        int got_a = 0, got_b = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd, j;
+        int attempts;
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic A");
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic B");
+        mock_produce(ctx.producer, topic_a, 3);
+        mock_produce(ctx.producer, topic_b, 3);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+
+        subscription = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subscription, topic_a,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subscription, topic_b,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "subscribe");
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Inject AUTH_FAILED on both topics, refresh once. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_a,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_b,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+
+        /* Drain consume_batch until both topics have surfaced once.
+         * The error string carries the topic name, so distinguish A
+         * from B by strstr. */
+        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        const char *errstr       = rd_kafka_error_string(error);
+                        if (code ==
+                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
+                                if (errstr && strstr(errstr, topic_a))
+                                        got_a = 1;
+                                else if (errstr && strstr(errstr, topic_b))
+                                        got_b = 1;
+                        }
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(got_a && got_b,
+                    "Both topics must surface AUTH_FAILED at least once");
+
+        /* Second refresh: neither should re-surface — both deduped. */
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(rkshare, 10,
+                                      "neither topic must re-surface "
+                                      "AUTH_FAILED after the first emit "
+                                      "(multi-topic dedup must be "
+                                      "independent)");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* The same topic failing with a different error code must surface a
+ * fresh op for the new code rather than being deduped against the
+ * previous one. */
 static void test_share_consumer_re_emits_when_err_code_changes(void) {
         test_ctx_t ctx;
         rd_kafka_share_t *rkshare;
@@ -2272,17 +2399,543 @@ static void test_share_consumer_re_emits_when_err_code_changes(void) {
 }
 
 
-/* Verify UNKNOWN_TOPIC_OR_PART does NOT surface — it's a transient
- * code we only debug-log.
- *
- * Note on topic.metadata.propagation.max.ms=0: with the default 30s
- * window, rd_kafka_topic_set_notexists defers the action block (and
- * therefore the propagate_notexists -> enq_error -> share variant
- * chain) until the window expires, because the rkt is still in
- * S_EXISTS state right after the mock topic was created. Setting the
- * window to 0 bypasses the defer so the share variant's log-and-drop
- * branch is actually exercised on the first metadata refresh, not 30s
- * later. */
+/* A topic that surfaces AUTH_FAILED, then recovers, then fails again
+ * with the same code must surface the error a second time. */
+static void test_share_consumer_re_surfaces_after_recovery(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-re-surface-after-recovery";
+        const char *group = "sg-0182-re-surface-after-recovery";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Phase 1: fail — first surface. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(
+            share_topic_err_wait_for_err(
+                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
+            "First AUTH_FAILED must surface");
+
+        /* Phase 2: recover — no error must reach the app. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_NO_ERROR);
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(rkshare, 5,
+                                      "no error must surface while recovered");
+
+        /* Phase 3: fail again with the same code — must surface a
+         * second time. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(
+            share_topic_err_wait_for_err(
+                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
+            "AUTH_FAILED must surface a second time after recovery");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* After a topic surfaces an error, unsubscribing must stop subsequent
+ * metadata refreshes from delivering the same error. Run for both
+ * app-facing codes. */
+static void do_test_share_consumer_unsubscribe_drops_errored_topic(
+    rd_kafka_resp_err_t inject_err) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        char topic[64];
+        char group[64];
+
+        SUB_TEST_QUICK("err=%s", rd_kafka_err2name(inject_err));
+
+        rd_snprintf(topic, sizeof(topic), "0182-unsubscribe-drops-%s",
+                    rd_kafka_err2name(inject_err));
+        rd_snprintf(group, sizeof(group), "sg-0182-unsubscribe-drops-%s",
+                    rd_kafka_err2name(inject_err));
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(rkshare, inject_err, 30),
+                    "first %s must surface before unsubscribe",
+                    rd_kafka_err2name(inject_err));
+
+        /* Unsubscribe, then refresh metadata. The mock topic still has
+         * the err set, but since we're no longer subscribed we must
+         * not be told about it. */
+        TEST_ASSERT(rd_kafka_share_unsubscribe(rkshare) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "unsubscribe");
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(
+            rkshare, 10,
+            "no error must surface for a topic that has been unsubscribed");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+static void test_share_consumer_unsubscribe_drops_errored_topic(void) {
+        do_test_share_consumer_unsubscribe_drops_errored_topic(
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        do_test_share_consumer_unsubscribe_drops_errored_topic(
+            RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+}
+
+
+/* A topic with multiple partitions failing must surface exactly one
+ * error per (topic, err) per metadata cycle, not one per partition.
+ * Run for both app-facing codes. */
+static void
+do_test_share_consumer_multi_partition_dedupe(rd_kafka_resp_err_t inject_err) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        char topic[64];
+        char group[64];
+        const int partition_cnt = 5;
+
+        SUB_TEST_QUICK("err=%s", rd_kafka_err2name(inject_err));
+
+        rd_snprintf(topic, sizeof(topic), "0182-multipart-%s",
+                    rd_kafka_err2name(inject_err));
+        rd_snprintf(group, sizeof(group), "sg-0182-multipart-%s",
+                    rd_kafka_err2name(inject_err));
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic,
+                                               partition_cnt,
+                                               1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic with %d partitions", partition_cnt);
+        mock_produce(ctx.producer, topic, partition_cnt * 3);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Inject the err: across all N partitions, per-rktp emits 2N times. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(rkshare, inject_err, 30),
+                    "first %s must surface", rd_kafka_err2name(inject_err));
+
+        /* assert_no_err drains for the configured attempts; pending
+         * dedup-on-add plus propagate's same-err skip means no second
+         * op should arrive even though 2N-1 per-rktp calls happened. */
+        share_topic_err_assert_no_err(
+            rkshare, 10,
+            "multi-partition topic must produce exactly one op per "
+            "(topic, err)");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+static void test_share_consumer_multi_partition_dedupe(void) {
+        do_test_share_consumer_multi_partition_dedupe(
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        do_test_share_consumer_multi_partition_dedupe(
+            RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+}
+
+
+/* A topic that surfaces TOPIC_EXCEPTION, then recovers, then fails
+ * again with the same code must surface the error a second time. */
+static void
+test_share_consumer_re_surfaces_after_recovery_topic_exception(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-re-surface-topic-exception";
+        const char *group = "sg-0182-re-surface-topic-exception";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Phase 1: fail. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
+                    "first TOPIC_EXCEPTION must surface");
+
+        /* Phase 2: recover. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_NO_ERROR);
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(
+            rkshare, 5, "no error must surface while topic is recovered");
+
+        /* Phase 3: re-fail with the same code — must surface again. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
+                    "TOPIC_EXCEPTION must surface a second time after "
+                    "recovery");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* Subscribed to {A, B} with both failing and surfaced. Narrowing the
+ * subscription to {A} must stop B from re-surfacing, while A (still
+ * subscribed and still failing) must not re-emit either. */
+static void test_share_consumer_subscribe_change_drops_dropped_topic(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic_a = "0182-subchange-a";
+        const char *topic_b = "0182-subchange-b";
+        const char *group   = "sg-0182-subchange";
+        rd_kafka_topic_partition_list_t *sub_both, *sub_only_a;
+        int got_a = 0, got_b = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd, j;
+        int attempts;
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create A");
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create B");
+        mock_produce(ctx.producer, topic_a, 3);
+        mock_produce(ctx.producer, topic_b, 3);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+
+        sub_both = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(sub_both, topic_a,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(sub_both, topic_b,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, sub_both) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "subscribe {A,B}");
+        rd_kafka_topic_partition_list_destroy(sub_both);
+
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Fail both. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_a,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_b,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+
+        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        const char *errstr       = rd_kafka_error_string(error);
+                        if (code ==
+                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
+                                if (errstr && strstr(errstr, topic_a))
+                                        got_a = 1;
+                                else if (errstr && strstr(errstr, topic_b))
+                                        got_b = 1;
+                        }
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(got_a && got_b,
+                    "both topics must surface AUTH_FAILED before narrowing");
+
+        /* Narrow to {A}. A stays subscribed and still failing; B is
+         * dropped. */
+        sub_only_a = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(sub_only_a, topic_a,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, sub_only_a) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "narrow subscription to {A}");
+        rd_kafka_topic_partition_list_destroy(sub_only_a);
+
+        share_topic_err_force_metadata(rkshare);
+
+        /* A must NOT re-surface (still deduped) and B must NOT
+         * re-surface either (subscription drop). */
+        share_topic_err_assert_no_err(
+            rkshare, 10,
+            "after narrowing subscription, neither still-subscribed-A nor "
+            "dropped-B should re-surface");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* Two topics fail and surface. One recovers while the other stays
+ * failing. The still-failing topic must not re-surface, and the
+ * recovered topic — if it fails again — must surface fresh. */
+static void test_share_consumer_partial_recovery_preserves_other(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic_a = "0182-partial-recovery-a";
+        const char *topic_b = "0182-partial-recovery-b";
+        const char *group   = "sg-0182-partial-recovery";
+        rd_kafka_topic_partition_list_t *subscription;
+        int got_a = 0, got_b = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd, j;
+        int attempts;
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create A");
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create B");
+        mock_produce(ctx.producer, topic_a, 3);
+        mock_produce(ctx.producer, topic_b, 3);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+
+        subscription = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subscription, topic_a,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subscription, topic_b,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "subscribe {A,B}");
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Phase 1: both fail. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_a,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_b,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+
+        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        const char *errstr       = rd_kafka_error_string(error);
+                        if (code ==
+                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
+                                if (errstr && strstr(errstr, topic_a))
+                                        got_a = 1;
+                                else if (errstr && strstr(errstr, topic_b))
+                                        got_b = 1;
+                        }
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(got_a && got_b,
+                    "both A and B must surface AUTH_FAILED on first cycle");
+
+        /* Phase 2: A recovers, B still failing. Refresh. Neither should
+         * re-surface: A is recovered, B is deduped against the prior
+         * surface. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic_a,
+                                      RD_KAFKA_RESP_ERR_NO_ERROR);
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(
+            rkshare, 10,
+            "after A recovers (B still failing), neither A nor B should "
+            "re-surface");
+
+        /* Phase 3: A fails again. It must surface fresh. B (still
+         * continuously failing with the same err) must NOT re-surface. */
+        got_a = 0;
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_a,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+
+        for (attempts = 0; attempts < 30 && !got_a; attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        const char *errstr       = rd_kafka_error_string(error);
+                        if (code ==
+                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
+                                if (errstr && strstr(errstr, topic_a)) {
+                                        got_a = 1;
+                                } else if (errstr && strstr(errstr, topic_b)) {
+                                        TEST_FAIL(
+                                            "B must not re-surface after "
+                                            "A's recovery+re-fail cycle");
+                                }
+                        }
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(got_a,
+                    "A must surface AUTH_FAILED again after recovery+re-fail");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* A topic surfaces TOPIC_EXCEPTION, gets unsubscribed (no surface),
+ * and is then re-subscribed while still failing. The error must
+ * surface again on re-subscribe — not be permanently suppressed. */
+static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-resubscribe-re-emit";
+        const char *group = "sg-0182-resubscribe-re-emit";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Phase 1: subscribe + fail + surface. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
+                    "first TOPIC_EXCEPTION must surface");
+
+        /* Phase 2: unsubscribe. No surface. */
+        TEST_ASSERT(rd_kafka_share_unsubscribe(rkshare) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "unsubscribe");
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(
+            rkshare, 5, "no error must surface while unsubscribed");
+
+        /* Phase 3: re-subscribe to the same still-failing topic; the
+         * error must surface again. Re-force metadata across the wait
+         * loop so the request happens after the share-assignment
+         * heartbeat re-populates the partition list. */
+        subscribe_one(rkshare, topic);
+        {
+                rd_bool_t saw_err = rd_false;
+                int outer;
+                for (outer = 0; outer < 10 && !saw_err; outer++) {
+                        share_topic_err_force_metadata(rkshare);
+                        if (share_topic_err_wait_for_err(
+                                rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 3))
+                                saw_err = rd_true;
+                }
+                TEST_ASSERT(saw_err,
+                            "TOPIC_EXCEPTION must surface again after "
+                            "re-subscribing to a still-failing topic");
+        }
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* UNKNOWN_TOPIC_OR_PART is debug-logged only and must not reach the
+ * app via consume_batch. */
 static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
         test_ctx_t ctx;
         rd_kafka_conf_t *conf;
@@ -2298,9 +2951,9 @@ static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
                     "create topic");
         mock_produce(ctx.producer, topic, 5);
 
-        /* Custom consumer that disables the set_notexists defer window
-         * so the log-and-drop path runs synchronously on the metadata
-         * refresh. */
+        /* Custom consumer with the metadata propagation defer window
+         * disabled so the no-surface path is exercised on the first
+         * metadata refresh rather than 30 s later. */
         test_conf_init(&conf, NULL, 0);
         test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
         test_conf_set(conf, "group.id", group);
@@ -2348,8 +3001,17 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         /* Topic-level metadata err surface + dedup. */
         test_share_consumer_surfaces_topic_exception();
         test_share_consumer_surfaces_topic_authorization_failed();
+        test_share_consumer_dedupes_repeated_auth_failed();
         test_share_consumer_dedupes_repeated_topic_exception();
+        test_share_consumer_two_topics_dedupe_independently();
         test_share_consumer_re_emits_when_err_code_changes();
+        test_share_consumer_re_surfaces_after_recovery();
+        test_share_consumer_unsubscribe_drops_errored_topic();
+        test_share_consumer_multi_partition_dedupe();
+        test_share_consumer_re_surfaces_after_recovery_topic_exception();
+        test_share_consumer_subscribe_change_drops_dropped_topic();
+        test_share_consumer_partial_recovery_preserves_other();
+        test_share_consumer_resubscribe_re_emits_persistent_failure();
         test_share_consumer_does_not_surface_unknown_topic_or_part();
 
         /* Socket timeout matrix (single broker).

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2230,47 +2230,6 @@ static void test_share_consumer_dedupes_repeated_auth_failed(void) {
 }
 
 
-/* TOPIC_EXCEPTION is surfaced once; a second metadata refresh that
- * sees the same error on the same topic must not surface a
- * duplicate. */
-static void test_share_consumer_dedupes_repeated_topic_exception(void) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        const char *topic = "0182-dedupe-topic-exception";
-        const char *group = "sg-0182-dedupe-topic-exception";
-
-        SUB_TEST();
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic");
-        mock_produce(ctx.producer, topic, 5);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-        subscribe_one(rkshare, topic);
-        share_topic_err_prime_assignment(rkshare);
-
-        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
-                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
-        share_topic_err_force_metadata(rkshare);
-        TEST_ASSERT(share_topic_err_wait_for_err(
-                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
-                    "First TOPIC_EXCEPTION must surface");
-
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(rkshare, 10,
-                                      "repeat TOPIC_EXCEPTION must be deduped");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-
 /* Two topics fail with the same error in one metadata cycle: both
  * surface once, and neither re-surfaces on the next refresh while
  * both stay failing. */
@@ -2534,8 +2493,7 @@ static void test_share_consumer_unsubscribe_drops_errored_topic(void) {
 
 
 /* A topic with multiple partitions failing must surface exactly one
- * error per (topic, err) per metadata cycle, not one per partition.
- * Run for both app-facing codes. */
+ * error per (topic, err) per metadata cycle, not one per partition. */
 static void
 do_test_share_consumer_multi_partition_dedupe(rd_kafka_resp_err_t inject_err) {
         test_ctx_t ctx;
@@ -2587,8 +2545,6 @@ do_test_share_consumer_multi_partition_dedupe(rd_kafka_resp_err_t inject_err) {
 static void test_share_consumer_multi_partition_dedupe(void) {
         do_test_share_consumer_multi_partition_dedupe(
             RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        do_test_share_consumer_multi_partition_dedupe(
-            RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
 }
 
 
@@ -3095,7 +3051,6 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         test_share_consumer_surfaces_topic_exception();
         test_share_consumer_surfaces_topic_authorization_failed();
         test_share_consumer_dedupes_repeated_auth_failed();
-        test_share_consumer_dedupes_repeated_topic_exception();
         test_share_consumer_two_topics_dedupe_independently();
         test_share_consumer_re_emits_when_err_code_changes();
         test_share_consumer_re_surfaces_after_recovery();

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2035,25 +2035,6 @@ static void share_topic_err_force_metadata(rd_kafka_share_t *rkshare) {
                 rd_kafka_metadata_destroy(md);
 }
 
-/* Force a PARTIAL metadata refresh covering only `topic_name`.
- *
- * Uses rd_kafka_metadata(all_topics=0, only_rkt=...) which underneath
- * sends a MetadataRequest with cgrp_update=false. This exercises the
- * share_metadata_update_check partial-view drain path. */
-static void share_topic_err_force_partial_metadata(rd_kafka_share_t *rkshare,
-                                                   const char *topic_name) {
-        const rd_kafka_metadata_t *md = NULL;
-        rd_kafka_t *rk;
-        rd_kafka_topic_t *rkt;
-
-        rk  = test_share_consumer_get_rk(rkshare);
-        rkt = rd_kafka_topic_new(rk, topic_name, NULL);
-        (void)rd_kafka_metadata(rk, 0 /*all_topics*/, rkt, &md, 5000);
-        if (md)
-                rd_kafka_metadata_destroy(md);
-        rd_kafka_topic_destroy(rkt);
-}
-
 /* Drain consume_batch until either the expected err code surfaces (then
  * return rd_true) or `max_attempts` calls go by without it (return
  * rd_false). Records that arrive are destroyed. */
@@ -2186,119 +2167,61 @@ static void test_share_consumer_surfaces_topic_authorization_failed(void) {
 }
 
 
-/* TOPIC_AUTHORIZATION_FAILED is surfaced once; a second metadata
- * refresh that sees the same error on the same topic must not surface
- * a duplicate. */
-static void test_share_consumer_dedupes_repeated_auth_failed(void) {
+/* A topic with N partitions failing in a single metadata cycle must
+ * surface exactly one op for that topic, not one per partition.
+ *
+ * share_toppar_enq_error keys its accumulator on topic_id and
+ * dedups-on-add, so the per-rktp calls from partition_cnt_update and
+ * propagate_notexists (2N total) collapse to a single entry in
+ * rkcg_errored_topics — and hence a single rd_kafka_consumer_err. */
+static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
         test_ctx_t ctx;
         rd_kafka_share_t *rkshare;
-        const char *topic = "0182-dedupe-auth-failed";
-        const char *group = "sg-0182-dedupe-auth-failed";
+        const char *topic       = "0182-multipart-single-op";
+        const char *group       = "sg-0182-multipart-single-op";
+        const int partition_cnt = 5;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd, j;
+        int err_count = 0;
+        int attempts;
 
         SUB_TEST();
 
         ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic");
-        mock_produce(ctx.producer, topic, 5);
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic,
+                                               partition_cnt,
+                                               1) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic with %d partitions", partition_cnt);
+        mock_produce(ctx.producer, topic, partition_cnt * 3);
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
         subscribe_one(rkshare, topic);
         share_topic_err_prime_assignment(rkshare);
 
-        /* First injection: must surface. */
+        /* Inject AUTH_FAILED on the topic; partition_cnt_update +
+         * propagate_notexists will each fire enq_error per rktp. */
         rd_kafka_mock_topic_set_error(
             ctx.mcluster, topic, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
         share_topic_err_force_metadata(rkshare);
-        TEST_ASSERT(
-            share_topic_err_wait_for_err(
-                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
-            "First AUTH_FAILED must surface");
 
-        /* Same error on the next refresh must not surface again. */
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(rkshare, 10,
-                                      "repeat AUTH_FAILED must be deduped");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-
-/* Two topics fail with the same error in one metadata cycle: both
- * surface once, and neither re-surfaces on the next refresh while
- * both stay failing. */
-static void test_share_consumer_two_topics_dedupe_independently(void) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        const char *topic_a = "0182-multi-topic-a";
-        const char *topic_b = "0182-multi-topic-b";
-        const char *group   = "sg-0182-multi-topic";
-        rd_kafka_topic_partition_list_t *subscription;
-        int got_a = 0, got_b = 0;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_error_t *error;
-        size_t rcvd, j;
-        int attempts;
-
-        SUB_TEST();
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic A");
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic B");
-        mock_produce(ctx.producer, topic_a, 3);
-        mock_produce(ctx.producer, topic_b, 3);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-
-        subscription = rd_kafka_topic_partition_list_new(2);
-        rd_kafka_topic_partition_list_add(subscription, topic_a,
-                                          RD_KAFKA_PARTITION_UA);
-        rd_kafka_topic_partition_list_add(subscription, topic_b,
-                                          RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "subscribe");
-        rd_kafka_topic_partition_list_destroy(subscription);
-
-        share_topic_err_prime_assignment(rkshare);
-
-        /* Inject AUTH_FAILED on both topics, refresh once. */
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_a,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_b,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        share_topic_err_force_metadata(rkshare);
-
-        /* Drain consume_batch until both topics have surfaced once.
-         * The error string carries the topic name, so distinguish A
-         * from B by strstr. */
-        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
+        /* Drain a short window immediately after the synchronous
+         * force_metadata. By the time it returns, propagate has emitted
+         * the (single) op for this cycle. The window is intentionally
+         * short to keep it within one heartbeat interval and count just
+         * what this cycle produced. */
+        for (attempts = 0; attempts < 3; attempts++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
                                                      &rcvd);
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         const char *errstr       = rd_kafka_error_string(error);
                         if (code ==
-                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
-                                if (errstr && strstr(errstr, topic_a))
-                                        got_a = 1;
-                                else if (errstr && strstr(errstr, topic_b))
-                                        got_b = 1;
-                        }
+                                RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED &&
+                            errstr && strstr(errstr, topic))
+                                err_count++;
                         rd_kafka_error_destroy(error);
                         continue;
                 }
@@ -2309,16 +2232,11 @@ static void test_share_consumer_two_topics_dedupe_independently(void) {
                         rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
-        TEST_ASSERT(got_a && got_b,
-                    "Both topics must surface AUTH_FAILED at least once");
 
-        /* Second refresh: neither should re-surface — both deduped. */
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(rkshare, 10,
-                                      "neither topic must re-surface "
-                                      "AUTH_FAILED after the first emit "
-                                      "(multi-topic dedup must be "
-                                      "independent)");
+        TEST_ASSERT(err_count == 1,
+                    "expected exactly 1 AUTH_FAILED op for a %d-partition "
+                    "topic in a single metadata cycle, got %d",
+                    partition_cnt, err_count);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2432,122 +2350,6 @@ static void test_share_consumer_re_surfaces_after_recovery(void) {
 }
 
 
-/* After a topic surfaces an error, unsubscribing must stop subsequent
- * metadata refreshes from delivering the same error. Run for both
- * app-facing codes. */
-static void do_test_share_consumer_unsubscribe_drops_errored_topic(
-    rd_kafka_resp_err_t inject_err) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        char topic[64];
-        char group[64];
-
-        SUB_TEST_QUICK("err=%s", rd_kafka_err2name(inject_err));
-
-        rd_snprintf(topic, sizeof(topic), "0182-unsubscribe-drops-%s",
-                    rd_kafka_err2name(inject_err));
-        rd_snprintf(group, sizeof(group), "sg-0182-unsubscribe-drops-%s",
-                    rd_kafka_err2name(inject_err));
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic");
-        mock_produce(ctx.producer, topic, 5);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-        subscribe_one(rkshare, topic);
-        share_topic_err_prime_assignment(rkshare);
-
-        rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
-        share_topic_err_force_metadata(rkshare);
-        TEST_ASSERT(share_topic_err_wait_for_err(rkshare, inject_err, 30),
-                    "first %s must surface before unsubscribe",
-                    rd_kafka_err2name(inject_err));
-
-        /* Unsubscribe, then refresh metadata. The mock topic still has
-         * the err set, but since we're no longer subscribed we must
-         * not be told about it. */
-        TEST_ASSERT(rd_kafka_share_unsubscribe(rkshare) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "unsubscribe");
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(
-            rkshare, 10,
-            "no error must surface for a topic that has been unsubscribed");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-static void test_share_consumer_unsubscribe_drops_errored_topic(void) {
-        do_test_share_consumer_unsubscribe_drops_errored_topic(
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        do_test_share_consumer_unsubscribe_drops_errored_topic(
-            RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
-}
-
-
-/* A topic with multiple partitions failing must surface exactly one
- * error per (topic, err) per metadata cycle, not one per partition. */
-static void
-do_test_share_consumer_multi_partition_dedupe(rd_kafka_resp_err_t inject_err) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        char topic[64];
-        char group[64];
-        const int partition_cnt = 5;
-
-        SUB_TEST_QUICK("err=%s", rd_kafka_err2name(inject_err));
-
-        rd_snprintf(topic, sizeof(topic), "0182-multipart-%s",
-                    rd_kafka_err2name(inject_err));
-        rd_snprintf(group, sizeof(group), "sg-0182-multipart-%s",
-                    rd_kafka_err2name(inject_err));
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic,
-                                               partition_cnt,
-                                               1) == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create topic with %d partitions", partition_cnt);
-        mock_produce(ctx.producer, topic, partition_cnt * 3);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-        subscribe_one(rkshare, topic);
-        share_topic_err_prime_assignment(rkshare);
-
-        /* Inject the err: across all N partitions, per-rktp emits 2N times. */
-        rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
-        share_topic_err_force_metadata(rkshare);
-        TEST_ASSERT(share_topic_err_wait_for_err(rkshare, inject_err, 30),
-                    "first %s must surface", rd_kafka_err2name(inject_err));
-
-        /* assert_no_err drains for the configured attempts; pending
-         * dedup-on-add plus propagate's same-err skip means no second
-         * op should arrive even though 2N-1 per-rktp calls happened. */
-        share_topic_err_assert_no_err(
-            rkshare, 10,
-            "multi-partition topic must produce exactly one op per "
-            "(topic, err)");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-static void test_share_consumer_multi_partition_dedupe(void) {
-        do_test_share_consumer_multi_partition_dedupe(
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-}
-
-
 /* A topic that surfaces TOPIC_EXCEPTION, then recovers, then fails
  * again with the same code must surface the error a second time. */
 static void
@@ -2593,248 +2395,6 @@ test_share_consumer_re_surfaces_after_recovery_topic_exception(void) {
                         rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
                     "TOPIC_EXCEPTION must surface a second time after "
                     "recovery");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-
-/* Subscribed to {A, B} with both failing and surfaced. Narrowing the
- * subscription to {A} must stop B from re-surfacing, while A (still
- * subscribed and still failing) must not re-emit either. */
-static void test_share_consumer_subscribe_change_drops_dropped_topic(void) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        const char *topic_a = "0182-subchange-a";
-        const char *topic_b = "0182-subchange-b";
-        const char *group   = "sg-0182-subchange";
-        rd_kafka_topic_partition_list_t *sub_both, *sub_only_a;
-        int got_a = 0, got_b = 0;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_error_t *error;
-        size_t rcvd, j;
-        int attempts;
-
-        SUB_TEST();
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create A");
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create B");
-        mock_produce(ctx.producer, topic_a, 3);
-        mock_produce(ctx.producer, topic_b, 3);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-
-        sub_both = rd_kafka_topic_partition_list_new(2);
-        rd_kafka_topic_partition_list_add(sub_both, topic_a,
-                                          RD_KAFKA_PARTITION_UA);
-        rd_kafka_topic_partition_list_add(sub_both, topic_b,
-                                          RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, sub_both) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "subscribe {A,B}");
-        rd_kafka_topic_partition_list_destroy(sub_both);
-
-        share_topic_err_prime_assignment(rkshare);
-
-        /* Fail both. */
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_a,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_b,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        share_topic_err_force_metadata(rkshare);
-
-        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
-                        const char *errstr       = rd_kafka_error_string(error);
-                        if (code ==
-                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
-                                if (errstr && strstr(errstr, topic_a))
-                                        got_a = 1;
-                                else if (errstr && strstr(errstr, topic_b))
-                                        got_b = 1;
-                        }
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
-                }
-        }
-        TEST_ASSERT(got_a && got_b,
-                    "both topics must surface AUTH_FAILED before narrowing");
-
-        /* Narrow to {A}. A stays subscribed and still failing; B is
-         * dropped. */
-        sub_only_a = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(sub_only_a, topic_a,
-                                          RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, sub_only_a) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "narrow subscription to {A}");
-        rd_kafka_topic_partition_list_destroy(sub_only_a);
-
-        share_topic_err_force_metadata(rkshare);
-
-        /* A must NOT re-surface (still deduped) and B must NOT
-         * re-surface either (subscription drop). */
-        share_topic_err_assert_no_err(
-            rkshare, 10,
-            "after narrowing subscription, neither still-subscribed-A nor "
-            "dropped-B should re-surface");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-
-/* Two topics fail and surface. One recovers while the other stays
- * failing. The still-failing topic must not re-surface, and the
- * recovered topic — if it fails again — must surface fresh. */
-static void test_share_consumer_partial_recovery_preserves_other(void) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        const char *topic_a = "0182-partial-recovery-a";
-        const char *topic_b = "0182-partial-recovery-b";
-        const char *group   = "sg-0182-partial-recovery";
-        rd_kafka_topic_partition_list_t *subscription;
-        int got_a = 0, got_b = 0;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_error_t *error;
-        size_t rcvd, j;
-        int attempts;
-
-        SUB_TEST();
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create A");
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create B");
-        mock_produce(ctx.producer, topic_a, 3);
-        mock_produce(ctx.producer, topic_b, 3);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-
-        subscription = rd_kafka_topic_partition_list_new(2);
-        rd_kafka_topic_partition_list_add(subscription, topic_a,
-                                          RD_KAFKA_PARTITION_UA);
-        rd_kafka_topic_partition_list_add(subscription, topic_b,
-                                          RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "subscribe {A,B}");
-        rd_kafka_topic_partition_list_destroy(subscription);
-
-        share_topic_err_prime_assignment(rkshare);
-
-        /* Phase 1: both fail. */
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_a,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_b,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        share_topic_err_force_metadata(rkshare);
-
-        for (attempts = 0; attempts < 60 && (!got_a || !got_b); attempts++) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
-                        const char *errstr       = rd_kafka_error_string(error);
-                        if (code ==
-                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
-                                if (errstr && strstr(errstr, topic_a))
-                                        got_a = 1;
-                                else if (errstr && strstr(errstr, topic_b))
-                                        got_b = 1;
-                        }
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
-                }
-        }
-        TEST_ASSERT(got_a && got_b,
-                    "both A and B must surface AUTH_FAILED on first cycle");
-
-        /* Phase 2: A recovers, B still failing. Refresh. Neither should
-         * re-surface: A is recovered, B is deduped against the prior
-         * surface. */
-        rd_kafka_mock_topic_set_error(ctx.mcluster, topic_a,
-                                      RD_KAFKA_RESP_ERR_NO_ERROR);
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(
-            rkshare, 10,
-            "after A recovers (B still failing), neither A nor B should "
-            "re-surface");
-
-        /* Phase 3: A fails again. It must surface fresh. B (still
-         * continuously failing with the same err) must NOT re-surface. */
-        got_a = 0;
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_a,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        share_topic_err_force_metadata(rkshare);
-
-        for (attempts = 0; attempts < 30 && !got_a; attempts++) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                     &rcvd);
-                if (error) {
-                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
-                        const char *errstr       = rd_kafka_error_string(error);
-                        if (code ==
-                            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED) {
-                                if (errstr && strstr(errstr, topic_a)) {
-                                        got_a = 1;
-                                } else if (errstr && strstr(errstr, topic_b)) {
-                                        TEST_FAIL(
-                                            "B must not re-surface after "
-                                            "A's recovery+re-fail cycle");
-                                }
-                        }
-                        rd_kafka_error_destroy(error);
-                        continue;
-                }
-                for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
-                }
-        }
-        TEST_ASSERT(got_a,
-                    "A must surface AUTH_FAILED again after recovery+re-fail");
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2909,80 +2469,6 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
 }
 
 
-/* Topic A is failing and has surfaced. A partial metadata refresh that
- * covers only topic B (a cgrp_update=false response) must NOT wipe A
- * from rkcg_errored_topics — otherwise the next full refresh would
- * spuriously re-emit A. Verified by asserting no error op arrives
- * after the partial refresh while A is continuously failing. */
-static void test_share_consumer_partial_refresh_preserves_other(void) {
-        test_ctx_t ctx;
-        rd_kafka_share_t *rkshare;
-        const char *topic_a = "0182-partial-refresh-a";
-        const char *topic_b = "0182-partial-refresh-b";
-        const char *group   = "sg-0182-partial-refresh";
-        rd_kafka_topic_partition_list_t *subscription;
-
-        SUB_TEST();
-
-        ctx = test_ctx_new();
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create A");
-        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "create B");
-        mock_produce(ctx.producer, topic_a, 3);
-        mock_produce(ctx.producer, topic_b, 3);
-
-        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
-                                             NULL, NULL);
-
-        subscription = rd_kafka_topic_partition_list_new(2);
-        rd_kafka_topic_partition_list_add(subscription, topic_a,
-                                          RD_KAFKA_PARTITION_UA);
-        rd_kafka_topic_partition_list_add(subscription, topic_b,
-                                          RD_KAFKA_PARTITION_UA);
-        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
-                        RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "subscribe {A,B}");
-        rd_kafka_topic_partition_list_destroy(subscription);
-
-        share_topic_err_prime_assignment(rkshare);
-
-        /* Make A fail and surface. B remains healthy. */
-        rd_kafka_mock_topic_set_error(
-            ctx.mcluster, topic_a,
-            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
-        share_topic_err_force_metadata(rkshare);
-        TEST_ASSERT(
-            share_topic_err_wait_for_err(
-                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
-            "First AUTH_FAILED for A must surface");
-
-        /* Trigger a PARTIAL metadata refresh covering only B (this is
-         * a cgrp_update=false request). The share fallthrough in
-         * parse_Metadata0 fires; share_metadata_update_check runs in
-         * partial-view mode and must MERGE A's existing entry forward
-         * rather than wholesale-replacing rkcg_errored_topics. */
-        share_topic_err_force_partial_metadata(rkshare, topic_b);
-
-        /* If A's entry was wiped by the partial refresh, the next full
-         * refresh (A still failing) would surface a spurious second
-         * emit. Assert that no error arrives — A is still deduped. */
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(
-            rkshare, 10,
-            "A must not re-emit: partial-view drain must have preserved "
-            "its rkcg_errored_topics entry");
-
-        test_share_consumer_close(rkshare);
-        test_share_destroy(rkshare);
-        test_ctx_destroy(&ctx);
-
-        SUB_TEST_PASS();
-}
-
-
 /* UNKNOWN_TOPIC_OR_PART is debug-logged only and must not reach the
  * app via consume_batch. */
 static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
@@ -3047,21 +2533,15 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         test_consume_batch_at_epoch_zero_strips_piggyback_acks();
         test_strip_pre_set_survives_sharefetch_err();
 
-        /* Topic-level metadata err surface + dedup. */
+        /* Topic-level metadata err surface */
         test_share_consumer_surfaces_topic_exception();
         test_share_consumer_surfaces_topic_authorization_failed();
-        test_share_consumer_dedupes_repeated_auth_failed();
-        test_share_consumer_two_topics_dedupe_independently();
+        test_share_consumer_multi_partition_single_op_per_cycle();
         test_share_consumer_re_emits_when_err_code_changes();
         test_share_consumer_re_surfaces_after_recovery();
-        test_share_consumer_unsubscribe_drops_errored_topic();
-        test_share_consumer_multi_partition_dedupe();
         test_share_consumer_re_surfaces_after_recovery_topic_exception();
-        test_share_consumer_subscribe_change_drops_dropped_topic();
-        test_share_consumer_partial_recovery_preserves_other();
         test_share_consumer_resubscribe_re_emits_persistent_failure();
         test_share_consumer_does_not_surface_unknown_topic_or_part();
-        test_share_consumer_partial_refresh_preserves_other();
 
         /* Socket timeout matrix (single broker).
          *

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -1976,6 +1976,358 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
         SUB_TEST_PASS();
 }
 
+/* ===================================================================
+ *  Topic-level metadata error tests.
+ *
+ *  These exercise rd_kafka_share_toppar_enq_error in rdkafka_partition.c:
+ *  metadata responses that mark a subscribed topic with an err flow
+ *  through set_notexists / set_error / propagate_notexists ->
+ *  toppar_enq_error -> share variant. The share variant surfaces
+ *  TOPIC_EXCEPTION and TOPIC_AUTHORIZATION_FAILED via consume_batch
+ *  (as an rd_kafka_error_t) and dedupes repeats of the same
+ *  (topic, err); other codes (UNKNOWN_TOPIC, UNKNOWN_TOPIC_OR_PART,
+ *  UNKNOWN_TOPIC_ID, UNKNOWN_PARTITION) are dropped silently (debug
+ *  log only) and never delivered to the app.
+ *
+ *  Real brokers don't dynamically flip topic-name validity, and the
+ *  share-assignment path requires the rktp to exist on rkt_desp before
+ *  toppar_enq_error can fire — both make these scenarios hard to
+ *  reproduce against a real broker. Mock injection is the deterministic
+ *  way to drive the code under test.
+ * =================================================================== */
+
+/* Prime the share assignment by driving at least one consume_batch so
+ * rd_kafka_share_assignment_add materialises the rktp and links it on
+ * rkt_desp (precondition for rd_kafka_share_toppar_enq_error to fire).
+ *
+ * The consumer is in explicit ack mode, so every consumed record is
+ * ACCEPTed before returning — otherwise subsequent consume_batch calls
+ * would return _STATE ("records from previous poll have not been
+ * acknowledged") and never reach the rkcg_q dequeue path where the
+ * OP_CONSUMER_ERR lives. */
+static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        size_t j;
+        int attempts;
+        rd_bool_t got_any = rd_false;
+
+        for (attempts = 0; attempts < 20; attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                                got_any = rd_true;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+                if (got_any)
+                        return;
+        }
+        TEST_FAIL(
+            "Pre-condition: expected to consume a batch before "
+            "injecting the metadata error");
+}
+
+/* Force a metadata refresh on the share consumer's underlying rk so
+ * the injected per-topic err is observed. */
+static void share_topic_err_force_metadata(rd_kafka_share_t *rkshare) {
+        const rd_kafka_metadata_t *md = NULL;
+        rd_kafka_t *rk;
+
+        rk = test_share_consumer_get_rk(rkshare);
+        (void)rd_kafka_metadata(rk, 1 /*all_topics*/, NULL, &md, 5000);
+        if (md)
+                rd_kafka_metadata_destroy(md);
+}
+
+/* Drain consume_batch until either the expected err code surfaces (then
+ * return rd_true) or `max_attempts` calls go by without it (return
+ * rd_false). Records that arrive are destroyed. */
+static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
+                                              rd_kafka_resp_err_t expected,
+                                              int max_attempts) {
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        size_t j;
+        int attempts;
+
+        for (attempts = 0; attempts < max_attempts; attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        TEST_SAY("consume_batch returned %s: %s\n",
+                                 rd_kafka_err2name(code),
+                                 rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                        if (code == expected)
+                                return rd_true;
+                        continue;
+                }
+                /* Ack received records so the next consume_batch can
+                 * proceed past the explicit-mode "previous poll
+                 * unacked" gate. */
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        return rd_false;
+}
+
+/* Run `n_attempts` consume_batch calls and fail the test if any of them
+ * returns an rd_kafka_error_t — used for the negative-assertion tests
+ * (transient-code log-only paths must not surface). */
+static void share_topic_err_assert_no_err(rd_kafka_share_t *rkshare,
+                                          int n_attempts,
+                                          const char *context) {
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        size_t j;
+        int attempts;
+
+        for (attempts = 0; attempts < n_attempts; attempts++) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_resp_err_t code = rd_kafka_error_code(error);
+                        rd_kafka_error_destroy(error);
+                        TEST_FAIL(
+                            "[%s] unexpected error from consume_batch: "
+                            "%s",
+                            context, rd_kafka_err2name(code));
+                }
+                /* Ack received records so the next consume_batch can
+                 * proceed past the explicit-mode "previous poll
+                 * unacked" gate. */
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err)
+                                rd_kafka_share_acknowledge(rkshare,
+                                                           rkmessages[j]);
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+}
+
+/* Run one share-topic-err scenario: assign, inject `inject_err`,
+ * verify consume_batch surfaces `expect_err` (or fails). */
+static void do_test_share_topic_err_surfaces(const char *topic_suffix,
+                                             rd_kafka_resp_err_t inject_err,
+                                             rd_kafka_resp_err_t expect_err) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        char topic[64];
+        char group[64];
+
+        SUB_TEST_QUICK("inject=%s expect=%s", rd_kafka_err2name(inject_err),
+                       rd_kafka_err2name(expect_err));
+
+        ctx = test_ctx_new();
+        rd_snprintf(topic, sizeof(topic), "0182-%s", topic_suffix);
+        rd_snprintf(group, sizeof(group), "sg-0182-%s", topic_suffix);
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
+        share_topic_err_force_metadata(rkshare);
+
+        TEST_ASSERT(share_topic_err_wait_for_err(rkshare, expect_err, 30),
+                    "Expected consume_batch to surface %s within 30 attempts",
+                    rd_kafka_err2name(expect_err));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+static void test_share_consumer_surfaces_topic_exception(void) {
+        do_test_share_topic_err_surfaces("surfaces-topic-exception",
+                                         RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION,
+                                         RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+}
+
+
+static void test_share_consumer_surfaces_topic_authorization_failed(void) {
+        do_test_share_topic_err_surfaces(
+            "surfaces-topic-auth-failed",
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+}
+
+
+/* Verify the same (topic, err) is only delivered once. After the first
+ * surface, a second metadata refresh with the same injected err must
+ * NOT deliver a second error op — dedup via rkcg_errored_topics. */
+static void test_share_consumer_dedupes_repeated_topic_exception(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-dedupe-topic-exception";
+        const char *group = "sg-0182-dedupe-topic-exception";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* First injection: must surface. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
+                    "First TOPIC_EXCEPTION must surface");
+
+        /* Second refresh with the same err: must NOT surface again. */
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(rkshare, 10,
+                                      "repeat TOPIC_EXCEPTION must be deduped");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* Verify the same topic with a NEW err code surfaces again (dedup is
+ * keyed on (topic, err), not just topic). */
+static void test_share_consumer_re_emits_when_err_code_changes(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-err-code-change";
+        const char *group = "sg-0182-err-code-change";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        /* First err: AUTH_FAILED. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(
+            share_topic_err_wait_for_err(
+                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
+            "First AUTH_FAILED must surface");
+
+        /* Second err for the same topic: TOPIC_EXCEPTION (different
+         * code) — must surface, dedup must NOT swallow it. */
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
+                    "TOPIC_EXCEPTION must surface after AUTH_FAILED "
+                    "(err code change must bypass dedup)");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* Verify UNKNOWN_TOPIC_OR_PART does NOT surface — it's a transient
+ * code we only debug-log.
+ *
+ * Note on topic.metadata.propagation.max.ms=0: with the default 30s
+ * window, rd_kafka_topic_set_notexists defers the action block (and
+ * therefore the propagate_notexists -> enq_error -> share variant
+ * chain) until the window expires, because the rkt is still in
+ * S_EXISTS state right after the mock topic was created. Setting the
+ * window to 0 bypasses the defer so the share variant's log-and-drop
+ * branch is actually exercised on the first metadata refresh, not 30s
+ * later. */
+static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
+        test_ctx_t ctx;
+        rd_kafka_conf_t *conf;
+        rd_kafka_share_t *rkshare;
+        const char *topic = "0182-no-surface-unknown-tp";
+        const char *group = "sg-0182-no-surface-unknown-tp";
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        mock_produce(ctx.producer, topic, 5);
+
+        /* Custom consumer that disables the set_notexists defer window
+         * so the log-and-drop path runs synchronously on the metadata
+         * refresh. */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "explicit");
+        test_conf_set(conf, "topic.metadata.propagation.max.ms", "0");
+        rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
+
+        subscribe_one(rkshare, topic);
+        share_topic_err_prime_assignment(rkshare);
+
+        rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
+                                      RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART);
+        share_topic_err_force_metadata(rkshare);
+
+        share_topic_err_assert_no_err(
+            rkshare, 20,
+            "UNKNOWN_TOPIC_OR_PART must be logged only, not surfaced");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -1992,6 +2344,13 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error();
         test_consume_batch_at_epoch_zero_strips_piggyback_acks();
         test_strip_pre_set_survives_sharefetch_err();
+
+        /* Topic-level metadata err surface + dedup. */
+        test_share_consumer_surfaces_topic_exception();
+        test_share_consumer_surfaces_topic_authorization_failed();
+        test_share_consumer_dedupes_repeated_topic_exception();
+        test_share_consumer_re_emits_when_err_code_changes();
+        test_share_consumer_does_not_surface_unknown_topic_or_part();
 
         /* Socket timeout matrix (single broker).
          *

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2035,6 +2035,25 @@ static void share_topic_err_force_metadata(rd_kafka_share_t *rkshare) {
                 rd_kafka_metadata_destroy(md);
 }
 
+/* Force a PARTIAL metadata refresh covering only `topic_name`.
+ *
+ * Uses rd_kafka_metadata(all_topics=0, only_rkt=...) which underneath
+ * sends a MetadataRequest with cgrp_update=false. This exercises the
+ * share_metadata_update_check partial-view drain path. */
+static void share_topic_err_force_partial_metadata(rd_kafka_share_t *rkshare,
+                                                   const char *topic_name) {
+        const rd_kafka_metadata_t *md = NULL;
+        rd_kafka_t *rk;
+        rd_kafka_topic_t *rkt;
+
+        rk  = test_share_consumer_get_rk(rkshare);
+        rkt = rd_kafka_topic_new(rk, topic_name, NULL);
+        (void)rd_kafka_metadata(rk, 0 /*all_topics*/, rkt, &md, 5000);
+        if (md)
+                rd_kafka_metadata_destroy(md);
+        rd_kafka_topic_destroy(rkt);
+}
+
 /* Drain consume_batch until either the expected err code surfaces (then
  * return rd_true) or `max_attempts` calls go by without it (return
  * rd_false). Records that arrive are destroyed. */
@@ -2934,6 +2953,80 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
 }
 
 
+/* Topic A is failing and has surfaced. A partial metadata refresh that
+ * covers only topic B (a cgrp_update=false response) must NOT wipe A
+ * from rkcg_errored_topics — otherwise the next full refresh would
+ * spuriously re-emit A. Verified by asserting no error op arrives
+ * after the partial refresh while A is continuously failing. */
+static void test_share_consumer_partial_refresh_preserves_other(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        const char *topic_a = "0182-partial-refresh-a";
+        const char *topic_b = "0182-partial-refresh-b";
+        const char *group   = "sg-0182-partial-refresh";
+        rd_kafka_topic_partition_list_t *subscription;
+
+        SUB_TEST();
+
+        ctx = test_ctx_new();
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_a, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create A");
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic_b, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create B");
+        mock_produce(ctx.producer, topic_a, 3);
+        mock_produce(ctx.producer, topic_b, 3);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+
+        subscription = rd_kafka_topic_partition_list_new(2);
+        rd_kafka_topic_partition_list_add(subscription, topic_a,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_topic_partition_list_add(subscription, topic_b,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_ASSERT(rd_kafka_share_subscribe(rkshare, subscription) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "subscribe {A,B}");
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        share_topic_err_prime_assignment(rkshare);
+
+        /* Make A fail and surface. B remains healthy. */
+        rd_kafka_mock_topic_set_error(
+            ctx.mcluster, topic_a,
+            RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+        share_topic_err_force_metadata(rkshare);
+        TEST_ASSERT(
+            share_topic_err_wait_for_err(
+                rkshare, RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED, 30),
+            "First AUTH_FAILED for A must surface");
+
+        /* Trigger a PARTIAL metadata refresh covering only B (this is
+         * a cgrp_update=false request). The share fallthrough in
+         * parse_Metadata0 fires; share_metadata_update_check runs in
+         * partial-view mode and must MERGE A's existing entry forward
+         * rather than wholesale-replacing rkcg_errored_topics. */
+        share_topic_err_force_partial_metadata(rkshare, topic_b);
+
+        /* If A's entry was wiped by the partial refresh, the next full
+         * refresh (A still failing) would surface a spurious second
+         * emit. Assert that no error arrives — A is still deduped. */
+        share_topic_err_force_metadata(rkshare);
+        share_topic_err_assert_no_err(
+            rkshare, 10,
+            "A must not re-emit: partial-view drain must have preserved "
+            "its rkcg_errored_topics entry");
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
 /* UNKNOWN_TOPIC_OR_PART is debug-logged only and must not reach the
  * app via consume_batch. */
 static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
@@ -3013,6 +3106,7 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         test_share_consumer_partial_recovery_preserves_other();
         test_share_consumer_resubscribe_re_emits_persistent_failure();
         test_share_consumer_does_not_surface_unknown_topic_or_part();
+        test_share_consumer_partial_refresh_preserves_other();
 
         /* Socket timeout matrix (single broker).
          *


### PR DESCRIPTION
## Summary

Share consumers reuse a number of code paths with regular consumers
(metadata-refresh, leader change, broker decommission, cgrp
terminate, PARTITION_JOIN). Several of those paths still drove
regular-consumer offset machinery (`OffsetForLeaderEpoch`,
`ListOffsets`, `offset_query_tmr`, `offset_store_stop`, version
barriers) or enqueued ops onto `rktp_fetchq`, which the share path
doesn't drain. This PR adds the missing `RD_KAFKA_IS_SHARE_CONSUMER`
guards so those operations are no-ops for share rk.

## Changes

### `src/rdkafka_topic.c` — `rd_kafka_toppar_leader_update`

Skip the `need_epoch_validation` block for share rk. The body
calls `rd_kafka_toppar_set_offset_validation_position` followed by
`rd_kafka_offset_validate`, which ultimately issues
`OffsetForLeaderEpoch` / `ListOffsets` and pipes the reply into
`rktp_fetchq`. Reachable on every metadata refresh.

### `src/rdkafka_partition.c` — `rd_kafka_toppar_enq_error`

Route `OP_ERR` to `rk_cgrp->rkcg_q` for share consumers instead of
`rktp_fetchq`. Topic-level errors surfaced through this helper
(`UNKNOWN_TOPIC_OR_PART` / `UNKNOWN_PARTITION` from the
metadata-refresh path) were previously stranded on a queue the share
path never drains.

### `src/rdkafka_partition.c` — `rd_kafka_toppar_broker_migrate`

Guard the `FETCH_OFFSET_WAIT -> offset_retry` transition with
`!IS_SHARE_CONSUMER`. Share rk never enters `OFFSET_WAIT` so this is
defensive today, but it keeps the offset machinery out of the
share leader-change path.

### `src/rdkafka_partition.c` — `rd_kafka_toppar_offset_retry`

Add an early-return at the top of the helper itself if
`IS_SHARE_CONSUMER`. Belt-and-suspenders: callers must guard, but if
a stray future call slipped through it would otherwise arm the
offset-query timer for a share-assigned rktp.

### `src/rdkafka_cgrp.c` — `cgrp_op_serve` `OP_PARTITION_JOIN`

Skip `rd_kafka_toppar_op_fetch_stop` for share rk in the
"PARTITION_JOIN while terminating" branch. `op_fetch_stop` bumps the
version barrier, touches `rktp_offset_query_tmr`, and calls
`offset_store_stop` — none of which apply to a share-assigned rktp
that never started a regular fetch.

### `src/rdkafka_broker.c` — `OP_PARTITION_JOIN` handler

Gate the `rktp_ts_fetch_backoff = 0` reset with
`!IS_SHARE_CONSUMER`. Surfaced by the broker-migrate call-graph
audit: share rk satisfies `rk_type == RD_KAFKA_CONSUMER`, so this
branch fired and wrote to a regular-fetch-only field. Dead-write
today (share doesn't read the field), but a forbidden-state
mutation worth closing.

### `src/rdkafka_msgset_reader.c` — `rd_kafka_msgset_reader_run`

Split the per-batch enqueue-debug log into share / non-share branches.
Three fields the regular log prints are misleading for share consumers:
`"fetch queue"` (share writes to the caller's `temp_fetchq`, not
`rktp_fetchq`), `v%d` (share always passes `tver.version=0`), and
`%d aborted msgsets` (share calls `share_msgset_parse` with
`aborted_txns=NULL`, so the counter is never bumped). The share
variant emits `"temp fetchq"`, drops the version field, and drops the
aborted-count field; `msetr_ctrl_cnt` stays as a "should be zero"
diagnostic.