### PR TITLE
[KIP-932] Implement mock broker partition-level request error injection 

### DIFF
--- a/src/rdkafka_mock.c
+++ b/src/rdkafka_mock.c
@@ -51,6 +51,8 @@ rd_kafka_mock_request_new(int32_t id, int16_t api_key, int64_t timestamp_us);
 static void rd_kafka_mock_request_free(void *element);
 static void rd_kafka_mock_coord_remove(rd_kafka_mock_cluster_t *mcluster,
                                        int32_t broker_id);
+static void
+rd_kafka_mock_error_stack_destroy(rd_kafka_mock_error_stack_t *errstack);
 
 static rd_kafka_mock_broker_t *
 rd_kafka_mock_broker_find(const rd_kafka_mock_cluster_t *mcluster,
@@ -873,6 +875,7 @@ static void rd_kafka_mock_partition_destroy(rd_kafka_mock_partition_t *mpart) {
         rd_kafka_mock_committed_offset_t *coff, *tmpcoff;
         rd_kafka_mock_partition_leader_t *mpart_leader, *tmp_mpart_leader;
         rd_kafka_mock_aborted_txn_t *mabort, *tmp_mabort;
+        rd_kafka_mock_error_stack_t *errstack, *tmp_errstack;
 
         TAILQ_FOREACH_SAFE(mset, &mpart->msgsets, link, tmp)
         rd_kafka_mock_msgset_destroy(mpart, mset);
@@ -889,6 +892,11 @@ static void rd_kafka_mock_partition_destroy(rd_kafka_mock_partition_t *mpart) {
         TAILQ_FOREACH_SAFE(mabort, &mpart->aborted_txns, link, tmp_mabort) {
                 TAILQ_REMOVE(&mpart->aborted_txns, mabort, link);
                 rd_free(mabort);
+        }
+
+        TAILQ_FOREACH_SAFE(errstack, &mpart->errstacks, link, tmp_errstack) {
+                TAILQ_REMOVE(&mpart->errstacks, errstack, link);
+                rd_kafka_mock_error_stack_destroy(errstack);
         }
 
         rd_free(mpart->replicas);
@@ -916,6 +924,7 @@ static void rd_kafka_mock_partition_init(rd_kafka_mock_topic_t *mtopic,
 
         TAILQ_INIT(&mpart->committed_offsets);
         TAILQ_INIT(&mpart->leader_responses);
+        TAILQ_INIT(&mpart->errstacks);
 
         rd_list_init(&mpart->pidstates, 0, rd_free);
 
@@ -2317,6 +2326,27 @@ rd_kafka_mock_next_request_error(rd_kafka_mock_connection_t *mconn,
         return err_rtt.err;
 }
 
+/**
+ * @brief Removes and returns the next partition request error for
+ *        request type \p ApiKey, or RD_KAFKA_RESP_ERR_NO_ERROR if
+ *        no error was injected for this partition and ApiKey.
+ *
+ * @locality mcluster thread
+ */
+rd_kafka_resp_err_t
+rd_kafka_mock_partition_next_request_error(rd_kafka_mock_partition_t *mpart,
+                                           int16_t ApiKey) {
+        rd_kafka_mock_error_stack_t *errstack;
+        rd_kafka_mock_error_rtt_t err_rtt;
+
+        errstack = rd_kafka_mock_error_stack_find(&mpart->errstacks, ApiKey);
+        if (likely(!errstack))
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+
+        err_rtt = rd_kafka_mock_error_stack_next(errstack);
+
+        return err_rtt.err;
+}
 
 void rd_kafka_mock_clear_request_errors(rd_kafka_mock_cluster_t *mcluster,
                                         int16_t ApiKey) {
@@ -2574,6 +2604,34 @@ rd_kafka_mock_partition_push_leader_response(rd_kafka_mock_cluster_t *mcluster,
         return rd_kafka_op_err_destroy(
             rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
 }
+
+rd_kafka_resp_err_t
+rd_kafka_mock_partition_push_request_errors(rd_kafka_mock_cluster_t *mcluster,
+                                            const char *topic,
+                                            int32_t partition,
+                                            int16_t ApiKey,
+                                            size_t cnt,
+                                            ...) {
+        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_MOCK);
+        va_list ap;
+        size_t i;
+
+        rko->rko_u.mock.cmd       = RD_KAFKA_MOCK_CMD_PART_PUSH_REQUEST_ERRORS;
+        rko->rko_u.mock.name      = rd_strdup(topic);
+        rko->rko_u.mock.partition = partition;
+        rko->rko_u.mock.lo        = (int64_t)ApiKey;
+        rko->rko_u.mock.hi        = (int64_t)cnt;
+        rko->rko_u.mock.errs = rd_malloc(sizeof(*rko->rko_u.mock.errs) * cnt);
+
+        va_start(ap, cnt);
+        for (i = 0; i < cnt; i++)
+                rko->rko_u.mock.errs[i] = va_arg(ap, rd_kafka_resp_err_t);
+        va_end(ap);
+
+        return rd_kafka_op_err_destroy(
+            rd_kafka_op_req(mcluster->ops, rko, RD_POLL_INFINITE));
+}
+
 
 rd_kafka_resp_err_t
 rd_kafka_mock_broker_set_down(rd_kafka_mock_cluster_t *mcluster,
@@ -2843,7 +2901,9 @@ rd_kafka_mock_cluster_cmd(rd_kafka_mock_cluster_t *mcluster,
         rd_kafka_mock_topic_t *mtopic;
         rd_kafka_mock_partition_t *mpart;
         rd_kafka_mock_broker_t *mrkb;
+        rd_kafka_mock_error_stack_t *errstack;
         size_t i;
+        size_t errcnt;
         rd_kafka_resp_err_t err;
 
         switch (rko->rko_u.mock.cmd) {
@@ -2995,6 +3055,38 @@ rd_kafka_mock_cluster_cmd(rd_kafka_mock_cluster_t *mcluster,
                 rd_kafka_mock_partition_push_leader_response0(
                     mpart, rko->rko_u.mock.leader_id,
                     rko->rko_u.mock.leader_epoch);
+                break;
+
+        case RD_KAFKA_MOCK_CMD_PART_PUSH_REQUEST_ERRORS:
+                errcnt = (size_t)rko->rko_u.mock.hi;
+
+                mpart = rd_kafka_mock_partition_get(
+                    mcluster, rko->rko_u.mock.name, rko->rko_u.mock.partition);
+                if (!mpart)
+                        return RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART;
+
+                rd_kafka_dbg(mcluster->rk, MOCK, "MOCK",
+                             "Push %s [%" PRId32 "] %" PRIusz
+                             " request error(s) for ApiKey %s",
+                             rko->rko_u.mock.name, rko->rko_u.mock.partition,
+                             errcnt,
+                             rd_kafka_ApiKey2str((int16_t)rko->rko_u.mock.lo));
+
+                errstack = rd_kafka_mock_error_stack_get(
+                    &mpart->errstacks, (int16_t)rko->rko_u.mock.lo);
+
+                if (errstack->cnt + errcnt > errstack->size) {
+                        errstack->size = errstack->cnt + errcnt + 4;
+                        errstack->errs = rd_realloc(
+                            errstack->errs,
+                            errstack->size * sizeof(*errstack->errs));
+                }
+
+                for (i = 0; i < errcnt; i++) {
+                        errstack->errs[errstack->cnt].err =
+                            rko->rko_u.mock.errs[i];
+                        errstack->errs[errstack->cnt++].rtt = 0;
+                }
                 break;
 
                 /* Broker commands */

--- a/src/rdkafka_mock.h
+++ b/src/rdkafka_mock.h
@@ -221,6 +221,40 @@ rd_kafka_mock_broker_error_stack_cnt(rd_kafka_mock_cluster_t *mcluster,
                                      int16_t ApiKey,
                                      size_t *cntp);
 
+/**
+ * @brief Push \p cnt errors in the \p ... va-arg list onto the partition's
+ *        error stack for the given \p ApiKey.
+ *
+ * \p ApiKey is the Kafka protocol request type, e.g., ProduceRequest (0).
+ *
+ * The injected errors will be returned as the partition-level ErrorCode,
+ * one per request, in the order they were pushed, for requests of type
+ * \p ApiKey referencing this partition. Other partitions in the same
+ * request are not affected.
+ *
+ * @remark Cluster errors (rd_kafka_mock_push_request_errors()) and broker
+ *         errors (rd_kafka_mock_broker_push_request_error_rtts()) take
+ *         precedence over partition errors.
+ *
+ * @remark The error codes are not validated against the set of errors
+ *         the Apache Kafka protocol permits for the given \p ApiKey and
+ *         response field, that is the test's responsibility.
+ *
+ * @remark If \p topic does not exist in the mock cluster it is
+ *         auto-created, same as for the other mock partition APIs.
+ *
+ * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success, or
+ *          RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART if \p topic exists
+ *          and \p partition is out of range.
+ */
+RD_EXPORT rd_kafka_resp_err_t
+rd_kafka_mock_partition_push_request_errors(rd_kafka_mock_cluster_t *mcluster,
+                                            const char *topic,
+                                            int32_t partition,
+                                            int16_t ApiKey,
+                                            size_t cnt,
+                                            ...);
+
 
 /**
  * @brief Set the topic error to return in protocol requests.

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -172,6 +172,10 @@ static int rd_kafka_mock_handle_Produce(rd_kafka_mock_connection_t *mconn,
                         else if (mpart->leader != mconn->broker)
                                 err =
                                     RD_KAFKA_RESP_ERR_NOT_LEADER_FOR_PARTITION;
+                        else
+                                err =
+                                    rd_kafka_mock_partition_next_request_error(
+                                        mpart, rkbuf->rkbuf_reqhdr.ApiKey);
 
                         /* Append to partition log */
                         if (!err)
@@ -501,6 +505,11 @@ static int rd_kafka_mock_handle_Fetch(rd_kafka_mock_connection_t *mconn,
                                 err =
                                     rd_kafka_mock_partition_leader_epoch_check(
                                         mpart, CurrentLeaderEpoch);
+
+                        if (!err && mpart)
+                                err =
+                                    rd_kafka_mock_partition_next_request_error(
+                                        mpart, rkbuf->rkbuf_reqhdr.ApiKey);
 
                         /* Find MessageSet for FetchOffset */
                         if (!err && FetchOffset != mpart->end_offset) {
@@ -4376,6 +4385,18 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                 if (mpart->leader != mconn->broker)
                                         continue;
 
+                                /* Injected partition error: skip acquisition
+                                 * so no records are locked for a partition
+                                 * the client will see as failed.  The error
+                                 * is stashed on the session's partition list
+                                 * element and consumed (read and cleared) by
+                                 * the response writer below. */
+                                rktpar->err =
+                                    rd_kafka_mock_partition_next_request_error(
+                                        mpart, rkbuf->rkbuf_reqhdr.ApiKey);
+                                if (rktpar->err)
+                                        continue;
+
                                 rd_kafka_mock_sgrp_partmeta_t *pmeta =
                                     rd_kafka_mock_sgrp_partmeta_get(
                                         sgrp, topic_id, rktpar->partition,
@@ -4501,8 +4522,13 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
                                         else
-                                                part_err =
-                                                    RD_KAFKA_RESP_ERR_NO_ERROR;
+                                                part_err = rktpar->err;
+
+                                        /* Consume the stashed injected error
+                                         * so it doesn't leak into subsequent
+                                         * responses. */
+                                        rktpar->err =
+                                            RD_KAFKA_RESP_ERR_NO_ERROR;
 
                                         /* Response: Partition */
                                         rd_kafka_buf_write_i32(
@@ -4572,7 +4598,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                         rd_kafka_buf_write_tags_empty(resp);
                                         /* Response: Records (all acquired
                                          * batches concatenated) */
-                                        if (mpart && pmeta)
+                                        if (mpart && pmeta && !part_err)
                                                 rd_kafka_mock_sgrp_write_acquired_records(
                                                     resp, pmeta, mpart,
                                                     &MemberId, now);
@@ -4580,7 +4606,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                                 rd_kafka_buf_write_uvarint(resp,
                                                                            1);
                                         /* Response: AcquiredRecords */
-                                        if (mpart && pmeta)
+                                        if (mpart && pmeta && !part_err)
                                                 rd_kafka_mock_sgrp_write_acquired_records_meta(
                                                     resp, pmeta, &MemberId,
                                                     now);
@@ -4840,6 +4866,35 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                         session->session_epoch++;
                 }
 
+                /* Pop injected partition-level errors and stash them on
+                 * the request-local partition list.  Done before ack
+                 * application so that acks for an errored partition are
+                 * NOT applied, keeping mock record state consistent with
+                 * the reported error. */
+                if (!err) {
+                        int p;
+                        for (p = 0; p < ack_partitions->cnt; p++) {
+                                rd_kafka_topic_partition_t *rktpar =
+                                    &ack_partitions->elems[p];
+                                rd_kafka_mock_topic_t *mtopic =
+                                    rd_kafka_mock_topic_find_by_id(
+                                        mcluster,
+                                        rd_kafka_topic_partition_get_topic_id(
+                                            rktpar));
+                                rd_kafka_mock_partition_t *mpart =
+                                    mtopic ? rd_kafka_mock_partition_find(
+                                                 mtopic, rktpar->partition)
+                                           : NULL;
+
+                                rktpar->err = RD_KAFKA_RESP_ERR_NO_ERROR;
+                                if (mpart && mpart->leader == mconn->broker)
+                                        rktpar->err =
+                                            rd_kafka_mock_partition_next_request_error(
+                                                mpart,
+                                                rkbuf->rkbuf_reqhdr.ApiKey);
+                        }
+                }
+
                 /* Apply acknowledgement batches */
                 if (!err && sgrp && rd_list_cnt(&ack_entries) > 0) {
                         int k;
@@ -4852,6 +4907,16 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                         for (k = 0; k < rd_list_cnt(&ack_entries); k++) {
                                 struct rd_kafka_mock_sgrp_ack_entry *entry =
                                     rd_list_elem(&ack_entries, k);
+                                int idx =
+                                    rd_kafka_topic_partition_list_find_idx_by_id(
+                                        ack_partitions, entry->topic_id,
+                                        entry->partition);
+
+                                /* Skip ack application for partitions with
+                                 * an injected error. */
+                                if (idx >= 0 && ack_partitions->elems[idx].err)
+                                        continue;
+
                                 entry->err = rd_kafka_mock_sgrp_apply_ack(
                                     sgrp, entry->topic_id, entry->partition,
                                     entry->first_offset, entry->last_offset,
@@ -4950,6 +5015,11 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                                         else if (mpart->leader != mconn->broker)
                                                 part_err =
                                                     RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER;
+                                        else if (rktpar->err)
+                                                /* Injected partition error
+                                                 * stashed before ack
+                                                 * application. */
+                                                part_err = rktpar->err;
                                         else
                                                 part_err =
                                                     rd_kafka_mock_sgrp_ack_error_for_partition(

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -528,6 +528,12 @@ typedef struct rd_kafka_mock_partition_s {
         /**< Leader responses */
         TAILQ_HEAD(, rd_kafka_mock_partition_leader_s)
         leader_responses;
+
+        /**< Per-ApiKey request error stack.
+         *   Pushed via RD_KAFKA_MOCK_CMD_PART_PUSH_REQUEST_ERRORS and
+         *   popped by the protocol request handlers.
+         *   Only accessed from the mock cluster thread, no locks needed. */
+        rd_kafka_mock_error_stack_head_t errstacks;
 } rd_kafka_mock_partition_t;
 
 
@@ -785,6 +791,10 @@ rd_kafka_mock_msgset_find(const rd_kafka_mock_partition_t *mpart,
 rd_kafka_resp_err_t
 rd_kafka_mock_next_request_error(rd_kafka_mock_connection_t *mconn,
                                  rd_kafka_buf_t *resp);
+
+rd_kafka_resp_err_t
+rd_kafka_mock_partition_next_request_error(rd_kafka_mock_partition_t *mpart,
+                                           int16_t ApiKey);
 
 rd_kafka_resp_err_t
 rd_kafka_mock_partition_log_append(rd_kafka_mock_partition_t *mpart,

--- a/src/rdkafka_op.c
+++ b/src/rdkafka_op.c
@@ -505,6 +505,7 @@ void rd_kafka_op_destroy(rd_kafka_op_t *rko) {
         case RD_KAFKA_OP_MOCK:
                 RD_IF_FREE(rko->rko_u.mock.name, rd_free);
                 RD_IF_FREE(rko->rko_u.mock.str, rd_free);
+                RD_IF_FREE(rko->rko_u.mock.errs, rd_free);
                 if (rko->rko_u.mock.metrics) {
                         int64_t i;
                         for (i = 0; i < rko->rko_u.mock.hi; i++)

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -617,6 +617,7 @@ struct rd_kafka_op_s {
                                 RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER,
                                 RD_KAFKA_MOCK_CMD_PART_SET_FOLLOWER_WMARKS,
                                 RD_KAFKA_MOCK_CMD_PART_PUSH_LEADER_RESPONSE,
+                                RD_KAFKA_MOCK_CMD_PART_PUSH_REQUEST_ERRORS,
                                 RD_KAFKA_MOCK_CMD_BROKER_SET_UPDOWN,
                                 RD_KAFKA_MOCK_CMD_BROKER_SET_RTT,
                                 RD_KAFKA_MOCK_CMD_BROKER_SET_RACK,
@@ -629,59 +630,63 @@ struct rd_kafka_op_s {
                                 RD_KAFKA_MOCK_CMD_TELEMETRY_PUSH_INTERVAL_SET,
                         } cmd;
 
-                        rd_kafka_resp_err_t err; /**< Error for:
-                                                  *    TOPIC_SET_ERROR */
-                        char *name;              /**< For:
-                                                  *    TOPIC_SET_ERROR
-                                                  *    TOPIC_CREATE
-                                                  *    PART_SET_FOLLOWER
-                                                  *    PART_SET_FOLLOWER_WMARKS
-                                                  *    BROKER_SET_RACK
-                                                  *    COORD_SET (key_type)
-                                                  *    PART_PUSH_LEADER_RESPONSE
-                                                  */
-                        char *str;               /**< For:
-                                                  *    COORD_SET (key)
-                                                  */
-                        int32_t partition;       /**< For:
-                                                  *    PART_SET_FOLLOWER
-                                                  *    PART_SET_FOLLOWER_WMARKS
-                                                  *    PART_SET_LEADER
-                                                  *    APIVERSION_SET (ApiKey)
-                                                  *    PART_PUSH_LEADER_RESPONSE
-                                                  */
-                        int32_t broker_id;       /**< For:
-                                                  *    PART_SET_FOLLOWER
-                                                  *    PART_SET_LEADER
-                                                  *    BROKER_SET_UPDOWN
-                                                  *    BROKER_SET_RACK
-                                                  *    BROKER_DECOMMISSION
-                                                  *    BROKER_ADD
-                                                  *    COORD_SET */
-                        int64_t lo;              /**< Low offset, for:
-                                                  *    TOPIC_CREATE (part cnt)
-                                                  *    PART_SET_FOLLOWER_WMARKS
-                                                  *    BROKER_SET_UPDOWN
-                                                  *    APIVERSION_SET (minver)
-                                                  *    BROKER_SET_RTT
-                                                  *    PART_DELETE_RECORDS
-                                                  *      (before_offset)
-                                                  */
-                        int64_t hi;              /**< High offset, for:
-                                                  *    TOPIC_CREATE (repl fact)
-                                                  *    PART_SET_FOLLOWER_WMARKS
-                                                  *    APIVERSION_SET (maxver)
-                                                  *    REQUESTED_METRICS_SET (metrics_cnt)
-                                                  *    TELEMETRY_PUSH_INTERVAL_SET (interval)
-                                                  */
-                        int32_t leader_id;       /**< Leader id, for:
-                                                  *   PART_PUSH_LEADER_RESPONSE
-                                                  */
-                        int32_t leader_epoch;    /**< Leader epoch, for:
-                                                  *   PART_PUSH_LEADER_RESPONSE
-                                                  */
-                        char **metrics;          /**< Metrics requested, for:
-                                                  *   REQUESTED_METRICS_SET */
+                        rd_kafka_resp_err_t err;   /**< Error for:
+                                                    *    TOPIC_SET_ERROR */
+                        char *name;                /**< For:
+                                                    *    TOPIC_SET_ERROR
+                                                    *    TOPIC_CREATE
+                                                    *    PART_SET_FOLLOWER
+                                                    *    PART_SET_FOLLOWER_WMARKS
+                                                    *    BROKER_SET_RACK
+                                                    *    COORD_SET (key_type)
+                                                    *    PART_PUSH_LEADER_RESPONSE
+                                                    */
+                        char *str;                 /**< For:
+                                                    *    COORD_SET (key)
+                                                    */
+                        int32_t partition;         /**< For:
+                                                    *    PART_SET_FOLLOWER
+                                                    *    PART_SET_FOLLOWER_WMARKS
+                                                    *    PART_SET_LEADER
+                                                    *    APIVERSION_SET (ApiKey)
+                                                    *    PART_PUSH_LEADER_RESPONSE
+                                                    */
+                        int32_t broker_id;         /**< For:
+                                                    *    PART_SET_FOLLOWER
+                                                    *    PART_SET_LEADER
+                                                    *    BROKER_SET_UPDOWN
+                                                    *    BROKER_SET_RACK
+                                                    *    BROKER_DECOMMISSION
+                                                    *    BROKER_ADD
+                                                    *    COORD_SET */
+                        int64_t lo;                /**< Low offset, for:
+                                                    *    TOPIC_CREATE (part cnt)
+                                                    *    PART_SET_FOLLOWER_WMARKS
+                                                    *    BROKER_SET_UPDOWN
+                                                    *    APIVERSION_SET (minver)
+                                                    *    BROKER_SET_RTT
+                                                    *    PART_DELETE_RECORDS
+                                                    *      (before_offset)
+                                                    */
+                        int64_t hi;                /**< High offset, for:
+                                                    *    TOPIC_CREATE (repl fact)
+                                                    *    PART_SET_FOLLOWER_WMARKS
+                                                    *    APIVERSION_SET (maxver)
+                                                    *    REQUESTED_METRICS_SET (metrics_cnt)
+                                                    *    TELEMETRY_PUSH_INTERVAL_SET (interval)
+                                                    */
+                        int32_t leader_id;         /**< Leader id, for:
+                                                    *   PART_PUSH_LEADER_RESPONSE
+                                                    */
+                        int32_t leader_epoch;      /**< Leader epoch, for:
+                                                    *   PART_PUSH_LEADER_RESPONSE
+                                                    */
+                        char **metrics;            /**< Metrics requested, for:
+                                                    *   REQUESTED_METRICS_SET */
+                        rd_kafka_resp_err_t *errs; /**< Errors to push, for:
+                                                    *   PART_PUSH_REQUEST_ERRORS
+                                                    *   (ApiKey in .lo,
+                                                    *    count in .hi) */
                 } mock;
 
                 struct {

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -3075,6 +3075,201 @@ static void do_test_fetch_stall_logged_on_no_broker(void) {
 }
 
 
+/* ===================================================================
+ *  Partition-level error injection: API basics.
+ * =================================================================== */
+static void test_partition_error_injection_general(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        char topic[64];
+        char group[64];
+        const int msgcnt = 3;
+        int acked;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        rd_snprintf(topic, sizeof(topic), "0182-part_err_general");
+        rd_snprintf(group, sizeof(group), "sg-0182-part_err_general");
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        /* Unknown topics are auto-created. */
+        TEST_ASSERT(rd_kafka_mock_partition_push_request_errors(
+                        ctx.mcluster, "0182-no-such-topic", 0,
+                        RD_KAFKAP_ShareFetch, 1,
+                        RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push to unknown topic");
+
+        /* Out-of-range partition is rejected. */
+        TEST_ASSERT(rd_kafka_mock_partition_push_request_errors(
+                        ctx.mcluster, topic, 99, RD_KAFKAP_ShareFetch, 1,
+                        RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR) ==
+                        RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART,
+                    "push to unknown partition");
+
+        TEST_ASSERT(rd_kafka_mock_partition_push_request_errors(
+                        ctx.mcluster, topic, 0, RD_KAFKAP_ShareFetch, 1,
+                        RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push partition error");
+
+        mock_produce_partition(ctx.producer, topic, 0, msgcnt);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* The injected error is transient: all records are delivered
+         * once it has been consumed off the stack. */
+        acked = consume_and_ack_all(rkshare, msgcnt);
+        TEST_ASSERT(acked == msgcnt, "expected %d acked, got %d", msgcnt,
+                    acked);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  ShareFetch partition error injection: errors on one partition
+ *  must not affect the other, and the partition recovers once the
+ *  error stack drains.
+ * =================================================================== */
+static void test_partition_error_injection_share_fetch(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        char topic[64];
+        char group[64];
+        const int msgs_per_part = 5;
+        int acked;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        rd_snprintf(topic, sizeof(topic), "0182-part_err_sharefetch");
+        rd_snprintf(group, sizeof(group), "sg-0182-part_err_sharefetch");
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 2, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        mock_produce_partition(ctx.producer, topic, 0, msgs_per_part);
+        mock_produce_partition(ctx.producer, topic, 1, msgs_per_part);
+
+        TEST_ASSERT(rd_kafka_mock_partition_push_request_errors(
+                        ctx.mcluster, topic, 1, RD_KAFKAP_ShareFetch, 2,
+                        RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER,
+                        RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push partition errors");
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* Partition 0 is unaffected and partition 1 recovers after
+         * the two errored fetches: nothing is lost. */
+        acked = consume_and_ack_all(rkshare, 2 * msgs_per_part);
+        TEST_ASSERT(acked == 2 * msgs_per_part, "expected %d acked, got %d",
+                    2 * msgs_per_part, acked);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
+/* ===================================================================
+ *  ShareAcknowledge partition error injection: the injected error
+ *  surfaces in commit_sync results for that partition only.
+ * =================================================================== */
+static void test_partition_error_injection_share_ack(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_topic_partition_list_t *partitions = NULL;
+        rd_kafka_error_t *error;
+        char topic[64];
+        char group[64];
+        const int msgs_per_part = 5;
+        const rd_kafka_resp_err_t injected_err =
+            RD_KAFKA_RESP_ERR_KAFKA_STORAGE_ERROR;
+        int acked;
+        int i;
+
+        SUB_TEST_QUICK();
+
+        ctx = test_ctx_new();
+
+        rd_snprintf(topic, sizeof(topic), "0182-part_err_shareack");
+        rd_snprintf(group, sizeof(group), "sg-0182-part_err_shareack");
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 2, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        mock_produce_partition(ctx.producer, topic, 0, msgs_per_part);
+        mock_produce_partition(ctx.producer, topic, 1, msgs_per_part);
+
+        rkshare = create_mock_share_consumer(ctx.bootstraps, group, "explicit",
+                                             NULL, NULL);
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        acked = consume_and_ack_all(rkshare, 2 * msgs_per_part);
+        TEST_ASSERT(acked == 2 * msgs_per_part, "expected %d acked, got %d",
+                    2 * msgs_per_part, acked);
+
+        TEST_ASSERT(rd_kafka_mock_partition_push_request_errors(
+                        ctx.mcluster, topic, 0, RD_KAFKAP_ShareAcknowledge, 1,
+                        injected_err) == RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "push partition error");
+
+        partitions = NULL;
+        error      = rd_kafka_share_commit_sync(rkshare, 30000, &partitions);
+        if (error)
+                rd_kafka_error_destroy(error);
+
+        TEST_ASSERT(partitions != NULL, "expected non-NULL partition results");
+        TEST_ASSERT(partitions->cnt == 2,
+                    "expected results for 2 partitions, got %d",
+                    partitions->cnt);
+
+        /* Partition 0 carries the injected error, partition 1 is
+         * unaffected. */
+        for (i = 0; i < partitions->cnt; i++) {
+                rd_kafka_topic_partition_t *rktpar = &partitions->elems[i];
+                rd_kafka_resp_err_t exp_err        = rktpar->partition == 0
+                                                         ? injected_err
+                                                         : RD_KAFKA_RESP_ERR_NO_ERROR;
+
+                TEST_SAY("%s [%" PRId32 "]: %s\n", rktpar->topic,
+                         rktpar->partition, rd_kafka_err2name(rktpar->err));
+                TEST_ASSERT(rktpar->err == exp_err,
+                            "partition [%" PRId32 "]: expected %s, got %s",
+                            rktpar->partition, rd_kafka_err2name(exp_err),
+                            rd_kafka_err2name(rktpar->err));
+        }
+
+        rd_kafka_topic_partition_list_destroy(partitions);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -3154,5 +3349,10 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         do_test_one_log_on_broker_down_during_active_empty_poll();
         do_test_fetch_stall_logged_on_no_broker();
 
+
+        /* Partition-level error injection. */
+        test_partition_error_injection_general();
+        test_partition_error_injection_share_fetch();
+        test_partition_error_injection_share_ack();
         return 0;
 }


### PR DESCRIPTION
Add rd_kafka_mock_partition_push_request_errors() to push a FIFO stack
of errors onto a single partition for a given ApiKey, complementing the
existing cluster- and broker-level injection which can only fail entire
requests. Errors are consumed one per request in push order until the
stack drains.

Consuming handlers: Produce, Fetch, ShareFetch, ShareAcknowledge.
The injected error suppresses the operation it claims failed, keeping
mock state consistent with the response (no append / no record
acquisition / no ack application), matching real broker behaviour.

Test 0182 adds three subtests: API mechanics, ShareFetch partition
scoping and recovery, ShareAcknowledge per-partition commit_sync
results.