### PR TITLE
[KIP-848] Fix error handling in rebalance/heartbeat flow in `consumer` protocol

### DIFF
--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3313,6 +3313,12 @@ err:
                     RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED,
 
                     RD_KAFKA_ERR_ACTION_END);
+
+                if (actions & RD_KAFKA_ERR_ACTION_PERMANENT &&
+                    err >= RD_KAFKA_RESP_ERR_UNKNOWN) {
+                        actions |= RD_KAFKA_ERR_ACTION_FATAL;
+                }
+
                 break;
         }
 

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3295,6 +3295,7 @@ err:
         case RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE:
         case RD_KAFKA_RESP_ERR_UNRELEASED_INSTANCE_ID:
         case RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED:
+        case RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND:
                 actions = RD_KAFKA_ERR_ACTION_FATAL;
                 break;
         default:

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -3288,6 +3288,14 @@ err:
                     RD_KAFKA_CGRP_CONSUMER_F_WAIT_REJOIN;
                 return;
 
+        case RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND:
+                /* If the leave heartbeat has already been sent the member is
+                 * on its way out of the group, so a GROUP_ID_NOT_FOUND on a
+                 * still-in-flight regular heartbeat is expected and benign.
+                 * Otherwise the group is genuinely gone and this is fatal. */
+                if (rkcg->rkcg_flags & RD_KAFKA_CGRP_F_WAIT_LEAVE)
+                        return;
+                /* FALLTHRU */
         case RD_KAFKA_RESP_ERR_INVALID_REQUEST:
         case RD_KAFKA_RESP_ERR_GROUP_MAX_SIZE_REACHED:
         case RD_KAFKA_RESP_ERR_UNSUPPORTED_ASSIGNOR:
@@ -3295,7 +3303,6 @@ err:
         case RD_KAFKA_RESP_ERR__UNSUPPORTED_FEATURE:
         case RD_KAFKA_RESP_ERR_UNRELEASED_INSTANCE_ID:
         case RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED:
-        case RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND:
                 actions = RD_KAFKA_ERR_ACTION_FATAL;
                 break;
         default:

--- a/src/rdkafka_cgrp.c
+++ b/src/rdkafka_cgrp.c
@@ -5180,9 +5180,14 @@ rd_kafka_cgrp_max_poll_interval_check_tmr_cb(rd_kafka_timers_t *rkts,
                             1 /*lock*/);
 
         if (rkcg->rkcg_group_protocol == RD_KAFKA_GROUP_PROTOCOL_CONSUMER) {
-                rd_kafka_cgrp_consumer_leave(rkcg);
+                /* Do not send the leave heartbeat immediately: defer it until
+                 * the assignment has been revoked (F_LEAVE_ON_UNASSIGN_DONE).
+                 * Sending it now races the rejoin -- a fast leave reply runs
+                 * consumer_reset, clearing F_WAIT_REJOIN before the serve loop
+                 * acts on it, stranding the member at epoch 0. */
                 rkcg->rkcg_consumer_flags |=
                     RD_KAFKA_CGRP_CONSUMER_F_WAIT_REJOIN;
+                rkcg->rkcg_flags |= RD_KAFKA_CGRP_F_LEAVE_ON_UNASSIGN_DONE;
                 rd_kafka_cgrp_consumer_expedite_next_heartbeat(
                     rkcg,
                     "max poll interval "

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -2877,6 +2877,16 @@ rd_kafka_mock_handle_ConsumerGroupHeartbeat(rd_kafka_mock_connection_t *mconn,
                         err = RD_KAFKA_RESP_ERR_NOT_COORDINATOR;
         }
 
+        /* A member (re-)joining (MemberEpoch 0) must provide a
+         * RebalanceTimeoutMs and a subscription (topic names or regex),
+         * otherwise the coordinator rejects the request. This mirrors the
+         * broker-side validation and catches malformed (re-)join heartbeats. */
+        if (!err && MemberEpoch == 0 &&
+            (RebalanceTimeoutMs == -1 ||
+             (!SubscribedTopicNames &&
+              RD_KAFKAP_STR_IS_NULL(&SubscribedTopicRegex))))
+                err = RD_KAFKA_RESP_ERR_INVALID_REQUEST;
+
         if (!err) {
                 mtx_lock(&mcluster->lock);
                 mcgrp = rd_kafka_mock_cgrp_consumer_get(mcluster, &GroupId);

--- a/tests/0147-consumer_group_consumer_mock.c
+++ b/tests/0147-consumer_group_consumer_mock.c
@@ -296,7 +296,12 @@ static void do_test_consumer_group_heartbeat_fatal_errors(void) {
             RD_KAFKA_RESP_ERR_UNSUPPORTED_ASSIGNOR,
             RD_KAFKA_RESP_ERR_UNSUPPORTED_VERSION,
             RD_KAFKA_RESP_ERR_UNRELEASED_INSTANCE_ID,
-            RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED};
+            RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED,
+            /* Group no longer exists and the member is not leaving. */
+            RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND,
+            /* Unexpected broker-level error not handled explicitly: an
+             * unrecognized permanent error must be fatal, not ignored. */
+            RD_KAFKA_RESP_ERR_CLUSTER_AUTHORIZATION_FAILED};
         size_t i;
         test_variation_t j;
         for (i = 0; i < RD_ARRAY_SIZE(fatal_errors); i++) {
@@ -1147,6 +1152,103 @@ static void do_test_max_poll_interval_rejoin_consume(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief A GROUP_ID_NOT_FOUND received on a regular heartbeat that is still in
+ *        flight when the leave heartbeat has already been sent must be ignored
+ *        (the member is on its way out of the group), not turned into a fatal
+ *        error.
+ *
+ * The window is forced deterministically: the next regular heartbeat is
+ * answered with GROUP_ID_NOT_FOUND, but its response is held back with a large
+ * RTT. While it is in flight the consumer unsubscribes, which sends the leave
+ * heartbeat and enters the leaving state. The mock sends a connection's
+ * responses in order (head-of-line), so the delayed GROUP_ID_NOT_FOUND is
+ * processed before the leave response leaves the leaving state -- exercising
+ * the skip path. A regression treats it as fatal instead.
+ */
+static void do_test_group_id_not_found_while_leaving(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_t *c;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        rd_kafka_topic_partition_list_t *assignment = NULL;
+        rd_kafka_resp_err_t fatal_err;
+        char errstr[512];
+        int64_t deadline;
+        rd_kafka_message_t *rkm;
+        int found_heartbeats;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        rd_kafka_mock_set_group_consumer_heartbeat_interval_ms(mcluster, 500);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        c = create_consumer(bootstraps, topic, rd_false);
+        test_consumer_subscribe(c, topic);
+
+        TEST_SAY("Waiting for steady assignment\n");
+        deadline = test_clock() + 10 * 1000000;
+        while (test_clock() < deadline) {
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (rkm)
+                        rd_kafka_message_destroy(rkm);
+                if (!rd_kafka_assignment(c, &assignment) && assignment &&
+                    assignment->cnt > 0) {
+                        rd_kafka_topic_partition_list_destroy(assignment);
+                        assignment = NULL;
+                        break;
+                }
+                RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
+                assignment = NULL;
+        }
+        TEST_SAY("Steady assignment reached\n");
+
+        /* Answer the next regular heartbeat with GROUP_ID_NOT_FOUND, holding
+         * its response back long enough to land after the leave heartbeat is
+         * sent (which happens within milliseconds of unsubscribe) but well
+         * below the in-flight request timeout so the response is not discarded
+         * as a client-side timeout. While that heartbeat is in flight no
+         * further regular heartbeat is sent, so it is the one that will carry
+         * the error. */
+        rd_kafka_mock_start_request_tracking(mcluster);
+        rd_kafka_mock_broker_push_request_error_rtts(
+            mcluster, 1, RD_KAFKAP_ConsumerGroupHeartbeat, 1,
+            RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND, 500);
+
+        TEST_SAY("Driving the poisoned heartbeat in flight\n");
+        found_heartbeats = wait_all_heartbeats_done(mcluster, 1, 100);
+        TEST_ASSERT(found_heartbeats == 1, "Expected 1 heartbeat, got %d",
+                    found_heartbeats);
+
+        TEST_SAY("Unsubscribing while the heartbeat is in flight\n");
+        TEST_CALL_ERR__(rd_kafka_unsubscribe(c));
+
+        /* Poll past the RTT so the delayed GROUP_ID_NOT_FOUND is processed
+         * (must be skipped) followed by the leave response. */
+        deadline  = test_clock() + 4 * 1000000;
+        fatal_err = RD_KAFKA_RESP_ERR_NO_ERROR;
+        while (test_clock() < deadline) {
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (rkm)
+                        rd_kafka_message_destroy(rkm);
+                fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+                if (fatal_err)
+                        break;
+        }
+
+        TEST_ASSERT(!fatal_err,
+                    "GROUP_ID_NOT_FOUND while leaving must be ignored, but the "
+                    "consumer went fatal: %s: %s",
+                    rd_kafka_err2name(fatal_err), errstr);
+
+        rd_kafka_mock_stop_request_tracking(mcluster);
+        test_consumer_close(c);
+        rd_kafka_destroy(c);
+        test_mock_cluster_destroy(mcluster);
+        SUB_TEST_PASS();
+}
+
 int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -1160,6 +1262,8 @@ int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
         do_test_max_poll_interval_rejoin_consume();
 
         do_test_consumer_group_heartbeat_fatal_errors();
+
+        do_test_group_id_not_found_while_leaving();
 
         do_test_consumer_group_heartbeat_retriable_errors();
 

--- a/tests/0147-consumer_group_consumer_mock.c
+++ b/tests/0147-consumer_group_consumer_mock.c
@@ -1036,6 +1036,117 @@ static void do_test_max_poll_interval_rejoin(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Stronger variant of do_test_max_poll_interval_rejoin(): after the
+ *        forced rejoin race, verify the consumer not only avoids a fatal
+ *        error but actually re-acquires its assignment and consumes all the
+ *        records.
+ *
+ * The topic is kept empty while the rejoin race is forced (so active fetching
+ * does not perturb the timing); the records are produced only afterwards. A
+ * regression strands the member at epoch 0 and the next heartbeat is rejected
+ * with a fatal INVALID_REQUEST -- which is detected first in the poll loop and
+ * fails the test fast. With the fix the consumer rejoins and (auto-commit
+ * disabled -> earliest) consumes the full set of records.
+ */
+static void do_test_max_poll_interval_rejoin_consume(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_t *c;
+        rd_kafka_conf_t *conf;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        uint64_t testid   = test_id_generate();
+        const int msgcnt  = 100;
+        rd_kafka_resp_err_t fatal_err;
+        char errstr[512];
+        int64_t deadline;
+        rd_kafka_message_t *rkm;
+        rd_kafka_topic_partition_list_t *assignment = NULL;
+        int received                                = 0;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        rd_kafka_mock_set_group_consumer_heartbeat_interval_ms(mcluster, 500);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        max_poll_inject_done = 0;
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        /* Disable auto-commit so the re-assigned partition has no committed
+         * offset after the rejoin and deterministically resets to earliest. */
+        test_conf_set(conf, "enable.auto.commit", "false");
+        test_conf_set(conf, "max.poll.interval.ms", "3000");
+        /* Intercept logs to force the rejoin race, see
+         * max_poll_rejoin_delay_log_cb(). */
+        test_conf_set(conf, "debug", "cgrp");
+        rd_kafka_conf_set_log_cb(conf, max_poll_rejoin_delay_log_cb);
+        c = test_create_consumer(topic, NULL, conf, NULL);
+
+        test_consumer_subscribe(c, topic);
+
+        /* Reach steady membership on an empty topic: the partition is assigned
+         * but there is nothing to fetch, so the forced rejoin race below is
+         * not perturbed by fetch traffic. */
+        TEST_SAY("Waiting for steady assignment\n");
+        deadline = test_clock() + 10 * 1000000;
+        while (test_clock() < deadline) {
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (rkm)
+                        rd_kafka_message_destroy(rkm);
+                if (!rd_kafka_assignment(c, &assignment) && assignment &&
+                    assignment->cnt > 0) {
+                        rd_kafka_topic_partition_list_destroy(assignment);
+                        assignment = NULL;
+                        break;
+                }
+                RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
+                assignment = NULL;
+        }
+
+        TEST_SAY("Stalling for 4s (> max.poll.interval.ms=3s)\n");
+        rd_sleep(4);
+
+        /* Produce only now, after the race window, so the records are consumed
+         * by the (re-)joined member rather than prefetched during the race. */
+        test_produce_msgs_easy_v(topic, testid, RD_KAFKA_PARTITION_UA, 0,
+                                 msgcnt, 64, "bootstrap.servers", bootstraps,
+                                 NULL);
+
+        /* Resume: a regression goes fatal here (detected first, fails fast);
+         * with the fix the consumer rejoins and consumes all records. */
+        TEST_SAY(
+            "Resuming poll; consumer must rejoin and consume all %d "
+            "records\n",
+            msgcnt);
+        deadline = test_clock() + 20 * 1000000;
+        while (received < msgcnt && test_clock() < deadline) {
+                fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+                if (fatal_err)
+                        TEST_FAIL(
+                            "Consumer went fatal after max.poll.interval.ms "
+                            "expiry instead of rejoining: %s: %s",
+                            rd_kafka_err2name(fatal_err), errstr);
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (!rkm)
+                        continue;
+                if (!rkm->err)
+                        received++;
+                rd_kafka_message_destroy(rkm);
+        }
+
+        TEST_ASSERT(received == msgcnt,
+                    "Expected to consume all %d records after rejoining, "
+                    "got %d: consumer failed to fully recover",
+                    msgcnt, received);
+
+        test_consumer_close(c);
+        rd_kafka_destroy(c);
+        test_mock_cluster_destroy(mcluster);
+        SUB_TEST_PASS();
+}
+
 int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -1045,6 +1156,8 @@ int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
         }
 
         do_test_max_poll_interval_rejoin();
+
+        do_test_max_poll_interval_rejoin_consume();
 
         do_test_consumer_group_heartbeat_fatal_errors();
 

--- a/tests/0147-consumer_group_consumer_mock.c
+++ b/tests/0147-consumer_group_consumer_mock.c
@@ -297,10 +297,7 @@ static void do_test_consumer_group_heartbeat_fatal_errors(void) {
             RD_KAFKA_RESP_ERR_UNSUPPORTED_VERSION,
             RD_KAFKA_RESP_ERR_UNRELEASED_INSTANCE_ID,
             RD_KAFKA_RESP_ERR_GROUP_AUTHORIZATION_FAILED,
-            /* Group no longer exists and the member is not leaving. */
             RD_KAFKA_RESP_ERR_GROUP_ID_NOT_FOUND,
-            /* Unexpected broker-level error not handled explicitly: an
-             * unrecognized permanent error must be fatal, not ignored. */
             RD_KAFKA_RESP_ERR_CLUSTER_AUTHORIZATION_FAILED};
         size_t i;
         test_variation_t j;
@@ -967,93 +964,9 @@ static void max_poll_rejoin_delay_log_cb(const rd_kafka_t *rk,
 /**
  * @brief After the poll timer (max.poll.interval.ms) expires the consumer
  *        leaves the group and must rejoin once polling resumes. Verify the
- *        rejoin is performed as a proper (re-)join and the consumer does not
- *        end up in a fatal state.
- */
-static void do_test_max_poll_interval_rejoin(void) {
-        rd_kafka_mock_cluster_t *mcluster;
-        const char *bootstraps;
-        rd_kafka_t *c;
-        rd_kafka_conf_t *conf;
-        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
-        rd_kafka_topic_partition_list_t *assignment = NULL;
-        rd_bool_t assigned                          = rd_false;
-        rd_kafka_resp_err_t fatal_err;
-        char errstr[512];
-        int64_t deadline;
-        rd_kafka_message_t *rkm;
-
-        SUB_TEST_QUICK();
-
-        mcluster = test_mock_cluster_new(1, &bootstraps);
-        rd_kafka_mock_set_group_consumer_heartbeat_interval_ms(mcluster, 500);
-        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
-
-        max_poll_inject_done = 0;
-        test_conf_init(&conf, NULL, 30);
-        test_conf_set(conf, "bootstrap.servers", bootstraps);
-        test_conf_set(conf, "auto.offset.reset", "earliest");
-        test_conf_set(conf, "max.poll.interval.ms", "3000");
-        /* Intercept logs to force the rejoin race, see
-         * max_poll_rejoin_delay_log_cb(). */
-        test_conf_set(conf, "debug", "cgrp");
-        rd_kafka_conf_set_log_cb(conf, max_poll_rejoin_delay_log_cb);
-        c = test_create_consumer(topic, NULL, conf, NULL);
-
-        test_consumer_subscribe(c, topic);
-
-        TEST_SAY("Waiting for steady assignment\n");
-        deadline = test_clock() + 10 * 1000000;
-        while (test_clock() < deadline) {
-                rkm = rd_kafka_consumer_poll(c, 200);
-                if (rkm)
-                        rd_kafka_message_destroy(rkm);
-                if (!rd_kafka_assignment(c, &assignment) && assignment &&
-                    assignment->cnt > 0) {
-                        rd_kafka_topic_partition_list_destroy(assignment);
-                        assignment = NULL;
-                        assigned   = rd_true;
-                        break;
-                }
-                RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
-                assignment = NULL;
-        }
-        TEST_ASSERT(assigned,
-                    "Timed out waiting for steady assignment before the test "
-                    "could proceed");
-        TEST_SAY("Steady assignment reached\n");
-
-        TEST_SAY("Stalling for 4s (> max.poll.interval.ms=3s)\n");
-        rd_sleep(4);
-
-        TEST_SAY("Resuming poll; consumer must rejoin cleanly\n");
-        deadline  = test_clock() + 5 * 1000000;
-        fatal_err = RD_KAFKA_RESP_ERR_NO_ERROR;
-        while (test_clock() < deadline) {
-                rkm = rd_kafka_consumer_poll(c, 200);
-                if (rkm)
-                        rd_kafka_message_destroy(rkm);
-                fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
-                if (fatal_err)
-                        break;
-        }
-
-        TEST_ASSERT(!fatal_err,
-                    "Consumer went fatal after max.poll.interval.ms expiry "
-                    "instead of rejoining: %s: %s",
-                    rd_kafka_err2name(fatal_err), errstr);
-
-        test_consumer_close(c);
-        rd_kafka_destroy(c);
-        test_mock_cluster_destroy(mcluster);
-        SUB_TEST_PASS();
-}
-
-/**
- * @brief Stronger variant of do_test_max_poll_interval_rejoin(): after the
- *        forced rejoin race, verify the consumer not only avoids a fatal
- *        error but actually re-acquires its assignment and consumes all the
- *        records.
+ *        rejoin is performed as a proper (re-)join, the consumer does not end
+ *        up in a fatal state, and it re-acquires its assignment and consumes
+ *        all the records.
  *
  * The topic is kept empty while the rejoin race is forced (so active fetching
  * does not perturb the timing); the records are produced only afterwards. A
@@ -1093,9 +1006,11 @@ static void do_test_max_poll_interval_rejoin_consume(void) {
         test_conf_set(conf, "enable.auto.commit", "false");
         test_conf_set(conf, "max.poll.interval.ms", "3000");
         /* Intercept logs to force the rejoin race, see
-         * max_poll_rejoin_delay_log_cb(). */
-        test_conf_set(conf, "debug", "cgrp");
-        rd_kafka_conf_set_log_cb(conf, max_poll_rejoin_delay_log_cb);
+         * max_poll_rejoin_delay_log_cb(). The interceptor enables the "cgrp"
+         * debug context on top of any set via the TEST_DEBUG env variable. */
+        const char *debug_contexts[2] = {"cgrp", NULL};
+        test_conf_set_log_interceptor(conf, max_poll_rejoin_delay_log_cb,
+                                      debug_contexts);
         c = test_create_consumer(topic, NULL, conf, NULL);
 
         test_consumer_subscribe(c, topic);
@@ -1274,8 +1189,6 @@ int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
                 TEST_SKIP("Test only for group.protocol=consumer\n");
                 return 0;
         }
-
-        do_test_max_poll_interval_rejoin();
 
         do_test_max_poll_interval_rejoin_consume();
 

--- a/tests/0147-consumer_group_consumer_mock.c
+++ b/tests/0147-consumer_group_consumer_mock.c
@@ -928,6 +928,114 @@ static void do_test_quick_unsubscribe_tests(void) {
         }
 }
 
+static int max_poll_inject_done = 0;
+
+/**
+ * @brief Log interception used to deterministically force the max-poll rejoin
+ *        race from the test, without modifying library code.
+ *
+ * The "Expediting next heartbeat ... max poll interval exceeded" line is
+ * emitted on the main thread right after the leave-group heartbeat has been
+ * enqueued and F_WAIT_REJOIN has been set. Sleeping here (synchronously, on
+ * the main thread) lets the broker thread deliver the leave reply: it is then
+ * processed on the next serve -- running consumer_reset, which clears
+ * F_WAIT_REJOIN -- BEFORE consumer_serve acts on the flag. The member is then
+ * stranded steady at epoch 0 and its next heartbeat is a malformed (re-)join.
+ */
+static void max_poll_rejoin_delay_log_cb(const rd_kafka_t *rk,
+                                         int level,
+                                         const char *fac,
+                                         const char *buf) {
+        if (!max_poll_inject_done && strstr(buf, "Expediting next heartbeat") &&
+            strstr(buf, "max poll interval exceeded")) {
+                max_poll_inject_done = 1;
+                fprintf(stderr,
+                        "### TEST: injecting 500ms delay after leave to force "
+                        "the rejoin race\n");
+                rd_usleep(500 * 1000, NULL);
+        }
+}
+
+/**
+ * @brief After the poll timer (max.poll.interval.ms) expires the consumer
+ *        leaves the group and must rejoin once polling resumes. Verify the
+ *        rejoin is performed as a proper (re-)join and the consumer does not
+ *        end up in a fatal state.
+ */
+static void do_test_max_poll_interval_rejoin(void) {
+        rd_kafka_mock_cluster_t *mcluster;
+        const char *bootstraps;
+        rd_kafka_t *c;
+        rd_kafka_conf_t *conf;
+        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
+        rd_kafka_topic_partition_list_t *assignment = NULL;
+        rd_kafka_resp_err_t fatal_err;
+        char errstr[512];
+        int64_t deadline;
+        rd_kafka_message_t *rkm;
+
+        SUB_TEST_QUICK();
+
+        mcluster = test_mock_cluster_new(1, &bootstraps);
+        rd_kafka_mock_set_group_consumer_heartbeat_interval_ms(mcluster, 500);
+        rd_kafka_mock_topic_create(mcluster, topic, 1, 1);
+
+        max_poll_inject_done = 0;
+        test_conf_init(&conf, NULL, 30);
+        test_conf_set(conf, "bootstrap.servers", bootstraps);
+        test_conf_set(conf, "auto.offset.reset", "earliest");
+        test_conf_set(conf, "max.poll.interval.ms", "3000");
+        /* Intercept logs to force the rejoin race, see
+         * max_poll_rejoin_delay_log_cb(). */
+        test_conf_set(conf, "debug", "cgrp");
+        rd_kafka_conf_set_log_cb(conf, max_poll_rejoin_delay_log_cb);
+        c = test_create_consumer(topic, NULL, conf, NULL);
+
+        test_consumer_subscribe(c, topic);
+
+        TEST_SAY("Waiting for steady assignment\n");
+        deadline = test_clock() + 10 * 1000000;
+        while (test_clock() < deadline) {
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (rkm)
+                        rd_kafka_message_destroy(rkm);
+                if (!rd_kafka_assignment(c, &assignment) && assignment &&
+                    assignment->cnt > 0) {
+                        rd_kafka_topic_partition_list_destroy(assignment);
+                        assignment = NULL;
+                        break;
+                }
+                RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
+                assignment = NULL;
+        }
+        TEST_SAY("Steady assignment reached\n");
+
+        TEST_SAY("Stalling for 4s (> max.poll.interval.ms=3s)\n");
+        rd_sleep(4);
+
+        TEST_SAY("Resuming poll; consumer must rejoin cleanly\n");
+        deadline  = test_clock() + 5 * 1000000;
+        fatal_err = RD_KAFKA_RESP_ERR_NO_ERROR;
+        while (test_clock() < deadline) {
+                rkm = rd_kafka_consumer_poll(c, 200);
+                if (rkm)
+                        rd_kafka_message_destroy(rkm);
+                fatal_err = rd_kafka_fatal_error(c, errstr, sizeof(errstr));
+                if (fatal_err)
+                        break;
+        }
+
+        TEST_ASSERT(!fatal_err,
+                    "Consumer went fatal after max.poll.interval.ms expiry "
+                    "instead of rejoining: %s: %s",
+                    rd_kafka_err2name(fatal_err), errstr);
+
+        test_consumer_close(c);
+        rd_kafka_destroy(c);
+        test_mock_cluster_destroy(mcluster);
+        SUB_TEST_PASS();
+}
+
 int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -935,6 +1043,8 @@ int main_0147_consumer_group_consumer_mock(int argc, char **argv) {
                 TEST_SKIP("Test only for group.protocol=consumer\n");
                 return 0;
         }
+
+        do_test_max_poll_interval_rejoin();
 
         do_test_consumer_group_heartbeat_fatal_errors();
 

--- a/tests/0147-consumer_group_consumer_mock.c
+++ b/tests/0147-consumer_group_consumer_mock.c
@@ -940,12 +940,15 @@ static int max_poll_inject_done = 0;
  *        race from the test, without modifying library code.
  *
  * The "Expediting next heartbeat ... max poll interval exceeded" line is
- * emitted on the main thread right after the leave-group heartbeat has been
- * enqueued and F_WAIT_REJOIN has been set. Sleeping here (synchronously, on
- * the main thread) lets the broker thread deliver the leave reply: it is then
- * processed on the next serve -- running consumer_reset, which clears
- * F_WAIT_REJOIN -- BEFORE consumer_serve acts on the flag. The member is then
- * stranded steady at epoch 0 and its next heartbeat is a malformed (re-)join.
+ * emitted on the main thread when the poll interval is exceeded and
+ * F_WAIT_REJOIN is set. This sleep reproduces the *pre-fix* race: back then the
+ * leave-group heartbeat was sent immediately at that point, and sleeping here
+ * (synchronously, on the main thread) let the broker thread deliver the leave
+ * reply, which was then processed on the next serve -- running consumer_reset
+ * and clearing F_WAIT_REJOIN BEFORE consumer_serve acted on it -- stranding the
+ * member steady at epoch 0 so its next heartbeat was a malformed (re-)join.
+ * The fix defers the leave until the assignment is revoked, so the consumer
+ * now rejoins cleanly even with this injected delay.
  */
 static void max_poll_rejoin_delay_log_cb(const rd_kafka_t *rk,
                                          int level,
@@ -974,6 +977,7 @@ static void do_test_max_poll_interval_rejoin(void) {
         rd_kafka_conf_t *conf;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         rd_kafka_topic_partition_list_t *assignment = NULL;
+        rd_bool_t assigned                          = rd_false;
         rd_kafka_resp_err_t fatal_err;
         char errstr[512];
         int64_t deadline;
@@ -1008,11 +1012,15 @@ static void do_test_max_poll_interval_rejoin(void) {
                     assignment->cnt > 0) {
                         rd_kafka_topic_partition_list_destroy(assignment);
                         assignment = NULL;
+                        assigned   = rd_true;
                         break;
                 }
                 RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
                 assignment = NULL;
         }
+        TEST_ASSERT(assigned,
+                    "Timed out waiting for steady assignment before the test "
+                    "could proceed");
         TEST_SAY("Steady assignment reached\n");
 
         TEST_SAY("Stalling for 4s (> max.poll.interval.ms=3s)\n");
@@ -1067,6 +1075,7 @@ static void do_test_max_poll_interval_rejoin_consume(void) {
         int64_t deadline;
         rd_kafka_message_t *rkm;
         rd_kafka_topic_partition_list_t *assignment = NULL;
+        rd_bool_t assigned                          = rd_false;
         int received                                = 0;
 
         SUB_TEST_QUICK();
@@ -1104,11 +1113,15 @@ static void do_test_max_poll_interval_rejoin_consume(void) {
                     assignment->cnt > 0) {
                         rd_kafka_topic_partition_list_destroy(assignment);
                         assignment = NULL;
+                        assigned   = rd_true;
                         break;
                 }
                 RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
                 assignment = NULL;
         }
+        TEST_ASSERT(assigned,
+                    "Timed out waiting for steady assignment before the test "
+                    "could proceed");
 
         TEST_SAY("Stalling for 4s (> max.poll.interval.ms=3s)\n");
         rd_sleep(4);
@@ -1172,6 +1185,7 @@ static void do_test_group_id_not_found_while_leaving(void) {
         rd_kafka_t *c;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         rd_kafka_topic_partition_list_t *assignment = NULL;
+        rd_bool_t assigned                          = rd_false;
         rd_kafka_resp_err_t fatal_err;
         char errstr[512];
         int64_t deadline;
@@ -1197,11 +1211,15 @@ static void do_test_group_id_not_found_while_leaving(void) {
                     assignment->cnt > 0) {
                         rd_kafka_topic_partition_list_destroy(assignment);
                         assignment = NULL;
+                        assigned   = rd_true;
                         break;
                 }
                 RD_IF_FREE(assignment, rd_kafka_topic_partition_list_destroy);
                 assignment = NULL;
         }
+        TEST_ASSERT(assigned,
+                    "Timed out waiting for steady assignment before the test "
+                    "could proceed");
         TEST_SAY("Steady assignment reached\n");
 
         /* Answer the next regular heartbeat with GROUP_ID_NOT_FOUND, holding


### PR DESCRIPTION
Fix multiple issues in ConsumerGroupHeartbeat error handling.

- Race condition in `max.poll.interval.ms` handling where the consumer was not rejoining and incorrectly sending the join request with 0 epoch without full request.
- Fix GROUP_ID_NOT_FOUND error handling which is ignored right now and we keep on sending the HB