### PR TITLE
[KIP-932]: Prevent Share Session Lists to be mutated for internal broker thread

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1408,18 +1408,6 @@ static void rd_kafka_destroy_internal(rd_kafka_t *rk) {
                 thrd  = rd_malloc(sizeof(*thrd));
                 *thrd = rk->rk_internal_rkb->rkb_thread;
 
-                /* TODO KIP-932: Clear any share-session state that may
-                 * have been populated on the internal broker during a
-                 * leader migration (PARTITION_JOIN runs on whichever
-                 * broker the toppar is transiently delegated to,
-                 * including :0/internal). Once the leader-migration
-                 * path is fixed to skip non-LEARNED brokers, this
-                 * SESSION_CLEAR enqueue can be removed. */
-                if (RD_KAFKA_IS_SHARE_CONSUMER(rk))
-                        rd_kafka_q_enq(
-                            rk->rk_internal_rkb->rkb_ops,
-                            rd_kafka_op_new(RD_KAFKA_OP_SHARE_SESSION_CLEAR));
-
                 /* Send op to trigger queue wake-up.
                  * WARNING: This is last time we can read
                  * from rk_internal_rkb in this thread! */

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3471,6 +3471,10 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 rd_kafka_broker_lock(rkb);
                 TAILQ_INSERT_TAIL(&rkb->rkb_toppars, rktp, rktp_rkblink);
                 rkb->rkb_toppar_cnt++;
+                /* TODO KIP-932: Check if we can use
+                 * rkb->rkb_source == RD_KAFKA_LEARNED instead of !=
+                 * RD_KAFKA_INTERNAL.
+                 */
                 if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk) &&
                     rd_kafka_toppar_is_on_cgrp(rktp, rd_false) &&
                     rkb->rkb_source != RD_KAFKA_INTERNAL) {
@@ -3583,6 +3587,10 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 rd_kafka_broker_lock(rkb);
                 TAILQ_REMOVE(&rkb->rkb_toppars, rktp, rktp_rkblink);
                 rkb->rkb_toppar_cnt--;
+                /* TODO KIP-932: Check if we can use
+                 * rkb->rkb_source == RD_KAFKA_LEARNED instead of !=
+                 * RD_KAFKA_INTERNAL.
+                 */
                 if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk) &&
                     rkb->rkb_source != RD_KAFKA_INTERNAL) {
                         rd_rkb_dbg(rkb, FETCH | RD_KAFKA_DBG_CGRP,
@@ -3594,7 +3602,6 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                                    rktp->rktp_partition);
                         rd_kafka_broker_share_session_toppar_remove(rkb, rktp);
                 }
-
 
                 rd_kafka_broker_unlock(rkb);
                 rd_kafka_broker_destroy(rktp->rktp_broker);
@@ -3807,26 +3814,44 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_SHARE_SESSION_PARTITION_ADD:
                 rd_rkb_dbg(rkb, CGRP, "SHARESESSION",
                            "Received SHARE_SESSION_PARTITION_ADD op for "
-                           "topic %s [%" PRId32 "] (epoch=%" PRId32 ")",
+                           "topic %s [%" PRId32 "] (epoch=%" PRId32 ")%s",
                            rko->rko_rktp->rktp_rkt->rkt_topic->str,
                            rko->rko_rktp->rktp_partition,
-                           rkb->rkb_share_fetch_session.epoch);
+                           rkb->rkb_share_fetch_session.epoch,
+                           rkb->rkb_source == RD_KAFKA_INTERNAL
+                               ? ", skipping for internal broker"
+                               : "");
 
-                /* TODO KIP-932: Skip this from caller itself */
-                if (rkb->rkb_source != RD_KAFKA_INTERNAL)
+                /* TODO KIP-932:
+                 * 1. Skip this from caller itself
+                 * 2. Check if we can use
+                 * rkb->rkb_source == RD_KAFKA_LEARNED instead of !=
+                 * RD_KAFKA_INTERNAL.
+                 */
+                if (rkb->rkb_source != RD_KAFKA_INTERNAL) {
                         rd_kafka_broker_share_session_toppar_add(rkb,
                                                                  rko->rko_rktp);
+                }
+
                 break;
 
         case RD_KAFKA_OP_SHARE_SESSION_PARTITION_REMOVE:
                 rd_rkb_dbg(rkb, CGRP, "SHARESESSION",
                            "Received SHARE_SESSION_PARTITION_REMOVE op for "
-                           "topic %s [%" PRId32 "] (epoch=%" PRId32 ")",
+                           "topic %s [%" PRId32 "] (epoch=%" PRId32 ")%s",
                            rko->rko_rktp->rktp_rkt->rkt_topic->str,
                            rko->rko_rktp->rktp_partition,
-                           rkb->rkb_share_fetch_session.epoch);
+                           rkb->rkb_share_fetch_session.epoch,
+                           rkb->rkb_source == RD_KAFKA_INTERNAL
+                               ? ", skipping for internal broker"
+                               : "");
 
-                /* TODO KIP-932: Skip this from caller itself */
+                /* TODO KIP-932:
+                 * 1. Skip this from caller itself
+                 * 2. Check if we can use
+                 * rkb->rkb_source == RD_KAFKA_LEARNED instead of !=
+                 * RD_KAFKA_INTERNAL.
+                 */
                 if (rkb->rkb_source != RD_KAFKA_INTERNAL)
                         rd_kafka_broker_share_session_toppar_remove(
                             rkb, rko->rko_rktp);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3812,6 +3812,7 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                            rko->rko_rktp->rktp_partition,
                            rkb->rkb_share_fetch_session.epoch);
 
+                /* TODO KIP-932: Skip this from caller itself */
                 if (rkb->rkb_source != RD_KAFKA_INTERNAL)
                         rd_kafka_broker_share_session_toppar_add(rkb,
                                                                  rko->rko_rktp);
@@ -3825,6 +3826,7 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                            rko->rko_rktp->rktp_partition,
                            rkb->rkb_share_fetch_session.epoch);
 
+                /* TODO KIP-932: Skip this from caller itself */
                 if (rkb->rkb_source != RD_KAFKA_INTERNAL)
                         rd_kafka_broker_share_session_toppar_remove(
                             rkb, rko->rko_rktp);

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3471,7 +3471,9 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 rd_kafka_broker_lock(rkb);
                 TAILQ_INSERT_TAIL(&rkb->rkb_toppars, rktp, rktp_rkblink);
                 rkb->rkb_toppar_cnt++;
-                if (rd_kafka_toppar_is_on_cgrp(rktp, rd_false)) {
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk) &&
+                    rd_kafka_toppar_is_on_cgrp(rktp, rd_false) &&
+                    rkb->rkb_source != RD_KAFKA_INTERNAL) {
                         rd_rkb_dbg(rkb, FETCH | RD_KAFKA_DBG_CGRP,
                                    "SHARESESSION",
                                    "%s [%" PRId32
@@ -3581,7 +3583,8 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                 rd_kafka_broker_lock(rkb);
                 TAILQ_REMOVE(&rkb->rkb_toppars, rktp, rktp_rkblink);
                 rkb->rkb_toppar_cnt--;
-                if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk))
+                if (RD_KAFKA_IS_SHARE_CONSUMER(rkb->rkb_rk) &&
+                    rkb->rkb_source != RD_KAFKA_INTERNAL) {
                         rd_rkb_dbg(rkb, FETCH | RD_KAFKA_DBG_CGRP,
                                    "SHARESESSION",
                                    "%s [%" PRId32
@@ -3589,7 +3592,10 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                                    "PARTITION_LEAVE",
                                    rktp->rktp_rkt->rkt_topic->str,
                                    rktp->rktp_partition);
-                rd_kafka_broker_share_session_toppar_remove(rkb, rktp);
+                        rd_kafka_broker_share_session_toppar_remove(rkb, rktp);
+                }
+
+
                 rd_kafka_broker_unlock(rkb);
                 rd_kafka_broker_destroy(rktp->rktp_broker);
                 if (rktp->rktp_msgq_wakeup_q) {
@@ -3806,7 +3812,9 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                            rko->rko_rktp->rktp_partition,
                            rkb->rkb_share_fetch_session.epoch);
 
-                rd_kafka_broker_share_session_toppar_add(rkb, rko->rko_rktp);
+                if (rkb->rkb_source != RD_KAFKA_INTERNAL)
+                        rd_kafka_broker_share_session_toppar_add(rkb,
+                                                                 rko->rko_rktp);
                 break;
 
         case RD_KAFKA_OP_SHARE_SESSION_PARTITION_REMOVE:
@@ -3817,7 +3825,9 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                            rko->rko_rktp->rktp_partition,
                            rkb->rkb_share_fetch_session.epoch);
 
-                rd_kafka_broker_share_session_toppar_remove(rkb, rko->rko_rktp);
+                if (rkb->rkb_source != RD_KAFKA_INTERNAL)
+                        rd_kafka_broker_share_session_toppar_remove(
+                            rkb, rko->rko_rktp);
                 break;
         case RD_KAFKA_OP_SHARE_SESSION_CLEAR:
                 rd_rkb_dbg(rkb, CGRP, "TERM",
@@ -4821,9 +4831,6 @@ static void rd_kafka_broker_serve(rd_kafka_broker_t *rkb, int timeout_ms) {
         rkb->rkb_persistconn.internal =
             rd_atomic32_get(&rkb->rkb_outbufs.rkbq_cnt) > 0;
 
-        /*
-         * TODO KIP-932: Check internal broker handling for shared consumer.
-         */
         if (rkb->rkb_source == RD_KAFKA_INTERNAL) {
                 rd_kafka_broker_internal_serve(rkb, abs_timeout);
                 return;


### PR DESCRIPTION
Internal broker thread does not make any ShareFetch and ShareAck network calls to the brokers so we shouldn't need to populate the `toppars_to_add` or `toppars_to_forget` lists when partitions migrate to/away from internal broker thread.
This PR adds check to update the lists only if the broker is not internal. It also removes the part where we enqueue SESSION_CLEAR op to the internal broker while destroying the client.


TODO - ~~Check if we should use `buf_enq2` instead of `buf_enq1` while enqueuing ShareAck and ShareFetch requests~~ Checked this - enq2 does NOT finalize the buffer. It assumes the caller already did. enq2 does NOT set the response callback or opaque. It assumes the rkbuf already has them. So it is probably not worth it to do it at the caller given that we ensure that we don't enqueue requests on internal thread.