### PR TITLE
[KIP-932] Add OAUTHBEARER token APIs for share consumers

### DIFF
--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3223,7 +3223,7 @@ rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare);
  * @param md_principal_name the mandatory Kafka principal name associated
  *  with the token.
  * @param extensions optional SASL extensions key-value array with
- *  \p extensions_size elements (number of keys * 2), where [i] is the key and
+ *  \p extension_size elements (number of keys * 2), where [i] is the key and
  *  [i+1] is the key's value, to be communicated to the broker
  *  as additional key-value pairs during the initial client response as per
  *  https://tools.ietf.org/html/rfc7628#section-3.1. The key-value pairs are

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3252,15 +3252,15 @@ rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare);
  * @sa rd_kafka_conf_set_oauthbearer_token_refresh_cb()
  */
 RD_EXPORT
-rd_kafka_resp_err_t rd_kafka_share_oauthbearer_set_token(
-    rd_kafka_share_t *rkshare,
-    const char *token_value,
-    int64_t md_lifetime_ms,
-    const char *md_principal_name,
-    const char **extensions,
-    size_t extension_size,
-    char *errstr,
-    size_t errstr_size);
+rd_kafka_resp_err_t
+rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
+                                     const char *token_value,
+                                     int64_t md_lifetime_ms,
+                                     const char *md_principal_name,
+                                     const char **extensions,
+                                     size_t extension_size,
+                                     char *errstr,
+                                     size_t errstr_size);
 
 /**
  * @brief SASL/OAUTHBEARER token refresh failure indicator for a share

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3191,6 +3191,105 @@ RD_EXPORT
 void rd_kafka_destroy_flags(rd_kafka_t *rk, int flags);
 
 /**
+ * @brief Get the SASL callback queue for a share consumer.
+ *
+ * @returns a reference to the SASL callback queue for the share consumer,
+ *          if a SASL mechanism with callbacks is configured
+ *          (currently only OAUTHBEARER), else returns NULL.
+ *
+ * @remark The dedicated SASL callback queue is only created when
+ *         rd_kafka_conf_enable_sasl_queue() was enabled on the configuration
+ *         before creating the share consumer; otherwise SASL callbacks are
+ *         served on the main queue and this returns NULL.
+ *
+ * Use rd_kafka_queue_destroy() to lose the reference.
+ *
+ * @sa rd_kafka_conf_enable_sasl_queue()
+ * @sa rd_kafka_queue_get_sasl()
+ * @sa rd_kafka_share_sasl_background_callbacks_enable()
+ */
+RD_EXPORT
+rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare);
+
+/**
+ * @brief Set SASL/OAUTHBEARER token and metadata for a share consumer.
+ *
+ * @param rkshare Share consumer instance.
+ * @param token_value the mandatory token value to set, often (but not
+ *  necessarily) a JWS compact serialization as per
+ *  https://tools.ietf.org/html/rfc7515#section-3.1.
+ * @param md_lifetime_ms when the token expires, in terms of the number of
+ *  milliseconds since the epoch.
+ * @param md_principal_name the mandatory Kafka principal name associated
+ *  with the token.
+ * @param extensions optional SASL extensions key-value array with
+ *  \p extensions_size elements (number of keys * 2), where [i] is the key and
+ *  [i+1] is the key's value, to be communicated to the broker
+ *  as additional key-value pairs during the initial client response as per
+ *  https://tools.ietf.org/html/rfc7628#section-3.1. The key-value pairs are
+ *  copied.
+ * @param extension_size the number of SASL extension keys plus values,
+ *  which must be a non-negative multiple of 2.
+ * @param errstr A human readable error string (nul-terminated) is written to
+ *               this location that must be of at least \p errstr_size bytes.
+ *               The \p errstr is only written in case of error.
+ * @param errstr_size Writable size in \p errstr.
+ *
+ * The SASL/OAUTHBEARER token refresh callback or event handler should invoke
+ * this method upon success.
+ *
+ * @returns \c RD_KAFKA_RESP_ERR_NO_ERROR on success, otherwise \p errstr set
+ *              and:<br>
+ *          \c RD_KAFKA_RESP_ERR__INVALID_ARG if any of the arguments are
+ *              invalid;<br>
+ *          \c RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED if SASL/OAUTHBEARER is not
+ *              supported by this build;<br>
+ *          \c RD_KAFKA_RESP_ERR__STATE if SASL/OAUTHBEARER is supported but is
+ *              not configured as the client's authentication mechanism.<br>
+ *
+ * @sa rd_kafka_oauthbearer_set_token()
+ * @sa rd_kafka_share_oauthbearer_set_token_failure()
+ * @sa rd_kafka_conf_set_oauthbearer_token_refresh_cb()
+ */
+RD_EXPORT
+rd_kafka_resp_err_t rd_kafka_share_oauthbearer_set_token(
+    rd_kafka_share_t *rkshare,
+    const char *token_value,
+    int64_t md_lifetime_ms,
+    const char *md_principal_name,
+    const char **extensions,
+    size_t extension_size,
+    char *errstr,
+    size_t errstr_size);
+
+/**
+ * @brief SASL/OAUTHBEARER token refresh failure indicator for a share
+ *        consumer.
+ *
+ * @param rkshare Share consumer instance.
+ * @param errstr mandatory human readable error reason for failing to acquire
+ *  a token.
+ *
+ * The SASL/OAUTHBEARER token refresh callback or event handler should invoke
+ * this method upon failure.
+ *
+ * @returns \c RD_KAFKA_RESP_ERR_NO_ERROR on success, otherwise:<br>
+ *          \c RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED if SASL/OAUTHBEARER is not
+ *              supported by this build;<br>
+ *          \c RD_KAFKA_RESP_ERR__STATE if SASL/OAUTHBEARER is supported but is
+ *              not configured as the client's authentication mechanism,<br>
+ *          \c RD_KAFKA_RESP_ERR__INVALID_ARG if no error string is supplied.
+ *
+ * @sa rd_kafka_oauthbearer_set_token_failure()
+ * @sa rd_kafka_share_oauthbearer_set_token()
+ * @sa rd_kafka_conf_set_oauthbearer_token_refresh_cb()
+ */
+RD_EXPORT
+rd_kafka_resp_err_t
+rd_kafka_share_oauthbearer_set_token_failure(rd_kafka_share_t *rkshare,
+                                             const char *errstr);
+
+/**
  * @brief Flags for rd_kafka_destroy_flags()
  */
 

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -490,6 +490,34 @@ rd_kafka_error_t *rd_kafka_share_sasl_set_credentials(rd_kafka_share_t *rkshare,
 }
 
 
+rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare) {
+        return rd_kafka_queue_get_sasl(rkshare->rkshare_rk);
+}
+
+
+rd_kafka_resp_err_t rd_kafka_share_oauthbearer_set_token(
+    rd_kafka_share_t *rkshare,
+    const char *token_value,
+    int64_t md_lifetime_ms,
+    const char *md_principal_name,
+    const char **extensions,
+    size_t extension_size,
+    char *errstr,
+    size_t errstr_size) {
+        return rd_kafka_oauthbearer_set_token(
+            rkshare->rkshare_rk, token_value, md_lifetime_ms, md_principal_name,
+            extensions, extension_size, errstr, errstr_size);
+}
+
+
+rd_kafka_resp_err_t
+rd_kafka_share_oauthbearer_set_token_failure(rd_kafka_share_t *rkshare,
+                                             const char *errstr) {
+        return rd_kafka_oauthbearer_set_token_failure(rkshare->rkshare_rk,
+                                                      errstr);
+}
+
+
 /**
  * Global SASL termination.
  */

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -495,15 +495,15 @@ rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare) {
 }
 
 
-rd_kafka_resp_err_t rd_kafka_share_oauthbearer_set_token(
-    rd_kafka_share_t *rkshare,
-    const char *token_value,
-    int64_t md_lifetime_ms,
-    const char *md_principal_name,
-    const char **extensions,
-    size_t extension_size,
-    char *errstr,
-    size_t errstr_size) {
+rd_kafka_resp_err_t
+rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
+                                     const char *token_value,
+                                     int64_t md_lifetime_ms,
+                                     const char *md_principal_name,
+                                     const char **extensions,
+                                     size_t extension_size,
+                                     char *errstr,
+                                     size_t errstr_size) {
         return rd_kafka_oauthbearer_set_token(
             rkshare->rkshare_rk, token_value, md_lifetime_ms, md_principal_name,
             extensions, extension_size, errstr, errstr_size);

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -491,6 +491,8 @@ rd_kafka_error_t *rd_kafka_share_sasl_set_credentials(rd_kafka_share_t *rkshare,
 
 
 rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare) {
+        if (unlikely(!rkshare))
+                return NULL;
         return rd_kafka_queue_get_sasl(rkshare->rkshare_rk);
 }
 
@@ -504,6 +506,12 @@ rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
                                      size_t extension_size,
                                      char *errstr,
                                      size_t errstr_size) {
+        if (unlikely(!rkshare || !md_principal_name)) {
+                rd_snprintf(errstr, errstr_size, "%s must not be NULL",
+                            !rkshare ? "Share consumer handle"
+                                     : "md_principal_name");
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
         return rd_kafka_oauthbearer_set_token(
             rkshare->rkshare_rk, token_value, md_lifetime_ms, md_principal_name,
             extensions, extension_size, errstr, errstr_size);
@@ -513,6 +521,8 @@ rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
 rd_kafka_resp_err_t
 rd_kafka_share_oauthbearer_set_token_failure(rd_kafka_share_t *rkshare,
                                              const char *errstr) {
+        if (unlikely(!rkshare))
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
         return rd_kafka_oauthbearer_set_token_failure(rkshare->rkshare_rk,
                                                       errstr);
 }

--- a/src/rdkafka_sasl.c
+++ b/src/rdkafka_sasl.c
@@ -490,8 +490,11 @@ rd_kafka_error_t *rd_kafka_share_sasl_set_credentials(rd_kafka_share_t *rkshare,
 }
 
 
+/* TODO KIP-932: add integration tests for the share-consumer OAUTHBEARER
+ * SASL APIs below (set_token, set_token_failure, queue_get_sasl). */
+
 rd_kafka_queue_t *rd_kafka_share_queue_get_sasl(rd_kafka_share_t *rkshare) {
-        if (unlikely(!rkshare))
+        if (unlikely(!rkshare || !rkshare->rkshare_rk))
                 return NULL;
         return rd_kafka_queue_get_sasl(rkshare->rkshare_rk);
 }
@@ -506,10 +509,14 @@ rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
                                      size_t extension_size,
                                      char *errstr,
                                      size_t errstr_size) {
-        if (unlikely(!rkshare || !md_principal_name)) {
+        if (unlikely(!rkshare || !rkshare->rkshare_rk)) {
+                rd_snprintf(errstr, errstr_size,
+                            "Share consumer handle is NULL or uninitialized");
+                return RD_KAFKA_RESP_ERR__INVALID_ARG;
+        }
+        if (unlikely(!token_value || !md_principal_name)) {
                 rd_snprintf(errstr, errstr_size, "%s must not be NULL",
-                            !rkshare ? "Share consumer handle"
-                                     : "md_principal_name");
+                            !token_value ? "token_value" : "md_principal_name");
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
         }
         return rd_kafka_oauthbearer_set_token(
@@ -521,7 +528,7 @@ rd_kafka_share_oauthbearer_set_token(rd_kafka_share_t *rkshare,
 rd_kafka_resp_err_t
 rd_kafka_share_oauthbearer_set_token_failure(rd_kafka_share_t *rkshare,
                                              const char *errstr) {
-        if (unlikely(!rkshare))
+        if (unlikely(!rkshare || !rkshare->rkshare_rk))
                 return RD_KAFKA_RESP_ERR__INVALID_ARG;
         return rd_kafka_oauthbearer_set_token_failure(rkshare->rkshare_rk,
                                                       errstr);


### PR DESCRIPTION
Adds three public APIs so applications can drive SASL/OAUTHBEARER for a
KIP-932 share consumer (which uses `rd_kafka_share_t*`, not `rd_kafka_t*`):

- `rd_kafka_share_queue_get_sasl()` — return the SASL callback queue for the
  share consumer (for manually serving token-refresh callbacks).
- `rd_kafka_share_oauthbearer_set_token()` — set the OAUTHBEARER token +
  metadata/extensions from the token-refresh callback (success path).
- `rd_kafka_share_oauthbearer_set_token_failure()` — report token-acquisition
  failure from the callback.
