### PR TITLE
[KIP-932] Skip !UP leaders in share-consumer fetch path + related cleanup

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3620,58 +3620,6 @@ void rd_kafka_share_enqueue_fetch_op(rd_kafka_t *rk,
                      should_leave ? "with" : "no",
                      rko_sf->rko_u.share_fetch.ack_details ? "with" : "no");
 
-        // /* TODO KIP-932: Remove this debug printing */
-        // {
-        //         static const char *ack_type_names[] = {
-        //             [0] = "GAP",
-        //             [1] = "ACCEPT",
-        //             [2] = "RELEASE",
-        //             [3] = "REJECT",
-        //         };
-        //         rd_list_t *ack_details =
-        //             rko_sf->rko_u.share_fetch.ack_details;
-
-        //         printf("[SHARE_FETCH] broker=%s should_fetch=%d",
-        //                rd_kafka_broker_name(rkb), should_fetch);
-
-        //         if (ack_details && rd_list_cnt(ack_details) > 0) {
-        //                 rd_kafka_share_ack_batches_t *batches;
-        //                 int k;
-        //                 printf(" ack_details=[");
-        //                 RD_LIST_FOREACH(batches, ack_details, k) {
-        //                         rd_kafka_share_ack_batch_entry_t *entry;
-        //                         int m;
-        //                         if (k > 0)
-        //                                 printf(", ");
-        //                         printf("%s[%" PRId32 "]:{",
-        //                                batches->rktpar->topic,
-        //                                batches->rktpar->partition);
-        //                         RD_LIST_FOREACH(entry, &batches->entries, m)
-        //                         {
-        //                                 int type_val =
-        //                                     (int)entry->types[0];
-        //                                 const char *type_str =
-        //                                     (type_val >= 0 && type_val <= 3)
-        //                                         ? ack_type_names[type_val]
-        //                                         : "UNKNOWN";
-        //                                 if (m > 0)
-        //                                         printf(", ");
-        //                                 printf("%" PRId64 "-%" PRId64
-        //                                        "(%s)",
-        //                                        entry->start_offset,
-        //                                        entry->end_offset,
-        //                                        type_str);
-        //                         }
-        //                         printf("}");
-        //                 }
-        //                 printf("]");
-        //         } else {
-        //                 printf(" ack_details=none");
-        //         }
-        //         printf("\n");
-        //         fflush(stdout);
-        // }
-
         rd_kafka_q_enq(rkb->rkb_ops, rko_sf);
 }
 

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3299,11 +3299,19 @@ static rd_kafka_broker_t *rd_kafka_share_select_broker(rd_kafka_t *rk,
 
                 /* Criteria to choose a broker:
                  * 1. It should be the leader of a partition.
-                 * 2. A share-fetch op must not already be enqueued on it.
-                 * 3. The broker or instance must not be terminating. */
+                 * 2. The broker or instance must not be terminating.
+                 * 3. A share-fetch op must not already be enqueued on it.
+                 * 4. The broker must currently be UP.
+                 *
+                 * The rkb_state read is intentionally unlocked: a stale
+                 * UP value at worst costs one stray op (broker thread
+                 * rejects with ERR__STATE), bounded to one per state
+                 * transition. Without this guard, a DOWN leader causes
+                 * an unbounded main<->broker thread bounce loop. */
                 if (leader) {
                         if (!rd_kafka_broker_or_instance_terminating(leader) &&
-                            !leader->rkb_share_fetch_enqueued) {
+                            !leader->rkb_share_fetch_enqueued &&
+                            leader->rkb_state == RD_KAFKA_BROKER_STATE_UP) {
                                 rd_kafka_broker_keep(leader);
                                 selected_rkb = leader;
                                 rd_kafka_dbg(

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3696,12 +3696,6 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                             rd_kafka_broker_state_names[rkb->rkb_state]);
                         rd_kafka_share_fetch_op_reply_and_update_ack_details_with_err(
                             rko, RD_KAFKA_RESP_ERR__STATE);
-                } else if (rkb->rkb_fetching) {
-                        rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                                     "Ignoring SHARE_FETCH op: "
-                                     "already fetching");
-                        rd_kafka_share_fetch_op_reply_and_update_ack_details_with_err(
-                            rko, RD_KAFKA_RESP_ERR__PREV_IN_PROGRESS);
                 } else if (rko->rko_u.share_fetch.should_leave) {
                         rd_kafka_broker_share_fetch_session_leave(rkb, rko,
                                                                   rd_clock());

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3685,11 +3685,10 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                         rd_kafka_share_fetch_op_reply_and_update_ack_details_with_err(
                             rko, rd_kafka_broker_destroy_error(rkb->rkb_rk));
                 } else if (rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP) {
-                        /* TODO KIP-932: The main thread should check
-                         * broker state before enqueuing SHARE_FETCH
-                         * ops, or back off after receiving ERR__STATE
-                         * replies, to avoid flooding the broker thread
-                         * with ops that are immediately rejected. */
+                        /* Backstop: the main thread filters on rkb_state
+                         * in rd_kafka_share_select_broker, so this only
+                         * fires when the broker transitioned to !UP
+                         * after that unlocked check. */
                         rd_kafka_dbg(
                             rkb->rkb_rk, BROKER, "SHAREFETCH",
                             "Ignoring SHARE_FETCH op: "

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3703,24 +3703,6 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                         rd_kafka_broker_share_rpc(rkb, rko, rd_clock());
                 }
 
-                /* TODO KIP-932: Add handling for commit sync partition level
-                 * and ack callback errors */
-                // if (!rko->rko_u.share_fetch.should_fetch) {
-                //         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                //                    "Ignoring SHARE_FETCH op: "
-                //                    "should_fetch is false");
-                //         rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__NOOP);
-                //         break;
-                // }
-
-                // if(rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP) {
-                //         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
-                //                    "Connection not up: Sending connect in
-                //                    progress as reply");
-                //         rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__STATE);
-                //         break;
-                // }
-
                 rko = NULL; /* the rko is reused for the reply */
 
                 break;
@@ -4581,25 +4563,6 @@ static void rd_kafka_broker_producer_serve(rd_kafka_broker_t *rkb,
 
         rd_kafka_broker_unlock(rkb);
 }
-
-/**
- * TODO KIP-932: Remove if not needed later during finalizing share session
- * implementation.
- */
-// void rd_kafka_broker_update_share_fetch_session(rd_kafka_broker_t *rkb) {
-//         rd_kafka_toppar_t *rktp;
-//         int i;
-//         rd_bool_t needs_update = rd_false;
-//
-//         RD_LIST_FOREACH(rktp,
-//                         rkb->rkb_share_fetch_session.toppars_in_session, i) {
-//                 rd_kafka_toppar_is_valid_to_send_for_share_fetch(rktp);
-//         }
-//
-//         if (needs_update)
-//                 rd_kafka_toppar_share_fetch_session_update(rkb);
-// }
-
 
 /**
  * Consumer serving

--- a/src/rdkafka_broker.h
+++ b/src/rdkafka_broker.h
@@ -158,11 +158,6 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
                                                 */
                 int32_t epoch;                 /* Current fetch session
                                                 * epoch, or -1 if leaving the session
-                                                * TODO KIP-932: Handle 0 and -1 properly.
-                                                *               * Can we move from -1 to 0?
-                                                *               * Maybe in some error case?
-                                                *               * Is there a way in which we
-                                                * close a previous session and start a new one?
                                                 */
         } rkb_share_fetch_session;
 
@@ -466,10 +461,6 @@ struct rd_kafka_broker_s { /* rd_kafka_broker_t */
         /**
          * Whether a share fetch should_fetch set is enqueued on
          * this broker's op queue or not.
-         *
-         * TODO KIP-932: Check the below fields are not causing
-         * thread safety issues. If causing, check if keeping the reference
-         * to the rkb will solve the issue or not.
          */
         rd_bool_t rkb_share_fetch_enqueued;
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -919,9 +919,6 @@ void rd_kafka_share_filter_acquired_records_and_update_ack_type(
                 if (in_acquired_range) {
                         /* Set ack type based on op type */
                         rd_kafka_msg_t *rkm = NULL;
-                        /* TODO KIP-932: Check and update the handling
-                         * of control messages
-                         */
                         if (unlikely(rd_kafka_op_is_ctrl_msg(rko)))
                                 continue;
                         if (rko->rko_type == RD_KAFKA_OP_FETCH) {
@@ -2379,10 +2376,6 @@ static void rd_kafka_broker_share_fetch_reply(rd_kafka_t *rk,
                 }
         }
 
-        /* TODO KIP-932: Partition add/remove is done unconditionally
-         * here. Likely correct — partitions stay in the session
-         * across response errors and migrate on the next metadata
-         * refresh. Verify this matches the intended KIP-932 flow. */
         rd_kafka_broker_session_update(rkb);
 
         if (unlikely(err)) {

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -2345,8 +2345,6 @@ static void rd_kafka_broker_share_fetch_reply(rd_kafka_t *rk,
         rd_kafka_op_t *rko_orig     = opaque;
         rd_kafka_op_t *response_rko = NULL;
 
-        rd_kafka_assert(rkb->rkb_rk, rkb->rkb_fetching > 0);
-
         /* Parse the response only if the network/broker layer didn't
          * report an error. If err is set (e.g. __TRANSPORT,
          * __TIMED_OUT, __DESTROY), the reply buffer is unusable so
@@ -2465,8 +2463,6 @@ static void rd_kafka_broker_share_fetch_reply(rd_kafka_t *rk,
          * before the app thread wakes up and enqueues a new FANOUT. */
         if (response_rko)
                 rd_kafka_q_enq(rkb->rkb_rk->rk_cgrp->rkcg_q, response_rko);
-
-        rkb->rkb_fetching = 0;
 }
 
 /**
@@ -2957,7 +2953,6 @@ void rd_kafka_ShareFetchRequest(rd_kafka_broker_t *rkb,
                     rd_list_copy(rkb->rkb_share_fetch_session.toppars_to_forget,
                                  rd_kafka_toppar_list_copy, NULL);
 
-        rkb->rkb_fetching = 1;
         rd_kafka_dbg(
             rkb->rkb_rk, MSG, "FETCH",
             "Issuing ShareFetch request (max wait %dms, min %d bytes, "

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1357,9 +1357,7 @@ static void do_test_mock_uses_share_acknowledge(void) {
                     "partitions count (%d)",
                     share_ack_cnt, commit_with_partitions);
 
-        TEST_SAY("Closing share consumer\n");
         test_share_consumer_close(rkshare);
-        TEST_SAY("Destroying share consumer\n");
         test_share_destroy(rkshare);
         TEST_SAY("Destroying mock test context\n");
         test_ctx_destroy(&ctx);

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -1185,24 +1185,32 @@ static void do_test_mock_uses_share_acknowledge(void) {
         SUB_TEST_QUICK();
 
         ctx = test_ctx_new();
+        TEST_SAY("Mock cluster ready, bootstraps=%s\n", ctx.bootstraps);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Failed to create mock topic");
+        TEST_SAY("Created mock topic [%s] (1 partition)\n", topic);
 
         mock_produce_messages(ctx.producer, topic, msgcnt);
+        TEST_SAY("Produced %d messages to [%s]\n", msgcnt, topic);
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, "sg-mock-cs-ack",
                                              "explicit");
+        TEST_SAY(
+            "Created share consumer (group=sg-mock-cs-ack, "
+            "ack=explicit)\n");
 
-        {
-                const char *t = topic;
-                subscribe_consumer(rkshare, &t, 1);
-        }
+        subscribe_consumer(rkshare, &topic, 1);
+        TEST_SAY("Subscribed to [%s]\n", topic);
 
         /* Clear and start tracking requests */
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
+        TEST_SAY(
+            "Started mock request tracking; entering consume loop "
+            "(msgcnt=%d, batch=%d)\n",
+            msgcnt, CONSUME_ARRAY);
 
         /* Consume all records, ACCEPT each, commit_sync every 10 */
         while (consumed < msgcnt && attempts++ < 30) {
@@ -1210,27 +1218,72 @@ static void do_test_mock_uses_share_acknowledge(void) {
                 size_t rcvd = 0;
                 size_t j;
 
+                TEST_SAY(
+                    "Iter %d: calling share_consume_batch "
+                    "(consumed=%d/%d, acked_since_last=%d)\n",
+                    attempts, consumed, msgcnt, acked_since_last_commit);
+
                 error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
                                                      &rcvd);
                 if (error) {
+                        TEST_SAY(
+                            "Iter %d: share_consume_batch error: %s "
+                            "(rcvd=%zu)\n",
+                            attempts, rd_kafka_error_string(error), rcvd);
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
+                TEST_SAY("Iter %d: share_consume_batch returned %zu msg(s)\n",
+                         attempts, rcvd);
+
                 for (j = 0; j < rcvd; j++) {
                         if (!rkmessages[j]->err) {
+                                TEST_SAY(
+                                    "  ACK %s [%" PRId32 "] @ offset %" PRId64
+                                    " (delivery_count=%d)\n",
+                                    rd_kafka_topic_name(rkmessages[j]->rkt),
+                                    rkmessages[j]->partition,
+                                    rkmessages[j]->offset,
+                                    (int)rd_kafka_message_delivery_count(
+                                        rkmessages[j]));
                                 rd_kafka_share_acknowledge(rkshare,
                                                            rkmessages[j]);
                                 consumed++;
                                 acked_since_last_commit++;
+                        } else {
+                                TEST_SAY(
+                                    "  msg #%zu carries error %s on "
+                                    "%s [%" PRId32 "] @ %" PRId64 "\n",
+                                    j, rd_kafka_err2name(rkmessages[j]->err),
+                                    rkmessages[j]->rkt ? rd_kafka_topic_name(
+                                                             rkmessages[j]->rkt)
+                                                       : "(no-rkt)",
+                                    rkmessages[j]->partition,
+                                    rkmessages[j]->offset);
                         }
                         rd_kafka_message_destroy(rkmessages[j]);
 
                         if (acked_since_last_commit == 10) {
                                 partitions = NULL;
-                                error      = rd_kafka_share_commit_sync(
+                                TEST_SAY(
+                                    "Calling commit_sync #%d "
+                                    "(timeout=30000ms, acked=%d, "
+                                    "consumed=%d)\n",
+                                    commit_cnt + 1, acked_since_last_commit,
+                                    consumed);
+                                error = rd_kafka_share_commit_sync(
                                     rkshare, 30000, &partitions);
                                 commit_cnt++;
+                                TEST_SAY(
+                                    "commit_sync #%d returned: "
+                                    "error=%s, partitions=%s, "
+                                    "partition_cnt=%d\n",
+                                    commit_cnt,
+                                    error ? rd_kafka_error_string(error)
+                                          : "NULL",
+                                    partitions ? "non-NULL" : "NULL",
+                                    partitions ? partitions->cnt : 0);
                                 TEST_ASSERT(
                                     !error, "commit_sync #%d failed: %s",
                                     commit_cnt,
@@ -1242,6 +1295,18 @@ static void do_test_mock_uses_share_acknowledge(void) {
                                                 rd_kafka_topic_partition_t
                                                     *rktpar =
                                                         &partitions->elems[i];
+                                                TEST_SAY(
+                                                    "  commit_sync #%d "
+                                                    "partition[%d]: "
+                                                    "%s [%" PRId32
+                                                    "] offset=%" PRId64
+                                                    " err=%s\n",
+                                                    commit_cnt, i,
+                                                    rktpar->topic,
+                                                    rktpar->partition,
+                                                    rktpar->offset,
+                                                    rd_kafka_err2name(
+                                                        rktpar->err));
                                                 TEST_ASSERT(
                                                     rktpar->err ==
                                                         RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1266,13 +1331,18 @@ static void do_test_mock_uses_share_acknowledge(void) {
         }
 
         TEST_SAY(
-            "Mock: consumed %d/%d, %d commit_sync calls, "
-            "%d with partition results\n",
-            consumed, msgcnt, commit_cnt, commit_with_partitions);
+            "Consume loop exited after %d iter(s): "
+            "consumed=%d/%d, commit_cnt=%d, with_partitions=%d, "
+            "acked_since_last=%d\n",
+            attempts, consumed, msgcnt, commit_cnt, commit_with_partitions,
+            acked_since_last_commit);
         TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
                     consumed);
 
         /* Wait for async ops to complete before counting requests */
+        TEST_SAY(
+            "Sleeping 3s for async ops to drain before counting "
+            "ShareAcknowledge requests\n");
         rd_sleep(3);
 
         share_ack_cnt = count_share_ack_requests(ctx.mcluster);
@@ -1287,8 +1357,11 @@ static void do_test_mock_uses_share_acknowledge(void) {
                     "partitions count (%d)",
                     share_ack_cnt, commit_with_partitions);
 
+        TEST_SAY("Closing share consumer\n");
         test_share_consumer_close(rkshare);
+        TEST_SAY("Destroying share consumer\n");
         test_share_destroy(rkshare);
+        TEST_SAY("Destroying mock test context\n");
         test_ctx_destroy(&ctx);
 
         SUB_TEST_PASS();

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2528,6 +2528,281 @@ static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
 }
 
 
+/* ===================================================================
+ *  Log callback shared by the two select_broker STATE_UP guard tests
+ *  below. Counts the broker-thread short-circuit log emitted at
+ *  src/rdkafka_broker.c when a SHARE_FETCH op is served against a
+ *  broker whose rkb_state is not STATE_UP.
+ * =================================================================== */
+static void no_bounce_loop_log_cb(const rd_kafka_t *rk,
+                                  int level,
+                                  const char *fac,
+                                  const char *buf) {
+        rd_atomic32_t *cnt = rd_kafka_opaque(rk);
+        if (cnt && !strcmp(fac, "SHAREFETCH") && strstr(buf, "broker not up"))
+                rd_atomic32_add(cnt, 1);
+}
+
+/* ===================================================================
+ *  do_test_no_bounce_loop_on_down_broker
+ *
+ *  Steady-state DOWN: the consumer is idle when the broker is taken
+ *  down, sleeps long enough for the broker thread to settle rkb_state
+ *  to !UP, then drives consume_batch for ~1s. Every FANOUT must skip
+ *  the DOWN leader via the select_broker STATE_UP guard, so no
+ *  "broker not up" log line should fire.
+ *
+ *  Wire never sees a ShareFetch on the DOWN broker (broker thread
+ *  rejects the internal op before any RPC is built), so we assert on
+ *  the count of the broker-thread short-circuit debug log instead of
+ *  on mock_get_requests.
+ * =================================================================== */
+static void do_test_no_bounce_loop_on_down_broker(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        rd_atomic32_t broker_not_up_cnt;
+        rd_kafka_error_t *commit_error;
+        const char *topic       = "0182-no_bounce_loop";
+        const char *group       = "sg-0182-no-bounce-loop";
+        const int msgcnt_phase1 = 5;
+        const int msgcnt_phase2 = 5;
+        int acked, cnt;
+        rd_ts_t end_ts;
+
+        SUB_TEST_QUICK();
+
+        /* Taking the only broker down legitimately raises
+         * __ALL_BROKERS_DOWN and __TRANSPORT on producer + consumer
+         * error callbacks. None of these should fail the test. */
+        test_curr->is_fatal_cb = test_error_is_not_fatal_cb;
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        mock_produce(ctx.producer, topic, msgcnt_phase1);
+
+        rd_atomic32_init(&broker_not_up_cnt, 0);
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "explicit");
+        test_conf_set(conf, "debug", "broker");
+        rd_kafka_conf_set_log_cb(conf, no_bounce_loop_log_cb);
+        rd_kafka_conf_set_opaque(conf, &broker_not_up_cnt);
+
+        rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
+
+        subscribe_one(rkshare, topic);
+
+        acked = consume_and_ack_all(rkshare, msgcnt_phase1);
+        TEST_ASSERT(acked == msgcnt_phase1, "phase1: expected %d acked, got %d",
+                    msgcnt_phase1, acked);
+
+        /* Flush any acks still cached in rkb_share_async_ack_details
+         * before taking the broker down. Otherwise the next FANOUT
+         * after set_down would dispatch an ack-only op to the DOWN
+         * broker (the FANOUT iteration must always deliver cached
+         * acks so the broker thread can surface the error), and the
+         * broker thread would legitimately log "broker not up" once.
+         * That log is unrelated to the select_broker guard. */
+        commit_error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!commit_error, "commit_async error: %s",
+                    commit_error ? rd_kafka_error_string(commit_error)
+                                 : "NULL");
+
+        /* Phase-2 records sit in the partition log; the post-recovery
+         * consume below drains them. */
+        mock_produce(ctx.producer, topic, msgcnt_phase2);
+
+        TEST_SAY("Taking broker 1 down\n");
+        rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
+
+        /* Settle: let the client's broker thread detect TCP close and
+         * transition rkb_state to !UP before we start counting. After
+         * this point every select_broker reads DOWN — no race window. */
+        rd_sleep(1);
+        rd_atomic32_set(&broker_not_up_cnt, 0);
+
+        end_ts = test_clock() + 1000 * 1000;
+        while (test_clock() < end_ts) {
+                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+                size_t rcvd             = 0;
+                rd_kafka_error_t *error = rd_kafka_share_consume_batch(
+                    rkshare, 100, rkmessages, &rcvd);
+                TEST_ASSERT(!error,
+                            "unexpected error from consume_batch while "
+                            "broker is down: %s",
+                            error ? rd_kafka_error_string(error) : "NULL");
+                TEST_ASSERT(rcvd == 0,
+                            "expected 0 records while broker is down, "
+                            "got %zu",
+                            rcvd);
+        }
+
+        cnt = rd_atomic32_get(&broker_not_up_cnt);
+        TEST_SAY("\"broker not up\" log count: %d (expected 0)\n", cnt);
+        TEST_ASSERT(cnt == 0,
+                    "select_broker should skip the DOWN leader on every "
+                    "FANOUT once rkb_state has settled; got %d "
+                    "\"broker not up\" log lines",
+                    cnt);
+
+        TEST_SAY("Bringing broker 1 back up\n");
+        rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
+
+        acked = consume_and_ack_all(rkshare, msgcnt_phase2);
+        TEST_ASSERT(acked == msgcnt_phase2,
+                    "phase2 (post-recovery): expected %d acked, got %d",
+                    msgcnt_phase2, acked);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        test_curr->is_fatal_cb = NULL;
+
+        SUB_TEST_PASS();
+}
+
+/* ===================================================================
+ *  do_test_one_log_on_broker_down_during_active_empty_poll
+ *
+ *  Race-window companion to do_test_no_bounce_loop_on_down_broker.
+ *
+ *  With an empty topic the consumer's FANOUT->ShareFetch->Step 6
+ *  empty-poll loop fires continuously. We take the broker down
+ *  while that loop is hot. A narrow window exists between the mock
+ *  TCP close and the client's broker thread updating rkb_state, in
+ *  which select_broker can read stale STATE_UP and enqueue one more
+ *  op. The broker thread (rkb_state has caught up by then) logs
+ *  "broker not up" once, replies ERR__STATE; the next Step 6
+ *  re-select then reads DOWN and skips, closing the loop.
+ *
+ *  Without the select_broker guard the Step 6 re-select would log
+ *  this hundreds of times per second for the duration of the down
+ *  window.
+ * =================================================================== */
+static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        rd_atomic32_t broker_not_up_cnt;
+        const char *topic             = "0182-race_bounce";
+        const char *group             = "sg-0182-race-bounce";
+        const int msgcnt_recovery     = 5;
+        const int max_allowed_log_cnt = 1;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        size_t rcvd;
+        rd_kafka_error_t *error;
+        rd_ts_t end_ts;
+        int cnt, acked;
+
+        SUB_TEST_QUICK();
+
+        /* Taking the only broker down legitimately raises
+         * __ALL_BROKERS_DOWN and __TRANSPORT on producer + consumer
+         * error callbacks. None of these should fail the test. */
+        test_curr->is_fatal_cb = test_error_is_not_fatal_cb;
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        rd_atomic32_init(&broker_not_up_cnt, 0);
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "explicit");
+        test_conf_set(conf, "debug", "broker");
+        rd_kafka_conf_set_log_cb(conf, no_bounce_loop_log_cb);
+        rd_kafka_conf_set_opaque(conf, &broker_not_up_cnt);
+
+        rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
+
+        subscribe_one(rkshare, topic);
+
+        /* Prime with one record so the share group has joined and the
+         * partition is assigned by the time we take the broker down.
+         * Without this guarantee, select_broker would return NULL
+         * (no toppars) and the bounce loop wouldn't fire at all,
+         * making the test pass for the wrong reason. */
+        mock_produce(ctx.producer, topic, 1);
+        acked = consume_and_ack_all(rkshare, 1);
+        TEST_ASSERT(acked == 1, "prime: expected 1 acked, got %d", acked);
+
+        /* Flush the prime ack still cached in rkb_share_async_ack_details
+         * before taking the broker down. Otherwise the next FANOUT
+         * iteration would dispatch an ack-only op to the DOWN broker
+         * and produce a "broker not up" log unrelated to the
+         * select_broker race we're measuring. */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+
+        /* Reset to drop any noise from cgrp/connection bring-up. */
+        rd_atomic32_set(&broker_not_up_cnt, 0);
+
+        /* Kickstart the empty-poll loop: one consume_batch on the now
+         * empty topic starts the FANOUT->Step 6 cycle which keeps
+         * firing on the main thread until consume_batch returns. */
+        rcvd  = 0;
+        error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages, &rcvd);
+        TEST_ASSERT(!error, "kickstart consume_batch error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+        TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
+
+        TEST_SAY("Taking broker 1 down mid-empty-poll\n");
+        rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
+
+        end_ts = test_clock() + 1000 * 1000;
+        while (test_clock() < end_ts) {
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages,
+                                                     &rcvd);
+                TEST_ASSERT(!error, "consume_batch error: %s",
+                            error ? rd_kafka_error_string(error) : "NULL");
+                TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
+        }
+
+        cnt = rd_atomic32_get(&broker_not_up_cnt);
+        TEST_SAY("\"broker not up\" log count: %d (max %d)\n", cnt,
+                 max_allowed_log_cnt);
+        TEST_ASSERT(cnt <= max_allowed_log_cnt,
+                    "race-window slip must be bounded to %d op; got %d "
+                    "log lines (without the guard this would be "
+                    "hundreds)",
+                    max_allowed_log_cnt, cnt);
+
+        /* Recovery: bring the broker back up, produce records, verify
+         * the consumer drains them. */
+        TEST_SAY("Bringing broker 1 back up\n");
+        rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
+
+        mock_produce(ctx.producer, topic, msgcnt_recovery);
+
+        acked = consume_and_ack_all(rkshare, msgcnt_recovery);
+        TEST_ASSERT(acked == msgcnt_recovery,
+                    "post-recovery: expected %d acked, got %d", msgcnt_recovery,
+                    acked);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        test_curr->is_fatal_cb = NULL;
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -2600,6 +2875,11 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         do_test_socket_timeout_partial_ack_then_remaining(
             5000, 1000, 3000); /* socket < rtt < api  */
         /* Boundary api == socket skipped — see comment above. */
+
+        /* select_broker STATE_UP guard: steady-state DOWN and
+         * race-window flavours. */
+        do_test_no_bounce_loop_on_down_broker();
+        do_test_one_log_on_broker_down_during_active_empty_poll();
 
         return 0;
 }

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -135,17 +135,6 @@ create_mock_share_consumer(const char *bootstraps,
         return rkshare;
 }
 
-static void subscribe_one(rd_kafka_share_t *rkshare, const char *topic) {
-        rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_resp_err_t err;
-
-        subs = rd_kafka_topic_partition_list_new(1);
-        rd_kafka_topic_partition_list_add(subs, topic, RD_KAFKA_PARTITION_UA);
-        err = rd_kafka_share_subscribe(rkshare, subs);
-        TEST_ASSERT(!err, "subscribe failed: %s", rd_kafka_err2str(err));
-        rd_kafka_topic_partition_list_destroy(subs);
-}
-
 static void mock_produce(rd_kafka_t *producer, const char *topic, int msgcnt) {
         int i;
         for (i = 0; i < msgcnt; i++) {
@@ -251,7 +240,7 @@ do_test_commit_sync_top_level_err(const char *test_name,
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         acked = consume_and_ack_all(rkshare, msgcnt);
         TEST_ASSERT(acked == msgcnt, "expected %d acked, got %d", msgcnt,
@@ -399,7 +388,7 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* Consume messages from all partitions */
         while (total_consumed < total_msgs && attempts++ < 50) {
@@ -532,7 +521,7 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         /* Use implicit mode - acks are piggybacked on ShareFetch */
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "implicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* First consume batch - establishes session, consumes messages */
         while (total_consumed < total_msgs && attempts++ < 50) {
@@ -672,7 +661,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* Phase 0: consume all 10 records. Hold message handles for
          * acknowledge in phase 1 and phase 2. */
@@ -873,7 +862,7 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* Phase 0: consume all msgcnt records in a single consume_batch
          * call (with retry-on-empty for transient cases). Explicit-mode
@@ -1083,7 +1072,7 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              &cb_state, test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* Phase 0: consume all msgcnt records in a single consume_batch
          * call (with retry-on-empty for transient cases). Explicit-mode
@@ -1588,7 +1577,7 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
         rkshare = create_share_consumer_socket_timeout(
             ctx.bootstraps, group, "explicit", socket_timeout_ms, &cb_state,
             test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
 
@@ -1850,7 +1839,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
         rkshare = create_share_consumer_socket_timeout(
             ctx.bootstraps, group, "explicit", socket_timeout_ms, &cb_state,
             test_share_ack_cb);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
 
@@ -2151,7 +2140,7 @@ static void do_test_share_topic_err_surfaces(const char *topic_suffix,
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         rd_kafka_mock_topic_set_error(ctx.mcluster, topic, inject_err);
@@ -2214,7 +2203,7 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         /* Inject AUTH_FAILED on the topic; partition_cnt_update +
@@ -2282,7 +2271,7 @@ static void test_share_consumer_re_emits_when_err_code_changes(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         /* First err: AUTH_FAILED. */
@@ -2330,7 +2319,7 @@ static void test_share_consumer_re_surfaces_after_recovery(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         /* Phase 1: fail — first surface. */
@@ -2386,7 +2375,7 @@ test_share_consumer_re_surfaces_after_recovery_topic_exception(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         /* Phase 1: fail. */
@@ -2440,7 +2429,7 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
 
         rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
                                              NULL, NULL);
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         /* Phase 1: subscribe + fail + surface. */
@@ -2460,7 +2449,7 @@ static void test_share_consumer_resubscribe_re_emits_persistent_failure(void) {
          * error must surface again. Re-force metadata across the wait
          * loop so the request happens after the share-assignment
          * heartbeat re-populates the partition list. */
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         rd_bool_t saw_err = rd_false;
         int outer;
         for (outer = 0; outer < 10 && !saw_err; outer++) {
@@ -2509,7 +2498,7 @@ static void test_share_consumer_does_not_surface_unknown_topic_or_part(void) {
         rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
         TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
 
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
         share_topic_err_prime_assignment(rkshare);
 
         rd_kafka_mock_topic_set_error(ctx.mcluster, topic,
@@ -2596,13 +2585,19 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         test_conf_set(conf, "group.id", group);
         test_conf_set(conf, "share.acknowledgement.mode", "explicit");
         test_conf_set(conf, "debug", "broker");
+        /* Cap reconnect backoff so the consumer recovers quickly after
+         * set_up. The default max (10s) extends past the recovery
+         * sleep below, causing the post-recovery ShareFetch not to
+         * land in time. */
+        test_conf_set(conf, "reconnect.backoff.ms", "100");
+        test_conf_set(conf, "reconnect.backoff.max.ms", "500");
         rd_kafka_conf_set_log_cb(conf, no_bounce_loop_log_cb);
         rd_kafka_conf_set_opaque(conf, &broker_not_up_cnt);
 
         rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
         TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
 
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         acked = consume_and_ack_all(rkshare, msgcnt_phase1);
         TEST_ASSERT(acked == msgcnt_phase1, "phase1: expected %d acked, got %d",
@@ -2760,13 +2755,17 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         test_conf_set(conf, "group.id", group);
         test_conf_set(conf, "share.acknowledgement.mode", "explicit");
         test_conf_set(conf, "debug", "broker");
+        /* Cap reconnect backoff so each set_up reconnects quickly
+         * across the chaos cycles. */
+        test_conf_set(conf, "reconnect.backoff.ms", "100");
+        test_conf_set(conf, "reconnect.backoff.max.ms", "500");
         rd_kafka_conf_set_log_cb(conf, no_bounce_loop_log_cb);
         rd_kafka_conf_set_opaque(conf, &broker_not_up_cnt);
 
         rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
         TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
 
-        subscribe_one(rkshare, topic);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
         /* Prime with one record so the share group has joined and the
          * partition is assigned by the time we take the broker down.

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2562,12 +2562,16 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_conf_t *conf;
         rd_atomic32_t broker_not_up_cnt;
-        rd_kafka_error_t *commit_error;
+        rd_kafka_error_t *error;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         const char *topic       = "0182-no_bounce_loop";
         const char *group       = "sg-0182-no-bounce-loop";
         const int msgcnt_phase1 = 5;
         const int msgcnt_phase2 = 5;
         int acked, cnt;
+        size_t rcvd, j;
+        size_t share_fetch_cnt_before_drain;
+        size_t share_fetch_cnt_after_drain;
         rd_ts_t end_ts;
 
         SUB_TEST_QUICK();
@@ -2578,6 +2582,7 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         test_curr->is_fatal_cb = test_error_is_not_fatal_cb;
 
         ctx = test_ctx_new();
+        rd_kafka_mock_start_request_tracking(ctx.mcluster);
 
         TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
                         RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -2610,10 +2615,9 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
          * acks so the broker thread can surface the error), and the
          * broker thread would legitimately log "broker not up" once.
          * That log is unrelated to the select_broker guard. */
-        commit_error = rd_kafka_share_commit_async(rkshare);
-        TEST_ASSERT(!commit_error, "commit_async error: %s",
-                    commit_error ? rd_kafka_error_string(commit_error)
-                                 : "NULL");
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
 
         /* Phase-2 records sit in the partition log; the post-recovery
          * consume below drains them. */
@@ -2630,10 +2634,9 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
 
         end_ts = test_clock() + 1000 * 1000;
         while (test_clock() < end_ts) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd             = 0;
-                rd_kafka_error_t *error = rd_kafka_share_consume_batch(
-                    rkshare, 100, rkmessages, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages,
+                                                     &rcvd);
                 TEST_ASSERT(!error,
                             "unexpected error from consume_batch while "
                             "broker is down: %s",
@@ -2655,10 +2658,44 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         TEST_SAY("Bringing broker 1 back up\n");
         rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
 
-        acked = consume_and_ack_all(rkshare, msgcnt_phase2);
-        TEST_ASSERT(acked == msgcnt_phase2,
-                    "phase2 (post-recovery): expected %d acked, got %d",
-                    msgcnt_phase2, acked);
+        /* The main-thread retrigger keeps calling select_broker. As
+         * soon as broker 1 reaches STATE_UP the next select_broker
+         * returns it and a ShareFetch fires automatically — records
+         * land on the consumer queue without any consume_batch call
+         * driving the fetch. */
+        rd_sleep(3);
+
+        share_fetch_cnt_before_drain = test_mock_get_matching_request_cnt(
+            ctx.mcluster, is_share_fetch_request, NULL);
+        TEST_SAY("ShareFetch count after recovery (pre-drain): %" PRIusz "\n",
+                 share_fetch_cnt_before_drain);
+        TEST_ASSERT(share_fetch_cnt_before_drain >= 1,
+                    "expected >= 1 ShareFetch via internal retry after "
+                    "set_up, got %" PRIusz,
+                    share_fetch_cnt_before_drain);
+
+        /* Drain the pre-fetched records. They're already on the
+         * consumer queue, so consume_batch returns them directly
+         * without enqueueing a FANOUT and no new ShareFetch fires. */
+        rcvd  = 0;
+        error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages, &rcvd);
+        TEST_ASSERT(!error, "post-recovery consume_batch error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+        TEST_ASSERT(rcvd == (size_t)msgcnt_phase2,
+                    "expected %d records from queue, got %" PRIusz,
+                    msgcnt_phase2, rcvd);
+
+        share_fetch_cnt_after_drain = test_mock_get_matching_request_cnt(
+            ctx.mcluster, is_share_fetch_request, NULL);
+        TEST_ASSERT(share_fetch_cnt_after_drain == share_fetch_cnt_before_drain,
+                    "consume_batch should drain the queue without firing "
+                    "a new ShareFetch; pre=%" PRIusz " post=%" PRIusz,
+                    share_fetch_cnt_before_drain, share_fetch_cnt_after_drain);
+
+        for (j = 0; j < rcvd; j++)
+                rd_kafka_message_destroy(rkmessages[j]);
+
+        rd_kafka_mock_clear_requests(ctx.mcluster);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2675,17 +2712,19 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
  *  Race-window companion to do_test_no_bounce_loop_on_down_broker.
  *
  *  With an empty topic the consumer's FANOUT->ShareFetch->Step 6
- *  empty-poll loop fires continuously. We take the broker down
- *  while that loop is hot. A narrow window exists between the mock
- *  TCP close and the client's broker thread updating rkb_state, in
- *  which select_broker can read stale STATE_UP and enqueue one more
- *  op. The broker thread (rkb_state has caught up by then) logs
- *  "broker not up" once, replies ERR__STATE; the next Step 6
- *  re-select then reads DOWN and skips, closing the loop.
+ *  empty-poll loop fires continuously. We rapidly flip the broker
+ *  up/down across N cycles while that loop is hot. Each set_down
+ *  has a narrow window between the mock TCP close and the client
+ *  broker thread updating rkb_state, in which select_broker can
+ *  read stale STATE_UP and enqueue one more op — the broker thread
+ *  (rkb_state has caught up by then) logs "broker not up" at most
+ *  once and replies ERR__STATE. The next Step 6 re-select reads
+ *  DOWN and skips, closing the loop until the next set_down.
  *
- *  Without the select_broker guard the Step 6 re-select would log
- *  this hundreds of times per second for the duration of the down
- *  window.
+ *  Total log count is therefore bounded by N (one slip per
+ *  set_down). Without the select_broker guard, each set_down would
+ *  produce hundreds of logs per second for the duration of the
+ *  down window — unbounded across cycles.
  * =================================================================== */
 static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         test_ctx_t ctx;
@@ -2695,12 +2734,12 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         const char *topic             = "0182-race_bounce";
         const char *group             = "sg-0182-race-bounce";
         const int msgcnt_recovery     = 5;
-        const int max_allowed_log_cnt = 1;
+        const int n_cycles            = 10;
+        const int max_allowed_log_cnt = n_cycles;
         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
         size_t rcvd;
         rd_kafka_error_t *error;
-        rd_ts_t end_ts;
-        int cnt, acked;
+        int i, cnt, acked;
 
         SUB_TEST_QUICK();
 
@@ -2759,33 +2798,48 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
                     error ? rd_kafka_error_string(error) : "NULL");
         TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
 
-        TEST_SAY("Taking broker 1 down mid-empty-poll\n");
-        rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
-
-        end_ts = test_clock() + 1000 * 1000;
-        while (test_clock() < end_ts) {
+        /* Chaos: rapidly flip the broker up/down across n_cycles
+         * while the consumer's empty-poll loop is hot. Each set_down
+         * may admit one race-window slip; total log count must stay
+         * bounded by n_cycles. */
+        for (i = 0; i < n_cycles; i++) {
+                TEST_SAY("Cycle %d/%d: taking broker 1 down\n", i + 1,
+                         n_cycles);
+                rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages,
+                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
                                                      &rcvd);
-                TEST_ASSERT(!error, "consume_batch error: %s",
+                TEST_ASSERT(!error, "cycle %d down: consume_batch error: %s",
+                            i + 1,
                             error ? rd_kafka_error_string(error) : "NULL");
-                TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
+                TEST_ASSERT(rcvd == 0,
+                            "cycle %d down: expected 0 records, got %zu", i + 1,
+                            rcvd);
+
+                TEST_SAY("Cycle %d/%d: bringing broker 1 back up\n", i + 1,
+                         n_cycles);
+                rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
+                rcvd  = 0;
+                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
+                                                     &rcvd);
+                TEST_ASSERT(!error, "cycle %d up: consume_batch error: %s",
+                            i + 1,
+                            error ? rd_kafka_error_string(error) : "NULL");
+                TEST_ASSERT(rcvd == 0,
+                            "cycle %d up: expected 0 records, got %zu", i + 1,
+                            rcvd);
         }
 
         cnt = rd_atomic32_get(&broker_not_up_cnt);
-        TEST_SAY("\"broker not up\" log count: %d (max %d)\n", cnt,
-                 max_allowed_log_cnt);
+        TEST_SAY("\"broker not up\" log count after %d cycles: %d (max %d)\n",
+                 n_cycles, cnt, max_allowed_log_cnt);
         TEST_ASSERT(cnt <= max_allowed_log_cnt,
-                    "race-window slip must be bounded to %d op; got %d "
-                    "log lines (without the guard this would be "
-                    "hundreds)",
-                    max_allowed_log_cnt, cnt);
+                    "race-window slips must be bounded to %d (one per "
+                    "set_down across %d cycles); got %d log lines",
+                    max_allowed_log_cnt, n_cycles, cnt);
 
-        /* Recovery: bring the broker back up, produce records, verify
-         * the consumer drains them. */
-        TEST_SAY("Bringing broker 1 back up\n");
-        rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
-
+        /* Recovery: broker is left UP at the end of the chaos loop.
+         * Produce records and verify the consumer drains them. */
         mock_produce(ctx.producer, topic, msgcnt_recovery);
 
         acked = consume_and_ack_all(rkshare, msgcnt_recovery);


### PR DESCRIPTION
- Guard `rd_kafka_share_select_broker` with `rkb_state == STATE_UP`. Without this a DOWN leader caused an unbounded main↔broker thread bounce loop. The read is unlocked; stale values are bounded to one stray op per state transition.
- Drop the now-redundant `rkb_fetching` check from the share-consumer SHARE_FETCH op handler — `rkb_share_fetch_enqueued` on the main thread already enforces the at-most-one-in-flight invariant.
- New 0182 subtests:
  - Steady-state DOWN: no "broker not up" logs, internal retry refills the queue after recovery without consume_batch driving the fetch.
  - Broker chaos during active empty-poll: log count bounded by cycle count even under rapid up/down churn.
- 0176: add verbose tracing to `do_test_mock_uses_share_acknowledge` for easier diagnosis.
- Remove stale TODOs and commented-out debug / dead code across the share-consumer files.