### PR TITLE
[KIP-932] Add ASAN/TSAN/Valgrind CI pipelines for share consumer tests

### DIFF
--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -29,7 +29,7 @@ global_job_config:
       value: '8.0.0'
 
 blocks:
-  - name: 'Share consumer tests under ASAN+LSAN'
+  - name: 'Share consumer tests (ASAN + LSAN)'
     dependencies: []
     task:
       agent:
@@ -40,7 +40,7 @@ blocks:
           commands:
             - artifact push workflow artifacts/ --destination artifacts/asan/
       jobs:
-        - name: 'ASAN+LSAN: TESTS_SKIP_BEFORE=0155'
+        - name: 'Share consumer suite (ASAN + LSAN)'
           env_vars:
             - name: ASAN_OPTIONS
               value: 'detect_leaks=1:halt_on_error=0:print_stacktrace=1:abort_on_error=0:symbolize=1'

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -1,0 +1,55 @@
+version: v1.0
+name: run-share-consumer-tests-asan
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-00
+
+execution_time_limit:
+  hours: 4
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
+      - sudo apt remove -y needrestart
+      - sudo DEBIAN_FRONTEND=noninteractive apt install -y libcurl4-openssl-dev libssl-dev
+      - python3 -m pip install -U pip
+      - (cd tests && python3 -m pip install -r requirements.txt)
+      - ./dev-conf.sh asan
+      - sem-version java 17
+      - mkdir -p artifacts
+  env_vars:
+    - name: CACHE_TAG
+      value: '7'
+    - name: KAFKA_VERSION
+      value: '4.2.0'
+    - name: CP_VERSION
+      value: '8.0.0'
+
+blocks:
+  - name: 'Share consumer tests under ASAN+LSAN'
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      epilogue:
+        always:
+          commands:
+            - artifact push workflow artifacts/ --destination artifacts/asan/
+      jobs:
+        - name: 'ASAN+LSAN: TESTS_SKIP_BEFORE=0155'
+          env_vars:
+            - name: ASAN_OPTIONS
+              value: 'detect_leaks=1:halt_on_error=0:print_stacktrace=1:abort_on_error=0:symbolize=1'
+          commands:
+            - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
+            - (cd tests && python3 -m trivup.clusters.KafkaCluster
+              --kraft
+              --version "${KAFKA_VERSION}"
+              --cpversion "${CP_VERSION}"
+              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/asan-share-tests.log") || true
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -36,18 +36,18 @@ blocks:
       epilogue:
         always:
           commands:
+            - cp tests/asan-share-tests.log artifacts/ || true
             - artifact push workflow artifacts/ --destination artifacts/asan/
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION} || true
       jobs:
         - name: 'Share consumer suite (ASAN + LSAN)'
           env_vars:
             - name: ASAN_OPTIONS
-              value: 'halt_on_error=0:abort_on_error=0:exitcode=0:print_stacktrace=1:symbolize=1'
+              value: 'halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1'
           commands:
             - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - (cd tests && python3 -m trivup.clusters.KafkaCluster
               --kraft
               --version "${KAFKA_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee asan-share-tests.log") || true
-            - cp tests/asan-share-tests.log artifacts/
-            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
+              --cmd "bash -c 'set -o pipefail; TESTS_SKIP_BEFORE=0155 make 2>&1 | tee asan-share-tests.log'")

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -52,5 +52,10 @@ blocks:
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee asan-share-tests.log") || true
+            - echo "=== ASAN log written by tee to tests/asan-share-tests.log ==="
+            - ls -la tests/asan-share-tests.log
             - cp tests/asan-share-tests.log artifacts/
+            - echo "=== Copied to artifacts/ — contents staged for upload ==="
+            - ls -la artifacts/
+            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/asan/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -6,7 +6,7 @@ agent:
     type: s1-prod-ubuntu24-04-amd64-00
 
 execution_time_limit:
-  hours: 4
+  hours: 2
 
 global_job_config:
   prologue:
@@ -25,8 +25,6 @@ global_job_config:
       value: '7'
     - name: KAFKA_VERSION
       value: '4.2.0'
-    - name: CP_VERSION
-      value: '8.0.0'
 
 blocks:
   - name: 'Share consumer tests (ASAN + LSAN)'
@@ -43,19 +41,13 @@ blocks:
         - name: 'Share consumer suite (ASAN + LSAN)'
           env_vars:
             - name: ASAN_OPTIONS
-              value: 'detect_leaks=1:halt_on_error=0:print_stacktrace=1:abort_on_error=0:symbolize=1'
+              value: 'halt_on_error=0:abort_on_error=0:exitcode=0:print_stacktrace=1:symbolize=1'
           commands:
             - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - (cd tests && python3 -m trivup.clusters.KafkaCluster
               --kraft
               --version "${KAFKA_VERSION}"
-              --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee asan-share-tests.log") || true
-            - echo "=== ASAN log written by tee to tests/asan-share-tests.log ==="
-            - ls -la tests/asan-share-tests.log
             - cp tests/asan-share-tests.log artifacts/
-            - echo "=== Copied to artifacts/ — contents staged for upload ==="
-            - ls -la artifacts/
-            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/asan/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -51,5 +51,6 @@ blocks:
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/asan-share-tests.log") || true
+              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee asan-share-tests.log") || true
+            - cp tests/asan-share-tests.log artifacts/
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-asan-tests.yml
+++ b/.semaphore/run-asan-tests.yml
@@ -50,6 +50,6 @@ blocks:
               --kraft
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
-              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/asan-share-tests.log") || true
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -34,7 +34,7 @@ global_job_config:
       value: '8.0.0'
 
 blocks:
-  - name: 'Share consumer tests under TSAN'
+  - name: 'Share consumer tests (TSAN)'
     dependencies: []
     task:
       agent:
@@ -45,7 +45,7 @@ blocks:
           commands:
             - artifact push workflow artifacts/ --destination artifacts/tsan/
       jobs:
-        - name: 'TSAN: TESTS_SKIP_BEFORE=0155'
+        - name: 'Share consumer suite (TSAN)'
           env_vars:
             - name: TSAN_OPTIONS
               value: 'halt_on_error=0:second_deadlock_stack=1:history_size=7:symbolize=1'

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -55,6 +55,6 @@ blocks:
               --kraft
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
-              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/tsan-share-tests.log") || true
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -12,10 +12,6 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      # TSAN's runtime aborts with "unexpected memory mapping" on Ubuntu 24.04
-      # because the kernel's default vm.mmap_rnd_bits=32 makes ASLR put
-      # allocations outside TSAN's expected shadow regions. Lower it to 28
-      # (TSAN's safe maximum) before any TSAN-instrumented binary runs.
       - sudo sysctl -w vm.mmap_rnd_bits=28
       - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
       - sudo apt remove -y needrestart
@@ -30,8 +26,6 @@ global_job_config:
       value: '7'
     - name: KAFKA_VERSION
       value: '4.2.0'
-    - name: CP_VERSION
-      value: '8.0.0'
 
 blocks:
   - name: 'Share consumer tests (TSAN)'
@@ -48,19 +42,13 @@ blocks:
         - name: 'Share consumer suite (TSAN)'
           env_vars:
             - name: TSAN_OPTIONS
-              value: 'halt_on_error=0:second_deadlock_stack=1:history_size=7:symbolize=1'
+              value: 'halt_on_error=0:exitcode=0:history_size=7:second_deadlock_stack=1:symbolize=1'
           commands:
             - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - (cd tests && python3 -m trivup.clusters.KafkaCluster
               --kraft
               --version "${KAFKA_VERSION}"
-              --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee tsan-share-tests.log") || true
-            - echo "=== TSAN log written by tee to tests/tsan-share-tests.log ==="
-            - ls -la tests/tsan-share-tests.log
             - cp tests/tsan-share-tests.log artifacts/
-            - echo "=== Copied to artifacts/ — contents staged for upload ==="
-            - ls -la artifacts/
-            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/tsan/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -1,0 +1,55 @@
+version: v1.0
+name: run-share-consumer-tests-tsan
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-00
+
+execution_time_limit:
+  hours: 2
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
+      - sudo apt remove -y needrestart
+      - sudo DEBIAN_FRONTEND=noninteractive apt install -y libcurl4-openssl-dev libssl-dev
+      - python3 -m pip install -U pip
+      - (cd tests && python3 -m pip install -r requirements.txt)
+      - ./dev-conf.sh tsan
+      - sem-version java 17
+      - mkdir -p artifacts
+  env_vars:
+    - name: CACHE_TAG
+      value: '7'
+    - name: KAFKA_VERSION
+      value: '4.2.0'
+    - name: CP_VERSION
+      value: '8.0.0'
+
+blocks:
+  - name: 'Share consumer tests under TSAN'
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      epilogue:
+        always:
+          commands:
+            - artifact push workflow artifacts/ --destination artifacts/tsan/
+      jobs:
+        - name: 'TSAN: TESTS_SKIP_BEFORE=0155'
+          env_vars:
+            - name: TSAN_OPTIONS
+              value: 'halt_on_error=0:second_deadlock_stack=1:history_size=7:symbolize=1'
+          commands:
+            - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
+            - (cd tests && python3 -m trivup.clusters.KafkaCluster
+              --kraft
+              --version "${KAFKA_VERSION}"
+              --cpversion "${CP_VERSION}"
+              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/tsan-share-tests.log") || true
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -57,5 +57,10 @@ blocks:
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee tsan-share-tests.log") || true
+            - echo "=== TSAN log written by tee to tests/tsan-share-tests.log ==="
+            - ls -la tests/tsan-share-tests.log
             - cp tests/tsan-share-tests.log artifacts/
+            - echo "=== Copied to artifacts/ — contents staged for upload ==="
+            - ls -la artifacts/
+            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/tsan/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -12,6 +12,11 @@ global_job_config:
   prologue:
     commands:
       - checkout
+      # TSAN's runtime aborts with "unexpected memory mapping" on Ubuntu 24.04
+      # because the kernel's default vm.mmap_rnd_bits=32 makes ASLR put
+      # allocations outside TSAN's expected shadow regions. Lower it to 28
+      # (TSAN's safe maximum) before any TSAN-instrumented binary runs.
+      - sudo sysctl -w vm.mmap_rnd_bits=28
       - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
       - sudo apt remove -y needrestart
       - sudo DEBIAN_FRONTEND=noninteractive apt install -y libcurl4-openssl-dev libssl-dev

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -56,5 +56,6 @@ blocks:
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee ../artifacts/tsan-share-tests.log") || true
+              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee tsan-share-tests.log") || true
+            - cp tests/tsan-share-tests.log artifacts/
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-tsan-tests.yml
+++ b/.semaphore/run-tsan-tests.yml
@@ -37,18 +37,18 @@ blocks:
       epilogue:
         always:
           commands:
+            - cp tests/tsan-share-tests.log artifacts/ || true
             - artifact push workflow artifacts/ --destination artifacts/tsan/
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION} || true
       jobs:
         - name: 'Share consumer suite (TSAN)'
           env_vars:
             - name: TSAN_OPTIONS
-              value: 'halt_on_error=0:exitcode=0:history_size=7:second_deadlock_stack=1:symbolize=1'
+              value: 'halt_on_error=0:history_size=7:second_deadlock_stack=1:symbolize=1'
           commands:
             - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - (cd tests && python3 -m trivup.clusters.KafkaCluster
               --kraft
               --version "${KAFKA_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 make 2>&1 | tee tsan-share-tests.log") || true
-            - cp tests/tsan-share-tests.log artifacts/
-            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
+              --cmd "bash -c 'set -o pipefail; TESTS_SKIP_BEFORE=0155 make 2>&1 | tee tsan-share-tests.log'")

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -49,6 +49,6 @@ blocks:
               --kraft
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
-              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee ../artifacts/valgrind-share-tests.log") || true
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -1,0 +1,54 @@
+version: v1.0
+name: run-share-consumer-tests-valgrind
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-00
+
+execution_time_limit:
+  hours: 2
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
+      - sudo apt remove -y needrestart
+      - sudo DEBIAN_FRONTEND=noninteractive apt install -y valgrind libcurl4-openssl-dev libssl-dev
+      - python3 -m pip install -U pip
+      - (cd tests && python3 -m pip install -r requirements.txt)
+      - ./configure --install-deps --enable-werror --enable-devel --disable-optimization
+      - make -j all
+      - make -j -C tests build
+      - sem-version java 17
+      - mkdir -p artifacts
+  env_vars:
+    - name: CACHE_TAG
+      value: '7'
+    - name: KAFKA_VERSION
+      value: '4.2.0'
+    - name: CP_VERSION
+      value: '8.0.0'
+
+blocks:
+  - name: 'Share consumer tests under valgrind (memcheck)'
+    dependencies: []
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      epilogue:
+        always:
+          commands:
+            - artifact push workflow artifacts/ --destination artifacts/valgrind/
+      jobs:
+        - name: 'Valgrind memcheck: TESTS_SKIP_BEFORE=0155'
+          commands:
+            - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
+            - (cd tests && python3 -m trivup.clusters.KafkaCluster
+              --kraft
+              --version "${KAFKA_VERSION}"
+              --cpversion "${CP_VERSION}"
+              --conf '["group.share.min.record.lock.duration.ms=1000", "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1"]'
+              --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee ../artifacts/valgrind-share-tests.log") || true
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -38,7 +38,9 @@ blocks:
       epilogue:
         always:
           commands:
+            - cp tests/valgrind-share-tests.log artifacts/ || true
             - artifact push workflow artifacts/ --destination artifacts/valgrind/
+            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION} || true
       jobs:
         - name: 'Share consumer suite (Valgrind memcheck)'
           commands:
@@ -47,6 +49,4 @@ blocks:
               --kraft
               --version "${KAFKA_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee valgrind-share-tests.log") || true
-            - cp tests/valgrind-share-tests.log artifacts/
-            - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}
+              --cmd "bash -c 'set -o pipefail; TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee valgrind-share-tests.log'")

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -51,5 +51,10 @@ blocks:
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee valgrind-share-tests.log") || true
+            - echo "=== Valgrind log written by tee to tests/valgrind-share-tests.log ==="
+            - ls -la tests/valgrind-share-tests.log
             - cp tests/valgrind-share-tests.log artifacts/
+            - echo "=== Copied to artifacts/ — contents staged for upload ==="
+            - ls -la artifacts/
+            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/valgrind/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -27,8 +27,6 @@ global_job_config:
       value: '7'
     - name: KAFKA_VERSION
       value: '4.2.0'
-    - name: CP_VERSION
-      value: '8.0.0'
 
 blocks:
   - name: 'Share consumer tests (Valgrind memcheck)'
@@ -48,13 +46,7 @@ blocks:
             - (cd tests && python3 -m trivup.clusters.KafkaCluster
               --kraft
               --version "${KAFKA_VERSION}"
-              --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
               --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee valgrind-share-tests.log") || true
-            - echo "=== Valgrind log written by tee to tests/valgrind-share-tests.log ==="
-            - ls -la tests/valgrind-share-tests.log
             - cp tests/valgrind-share-tests.log artifacts/
-            - echo "=== Copied to artifacts/ — contents staged for upload ==="
-            - ls -la artifacts/
-            - echo "=== Epilogue will push artifacts/ to Semaphore at artifacts/valgrind/ ==="
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -31,7 +31,7 @@ global_job_config:
       value: '8.0.0'
 
 blocks:
-  - name: 'Share consumer tests under valgrind (memcheck)'
+  - name: 'Share consumer tests (Valgrind memcheck)'
     dependencies: []
     task:
       agent:
@@ -42,7 +42,7 @@ blocks:
           commands:
             - artifact push workflow artifacts/ --destination artifacts/valgrind/
       jobs:
-        - name: 'Valgrind memcheck: TESTS_SKIP_BEFORE=0155'
+        - name: 'Share consumer suite (Valgrind memcheck)'
           commands:
             - cache restore trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG}
             - (cd tests && python3 -m trivup.clusters.KafkaCluster

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -12,16 +12,16 @@ global_job_config:
   prologue:
     commands:
       - checkout
+      - mkdir -p artifacts
       - '[[ -z "$GIT_REF" ]] || git checkout $GIT_REF'
       - sudo apt remove -y needrestart
       - sudo DEBIAN_FRONTEND=noninteractive apt install -y valgrind libcurl4-openssl-dev libssl-dev
       - python3 -m pip install -U pip
       - (cd tests && python3 -m pip install -r requirements.txt)
-      - ./configure --install-deps --enable-werror --enable-devel --disable-optimization
+      - ./configure --install-deps --enable-devel --disable-optimization
       - make -j all
       - make -j -C tests build
       - sem-version java 17
-      - mkdir -p artifacts
   env_vars:
     - name: CACHE_TAG
       value: '7'

--- a/.semaphore/run-valgrind-tests.yml
+++ b/.semaphore/run-valgrind-tests.yml
@@ -50,5 +50,6 @@ blocks:
               --version "${KAFKA_VERSION}"
               --cpversion "${CP_VERSION}"
               --conf '["group.share.min.record.lock.duration.ms=1000"]'
-              --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee ../artifacts/valgrind-share-tests.log") || true
+              --cmd "TESTS_SKIP_BEFORE=0155 ./run-test.sh valgrind 2>&1 | tee valgrind-share-tests.log") || true
+            - cp tests/valgrind-share-tests.log artifacts/
             - cache store trivup-kafka-${KAFKA_VERSION}-${CACHE_TAG} tests/tmp-KafkaCluster/KafkaCluster/KafkaBrokerApp/kafka/${KAFKA_VERSION}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -567,3 +567,9 @@ promotions:
             - "x86_64,aarch64"
             - "x86_64"
             - "aarch64"
+  - name: Run share consumer tests under ASAN+LSAN
+    pipeline_file: run-asan-tests.yml
+  - name: Run share consumer tests under TSAN
+    pipeline_file: run-tsan-tests.yml
+  - name: Run share consumer tests under valgrind
+    pipeline_file: run-valgrind-tests.yml

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -739,7 +739,7 @@ void rd_kafka_broker_fail(rd_kafka_broker_t *rkb,
                 }
                 rd_kafka_toppar_unlock(rktp);
 
-                /* TODO: rktp_leader_id and rktp_broker_id are read
+                /* TODO KIP-932: rktp_leader_id and rktp_broker_id are read
                  * here without holding rd_kafka_toppar_lock, but they are
                  * written under that lock by rd_kafka_toppar_leader_update
                  * on the main thread during metadata refresh.

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -739,6 +739,12 @@ void rd_kafka_broker_fail(rd_kafka_broker_t *rkb,
                 }
                 rd_kafka_toppar_unlock(rktp);
 
+                /* TODO: rktp_leader_id and rktp_broker_id are read
+                 * here without holding rd_kafka_toppar_lock, but they are
+                 * written under that lock by rd_kafka_toppar_leader_update
+                 * on the main thread during metadata refresh.
+                 * TSAN flags this in test 0179_share_consumer_destroy_local
+                 * during broker decommission. */
                 if (rktp->rktp_leader_id != rktp->rktp_broker_id) {
                         rd_kafka_toppar_delegate_to_leader(rktp);
                 } else if (rd_kafka_broker_termination_in_progress(rkb)) {

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -126,6 +126,11 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_q_t *rkcg_q;            /* Application poll queue */
         rd_kafka_q_t *rkcg_ops;          /* Manager ops queue */
         rd_kafka_q_t *rkcg_wait_coord_q; /* Ops awaiting coord */
+        /* TODO: rkcg_flags is written by the main thread (heartbeat
+         * builder/response handler) and read lock-free by the app thread on
+         * every poll via rd_kafka_app_polled(). TSAN flags this as a data
+         * race because the writer and reader are on different threads with
+         * no synchronization between them. */
         int rkcg_flags;
 #define RD_KAFKA_CGRP_F_TERMINATE 0x1 /* Terminate cgrp (async) */
 #define RD_KAFKA_CGRP_F_LEAVE_ON_UNASSIGN_DONE                                 \

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -126,7 +126,7 @@ typedef struct rd_kafka_cgrp_s {
         rd_kafka_q_t *rkcg_q;            /* Application poll queue */
         rd_kafka_q_t *rkcg_ops;          /* Manager ops queue */
         rd_kafka_q_t *rkcg_wait_coord_q; /* Ops awaiting coord */
-        /* TODO: rkcg_flags is written by the main thread (heartbeat
+        /* TODO KIP-932: rkcg_flags is written by the main thread (heartbeat
          * builder/response handler) and read lock-free by the app thread on
          * every poll via rd_kafka_app_polled(). TSAN flags this as a data
          * race because the writer and reader are on different threads with

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -48,8 +48,9 @@ VALGRIND_ARGS="--error-exitcode=3"
 # Enable vgdb on valgrind errors.
 #VALGRIND_ARGS="$VALGRIND_ARGS --vgdb-error=1"
 
-# Exit valgrind on first error
-VALGRIND_ARGS="$VALGRIND_ARGS --exit-on-first-error=yes"
+# Report all errors instead of stopping at the first one, so a leading
+# "still reachable" block (e.g. from OpenSSL) doesn't hide later real leaks.
+VALGRIND_ARGS="$VALGRIND_ARGS --exit-on-first-error=no"
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:../src:../src-cpp
 export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:../src:../src-cpp
@@ -62,7 +63,7 @@ for mode in $MODES; do
     case "$mode" in
 	valgrind)
 	    valgrind $VALGRIND_ARGS --leak-check=full --show-leak-kinds=all \
-		     --errors-for-leak-kinds=all \
+		     --errors-for-leak-kinds=definite,possible \
 		     --track-origins=yes \
                      --track-fds=yes \
 		     $SUPP $GEN_SUPP \


### PR DESCRIPTION
Adds three Semaphore CI pipelines that run the share consumer test suite
(tests 0155+) under runtime sanitizers and memory checkers, to catch
leaks, data races, and memory errors introduced by the KIP-932 work.

- **ASAN + LSAN** — `.semaphore/run-asan-tests.yml`
- **TSAN** — `.semaphore/run-tsan-tests.yml`
- **Valgrind (memcheck)** — `.semaphore/run-valgrind-tests.yml`