### PR TITLE
[KIP-932]: Modify close() API to send leave even when fatal error is set

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -1162,6 +1162,10 @@ static void rd_kafka_destroy_app(rd_kafka_t *rk, int flags) {
             "Terminate", "DestroyCalled", "Immediate", "NoConsumerClose", NULL};
 
         /* Fatal errors and _F_IMMEDIATE also sets .._NO_CONSUMER_CLOSE */
+        /* TODO KIP-932: Decide how destroy should behave when a fatal error
+         * is set: flush pending acks and send the share-session leave
+         * (as the explicit close() path does), or keep forcing
+         * NO_CONSUMER_CLOSE and skip those network calls. */
         if (flags & RD_KAFKA_DESTROY_F_IMMEDIATE ||
             rd_kafka_fatal_error_code(rk))
                 flags |= RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE;
@@ -5155,8 +5159,16 @@ static rd_kafka_error_t *rd_kafka_consumer_close_q(rd_kafka_t *rk,
         /* If a fatal error has been raised and this is an
          * explicit consumer_close() from the application we return
          * a fatal error. Otherwise let the "silent" no_consumer_close
-         * logic be performed to clean up properly. */
-        if (!rd_kafka_destroy_flags_no_consumer_close(rk) &&
+         * logic be performed to clean up properly.
+         *
+         * Share consumers are exempt: an explicit close() must still
+         * flush pending acks and send the share-session leave even when
+         * a fatal error is set. The destroy-after-fatal path is
+         * unaffected because it sets NO_CONSUMER_CLOSE (so the
+         * !no_consumer_close clause is already false there, and the cgrp
+         * terminate handler drops the acks regardless). */
+        if (!RD_KAFKA_IS_SHARE_CONSUMER(rk) &&
+            !rd_kafka_destroy_flags_no_consumer_close(rk) &&
             (error = rd_kafka_get_fatal_error(rk)))
                 return error;
 
@@ -5321,10 +5333,6 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare) {
                      NULL))
                 goto done;
 
-        /* TODO KIP-932: when a fatal error has been raised, check what the
-         * Java client does in the fatal-error case and decide whether we
-         * should still close the share session and send the leave-group
-         * heartbeat during consumer close. */
         rk                                = rkshare->rkshare_rk;
         rkshare->rkshare_consumer_closing = rd_true;
         error                             = rd_kafka_consumer_close0(rk);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -939,10 +939,6 @@ int rd_kafka_set_fatal_error0(rd_kafka_t *rk,
          * consumer error so it is returned from consumer_poll(),
          * while for all other client types (the producer) we propagate to
          * the standard error handler (typically error_cb). */
-        /* TODO KIP-932: when a fatal error has been raised, check what the
-         * Java client does in the fatal-error case and decide whether we
-         * should still close the share session and send the leave-group
-         * heartbeat during consumer close. */
         if (rk->rk_type == RD_KAFKA_CONSUMER && rk->rk_cgrp)
                 rd_kafka_consumer_err(
                     rk->rk_cgrp->rkcg_q, RD_KAFKA_NODEID_UA,

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -6071,6 +6071,25 @@ rd_kafka_cgrp_consumer_unsubscribe(rd_kafka_cgrp_t *rkcg,
          * When group is already leaving we just wait that previous
          * leave request finishes.
          */
+
+        /* TODO KIP-932: Revisit how the fatal-error case suppresses the
+         * leave heartbeat and consider simplifying it.
+         *
+         * Today, after a fatal error raised from the ShareGroupHeartbeat
+         * response handler, the leave is suppressed implicitly: that
+         * handler calls revoke_all_rejoin_maybe(), and because a fatal
+         * error code is now set, rebalance_op_incr() eventually sets
+         * rkcg_generation_id = 0 within the same op. So by the time the
+         * application observes the fatal error (via consume_batch) and calls
+         * close(), the member is back in join-state INIT with generation_id ==
+         * 0, hence HAS_JOINED below is false and no leave ShareGroupHeartbeat
+         * is sent.
+         *
+         * This works but is indirect and easy to break. Consider adding an
+         * explicit fatal-error guard here (as the Java client does) so the
+         * no-leave behaviour is stated directly rather than relying on the
+         * generation-id reset happening first.
+         */
         if (leave_group && !rd_kafka_cgrp_consumer_will_rejoin(rkcg) &&
             RD_KAFKA_CGRP_HAS_JOINED(rkcg) && !rd_kafka_cgrp_will_leave(rkcg)) {
                 rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_LEAVE_ON_UNASSIGN_DONE;

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -568,14 +568,11 @@ static void do_test_share_group_error_injection(void) {
                  rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 
-        /* Cleanup. Consumer is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. Consumer is in fatal state, but close() still flushes
+         * pending acks and leaves the share session, so it succeeds. */
         error = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(rd_kafka_error_code(error) ==
-                        RD_KAFKA_RESP_ERR_INVALID_REQUEST,
-                    "Expected close to return INVALID_REQUEST, got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        rd_kafka_error_destroy(error);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -1302,15 +1299,11 @@ static void do_test_group_authorization_failed_error(void) {
                  rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 
-        /* Cleanup. Consumer is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. Consumer is in fatal state, but close() still flushes
+         * pending acks and leaves the share session, so it succeeds. */
         error = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(rd_kafka_error_code(error) ==
-                        RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED,
-                    "Expected close to return GROUP_AUTHORIZATION_FAILED, "
-                    "got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        rd_kafka_error_destroy(error);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -1381,17 +1374,15 @@ static void do_test_group_max_size_reached_error(void) {
 
         rd_kafka_topic_partition_list_destroy(subscription);
 
-        /* Cleanup. share_c2 is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. share_c2 is in fatal state, but close() no longer
+         * early-returns the stored fatal error, so it succeeds. */
         test_share_consumer_close(share_c1);
         rd_kafka_error_t *c2_close_error =
             rd_kafka_share_consumer_close(share_c2);
-        TEST_ASSERT(rd_kafka_error_code(c2_close_error) ==
-                        RD_KAFKA_RESP_ERR_GROUP_MAX_SIZE_REACHED,
-                    "Expected share_c2 close to return "
-                    "GROUP_MAX_SIZE_REACHED, got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(c2_close_error)));
-        rd_kafka_error_destroy(c2_close_error);
+        TEST_ASSERT(!c2_close_error,
+                    "Expected share_c2 close to succeed, "
+                    "got %s",
+                    rd_kafka_error_name(c2_close_error));
         test_share_destroy(share_c1);
         test_share_destroy(share_c2);
 
@@ -2069,14 +2060,11 @@ static void do_test_group_id_not_found_while_stable_is_fatal(void) {
                  rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 
-        /* Cleanup. Consumer is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. Consumer is in fatal state, but close() still flushes
+         * pending acks and leaves the share session, so it succeeds. */
         error = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(rd_kafka_error_code(error) ==
-                        RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND,
-                    "Expected close to return GROUP_ID_NOT_FOUND, got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        rd_kafka_error_destroy(error);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -2137,14 +2125,11 @@ static void do_test_invalid_request_error(void) {
                  rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 
-        /* Cleanup. Consumer is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. Consumer is in fatal state, but close() still flushes
+         * pending acks and leaves the share session, so it succeeds. */
         error = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(rd_kafka_error_code(error) ==
-                        RD_KAFKA_RESP_ERR_INVALID_REQUEST,
-                    "Expected close to return INVALID_REQUEST, got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        rd_kafka_error_destroy(error);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);
@@ -2205,14 +2190,11 @@ static void do_test_unsupported_version_error(void) {
                  rd_kafka_error_string(error));
         rd_kafka_error_destroy(error);
 
-        /* Cleanup. Consumer is in fatal state, so close is expected
-         * to return the stored fatal error. */
+        /* Cleanup. Consumer is in fatal state, but close() still flushes
+         * pending acks and leaves the share session, so it succeeds. */
         error = rd_kafka_share_consumer_close(share_c);
-        TEST_ASSERT(rd_kafka_error_code(error) ==
-                        RD_KAFKA_RESP_ERR_UNSUPPORTED_VERSION,
-                    "Expected close to return UNSUPPORTED_VERSION, got %s",
-                    rd_kafka_err2name(rd_kafka_error_code(error)));
-        rd_kafka_error_destroy(error);
+        TEST_ASSERT(!error, "Expected close to succeed, got %s",
+                    rd_kafka_error_name(error));
         test_share_destroy(share_c);
 
         rd_kafka_mock_stop_request_tracking(mcluster);

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -1,0 +1,295 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, Confluent Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test.h"
+
+#include "../src/rdkafka_proto.h"
+
+#define CONSUME_ARRAY 1024
+
+/**
+ * @brief Create a share consumer connected to the mock cluster.
+ *
+ * @param ack_mode "implicit" or "explicit" (NULL for the default).
+ * @param cb_state Opaque ack-commit-callback state (NULL to skip the cb).
+ */
+static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
+                                               const char *group_id,
+                                               const char *ack_mode,
+                                               test_ack_cb_state_t *cb_state) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_share_t *rkshare;
+        char errstr[512];
+
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "group.id", group_id);
+        if (ack_mode)
+                test_conf_set(conf, "share.acknowledgement.mode", ack_mode);
+        if (cb_state) {
+                rd_kafka_conf_set_share_acknowledgement_commit_cb(
+                    conf, test_share_ack_cb);
+                rd_kafka_conf_set_opaque(conf, cb_state);
+        }
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer: %s",
+                    errstr);
+
+        return rkshare;
+}
+
+/**
+ * @brief No more records after the first fatal error, even when records
+ *        are available on the broker.
+ *
+ * 1. Create a topic. Produce 10 messages.
+ * 2. Consume them via consume_batch (implicit ack).
+ * 3. Inject a fatal error (GROUP_AUTHORIZATION_FAILED) on the next
+ *    ShareGroupHeartbeat and poll consume_batch until the fatal error
+ *    surfaces. No records are available, so every call returns zero.
+ * 4. Produce 10 more messages: these are now available on the broker.
+ * 5. Every consume_batch call must still return zero records, since the
+ *    consumer is in a fatal state.
+ * 6. Close and destroy the consumer.
+ */
+static void do_test_no_records_after_fatal_error(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *subscription;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        const char *group = "sg-0186-no-records-after-fatal";
+        const rd_kafka_resp_err_t fatal_err =
+            RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED;
+        const int msgcnt = 10;
+        int consumed;
+        int attempts;
+        rd_bool_t got_fatal = rd_false;
+        int i;
+
+        SUB_TEST_QUICK();
+
+        /* 1. Setup mock cluster and a topic, produce 10 messages. */
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(mcluster, 1);
+
+        test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 16,
+                                 "bootstrap.servers", bootstraps, NULL);
+
+        /* Create the share consumer (implicit ack) and subscribe. */
+        rkshare = create_share_consumer(bootstraps, group, "implicit", NULL);
+        subscription = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subscription, topic,
+                                          RD_KAFKA_PARTITION_UA);
+        rd_kafka_share_subscribe(rkshare, subscription);
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        /* 2. Consume all messages (implicit ack). */
+        consumed = test_share_consume_msgs(rkshare, msgcnt, 30, 3000, NULL, 0);
+        TEST_ASSERT(consumed == msgcnt, "expected %d consumed, got %d", msgcnt,
+                    consumed);
+
+        /* 3. Inject the fatal error on the next ShareGroupHeartbeat and poll
+         *    until it surfaces via consume_batch. No records are available
+         *    yet, so every call must return zero records. */
+        TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
+                        mcluster, 1, RD_KAFKAP_ShareGroupHeartbeat, 1,
+                        fatal_err, 0) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push fatal error on ShareGroupHeartbeat");
+
+        attempts = 0;
+        while (attempts++ < 50) {
+                size_t rcvd = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
+                                                     &rcvd);
+                TEST_ASSERT(rcvd == 0,
+                            "no records expected while waiting for the fatal "
+                            "error, got %d",
+                            (int)rcvd);
+                if (error) {
+                        TEST_ASSERT(rd_kafka_error_is_fatal(error),
+                                    "expected a fatal error, got non-fatal %s",
+                                    rd_kafka_error_name(error));
+                        TEST_ASSERT(rd_kafka_error_code(error) == fatal_err,
+                                    "expected fatal %s, got %s",
+                                    rd_kafka_err2name(fatal_err),
+                                    rd_kafka_error_name(error));
+                        rd_kafka_error_destroy(error);
+                        got_fatal = rd_true;
+                        break;
+                }
+        }
+        TEST_ASSERT(got_fatal,
+                    "expected a fatal error to surface within timeout");
+
+        /* 4. Produce more messages: they are now available on the broker. */
+        test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 16,
+                                 "bootstrap.servers", bootstraps, NULL);
+
+        /* 5. Every subsequent consume_batch call must keep returning zero
+         *    records, even though new messages are available. */
+        for (i = 0; i < 10; i++) {
+                size_t rcvd = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
+                                                     &rcvd);
+                TEST_ASSERT(rcvd == 0,
+                            "expected 0 records on post-fatal call %d, got %d",
+                            i, (int)rcvd);
+                if (error)
+                        rd_kafka_error_destroy(error);
+        }
+
+        /* 6. Close and destroy. */
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief close() flushes acks and leaves the share session even when a
+ *        fatal error is already set.
+ *
+ * 1. Create a 1-partition topic and produce 10 messages.
+ * 2. Consume at least one batch, breaking out as soon as records arrive.
+ * 3. Acknowledge (ACCEPT) every consumed record in explicit mode (the
+ *    acks are pending, not yet sent to the broker).
+ * 4. Set a fatal error on the underlying handle, then call close():
+ *    despite the fatal error, close() must still flush the pending
+ *    acknowledgements and leave the share session.
+ * 5. Destroy the consumer.
+ * 6. Verify the ack commit callback fired without any error, which
+ *    confirms the pending acks were flushed during close().
+ */
+static void do_test_close_flushes_acks_after_fatal_error(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *subscription;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_error_t *error;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        const char *group = "sg-0186-close-flushes-acks";
+        const int msgcnt  = 10;
+        test_ack_cb_state_t cb_state = {0};
+        rd_kafka_t *rk;
+        int consumed = 0;
+        int attempts = 0;
+
+        SUB_TEST_QUICK();
+
+        /* 1. Setup mock cluster and a topic, produce 10 messages. */
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        TEST_ASSERT(rd_kafka_mock_topic_create(mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+        rd_kafka_mock_sharegroup_set_auto_offset_reset(mcluster, 1);
+
+        test_produce_msgs_easy_v(topic, 0, 0, 0, msgcnt, 16,
+                                 "bootstrap.servers", bootstraps, NULL);
+
+        /* Create an explicit-ack share consumer with a commit callback. */
+        rkshare = create_share_consumer(bootstraps, group, "explicit",
+                                        &cb_state);
+        subscription = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subscription, topic,
+                                          RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(rkshare, subscription));
+        rd_kafka_topic_partition_list_destroy(subscription);
+
+        /* 2 & 3. Consume atmost one batch and acknowledge every record.
+         *        Break out as soon as we have received some records. */
+        while (consumed == 0 && attempts++ < 30) {
+                size_t rcvd = 0;
+                size_t j;
+                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                for (j = 0; j < rcvd; j++) {
+                        if (!rkmessages[j]->err) {
+                                TEST_CALL_ERR__(rd_kafka_share_acknowledge(
+                                    rkshare, rkmessages[j]));
+                                consumed++;
+                        }
+                        rd_kafka_message_destroy(rkmessages[j]);
+                }
+        }
+        TEST_ASSERT(consumed == 10, "expected to consume 10 records");
+        TEST_SAY("Consumed %d records\n", consumed);
+
+        /* 4. Set a fatal error, then close(): despite the fatal error,
+         *    close() must still flush the pending acks and leave the share
+         *    session. */
+        rk = test_share_consumer_get_rk(rkshare);
+        TEST_ASSERT(rd_kafka_test_fatal_error(
+                        rk, RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED,
+                        "injected fatal error") == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "failed to set fatal error");
+
+        error = rd_kafka_share_consumer_close(rkshare);
+        if (error)
+                rd_kafka_error_destroy(error);
+
+        /* 5. Destroy. */
+        test_share_destroy(rkshare);
+
+        /* 6. The ack commit callback must have fired without any error,
+         *    confirming the pending acks were flushed during close(). */
+        TEST_ASSERT(cb_state.callback_cnt > 0,
+                    "expected the ack commit callback to be invoked, got %d",
+                    cb_state.callback_cnt);
+        TEST_ASSERT(cb_state.last_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "expected ack callback with no error, got %s",
+                    rd_kafka_err2name(cb_state.last_err));
+        TEST_SAY("Ack callback invoked %d time(s), %zu offsets, err=%s\n",
+                 cb_state.callback_cnt, cb_state.total_offsets,
+                 rd_kafka_err2name(cb_state.last_err));
+
+        test_mock_cluster_destroy(mcluster);
+
+        SUB_TEST_PASS();
+}
+
+int main_0186_share_consumer_fatal_error(int argc, char **argv) {
+        TEST_SKIP_MOCK_CLUSTER(0);
+
+        do_test_no_records_after_fatal_error();
+        do_test_close_flushes_acks_after_fatal_error();
+
+        return 0;
+}

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -200,9 +200,9 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         rd_kafka_error_t *error;
-        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
-        const char *group = "sg-0186-close-flushes-acks";
-        const int msgcnt  = 10;
+        const char *topic            = test_mk_topic_name(__FUNCTION__, 0);
+        const char *group            = "sg-0186-close-flushes-acks";
+        const int msgcnt             = 10;
         test_ack_cb_state_t cb_state = {0};
         rd_kafka_t *rk;
         int consumed = 0;
@@ -221,8 +221,8 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
                                  "bootstrap.servers", bootstraps, NULL);
 
         /* Create an explicit-ack share consumer with a commit callback. */
-        rkshare = create_share_consumer(bootstraps, group, "explicit",
-                                        &cb_state);
+        rkshare =
+            create_share_consumer(bootstraps, group, "explicit", &cb_state);
         subscription = rd_kafka_topic_partition_list_new(1);
         rd_kafka_topic_partition_list_add(subscription, topic,
                                           RD_KAFKA_PARTITION_UA);

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -32,6 +32,12 @@
 
 #define CONSUME_ARRAY 1024
 
+static rd_bool_t is_share_heartbeat_request(rd_kafka_mock_request_t *request,
+                                            void *opaque) {
+        return rd_kafka_mock_request_api_key(request) ==
+               RD_KAFKAP_ShareGroupHeartbeat;
+}
+
 /**
  * @brief Create a share consumer connected to the mock cluster.
  *
@@ -51,15 +57,19 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
         test_conf_set(conf, "group.id", group_id);
         if (ack_mode)
                 test_conf_set(conf, "share.acknowledgement.mode", ack_mode);
-        if (cb_state) {
-                rd_kafka_conf_set_share_acknowledgement_commit_cb(
-                    conf, test_share_ack_cb);
-                rd_kafka_conf_set_opaque(conf, cb_state);
-        }
 
         rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(rkshare != NULL, "Failed to create share consumer: %s",
                     errstr);
+
+        if (cb_state) {
+                rd_kafka_error_t *cb_err =
+                    rd_kafka_share_set_acknowledgement_commit_cb(
+                        rkshare, test_share_ack_cb, cb_state);
+                TEST_ASSERT(cb_err == NULL,
+                            "Failed to set ack commit callback: %s",
+                            rd_kafka_error_string(cb_err));
+        }
 
         return rkshare;
 }
@@ -179,19 +189,23 @@ static void do_test_no_records_after_fatal_error(void) {
 }
 
 /**
- * @brief close() flushes acks and leaves the share session even when a
- *        fatal error is already set.
+ * @brief close() flushes pending acks but does NOT send a share-group
+ *        leave heartbeat when a fatal error was raised naturally.
+ *
+ * When a fatal error arises from the ShareGroupHeartbeat path the member
+ * is no longer in a state to leave the group, so close() must not send a
+ * leaving ShareGroupHeartbeat. It must still flush the pending
+ * acknowledgements (so the ack commit callback fires without error).
  *
  * 1. Create a 1-partition topic and produce 10 messages.
- * 2. Consume at least one batch, breaking out as soon as records arrive.
- * 3. Acknowledge (ACCEPT) every consumed record in explicit mode (the
- *    acks are pending, not yet sent to the broker).
- * 4. Set a fatal error on the underlying handle, then call close():
- *    despite the fatal error, close() must still flush the pending
- *    acknowledgements and leave the share session.
- * 5. Destroy the consumer.
- * 6. Verify the ack commit callback fired without any error, which
- *    confirms the pending acks were flushed during close().
+ * 2. Consume at least one batch (explicit ack), acknowledging every
+ *    record so the acks are pending (not yet sent to the broker).
+ * 3. Inject GROUP_AUTHORIZATION_FAILED on the next ShareGroupHeartbeat
+ *    and wait for a heartbeat so the fatal error is raised naturally.
+ * 4. Poll consume_batch until the fatal error surfaces.
+ * 5. Start request tracking, then call close().
+ * 6. Assert NO ShareGroupHeartbeat (leave) request is sent during close.
+ * 7. Destroy, and verify the ack commit callback fired without error.
  */
 static void do_test_close_flushes_acks_after_fatal_error(void) {
         rd_kafka_mock_cluster_t *mcluster;
@@ -200,13 +214,16 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         rd_kafka_topic_partition_list_t *subscription;
         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         rd_kafka_error_t *error;
-        const char *topic            = test_mk_topic_name(__FUNCTION__, 0);
-        const char *group            = "sg-0186-close-flushes-acks";
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        const char *group = "sg-0186-close-no-leave-after-fatal";
+        const rd_kafka_resp_err_t fatal_err =
+            RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED;
         const int msgcnt             = 10;
         test_ack_cb_state_t cb_state = {0};
-        rd_kafka_t *rk;
-        int consumed = 0;
-        int attempts = 0;
+        int heartbeats_after_close;
+        int consumed        = 0;
+        int attempts        = 0;
+        rd_bool_t got_fatal = rd_false;
 
         SUB_TEST_QUICK();
 
@@ -229,8 +246,8 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         TEST_CALL_ERR__(rd_kafka_share_subscribe(rkshare, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
-        /* 2 & 3. Consume atmost one batch and acknowledge every record.
-         *        Break out as soon as we have received some records. */
+        /* 2. Consume at least one batch and acknowledge every record.
+         *    Break out as soon as we have received some records. */
         while (consumed == 0 && attempts++ < 30) {
                 size_t rcvd = 0;
                 size_t j;
@@ -249,37 +266,76 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
                         rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
-        TEST_ASSERT(consumed == 10, "expected to consume 10 records");
-        TEST_SAY("Consumed %d records\n", consumed);
+        TEST_ASSERT(consumed > 0, "expected to consume and ack > 0 records");
+        TEST_SAY("Consumed and acknowledged %d records\n", consumed);
 
-        /* 4. Set a fatal error, then close(): despite the fatal error,
-         *    close() must still flush the pending acks and leave the share
-         *    session. */
-        rk = test_share_consumer_get_rk(rkshare);
-        TEST_ASSERT(rd_kafka_test_fatal_error(
-                        rk, RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED,
-                        "injected fatal error") == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "failed to set fatal error");
+        /* 3. Inject the fatal error on the next ShareGroupHeartbeat so the
+         *    fatal error gets raised naturally. */
+        TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
+                        mcluster, 1, RD_KAFKAP_ShareGroupHeartbeat, 1,
+                        fatal_err, 0) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push fatal error on ShareGroupHeartbeat");
+
+        /* 4. Poll consume_batch until the fatal error surfaces. The fatal
+         *    error is delivered only after a heartbeat has hit the injected
+         *    error and the cgrp has processed it (revoking the assignment
+         *    and resetting the generation id), so this loop also serves as
+         *    the synchronization point for that handling. */
+        attempts = 0;
+        while (attempts++ < 50) {
+                size_t rcvd = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
+                                                     &rcvd);
+                if (error) {
+                        TEST_ASSERT(rd_kafka_error_is_fatal(error),
+                                    "expected a fatal error, got non-fatal %s",
+                                    rd_kafka_error_name(error));
+                        rd_kafka_error_destroy(error);
+                        got_fatal = rd_true;
+                        break;
+                }
+        }
+        TEST_ASSERT(got_fatal,
+                    "expected a fatal error to surface within timeout");
+
+        /* 5. Reset the tracked-request baseline (start_request_tracking
+         *    clears the list), then close(). */
+        rd_kafka_mock_start_request_tracking(mcluster);
 
         error = rd_kafka_share_consumer_close(rkshare);
         if (error)
                 rd_kafka_error_destroy(error);
 
-        /* 5. Destroy. */
+        /* 6. No leaving ShareGroupHeartbeat must be sent during close. The
+         *    natural fatal handling already revoked the assignment and reset
+         *    the generation id (HAS_JOINED is false), so the group-leave path
+         *    is skipped. (The share session is still closed, but via a
+         *    ShareAcknowledge with epoch=-1, not a ShareGroupHeartbeat.) */
+        heartbeats_after_close = (int)test_mock_get_matching_request_cnt(
+            mcluster, is_share_heartbeat_request, NULL);
+
+        rd_kafka_mock_stop_request_tracking(mcluster);
+
+        /* 7. Destroy and verify the ack commit callback fired without error,
+         *    confirming the pending acks were flushed during close(). */
         test_share_destroy(rkshare);
 
-        /* 6. The ack commit callback must have fired without any error,
-         *    confirming the pending acks were flushed during close(). */
+        TEST_ASSERT(heartbeats_after_close == 0,
+                    "expected no ShareGroupHeartbeat during close, got %d",
+                    heartbeats_after_close);
         TEST_ASSERT(cb_state.callback_cnt > 0,
                     "expected the ack commit callback to be invoked, got %d",
                     cb_state.callback_cnt);
-        TEST_ASSERT(cb_state.last_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+        rd_kafka_resp_err_t cb_first_err =
+            test_ack_cb_state_first_err(&cb_state);
+        TEST_ASSERT(cb_first_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "expected ack callback with no error, got %s",
-                    rd_kafka_err2name(cb_state.last_err));
+                    rd_kafka_err2name(cb_first_err));
         TEST_SAY("Ack callback invoked %d time(s), %zu offsets, err=%s\n",
                  cb_state.callback_cnt, cb_state.total_offsets,
-                 rd_kafka_err2name(cb_state.last_err));
+                 rd_kafka_err2name(cb_first_err));
 
+        test_ack_cb_state_destroy(&cb_state);
         test_mock_cluster_destroy(mcluster);
 
         SUB_TEST_PASS();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -164,6 +164,7 @@ set(
     0183-share_consumer_leader_change_mock.c
     0184-share_consumer_topic_recreate.c
     0185-share_consumer_max_poll_interval.c
+    0186-share_consumer_fatal_error.c
     0190-share_consumer_telemetry.c
     8000-idle.cpp
     8001-fetch_from_follower_mock_manual.c

--- a/tests/test.c
+++ b/tests/test.c
@@ -312,6 +312,7 @@ _TEST_DECL(0183_share_consumer_leader_change_mock);
 _TEST_DECL(0184_share_consumer_topic_recreate);
 _TEST_DECL(0184_share_consumer_topic_recreate_local);
 _TEST_DECL(0185_share_consumer_max_poll_interval);
+_TEST_DECL(0186_share_consumer_fatal_error);
 _TEST_DECL(0190_share_consumer_telemetry);
 
 /* Manual tests */
@@ -607,6 +608,7 @@ struct test tests[] = {
     _TEST(0184_share_consumer_topic_recreate, 0, TEST_BRKVER(4, 2, 0, 0)),
     _TEST(0184_share_consumer_topic_recreate_local, TEST_F_LOCAL),
     _TEST(0185_share_consumer_max_poll_interval, 0, TEST_BRKVER(4, 2, 0, 0)),
+        _TEST(0186_share_consumer_fatal_error, TEST_F_LOCAL),
     _TEST(0190_share_consumer_telemetry,
           TEST_F_MANUAL,
           TEST_BRKVER(4, 2, 0, 0)),

--- a/tests/test.c
+++ b/tests/test.c
@@ -608,7 +608,7 @@ struct test tests[] = {
     _TEST(0184_share_consumer_topic_recreate, 0, TEST_BRKVER(4, 2, 0, 0)),
     _TEST(0184_share_consumer_topic_recreate_local, TEST_F_LOCAL),
     _TEST(0185_share_consumer_max_poll_interval, 0, TEST_BRKVER(4, 2, 0, 0)),
-        _TEST(0186_share_consumer_fatal_error, TEST_F_LOCAL),
+    _TEST(0186_share_consumer_fatal_error, TEST_F_LOCAL),
     _TEST(0190_share_consumer_telemetry,
           TEST_F_MANUAL,
           TEST_BRKVER(4, 2, 0, 0)),

--- a/win32/tests/tests.vcxproj
+++ b/win32/tests/tests.vcxproj
@@ -257,6 +257,7 @@
     <ClCompile Include="..\..\tests\0183-share_consumer_leader_change_mock.c" />
     <ClCompile Include="..\..\tests\0184-share_consumer_topic_recreate.c" />
     <ClCompile Include="..\..\tests\0185-share_consumer_max_poll_interval.c" />
+    <ClCompile Include="..\..\tests\0186-share_consumer_fatal_error.c" />
     <ClCompile Include="..\..\tests\0190-share_consumer_telemetry.c" />
     <ClCompile Include="..\..\tests\8000-idle.cpp" />
     <ClCompile Include="..\..\tests\8001-fetch_from_follower_mock_manual.c" />


### PR DESCRIPTION
1. Currently if close() is called after a fatal error has been set, close() would return early to return the same fatal error. This behaviour is different from Java's Share consumer where session leave request is sent even if fatal error has been returned earlier. This PR modifies close() API to mimic Java's behaviour.

2. Destroy() API is untouched and a TODO is added to evalute it later.

3. Test cases have been added to verify fatal error handling in consume_batch and close.
