### PR TITLE
[KIP-932]: Add subscription gaurd while polling

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3034,6 +3034,10 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
         rkshare->rkshare_unacked_cnt      = 0;
         rkshare->rkshare_consumer_closing = rd_false;
 
+        /**
+         * TODO KIP-932: Check for uniform naming structure for all
+         * share consumer variables.
+         */
         rk->rk_share_consumer.share_acknowledgement_commit_cb      = NULL;
         rk->rk_share_consumer.acknowledgement_commit_cb_opaque     = NULL;
         rk->rk_share_consumer.in_callback                          = rd_false;

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3882,10 +3882,10 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                 goto done;
 
         /* Fail early if no subscription is active.
-         * RD_KAFKA_CGRP_F_SUBSCRIPTION is set by cgrp_subscription_set
-         * only when the subscription list is non-NULL, and cleared on
-         * unsubscribe or subscribe with an empty topic list. */
-        if (unlikely(!(rkcg->rkcg_flags & RD_KAFKA_CGRP_F_SUBSCRIPTION))) {
+         * rkshare_subscribed is app-thread-owned and set/cleared by
+         * rd_kafka_share_subscribe / rd_kafka_share_unsubscribe under
+         * the same rkshare_acquire/release lock that guards this call. */
+        if (unlikely(!rkshare->rkshare_subscribed)) {
                 error = rd_kafka_error_new(
                     RD_KAFKA_RESP_ERR__STATE,
                     "Consumer is not subscribed to any topics");

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3881,6 +3881,17 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
         if (error)
                 goto done;
 
+        /* Fail early if no subscription is active.
+         * RD_KAFKA_CGRP_F_SUBSCRIPTION is set by cgrp_subscription_set
+         * only when the subscription list is non-NULL, and cleared on
+         * unsubscribe or subscribe with an empty topic list. */
+        if (unlikely(!(rkcg->rkcg_flags & RD_KAFKA_CGRP_F_SUBSCRIPTION))) {
+                error = rd_kafka_error_new(
+                    RD_KAFKA_RESP_ERR__STATE,
+                    "Consumer is not subscribed to any topics");
+                goto done;
+        }
+
         ack_batches = rd_kafka_share_build_ack_details(rk->rk_rkshare);
 
         has_records      = rd_kafka_q_len(rkcg->rkcg_q) > 0;

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5115,37 +5115,31 @@ RD_EXPORT rd_kafka_error_t *rd_kafka_consumer_group_metadata_read(
  *    internal rkshare_rk to be present.
  */
 /**
- * @brief Subscribe to topic set using balanced consumer groups.
+ * @brief Subscribe a share consumer to a set of topics.
  *
- * Wildcard (regex) topics are not supported.
+ * Wildcard (regex) topics are not supported. Only the \c .topic field
+ * is used in \p topics; all other fields are ignored.
  *
- * @remark Only the \c .topic field is used in the supplied \p topics list,
- *         all other fields are ignored.
- *
- * @remark subscribe() is an asynchronous method which returns immediately:
- *         background threads will (re)join the group, wait for group rebalance,
- *         issue any registered rebalance_cb, assign() the assigned partitions,
- *         and then start fetching messages.
- *
- * @remark After this call returns a consumer error will be returned by
- *         rd_kafka_consumer_poll (et.al) for each unavailable topic in the
- *         \p topics. The error will be RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART
- *         for non-existent topics, and
- *         RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED for unauthorized topics.
- *         The consumer error will be raised through rd_kafka_consumer_poll()
- *         (et.al.) with the \c rd_kafka_message_t.err field set to one of the
- *         error codes mentioned above.
- *         The subscribe function itself is asynchronous and will not return
- *         an error on unavailable topics.
- *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or
- *          RD_KAFKA_RESP_ERR__INVALID_ARG if list is empty, contains empty
- *          topic names, or duplicate entries,
- *          RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
+ * @remark This call is asynchronous and returns immediately. The background
+ *         thread sends a ShareGroupHeartbeat to the broker, which assigns
+ *         partitions to the consumer. Partition assignment is entirely
+ *         broker-driven; there is no client-side rebalance callback or
+ *         assign() step.
  *
  * @remark Topic names are forwarded verbatim to the broker via the share
- *         group heartbeat. The broker validates them and rejects invalid
- *         topic names.
+ *         group heartbeat. The broker validates them; unavailable or
+ *         unauthorized topics will surface as errors via
+ *         rd_kafka_share_consume_batch().
+ *
+ * @remark If \p topics is empty (cnt == 0), the call is equivalent to
+ *         rd_kafka_share_unsubscribe(): the subscription is cleared and
+ *         RD_KAFKA_RESP_ERR_NO_ERROR is returned.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or when \p topics is empty
+ *          (treated as unsubscribe),
+ *          RD_KAFKA_RESP_ERR__INVALID_ARG if \p topics contains empty topic
+ *          names or duplicate entries,
+ *          RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
  */
 RD_EXPORT rd_kafka_resp_err_t
 rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -890,6 +890,14 @@ struct rd_kafka_share_s {
          * while closing
          */
         rd_bool_t rkshare_consumer_closing;
+
+        /** True when the consumer has an active subscription (i.e.
+         *  rd_kafka_share_subscribe() succeeded with a non-empty list
+         *  and rd_kafka_share_unsubscribe() has not been called since).
+         *  Written only on the app thread under rkshare_acquire/release;
+         *  read only in consume_batch while the same lock is held.
+         *  @locality app thread */
+        rd_bool_t rkshare_subscribed;
 };
 
 #define rd_kafka_wrlock(rk)   rwlock_wrlock(&(rk)->rk_lock)

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -981,6 +981,9 @@ rd_kafka_share_acknowledge_offset0(rd_kafka_share_t *rkshare,
         int64_t idx;
         rd_kafka_resp_err_t err;
 
+        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
+                return err;
+
         if (!topic || partition < 0 || offset < 0)
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
 
@@ -992,9 +995,6 @@ rd_kafka_share_acknowledge_offset0(rd_kafka_share_t *rkshare,
         if (type < RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT ||
             type > RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT)
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
-
-        if (unlikely((err = rd_kafka_share_consumer_closed_err(rkshare))))
-                return err;
 
         /* Find partition and entry containing the offset */
         err = rd_kafka_share_find_ack_entry(rkshare, topic, partition, offset,
@@ -1023,11 +1023,11 @@ rd_kafka_share_acknowledge_type(rd_kafka_share_t *rkshare,
                                 const rd_kafka_message_t *rkmessage,
                                 rd_kafka_share_AcknowledgeType_t type) {
         rd_kafka_resp_err_t err;
-        rd_kafka_error_t *acq_err = NULL;
+        rd_kafka_error_t *error = NULL;
 
-        if (unlikely((acq_err = rd_kafka_share_acquire(rkshare)) != NULL)) {
-                err = rd_kafka_error_code(acq_err);
-                rd_kafka_error_destroy(acq_err);
+        if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL)) {
+                err = rd_kafka_error_code(error);
+                rd_kafka_error_destroy(error);
                 return err;
         }
 
@@ -1057,11 +1057,11 @@ rd_kafka_share_acknowledge_offset(rd_kafka_share_t *rkshare,
                                   int64_t offset,
                                   rd_kafka_share_AcknowledgeType_t type) {
         rd_kafka_resp_err_t err;
-        rd_kafka_error_t *acq_err = NULL;
+        rd_kafka_error_t *error = NULL;
 
-        if (unlikely((acq_err = rd_kafka_share_acquire(rkshare)) != NULL)) {
-                err = rd_kafka_error_code(acq_err);
-                rd_kafka_error_destroy(acq_err);
+        if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL)) {
+                err = rd_kafka_error_code(error);
+                rd_kafka_error_destroy(error);
                 return err;
         }
 
@@ -1251,8 +1251,10 @@ void rd_kafka_share_dispatch_ack_callbacks(rd_kafka_t *rk,
         int k;
 
         /* Locality: main thread - checks runtime-set registration flag. */
-        if (!rk->rk_rkshare ||
-            !rk->rk_share_consumer.acknowledgement_commit_cb_registered ||
+        /**
+         * TODO KIP-932: Check if we want to send individual ops or 1 op.
+         */
+        if (!rk->rk_share_consumer.acknowledgement_commit_cb_registered ||
             !ack_details || rd_list_cnt(ack_details) == 0)
                 return;
 

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -48,15 +48,15 @@ rd_kafka_resp_err_t rd_kafka_unsubscribe(rd_kafka_t *rk) {
 
 rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare) {
         rd_kafka_resp_err_t err;
-        rd_kafka_error_t *acq_err = NULL;
+        rd_kafka_error_t *error = NULL;
 
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely((acq_err = rd_kafka_share_acquire(rkshare)) != NULL)) {
-                err = rd_kafka_error_code(acq_err);
-                rd_kafka_error_destroy(acq_err);
+        if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL)) {
+                err = rd_kafka_error_code(error);
+                rd_kafka_error_destroy(error);
                 return err;
         }
 
@@ -142,15 +142,15 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
         rd_kafka_cgrp_t *rkcg;
         rd_kafka_topic_partition_list_t *topics_cpy;
         rd_kafka_resp_err_t err;
-        rd_kafka_error_t *acq_err = NULL;
+        rd_kafka_error_t *error = NULL;
 
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely((acq_err = rd_kafka_share_acquire(rkshare)) != NULL)) {
-                err = rd_kafka_error_code(acq_err);
-                rd_kafka_error_destroy(acq_err);
+        if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL)) {
+                err = rd_kafka_error_code(error);
+                rd_kafka_error_destroy(error);
                 return err;
         }
 
@@ -191,6 +191,12 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
 
         err = rd_kafka_op_err_destroy(
             rd_kafka_op_req(rkcg->rkcg_ops, rko, RD_POLL_INFINITE));
+        /**
+         * TODO KIP-932: It can only return FATAL error from the main thread.
+         * In which case it unsubscribes. Check if we should change the flag
+         * to false when FATAL error is received or  keep it as true which
+         * will let the user go through the normal consumer flow.
+         */
         if (!err)
                 rkshare->rkshare_subscribed = rd_true;
 done:
@@ -363,15 +369,15 @@ rd_kafka_resp_err_t
 rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
                             rd_kafka_topic_partition_list_t **topics) {
         rd_kafka_resp_err_t err;
-        rd_kafka_error_t *acq_err = NULL;
+        rd_kafka_error_t *error = NULL;
 
         /**
          * TODO KIP-932: Guard this with checks for rkshare and
          *               rkshare->rkshare_rk?
          */
-        if (unlikely((acq_err = rd_kafka_share_acquire(rkshare)) != NULL)) {
-                err = rd_kafka_error_code(acq_err);
-                rd_kafka_error_destroy(acq_err);
+        if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL)) {
+                err = rd_kafka_error_code(error);
+                rd_kafka_error_destroy(error);
                 return err;
         }
 

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -160,11 +160,17 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
                 goto done;
         }
 
+        /* An empty topic list is equivalent to unsubscribe. */
+        if (topics->cnt == 0) {
+                err = rd_kafka_share_unsubscribe(rkshare);
+                goto done;
+        }
+
         /* Share consumer subscriptions are literal topic names only:
-         * regex/wildcard entries are not supported. Reject empty entries;
-         * pass everything else through to the broker via the heartbeat. */
-        if (topics->cnt == 0 ||
-            rd_kafka_topic_partition_list_sum(topics, _share_invalid_topic_cb,
+         * regex/wildcard entries are not supported. Reject empty
+         * entries; pass everything else through to the broker via the
+         * heartbeat. */
+        if (rd_kafka_topic_partition_list_sum(topics, _share_invalid_topic_cb,
                                               NULL) > 0) {
                 err = RD_KAFKA_RESP_ERR__INVALID_ARG;
                 goto done;

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -64,6 +64,8 @@ rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare) {
                 goto done;
 
         err = rd_kafka_unsubscribe(rkshare->rkshare_rk);
+        if (!err)
+                rkshare->rkshare_subscribed = rd_false;
 done:
         rd_kafka_share_release(rkshare);
         return err;
@@ -189,6 +191,8 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
 
         err = rd_kafka_op_err_destroy(
             rd_kafka_op_req(rkcg->rkcg_ops, rko, RD_POLL_INFINITE));
+        if (!err)
+                rkshare->rkshare_subscribed = rd_true;
 done:
         rd_kafka_share_release(rkshare);
         return err;

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -2625,11 +2625,9 @@ static void do_test_empty_topic_subscription(void) {
 
 
 /**
- * @brief Empty topic list subscription returns INVALID_ARG.
- *
- * librdkafka intentionally rejects subscribe() with an empty topic list,
- * unlike Java which treats it as unsubscribe(). This is an intentional
- * difference (see sghb_test_discrepancies.txt #1).
+ * @brief subscribe() with an empty topic list is equivalent to
+ *        unsubscribe() — must return NO_ERROR and leave the consumer
+ *        in the unsubscribed state.
  */
 static void do_test_empty_topic_list_subscription(void) {
         rd_kafka_mock_cluster_t *mcluster;
@@ -2645,16 +2643,14 @@ static void do_test_empty_topic_list_subscription(void) {
 
         share_c = create_share_consumer(bootstraps, group);
 
-        /* Subscribe with empty topic list - should return INVALID_ARG */
+        /* subscribe(empty_list) must succeed and act as unsubscribe. */
         empty_list = rd_kafka_topic_partition_list_new(0);
         err        = rd_kafka_share_subscribe(share_c, empty_list);
-        TEST_ASSERT(err == RD_KAFKA_RESP_ERR__INVALID_ARG,
-                    "Expected INVALID_ARG from subscribe(empty_list), got %s",
+        TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Expected NO_ERROR from subscribe(empty_list), got %s",
                     rd_kafka_err2str(err));
-        TEST_SAY("subscribe(empty_list) correctly returned %s\n",
-                 rd_kafka_err2str(err));
-
         rd_kafka_topic_partition_list_destroy(empty_list);
+
         test_share_destroy(share_c);
 
         test_mock_cluster_destroy(mcluster);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -73,6 +73,8 @@ typedef enum {
                                */
         TEST_OP_SUBSCRIBE_EXISTING, /**< Subscribe to already created topics */
         TEST_OP_PRODUCE_TO_TOPIC,   /**< Produce to specific topic index */
+        TEST_OP_SUBSCRIBE_EMPTY,    /**< Subscribe with empty list (==
+                                     unsubscribe) */
 } test_op_type_t;
 
 /**
@@ -189,6 +191,8 @@ typedef struct {
         { .op = TEST_OP_SUBSCRIBE_EXISTING, .repeat_cnt = 1 }
 #define POLL_NO_SUB()                                                          \
         { .op = TEST_OP_POLL_NO_SUB }
+#define SUBSCRIBE_EMPTY()                                                      \
+        { .op = TEST_OP_SUBSCRIBE_EMPTY }
 #define TEST_OPS_END()                                                         \
         { .op = TEST_OP_END }
 
@@ -415,6 +419,26 @@ static void exec_unsubscribe(sub_test_state_t *state, const test_op_t *op) {
 }
 
 /**
+ * @brief Execute TEST_OP_SUBSCRIBE_EMPTY
+ *
+ * Subscribe with an empty topic list is equivalent to unsubscribe:
+ * must return NO_ERROR and clear the subscription flag.
+ */
+static void exec_subscribe_empty(sub_test_state_t *state, const test_op_t *op) {
+        rd_kafka_topic_partition_list_t *tlist;
+        int cidx = op->consumer_idx;
+
+        TEST_SAY("  SUBSCRIBE_EMPTY: consumer=%d\n", cidx);
+
+        tlist = rd_kafka_topic_partition_list_new(0);
+        TEST_CALL_ERR__(
+            rd_kafka_share_subscribe(state->consumers[cidx], tlist));
+        rd_kafka_topic_partition_list_destroy(tlist);
+
+        state->sub_count[cidx] = 0;
+}
+
+/**
  * @brief Execute TEST_OP_PRODUCE
  */
 static void exec_produce(sub_test_state_t *state, const test_op_t *op) {
@@ -545,6 +569,9 @@ static void exec_create_consumer(sub_test_state_t *state, const test_op_t *op) {
 
 /**
  * @brief Execute TEST_OP_POLL_NO_SUB
+ *
+ * consume_batch must surface RD_KAFKA_RESP_ERR__STATE with a "not
+ * subscribed" message when no subscription is active.
  */
 static void exec_poll_no_sub(sub_test_state_t *state, const test_op_t *op) {
         rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
@@ -556,9 +583,19 @@ static void exec_poll_no_sub(sub_test_state_t *state, const test_op_t *op) {
 
         err = rd_kafka_share_consume_batch(state->consumers[cidx], 2000, batch,
                                            &rcvd);
-        /* TODO KIP-932: Should return error */
-        if (err)
-                rd_kafka_error_destroy(err);
+        TEST_ASSERT(err != NULL,
+                    "POLL_NO_SUB consumer=%d: expected error, got NULL", cidx);
+        TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
+                    "POLL_NO_SUB consumer=%d: expected __STATE, got: %s", cidx,
+                    rd_kafka_err2name(rd_kafka_error_code(err)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(err), "not subscribed"),
+                    "POLL_NO_SUB consumer=%d: expected 'not subscribed' "
+                    "substring, got: %s",
+                    cidx, rd_kafka_error_string(err));
+        TEST_ASSERT(rcvd == 0,
+                    "POLL_NO_SUB consumer=%d: expected 0 messages, got %zu",
+                    cidx, rcvd);
+        rd_kafka_error_destroy(err);
 }
 
 /**
@@ -664,6 +701,9 @@ static void do_test_scenario(const test_scenario_t *scenario) {
                         break;
                 case TEST_OP_POLL_NO_SUB:
                         exec_poll_no_sub(&state, op);
+                        break;
+                case TEST_OP_SUBSCRIBE_EMPTY:
+                        exec_subscribe_empty(&state, op);
                         break;
                 default:
                         TEST_FAIL("Unknown operation: %d", op->op);
@@ -1482,6 +1522,143 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Verify consume_batch surfaces RD_KAFKA_RESP_ERR__STATE with
+ *        "not subscribed" when there is no active subscription.
+ *
+ * Walks the subscription state machine:
+ *   Case 1: never subscribed                     -> __STATE
+ *   Case 2: after subscribe                      -> not __STATE (recovery)
+ *   Case 3: after unsubscribe                    -> __STATE
+ *   Case 4: after re-subscribe following unsub   -> not __STATE (recovery)
+ *   Case 5: subscribe([]) (== unsubscribe)       -> __STATE
+ */
+static void do_test_consume_batch_without_subscription(void) {
+        rd_kafka_share_t *consumer;
+        rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_error_t *err;
+        size_t rcvd = 0;
+        size_t i;
+        const char *group = "share-no-subscription";
+        const char *topic;
+
+        SUB_TEST();
+
+        topic = test_mk_topic_name("0170-no-subscription", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+
+        consumer = test_create_share_consumer(group, NULL);
+
+        /* Case 1: never subscribed. */
+        rcvd = 0;
+        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        TEST_ASSERT(err != NULL,
+                    "Case 1 (never subscribed): expected error, got NULL");
+        TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
+                    "Case 1: expected __STATE, got: %s",
+                    rd_kafka_err2name(rd_kafka_error_code(err)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(err), "not subscribed"),
+                    "Case 1: expected 'not subscribed' substring, got: %s",
+                    rd_kafka_error_string(err));
+        TEST_ASSERT(rcvd == 0, "Case 1: expected 0 msgs, got %zu", rcvd);
+        rd_kafka_error_destroy(err);
+
+        /* Case 2: subscribed -> must not surface __STATE. */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        rcvd = 0;
+        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        if (err) {
+                TEST_ASSERT(rd_kafka_error_code(err) !=
+                                RD_KAFKA_RESP_ERR__STATE,
+                            "Case 2 (subscribed): unexpected __STATE: %s",
+                            rd_kafka_error_string(err));
+                rd_kafka_error_destroy(err);
+        }
+        for (i = 0; i < rcvd; i++)
+                rd_kafka_message_destroy(batch[i]);
+
+        /* Case 3: unsubscribed -> __STATE again. */
+        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
+
+        rcvd = 0;
+        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        TEST_ASSERT(err != NULL,
+                    "Case 3 (after unsubscribe): expected error, got NULL");
+        TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
+                    "Case 3: expected __STATE, got: %s",
+                    rd_kafka_err2name(rd_kafka_error_code(err)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(err), "not subscribed"),
+                    "Case 3: expected 'not subscribed' substring, got: %s",
+                    rd_kafka_error_string(err));
+        TEST_ASSERT(rcvd == 0, "Case 3: expected 0 msgs, got %zu", rcvd);
+        rd_kafka_error_destroy(err);
+
+        /* Case 4: re-subscribed after unsubscribe -> must not surface __STATE.
+         */
+        subs = rd_kafka_topic_partition_list_new(1);
+        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
+        TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
+        rd_kafka_topic_partition_list_destroy(subs);
+
+        rcvd = 0;
+        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        if (err) {
+                TEST_ASSERT(rd_kafka_error_code(err) !=
+                                RD_KAFKA_RESP_ERR__STATE,
+                            "Case 4 (re-subscribed): unexpected __STATE: %s",
+                            rd_kafka_error_string(err));
+                rd_kafka_error_destroy(err);
+        }
+        for (i = 0; i < rcvd; i++)
+                rd_kafka_message_destroy(batch[i]);
+
+        /* Case 5: subscribe([]) is equivalent to unsubscribe — must
+         * return NO_ERROR and clear the F_SUBSCRIPTION flag, so the
+         * next consume_batch returns __STATE. */
+        {
+                rd_kafka_resp_err_t empty_err;
+
+                subs      = rd_kafka_topic_partition_list_new(0);
+                empty_err = rd_kafka_share_subscribe(consumer, subs);
+                TEST_ASSERT(empty_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Case 5 (subscribe([])): expected NO_ERROR "
+                            "(treated as unsubscribe), got: %s",
+                            rd_kafka_err2name(empty_err));
+                rd_kafka_topic_partition_list_destroy(subs);
+        }
+
+        rcvd = 0;
+        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        TEST_ASSERT(err != NULL,
+                    "Case 5 (after subscribe([])): expected error, got NULL");
+        TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
+                    "Case 5: expected __STATE, got: %s",
+                    rd_kafka_err2name(rd_kafka_error_code(err)));
+        TEST_ASSERT(strstr(rd_kafka_error_string(err), "not subscribed"),
+                    "Case 5: expected 'not subscribed' substring, got: %s",
+                    rd_kafka_error_string(err));
+        TEST_ASSERT(rcvd == 0, "Case 5: expected 0 msgs, got %zu", rcvd);
+        rd_kafka_error_destroy(err);
+
+        test_share_consumer_close(consumer);
+        test_share_destroy(consumer);
+
+        SUB_TEST_PASS();
+}
+
+/* subscribe([]) is equivalent to unsubscribe — must clear the
+ * subscription flag so the subsequent poll surfaces __STATE. */
+static const test_scenario_t test_poll_after_empty_subscribe = {
+    .name = "poll-after-empty-subscribe",
+    .ops  = {SUBSCRIBE(1), PRODUCE(5), CONSUME_ANY(),
+             SUBSCRIBE_EMPTY(), /* Empty list == unsubscribe */
+             POLL_NO_SUB(), TEST_OPS_END()}};
+
 int main_0170_share_consumer_subscription(int argc, char **argv) {
         /* Create common handles for all tests */
         common_producer = test_create_producer();
@@ -1535,6 +1712,10 @@ int main_0170_share_consumer_subscription(int argc, char **argv) {
         /* Input validation tests */
         do_test_subscribe_input_validation();
         do_test_subscribe_caret_treated_as_literal_e2e();
+
+        /* Subscription state guard tests */
+        do_test_consume_batch_without_subscription();
+        do_test_scenario(&test_poll_after_empty_subscribe);
 
         /* Cleanup common handles */
         rd_kafka_destroy(common_admin);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -1620,17 +1620,15 @@ static void do_test_consume_batch_without_subscription(void) {
         /* Case 5: subscribe([]) is equivalent to unsubscribe — must
          * return NO_ERROR and clear the F_SUBSCRIPTION flag, so the
          * next consume_batch returns __STATE. */
-        {
-                rd_kafka_resp_err_t empty_err;
+        rd_kafka_resp_err_t empty_err;
 
-                subs      = rd_kafka_topic_partition_list_new(0);
-                empty_err = rd_kafka_share_subscribe(consumer, subs);
-                TEST_ASSERT(empty_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Case 5 (subscribe([])): expected NO_ERROR "
-                            "(treated as unsubscribe), got: %s",
-                            rd_kafka_err2name(empty_err));
-                rd_kafka_topic_partition_list_destroy(subs);
-        }
+        subs      = rd_kafka_topic_partition_list_new(0);
+        empty_err = rd_kafka_share_subscribe(consumer, subs);
+        TEST_ASSERT(empty_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "Case 5 (subscribe([])): expected NO_ERROR "
+                    "(treated as unsubscribe), got: %s",
+                    rd_kafka_err2name(empty_err));
+        rd_kafka_topic_partition_list_destroy(subs);
 
         rcvd = 0;
         err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2461,19 +2461,17 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
          * loop so the request happens after the share-assignment
          * heartbeat re-populates the partition list. */
         subscribe_one(rkshare, topic);
-        {
-                rd_bool_t saw_err = rd_false;
-                int outer;
-                for (outer = 0; outer < 10 && !saw_err; outer++) {
-                        share_topic_err_force_metadata(rkshare);
-                        if (share_topic_err_wait_for_err(
-                                rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 3))
-                                saw_err = rd_true;
-                }
-                TEST_ASSERT(saw_err,
-                            "TOPIC_EXCEPTION must surface again after "
-                            "re-subscribing to a still-failing topic");
+        rd_bool_t saw_err = rd_false;
+        int outer;
+        for (outer = 0; outer < 10 && !saw_err; outer++) {
+                share_topic_err_force_metadata(rkshare);
+                if (share_topic_err_wait_for_err(
+                        rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 3))
+                        saw_err = rd_true;
         }
+        TEST_ASSERT(saw_err,
+                    "TOPIC_EXCEPTION must surface again after "
+                    "re-subscribing to a still-failing topic");
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2451,13 +2451,10 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
                         rkshare, RD_KAFKA_RESP_ERR_TOPIC_EXCEPTION, 30),
                     "first TOPIC_EXCEPTION must surface");
 
-        /* Phase 2: unsubscribe. No surface. */
+        /* Phase 2: unsubscribe. */
         TEST_ASSERT(rd_kafka_share_unsubscribe(rkshare) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "unsubscribe");
-        share_topic_err_force_metadata(rkshare);
-        share_topic_err_assert_no_err(
-            rkshare, 5, "no error must surface while unsubscribed");
 
         /* Phase 3: re-subscribe to the same still-failing topic; the
          * error must surface again. Re-force metadata across the wait


### PR DESCRIPTION
Add subscription gaurd while polling
Treat empty list as unsubscribe instead of invalid arg (Java's parity)
Add tests to check the above behaviour