### PR TITLE
[KIP-932]: Implement Interface change

### DIFF
--- a/examples/rdkafka_performance.c
+++ b/examples/rdkafka_performance.c
@@ -1788,12 +1788,6 @@ int main(int argc, char **argv) {
         } else if (mode == 'S') {
                 /* Share Consumer */
                 rd_kafka_share_t *rkshare;
-                rd_kafka_message_t **rkmessages = NULL;
-                /* TODO: integrate with max.poll.records once we decide
-                 * how -B should map to share consumer batch sizing. */
-                int share_batch_size = 10001;
-
-                rkmessages = malloc(sizeof(*rkmessages) * share_batch_size);
 
                 /* Create share consumer instance. */
                 rkshare =
@@ -1817,14 +1811,14 @@ int main(int argc, char **argv) {
 
                 while (run && (msgcnt == -1 || msgcnt > (int)cnt.msgs)) {
                         uint64_t fetch_latency;
-                        size_t rcvd_msgs = 0;
+                        rd_kafka_messages_t *rkmessages = NULL;
+                        size_t rcvd_msgs;
                         size_t i;
                         rd_kafka_error_t *error;
 
                         fetch_latency = rd_clock();
 
-                        error = rd_kafka_share_consume_batch(
-                            rkshare, 1000, rkmessages, &rcvd_msgs);
+                        error = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
 
                         cnt.t_fetch_latency += rd_clock() - fetch_latency;
 
@@ -1832,13 +1826,15 @@ int main(int argc, char **argv) {
                                 fprintf(stderr, "%% Share consume error: %s\n",
                                         rd_kafka_error_string(error));
                                 rd_kafka_error_destroy(error);
+                                rd_kafka_messages_destroy(rkmessages);
                                 continue;
                         }
 
-                        for (i = 0; i < rcvd_msgs; i++) {
-                                msg_consume(rkmessages[i], NULL);
-                                rd_kafka_message_destroy(rkmessages[i]);
-                        }
+                        rcvd_msgs = rd_kafka_messages_count(rkmessages);
+                        for (i = 0; i < rcvd_msgs; i++)
+                                msg_consume(
+                                    rd_kafka_messages_get(rkmessages, i), NULL);
+                        rd_kafka_messages_destroy(rkmessages);
 
                         if (rcvd_msgs > 0 && rate_sleep)
                                 do_sleep(rate_sleep);
@@ -1850,8 +1846,6 @@ int main(int argc, char **argv) {
                 fprintf(stderr, "%% Closing share consumer\n");
                 rd_kafka_share_consumer_close(rkshare);
                 rd_kafka_share_destroy(rkshare);
-
-                free(rkmessages);
         }
 
         if (hdrs)

--- a/examples/share_consumer.c
+++ b/examples/share_consumer.c
@@ -202,19 +202,17 @@ int main(int argc, char **argv) {
          * since a rebalance may happen at any time.
          * Start polling for messages. */
 
-        rd_kafka_message_t *rkmessages[10001];
         while (run) {
-                rd_kafka_message_t *rkm = NULL;
-                size_t rcvd_msgs        = 0;
-                int i;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd_msgs                = 0;
+                size_t i;
                 rd_kafka_error_t *error;
                 double __elapsed_ms;
 
-                TIME_BLOCK_MS(__elapsed_ms,
-                              error = rd_kafka_share_consume_batch(
-                                  rkshare, 3000, rkmessages, &rcvd_msgs));
+                TIME_BLOCK_MS(__elapsed_ms, error = rd_kafka_share_poll(
+                                                rkshare, 3000, &rkmessages));
                 fprintf(stdout,
-                        "%% rd_kafka_share_consume_batch() took "
+                        "%% rd_kafka_share_poll() took "
                         "%.3f ms\n",
                         __elapsed_ms);
 
@@ -222,19 +220,21 @@ int main(int argc, char **argv) {
                         fprintf(stderr, "%% Consume error: %s\n",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(rkmessages);
                         continue;
                 }
 
+                rcvd_msgs = rd_kafka_messages_count(rkmessages);
                 fprintf(stderr, "%% Received %zu messages\n", rcvd_msgs);
-                for (i = 0; i < (int)rcvd_msgs; i++) {
-                        rkm = rkmessages[i];
+                for (i = 0; i < rcvd_msgs; i++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(rkmessages, i);
 
                         if (rkm->err) {
                                 fprintf(stderr,
                                         "%% Consumer error: %d: "
                                         "%s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
-                                rd_kafka_message_destroy(rkm);
                                 continue;
                         }
 
@@ -258,9 +258,8 @@ int main(int argc, char **argv) {
                                        (const char *)rkm->payload);
                         else if (rkm->payload)
                                 printf(" - Value: (%d bytes)\n", (int)rkm->len);
-
-                        rd_kafka_message_destroy(rkm);
                 }
+                rd_kafka_messages_destroy(rkmessages);
         }
 
 

--- a/examples/share_consumer_commit_async.c
+++ b/examples/share_consumer_commit_async.c
@@ -164,34 +164,38 @@ int main(int argc, char **argv) {
 
         srand((unsigned int)time(NULL));
 
-        rd_kafka_message_t *rkmessages[10001];
         while (run) {
-                size_t rcvd_msgs = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd_msgs;
                 rd_kafka_error_t *error;
+                size_t k;
 
-                printf("Calling rd_kafka_share_consume_batch()\n");
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd_msgs);
+                printf("Calling rd_kafka_share_poll()\n");
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         fprintf(stderr, "%% Consume error: %s\n",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(rkmessages);
                         continue;
                 }
 
-                if (rcvd_msgs == 0)
+                rcvd_msgs = rd_kafka_messages_count(rkmessages);
+                if (rcvd_msgs == 0) {
+                        rd_kafka_messages_destroy(rkmessages);
                         continue;
+                }
 
                 printf("Received %zu messages\n", rcvd_msgs);
 
-                for (i = 0; i < (int)rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkm = rkmessages[i];
+                for (k = 0; k < rcvd_msgs; k++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(rkmessages, k);
 
                         if (rkm->err) {
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
-                                rd_kafka_message_destroy(rkm);
                                 continue;
                         }
 
@@ -232,8 +236,6 @@ int main(int argc, char **argv) {
                                         rkm->partition, rkm->offset,
                                         rd_kafka_err2str(err));
 
-                        rd_kafka_message_destroy(rkm);
-
                         /* Randomly commit ~10% of the time to
                          * exercise async commit mid-batch. */
                         if (run && (rand() % 100) < 10) {
@@ -250,6 +252,7 @@ int main(int argc, char **argv) {
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(rkmessages);
         }
 
         fprintf(stderr, "%% Closing share consumer\n");

--- a/examples/share_consumer_commit_async.c
+++ b/examples/share_consumer_commit_async.c
@@ -34,7 +34,7 @@
  *   share_consumer_commit_async <broker> <group.id> <topic1> [topic2 ...]
  *
  * This example demonstrates:
- *  - Consuming records with rd_kafka_share_consume_batch()
+ *  - Consuming records with rd_kafka_share_poll()
  *  - Explicitly acknowledging individual records with
  *    rd_kafka_share_acknowledge_type() using ACCEPT or RELEASE
  *    (RELEASE at ~50% rate to simulate redelivery)

--- a/examples/share_consumer_commit_sync.c
+++ b/examples/share_consumer_commit_sync.c
@@ -177,36 +177,40 @@ int main(int argc, char **argv) {
 
         srand((unsigned int)time(NULL));
 
-        rd_kafka_message_t *rkmessages[10001];
         while (run) {
-                size_t rcvd_msgs = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd_msgs;
                 rd_kafka_error_t *error;
+                size_t k;
 
-                printf("Calling rd_kafka_share_consume_batch()\n");
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd_msgs);
+                printf("Calling rd_kafka_share_poll()\n");
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         fprintf(stderr, "%% Consume error: %s\n",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(rkmessages);
                         continue;
                 }
 
-                if (rcvd_msgs == 0)
+                rcvd_msgs = rd_kafka_messages_count(rkmessages);
+                if (rcvd_msgs == 0) {
+                        rd_kafka_messages_destroy(rkmessages);
                         continue;
+                }
 
                 printf("Received %zu messages\n", rcvd_msgs);
 
-                for (i = 0; i < (int)rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkm = rkmessages[i];
+                for (k = 0; k < rcvd_msgs; k++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(rkmessages, k);
                         rd_kafka_share_AcknowledgeType_t ack_type;
                         int r;
 
                         if (rkm->err) {
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
-                                rd_kafka_message_destroy(rkm);
                                 continue;
                         }
 
@@ -251,8 +255,6 @@ int main(int argc, char **argv) {
                                         rkm->partition, rkm->offset,
                                         rd_kafka_err2str(err));
 
-                        rd_kafka_message_destroy(rkm);
-
                         /* Randomly commit ~10% of the time to
                          * exercise sync commit mid-batch. */
                         if (run && (rand() % 100) < 10) {
@@ -293,6 +295,7 @@ int main(int argc, char **argv) {
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(rkmessages);
         }
 
         fprintf(stderr, "%% Closing share consumer\n");

--- a/examples/share_consumer_commit_sync.c
+++ b/examples/share_consumer_commit_sync.c
@@ -34,7 +34,7 @@
  *   share_consumer_commit_sync <broker> <group.id> <topic1> [topic2 ...]
  *
  * This example demonstrates:
- *  - Consuming records with rd_kafka_share_consume_batch()
+ *  - Consuming records with rd_kafka_share_poll()
  *  - Explicitly acknowledging individual records with
  *    rd_kafka_share_acknowledge_type() using ACCEPT, RELEASE, or REJECT
  *  - Committing acknowledgements synchronously with

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3885,12 +3885,7 @@ void rd_kafka_messages_destroy(rd_kafka_messages_t *messages) {
         if (!messages)
                 return;
         for (i = 0; i < messages->cnt; i++) {
-                /* Skip slots the caller has already destroyed individually
-                 * via rd_kafka_message_destroy() and NULLed; mixing
-                 * per-message and bulk destroy is permitted as long as
-                 * destroyed slots are NULLed out by the caller. */
-                if (messages->elems[i])
-                        rd_kafka_message_destroy(messages->elems[i]);
+                rd_kafka_message_destroy(messages->elems[i]);
         }
         rd_free(messages);
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3884,8 +3884,14 @@ void rd_kafka_messages_destroy(rd_kafka_messages_t *messages) {
         size_t i;
         if (!messages)
                 return;
-        for (i = 0; i < messages->cnt; i++)
-                rd_kafka_message_destroy(messages->elems[i]);
+        for (i = 0; i < messages->cnt; i++) {
+                /* Skip slots the caller has already destroyed individually
+                 * via rd_kafka_message_destroy() and NULLed; mixing
+                 * per-message and bulk destroy is permitted as long as
+                 * destroyed slots are NULLed out by the caller. */
+                if (messages->elems[i])
+                        rd_kafka_message_destroy(messages->elems[i]);
+        }
         rd_free(messages);
 }
 
@@ -3907,7 +3913,6 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                                       rd_kafka_messages_t **rkmessages) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_cgrp_t *rkcg;
-        size_t max_poll_records = (size_t)rk->rk_conf.share.max_poll_records;
         rd_bool_t has_records;
         rd_bool_t has_pending_acks;
         rd_kafka_error_t *error = NULL;
@@ -3979,9 +3984,13 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                 rd_kafka_share_fetch_fanout(rk, need_fetch_more_records,
                                             ack_batches);
 
-        scratch = rd_malloc(max_poll_records * sizeof(*scratch));
-        error   = rd_kafka_q_serve_share_rkmessages(
-            rkcg->rkcg_q, timeout_ms, scratch, max_poll_records, &cnt);
+        /* q_serve_share_rkmessages allocates the scratch buffer
+         * internally, sized to the actual op's message count, so it
+         * never overflows regardless of how many records a single
+         * SHARE_FETCH_RESPONSE aggregates (max.poll.records is enforced
+         * upstream during fetch scheduling, not here). */
+        error = rd_kafka_q_serve_share_rkmessages(rkcg->rkcg_q, timeout_ms,
+                                                  &scratch, &cnt);
 
         /* Drain rk_rep for callbacks again before returning */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -6065,7 +6065,7 @@ rd_kafka_op_res_t rd_kafka_poll_cb(rd_kafka_t *rk,
                    be handled from this cb in Share Consumer except maybe in
                    case of closing as this op we don't forward rk_rep queue to
                    rkcg.q. This op is handled separately in
-                   rd_kafka_share_consume_batch() during normal working of Share
+                   rd_kafka_share_poll() during normal working of Share
                    Consumer. Check what is the correct way to handle this op
                    while closing. */
                 rd_kafka_assert(rk, rk->rk_rkshare->rkshare_consumer_closing);

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3918,8 +3918,8 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
         rd_kafka_error_t *error = NULL;
         rd_list_t *ack_batches  = NULL;
         rd_bool_t need_fetch_more_records;
-        rd_kafka_message_t **scratch = NULL;
-        size_t cnt                   = 0;
+        rd_kafka_message_t **rkshare_accumulated_msgs = NULL;
+        size_t cnt                                    = 0;
 
         /* Always NULL the out param so error/empty paths are well-defined. */
         *rkmessages = NULL;
@@ -3984,13 +3984,13 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                 rd_kafka_share_fetch_fanout(rk, need_fetch_more_records,
                                             ack_batches);
 
-        /* q_serve_share_rkmessages allocates the scratch buffer
+        /* q_serve_share_rkmessages allocates the accumulated-msgs buffer
          * internally, sized to the actual op's message count, so it
          * never overflows regardless of how many records a single
          * SHARE_FETCH_RESPONSE aggregates (max.poll.records is enforced
          * upstream during fetch scheduling, not here). */
-        error = rd_kafka_q_serve_share_rkmessages(rkcg->rkcg_q, timeout_ms,
-                                                  &scratch, &cnt);
+        error = rd_kafka_q_serve_share_rkmessages(
+            rkcg->rkcg_q, timeout_ms, &rkshare_accumulated_msgs, &cnt);
 
         /* Drain rk_rep for callbacks again before returning */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -4005,14 +4005,16 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                          * never both). Destroy messages to avoid leaks. */
                         size_t i;
                         for (i = 0; i < cnt; i++)
-                                rd_kafka_message_destroy(scratch[i]);
+                                rd_kafka_message_destroy(
+                                    rkshare_accumulated_msgs[i]);
                 } else {
-                        *rkmessages = rd_kafka_messages_new(scratch, cnt);
+                        *rkmessages = rd_kafka_messages_new(
+                            rkshare_accumulated_msgs, cnt);
                 }
         }
 done:
-        if (scratch)
-                rd_free(scratch);
+        if (rkshare_accumulated_msgs)
+                rd_free(rkshare_accumulated_msgs);
         rd_kafka_share_release(rkshare);
         return error;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3867,14 +3867,44 @@ static void rd_kafka_share_record_poll_end(rd_kafka_t *rk) {
         }
 }
 
-rd_kafka_error_t *rd_kafka_share_consume_batch(
-    rd_kafka_share_t *rkshare,
-    int timeout_ms,
-    /* There is some benefit to making this ***rkmessages and allocating it
-       within this function, but on the flipside this means that it will always
-       be allocated on the heap. */
-    rd_kafka_message_t **rkmessages /* out */,
-    size_t *rkmessages_size /* out */) {
+size_t rd_kafka_messages_count(const rd_kafka_messages_t *messages) {
+        if (!messages)
+                return 0;
+        return messages->cnt;
+}
+
+rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *messages,
+                                          size_t index) {
+        if (!messages || index >= messages->cnt)
+                return NULL;
+        return messages->elems[index];
+}
+
+void rd_kafka_messages_destroy(rd_kafka_messages_t *messages) {
+        size_t i;
+        if (!messages)
+                return;
+        for (i = 0; i < messages->cnt; i++)
+                rd_kafka_message_destroy(messages->elems[i]);
+        rd_free(messages);
+}
+
+/**
+ * @brief Allocate an rd_kafka_messages_t sized to hold exactly \p cnt
+ *        message pointers, copied from \p src.
+ */
+static rd_kafka_messages_t *rd_kafka_messages_new(rd_kafka_message_t **src,
+                                                  size_t cnt) {
+        rd_kafka_messages_t *messages =
+            rd_malloc(sizeof(*messages) + cnt * sizeof(*messages->elems));
+        messages->cnt = cnt;
+        memcpy(messages->elems, src, cnt * sizeof(*messages->elems));
+        return messages;
+}
+
+rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
+                                      int timeout_ms,
+                                      rd_kafka_messages_t **rkmessages) {
         rd_kafka_t *rk = rkshare->rkshare_rk;
         rd_kafka_cgrp_t *rkcg;
         size_t max_poll_records = (size_t)rk->rk_conf.share.max_poll_records;
@@ -3883,10 +3913,11 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
         rd_kafka_error_t *error = NULL;
         rd_list_t *ack_batches  = NULL;
         rd_bool_t need_fetch_more_records;
+        rd_kafka_message_t **scratch = NULL;
+        size_t cnt                   = 0;
 
-        /* Default the out count to 0 so error returns leave it
-         * well-defined. */
-        *rkmessages_size = 0;
+        /* Always NULL the out param so error/empty paths are well-defined. */
+        *rkmessages = NULL;
 
         if (unlikely((error = rd_kafka_share_acquire(rkshare)) != NULL))
                 return error;
@@ -3894,11 +3925,11 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
         /* TODO KIP-932: the non-fatal errors returned from the other paths
          * below (consumer-group-not-initialized, consumer-closed, and the
          * not-all-acknowledged guard) should be marked retriable so the app
-         * knows it can retry the consume_batch call, consistent with the
+         * knows it can retry the share_poll call, consistent with the
          * retriable errors built in rd_kafka_q_serve_share_rkmessages(). */
         if (unlikely(!(rkcg = rd_kafka_cgrp_get(rk)))) {
                 error = rd_kafka_error_new(RD_KAFKA_RESP_ERR__STATE,
-                                           "rd_kafka_share_consume_batch(): "
+                                           "rd_kafka_share_poll(): "
                                            "Consumer group not initialized");
                 goto done;
         }
@@ -3948,16 +3979,31 @@ rd_kafka_error_t *rd_kafka_share_consume_batch(
                 rd_kafka_share_fetch_fanout(rk, need_fetch_more_records,
                                             ack_batches);
 
-        error = rd_kafka_q_serve_share_rkmessages(rkcg->rkcg_q, timeout_ms,
-                                                  rkmessages, max_poll_records,
-                                                  rkmessages_size);
+        scratch = rd_malloc(max_poll_records * sizeof(*scratch));
+        error   = rd_kafka_q_serve_share_rkmessages(
+            rkcg->rkcg_q, timeout_ms, scratch, max_poll_records, &cnt);
 
         /* Drain rk_rep for callbacks again before returning */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
                          rd_kafka_poll_cb, NULL);
 
         rd_kafka_share_record_poll_end(rk);
+
+        if (cnt > 0) {
+                if (error) {
+                        /* Defensive: queue contract makes this unreachable
+                         * (a single op produces either messages or an error,
+                         * never both). Destroy messages to avoid leaks. */
+                        size_t i;
+                        for (i = 0; i < cnt; i++)
+                                rd_kafka_message_destroy(scratch[i]);
+                } else {
+                        *rkmessages = rd_kafka_messages_new(scratch, cnt);
+                }
+        }
 done:
+        if (scratch)
+                rd_free(scratch);
         rd_kafka_share_release(rkshare);
         return error;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3890,18 +3890,6 @@ void rd_kafka_messages_destroy(rd_kafka_messages_t *messages) {
         rd_free(messages);
 }
 
-/**
- * @brief Allocate an rd_kafka_messages_t sized to hold exactly \p cnt
- *        message pointers, copied from \p src.
- */
-static rd_kafka_messages_t *rd_kafka_messages_new(rd_kafka_message_t **src,
-                                                  size_t cnt) {
-        rd_kafka_messages_t *messages =
-            rd_malloc(sizeof(*messages) + cnt * sizeof(*messages->elems));
-        messages->cnt = cnt;
-        memcpy(messages->elems, src, cnt * sizeof(*messages->elems));
-        return messages;
-}
 
 rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                                       int timeout_ms,
@@ -3913,8 +3901,6 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
         rd_kafka_error_t *error = NULL;
         rd_list_t *ack_batches  = NULL;
         rd_bool_t need_fetch_more_records;
-        rd_kafka_message_t **rkshare_accumulated_msgs = NULL;
-        size_t cnt                                    = 0;
 
         /* Always NULL the out param so error/empty paths are well-defined. */
         *rkmessages = NULL;
@@ -3979,13 +3965,12 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                 rd_kafka_share_fetch_fanout(rk, need_fetch_more_records,
                                             ack_batches);
 
-        /* q_serve_share_rkmessages allocates the accumulated-msgs buffer
-         * internally, sized to the actual op's message count, so it
-         * never overflows regardless of how many records a single
-         * SHARE_FETCH_RESPONSE aggregates (max.poll.records is enforced
-         * upstream during fetch scheduling, not here). */
-        error = rd_kafka_q_serve_share_rkmessages(
-            rkcg->rkcg_q, timeout_ms, &rkshare_accumulated_msgs, &cnt);
+        /* q_serve_share_rkmessages allocates the caller-visible
+         * rd_kafka_messages_t directly, sized to the actual op's message
+         * count, so it never overflows regardless of how many records a
+         * single SHARE_FETCH_RESPONSE aggregates */
+        error = rd_kafka_q_serve_share_rkmessages(rkcg->rkcg_q, timeout_ms,
+                                                  rkmessages);
 
         /* Drain rk_rep for callbacks again before returning */
         rd_kafka_q_serve(rk->rk_rep, RD_POLL_NOWAIT, 0, RD_KAFKA_Q_CB_CALLBACK,
@@ -3993,23 +3978,7 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
 
         rd_kafka_share_record_poll_end(rk);
 
-        if (cnt > 0) {
-                if (error) {
-                        /* Defensive: queue contract makes this unreachable
-                         * (a single op produces either messages or an error,
-                         * never both). Destroy messages to avoid leaks. */
-                        size_t i;
-                        for (i = 0; i < cnt; i++)
-                                rd_kafka_message_destroy(
-                                    rkshare_accumulated_msgs[i]);
-                } else {
-                        *rkmessages = rd_kafka_messages_new(
-                            rkshare_accumulated_msgs, cnt);
-                }
-        }
 done:
-        if (rkshare_accumulated_msgs)
-                rd_free(rkshare_accumulated_msgs);
         rd_kafka_share_release(rkshare);
         return error;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3875,7 +3875,7 @@ size_t rd_kafka_messages_count(const rd_kafka_messages_t *messages) {
 
 rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *messages,
                                           size_t index) {
-        if (!messages || index >= messages->cnt)
+        if (index >= messages->cnt)
                 return NULL;
         return messages->elems[index];
 }
@@ -3965,10 +3965,6 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
                 rd_kafka_share_fetch_fanout(rk, need_fetch_more_records,
                                             ack_batches);
 
-        /* q_serve_share_rkmessages allocates the caller-visible
-         * rd_kafka_messages_t directly, sized to the actual op's message
-         * count, so it never overflows regardless of how many records a
-         * single SHARE_FETCH_RESPONSE aggregates */
         error = rd_kafka_q_serve_share_rkmessages(rkcg->rkcg_q, timeout_ms,
                                                   rkmessages);
 

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3266,7 +3266,9 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
                                               size_t errstr_size);
 
 /**
- * @brief Poll the share consumer for a batch of messages.
+ * @brief Poll the share consumer for a batch of messages. It is different from
+ *        normal consumer poll where a single record is returned, this API
+ *        returns a batch of messages in a single call.
  *
  * @param rkshare    Share consumer instance.
  * @param timeout_ms Maximum time to block waiting for messages.
@@ -3276,7 +3278,7 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
  *                     points to an \c rd_kafka_messages_t handle owned by the
  *                     caller, who must release it with
  *                     rd_kafka_messages_destroy().
- *                   - On error, empty poll, or timeout with no messages:
+ *                   - On error or timeout with no messages:
  *                     \c *rkmessages is set to NULL.
  *                   \c rd_kafka_messages_destroy(NULL) is a safe no-op so
  *                   callers may unconditionally destroy.
@@ -3323,7 +3325,10 @@ rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *messages,
  * @brief Destroys \p messages and all messages it contains.
  *
  * After this call any \c rd_kafka_message_t pointer previously obtained via
- * rd_kafka_messages_get() on \p messages is invalid.
+ * rd_kafka_messages_get() on \p messages is invalid. Users should only use
+ * this method to destroy the \p messages handle returned by
+ * rd_kafka_share_poll() and set the pointer to NULL after destroying to avoid
+ * use-after-free bugs.
  *
  * @param messages Message list to destroy. NULL is a safe no-op.
  */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -3286,6 +3286,9 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
  * Use rd_kafka_messages_count() and rd_kafka_messages_get() to access the
  * returned messages.
  *
+ * @note The rkmessages should always be pointing to NULL otherwise it will
+ *       be lost and there will be memory leak.
+ *
  * @returns NULL on success or an \c rd_kafka_error_t (caller must
  *          rd_kafka_error_destroy()) on failure.
  */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -266,6 +266,7 @@ typedef struct rd_kafka_Uuid_s rd_kafka_Uuid_t;
 typedef struct rd_kafka_topic_partition_result_s
     rd_kafka_topic_partition_result_t;
 typedef struct rd_kafka_share_s rd_kafka_share_t;
+typedef struct rd_kafka_messages_s rd_kafka_messages_t;
 /* @endcond */
 
 
@@ -3265,20 +3266,69 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
                                               size_t errstr_size);
 
 /**
- * @brief Consume a batch of messages from the share consumer instance.
+ * @brief Poll the share consumer for a batch of messages.
  *
  * @param rkshare    Share consumer instance.
  * @param timeout_ms Maximum time to block waiting for messages.
- * @param rkmessages Output array of messages - this must be preallocated with
- * at least enough capacity for size max.poll.records.
- * @param rkmessages_size Output number of messages returned in rkmessages.
+ * @param rkmessages Output pointer to a newly-allocated message list (callee
+ *                   allocates). On return:
+ *                   - On success with at least one message: \c *rkmessages
+ *                     points to an \c rd_kafka_messages_t handle owned by the
+ *                     caller, who must release it with
+ *                     rd_kafka_messages_destroy().
+ *                   - On error, empty poll, or timeout with no messages:
+ *                     \c *rkmessages is set to NULL.
+ *                   \c rd_kafka_messages_destroy(NULL) is a safe no-op so
+ *                   callers may unconditionally destroy.
+ *
+ * Use rd_kafka_messages_count() and rd_kafka_messages_get() to access the
+ * returned messages.
+ *
+ * @returns NULL on success or an \c rd_kafka_error_t (caller must
+ *          rd_kafka_error_destroy()) on failure.
  */
 RD_EXPORT
-rd_kafka_error_t *
-rd_kafka_share_consume_batch(rd_kafka_share_t *rkshare,
-                             int timeout_ms,
-                             rd_kafka_message_t **rkmessages /* out */,
-                             size_t *rkmessages_size /* out */);
+rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
+                                      int timeout_ms,
+                                      rd_kafka_messages_t **rkmessages);
+
+/**
+ * @brief Returns the number of messages in \p messages.
+ *
+ * @param messages Message list returned by rd_kafka_share_poll().
+ *                 May be NULL, in which case 0 is returned.
+ *
+ * @returns The number of messages in \p messages.
+ */
+RD_EXPORT
+size_t rd_kafka_messages_count(const rd_kafka_messages_t *messages);
+
+/**
+ * @brief Returns the message at zero-based \p index in \p messages.
+ *
+ * The returned message is owned by \p messages and remains valid until
+ * rd_kafka_messages_destroy() is called.
+ *
+ * @param messages Message list returned by rd_kafka_share_poll().
+ * @param index    Zero-based index of the message to return.
+ *
+ * @returns The message at \p index, or NULL if \p messages is NULL or
+ *          \p index is out of bounds.
+ */
+RD_EXPORT
+rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *messages,
+                                          size_t index);
+
+/**
+ * @brief Destroys \p messages and all messages it contains.
+ *
+ * After this call any \c rd_kafka_message_t pointer previously obtained via
+ * rd_kafka_messages_get() on \p messages is invalid.
+ *
+ * @param messages Message list to destroy. NULL is a safe no-op.
+ */
+RD_EXPORT
+void rd_kafka_messages_destroy(rd_kafka_messages_t *messages);
 
 /**
  * @enum rd_kafka_share_AcknowledgeType_t

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -4075,7 +4075,7 @@ rd_kafka_resp_err_t rd_kafka_set_log_queue(rd_kafka_t *rk,
  * @param rkshare Share consumer instance.
  * @param rkqu    Queue to forward logs to. If NULL the logs are forwarded
  *                to the share consumer's internal rk_rep, which is drained
- *                by rd_kafka_share_consume_batch() /
+ *                by rd_kafka_share_poll() /
  *                rd_kafka_share_commit_sync() / rd_kafka_share_commit_async()
  *                on the application's poll thread.
  *
@@ -5215,7 +5215,7 @@ RD_EXPORT rd_kafka_error_t *rd_kafka_consumer_group_metadata_read(
  * @remark Topic names are forwarded verbatim to the broker via the share
  *         group heartbeat. The broker validates them; unavailable or
  *         unauthorized topics will surface as errors via
- *         rd_kafka_share_consume_batch().
+ *         rd_kafka_share_poll().
  *
  * @remark If \p topics is empty (cnt == 0), the call is equivalent to
  *         rd_kafka_share_unsubscribe(): the subscription is cleared and

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -951,6 +951,8 @@ struct rd_kafka_messages_s {
         rd_kafka_message_t *elems[]; /**< Message pointer array. */
 };
 
+rd_kafka_messages_t *rd_kafka_messages_new(size_t cnt);
+
 #define rd_kafka_wrlock(rk)   rwlock_wrlock(&(rk)->rk_lock)
 #define rd_kafka_rdlock(rk)   rwlock_rdlock(&(rk)->rk_lock)
 #define rd_kafka_rdunlock(rk) rwlock_rdunlock(&(rk)->rk_lock)

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -946,6 +946,10 @@ struct rd_kafka_share_s {
  * count returned by a single poll. The caller releases the list and all
  * contained messages via rd_kafka_messages_destroy().
  */
+/**
+ * TODO KIP-932: GA: Fix this to use FAM with message struct not
+ * pointer to messages.
+ */
 struct rd_kafka_messages_s {
         size_t cnt;                  /**< Number of messages. */
         rd_kafka_message_t *elems[]; /**< Message pointer array. */

--- a/src/rdkafka_int.h
+++ b/src/rdkafka_int.h
@@ -939,6 +939,18 @@ struct rd_kafka_share_s {
         rd_bool_t rkshare_subscribed;
 };
 
+/**
+ * @brief Opaque message list returned by rd_kafka_share_poll().
+ *
+ * The struct is allocated as a flexible array sized to the exact message
+ * count returned by a single poll. The caller releases the list and all
+ * contained messages via rd_kafka_messages_destroy().
+ */
+struct rd_kafka_messages_s {
+        size_t cnt;                  /**< Number of messages. */
+        rd_kafka_message_t *elems[]; /**< Message pointer array. */
+};
+
 #define rd_kafka_wrlock(rk)   rwlock_wrlock(&(rk)->rk_lock)
 #define rd_kafka_rdlock(rk)   rwlock_rdlock(&(rk)->rk_lock)
 #define rd_kafka_rdunlock(rk) rwlock_rdunlock(&(rk)->rk_lock)

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1313,7 +1313,7 @@ rd_kafka_message_t *rd_kafka_message_new(void) {
  */
 rd_kafka_messages_t *rd_kafka_messages_new(size_t cnt) {
         rd_kafka_messages_t *messages =
-            rd_malloc(sizeof(*messages) + cnt * sizeof(*messages->elems));
+            rd_calloc(1, (sizeof(*messages) + cnt * sizeof(*messages->elems)));
         messages->cnt = cnt;
         return messages;
 }

--- a/src/rdkafka_msg.c
+++ b/src/rdkafka_msg.c
@@ -1304,6 +1304,22 @@ rd_kafka_message_t *rd_kafka_message_new(void) {
 
 
 /**
+ * @brief Allocate an rd_kafka_messages_t whose flex \c elems[] array has
+ *        room for exactly \p cnt message pointers, with \c cnt populated.
+ *
+ * The caller is responsible for filling \c elems[0..cnt). Internal helper
+ * used by the share-consumer queue serve to allocate the caller-visible
+ * messages handle in a single step (no intermediate buffer).
+ */
+rd_kafka_messages_t *rd_kafka_messages_new(size_t cnt) {
+        rd_kafka_messages_t *messages =
+            rd_malloc(sizeof(*messages) + cnt * sizeof(*messages->elems));
+        messages->cnt = cnt;
+        return messages;
+}
+
+
+/**
  * @brief Set up a rkmessage from an rko for passing to the application.
  * @remark Will trigger on_consume() interceptors if any.
  */

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1629,7 +1629,7 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                                  * acquired-range filter would drop any op
                                  * without a valid offset. Enqueue the error
                                  * directly onto the cgrp queue served by
-                                 * rd_kafka_share_consume_batch so the app
+                                 * rd_kafka_share_poll so the app
                                  * sees the partition-level failure. */
                                 rd_kafka_consumer_err(
                                     msetr->msetr_rkb->rkb_rk->rk_cgrp->rkcg_q,

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -876,8 +876,7 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
 rd_kafka_error_t *
 rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                                   int timeout_ms,
-                                  rd_kafka_message_t **rkmessages,
-                                  size_t rkmessages_size,
+                                  rd_kafka_message_t ***rkmessages_out,
                                   size_t *rkmessages_size_out) {
         rd_kafka_op_t *rko;
         rd_kafka_t *rk = rkq->rkq_rk;
@@ -888,14 +887,14 @@ rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
         rd_kafka_resp_err_t fatal_err;
         char fatal_errstr[512];
 
+        *rkmessages_out      = NULL;
         *rkmessages_size_out = 0;
 
         mtx_lock(&rkq->rkq_lock);
         if ((fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
                 mtx_unlock(&rkq->rkq_lock);
                 error = rd_kafka_q_serve_share_rkmessages(
-                    fwdq, timeout_ms, rkmessages, rkmessages_size,
-                    rkmessages_size_out);
+                    fwdq, timeout_ms, rkmessages_out, rkmessages_size_out);
                 rd_kafka_q_destroy(fwdq);
                 return error;
         }
@@ -928,9 +927,19 @@ rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                      rd_kafka_op2str(rko->rko_type), rko->rko_type);
 
         if (rko->rko_type == RD_KAFKA_OP_SHARE_FETCH_RESPONSE) {
-                /* Return messages from this response */
-                cnt = rd_kafka_op_process_share_fetch_response(
-                    rko, rkq->rkq_rk->rk_rkshare, rkmessages, cnt);
+                /* Allocate the messages buffer sized exactly to this op's
+                 * payload — the response may contain more records than
+                 * max.poll.records when multiple partitions are aggregated
+                 * into a single fetch response, so any caller-side
+                 * pre-allocation against max.poll.records would overflow. */
+                int total_msgs =
+                    rd_list_cnt(rko->rko_u.share_fetch_response.message_rkos);
+                if (total_msgs > 0) {
+                        *rkmessages_out = rd_malloc((size_t)total_msgs *
+                                                    sizeof(**rkmessages_out));
+                        cnt = rd_kafka_op_process_share_fetch_response(
+                            rko, rkq->rkq_rk->rk_rkshare, *rkmessages_out, 0);
+                }
                 rkq->rkq_rk->rk_rkshare->rkshare_fetch_more_records_requested =
                     rd_false;
         } else if (rko->rko_type == RD_KAFKA_OP_CONSUMER_ERR) {

--- a/src/rdkafka_queue.c
+++ b/src/rdkafka_queue.c
@@ -876,25 +876,22 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
 rd_kafka_error_t *
 rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                                   int timeout_ms,
-                                  rd_kafka_message_t ***rkmessages_out,
-                                  size_t *rkmessages_size_out) {
+                                  rd_kafka_messages_t **rkmessages_out) {
         rd_kafka_op_t *rko;
         rd_kafka_t *rk = rkq->rkq_rk;
         rd_kafka_q_t *fwdq;
         rd_ts_t abs_timeout;
         rd_kafka_error_t *error = NULL;
-        unsigned int cnt        = 0;
         rd_kafka_resp_err_t fatal_err;
         char fatal_errstr[512];
 
-        *rkmessages_out      = NULL;
-        *rkmessages_size_out = 0;
+        *rkmessages_out = NULL;
 
         mtx_lock(&rkq->rkq_lock);
         if ((fwdq = rd_kafka_q_fwd_get(rkq, 0))) {
                 mtx_unlock(&rkq->rkq_lock);
-                error = rd_kafka_q_serve_share_rkmessages(
-                    fwdq, timeout_ms, rkmessages_out, rkmessages_size_out);
+                error = rd_kafka_q_serve_share_rkmessages(fwdq, timeout_ms,
+                                                          rkmessages_out);
                 rd_kafka_q_destroy(fwdq);
                 return error;
         }
@@ -927,18 +924,18 @@ rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                      rd_kafka_op2str(rko->rko_type), rko->rko_type);
 
         if (rko->rko_type == RD_KAFKA_OP_SHARE_FETCH_RESPONSE) {
-                /* Allocate the messages buffer sized exactly to this op's
+                /* Allocate the messages handle sized exactly to this op's
                  * payload — the response may contain more records than
                  * max.poll.records when multiple partitions are aggregated
                  * into a single fetch response, so any caller-side
                  * pre-allocation against max.poll.records would overflow. */
-                int total_msgs =
-                    rd_list_cnt(rko->rko_u.share_fetch_response.message_rkos);
+                size_t total_msgs = (size_t)rd_list_cnt(
+                    rko->rko_u.share_fetch_response.message_rkos);
                 if (total_msgs > 0) {
-                        *rkmessages_out = rd_malloc((size_t)total_msgs *
-                                                    sizeof(**rkmessages_out));
-                        cnt = rd_kafka_op_process_share_fetch_response(
-                            rko, rkq->rkq_rk->rk_rkshare, *rkmessages_out, 0);
+                        *rkmessages_out = rd_kafka_messages_new(total_msgs);
+                        rd_kafka_op_process_share_fetch_response(
+                            rko, rkq->rkq_rk->rk_rkshare,
+                            (*rkmessages_out)->elems, 0);
                 }
                 rkq->rkq_rk->rk_rkshare->rkshare_fetch_more_records_requested =
                     rd_false;
@@ -976,7 +973,6 @@ rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
         }
 
         rd_kafka_op_destroy(rko);
-        *rkmessages_size_out = cnt;
         return error;
 }
 

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -881,21 +881,18 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
 /**
  * @brief Serve up to one share-consumer op from \p rkq.
  *
- * On success with a SHARE_FETCH_RESPONSE op, \c *rkmessages_out is set to
- * an rd_malloc()ed array sized exactly to the op's payload (so it always
- * fits, regardless of max.poll.records); \c *rkmessages_size_out is the
- * count. The caller takes ownership of the array (rd_free) and of each
- * contained rd_kafka_message_t (rd_kafka_message_destroy).
+ * On success with a non-empty SHARE_FETCH_RESPONSE op, \c *rkmessages_out
+ * is set to a newly-allocated rd_kafka_messages_t sized exactly to the op's
+ * payload. The caller takes ownership and must release it with
+ * rd_kafka_messages_destroy().
  *
- * On error / empty queue / non-fetch ops, \c *rkmessages_out is NULL and
- * \c *rkmessages_size_out is 0. The returned rd_kafka_error_t (if non-NULL)
- * is owned by the caller.
+ * On error / empty queue / non-fetch ops, \c *rkmessages_out is NULL.
+ * The returned rd_kafka_error_t (if non-NULL) is owned by the caller.
  */
 rd_kafka_error_t *
 rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                                   int timeout_ms,
-                                  rd_kafka_message_t ***rkmessages_out,
-                                  size_t *rkmessages_size_out);
+                                  rd_kafka_messages_t **rkmessages_out);
 rd_kafka_resp_err_t rd_kafka_q_wait_result(rd_kafka_q_t *rkq, int timeout_ms);
 
 int rd_kafka_q_apply(rd_kafka_q_t *rkq,

--- a/src/rdkafka_queue.h
+++ b/src/rdkafka_queue.h
@@ -878,12 +878,23 @@ int rd_kafka_q_serve_rkmessages(rd_kafka_q_t *rkq,
                                 int timeout_ms,
                                 rd_kafka_message_t **rkmessages,
                                 size_t rkmessages_size);
-/** Returns error (caller must destroy) or NULL. */
+/**
+ * @brief Serve up to one share-consumer op from \p rkq.
+ *
+ * On success with a SHARE_FETCH_RESPONSE op, \c *rkmessages_out is set to
+ * an rd_malloc()ed array sized exactly to the op's payload (so it always
+ * fits, regardless of max.poll.records); \c *rkmessages_size_out is the
+ * count. The caller takes ownership of the array (rd_free) and of each
+ * contained rd_kafka_message_t (rd_kafka_message_destroy).
+ *
+ * On error / empty queue / non-fetch ops, \c *rkmessages_out is NULL and
+ * \c *rkmessages_size_out is 0. The returned rd_kafka_error_t (if non-NULL)
+ * is owned by the caller.
+ */
 rd_kafka_error_t *
 rd_kafka_q_serve_share_rkmessages(rd_kafka_q_t *rkq,
                                   int timeout_ms,
-                                  rd_kafka_message_t **rkmessages,
-                                  size_t rkmessages_size,
+                                  rd_kafka_message_t ***rkmessages_out,
                                   size_t *rkmessages_size_out);
 rd_kafka_resp_err_t rd_kafka_q_wait_result(rd_kafka_q_t *rkq, int timeout_ms);
 

--- a/tests/0022-consume_batch.c
+++ b/tests/0022-consume_batch.c
@@ -207,13 +207,13 @@ share_refresh_cb(rd_kafka_t *rk, const char *oauthbearer_config, void *opaque) {
 
 /**
  * @brief Verify that the oauthbearer_refresh_cb() is triggered
- *        when using rd_kafka_share_consume_batch() with a share consumer.
+ *        when using rd_kafka_share_poll() with a share consumer.
  */
 static void do_test_share_consume_batch_oauthbearer_cb(void) {
         rd_kafka_share_t *rk;
         rd_kafka_conf_t *conf;
-        rd_kafka_message_t *rkms[1];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *rkms = NULL;
+        size_t rcvd               = 0;
         rd_kafka_error_t *err;
         char errstr[512];
 
@@ -232,9 +232,12 @@ static void do_test_share_consume_batch_oauthbearer_cb(void) {
         TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
 
         /* Poll to trigger the token refresh callback */
-        err = rd_kafka_share_consume_batch(rk, 1000, rkms, &rcvd);
+        err  = rd_kafka_share_poll(rk, 1000, &rkms);
+        rcvd = rd_kafka_messages_count(rkms);
+        (void)rcvd;
         if (err)
                 rd_kafka_error_destroy(err);
+        rd_kafka_messages_destroy(rkms);
 
         TEST_SAY("share_refresh_called = %d\n", share_refresh_called);
         TEST_ASSERT(share_refresh_called,
@@ -297,8 +300,6 @@ static void do_test_consume_batch_non_existent_topic(void) {
         TEST_SAY("Received ERR_UNKNOWN_TOPIC_OR_PART\n");
 
         TEST_SAY("Stopping consumer\n");
-
-        rd_kafka_message_destroy(rkms[0]);
 
         rd_kafka_queue_destroy(rkq);
 

--- a/tests/0022-consume_batch.c
+++ b/tests/0022-consume_batch.c
@@ -212,8 +212,7 @@ share_refresh_cb(rd_kafka_t *rk, const char *oauthbearer_config, void *opaque) {
 static void do_test_share_consume_batch_oauthbearer_cb(void) {
         rd_kafka_share_t *rk;
         rd_kafka_conf_t *conf;
-        rd_kafka_messages_t *rkms = NULL;
-        size_t rcvd               = 0;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         char errstr[512];
 
@@ -232,12 +231,10 @@ static void do_test_share_consume_batch_oauthbearer_cb(void) {
         TEST_ASSERT(rk, "Failed to create share consumer: %s", errstr);
 
         /* Poll to trigger the token refresh callback */
-        err  = rd_kafka_share_poll(rk, 1000, &rkms);
-        rcvd = rd_kafka_messages_count(rkms);
-        (void)rcvd;
+        err = rd_kafka_share_poll(rk, 1000, &batch);
         if (err)
                 rd_kafka_error_destroy(err);
-        rd_kafka_messages_destroy(rkms);
+        rd_kafka_messages_destroy(batch);
 
         TEST_SAY("share_refresh_called = %d\n", share_refresh_called);
         TEST_ASSERT(share_refresh_called,
@@ -300,6 +297,8 @@ static void do_test_consume_batch_non_existent_topic(void) {
         TEST_SAY("Received ERR_UNKNOWN_TOPIC_OR_PART\n");
 
         TEST_SAY("Stopping consumer\n");
+
+        rd_kafka_message_destroy(rkms[0]);
 
         rd_kafka_queue_destroy(rkq);
 

--- a/tests/0022-consume_batch.c
+++ b/tests/0022-consume_batch.c
@@ -209,7 +209,7 @@ share_refresh_cb(rd_kafka_t *rk, const char *oauthbearer_config, void *opaque) {
  * @brief Verify that the oauthbearer_refresh_cb() is triggered
  *        when using rd_kafka_share_poll() with a share consumer.
  */
-static void do_test_share_consume_batch_oauthbearer_cb(void) {
+static void do_test_share_poll_oauthbearer_cb(void) {
         rd_kafka_share_t *rk;
         rd_kafka_conf_t *conf;
         rd_kafka_messages_t *batch = NULL;
@@ -323,7 +323,7 @@ int main_0022_consume_batch(int argc, char **argv) {
 int main_0022_consume_batch_local(int argc, char **argv) {
 #if WITH_SASL_OAUTHBEARER
         do_test_consume_batch_oauthbearer_cb();
-        do_test_share_consume_batch_oauthbearer_cb();
+        do_test_share_poll_oauthbearer_cb();
 #else
         TEST_SKIP("No OAUTHBEARER support\n");
 #endif

--- a/tests/0126-oauthbearer_oidc.c
+++ b/tests/0126-oauthbearer_oidc.c
@@ -106,7 +106,7 @@ do_test_produce_share_consumer_with_OIDC(const char *test_name,
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[500];
+        rd_kafka_messages_t *batch = NULL;
         const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         int consumed           = 0, attempts;
         const int msg_cnt      = 10;
@@ -157,16 +157,16 @@ do_test_produce_share_consumer_with_OIDC(const char *test_name,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(sc1, 3000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 3000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -244,8 +244,8 @@ static void do_test_produce_share_consumer_with_OIDC_expired_token_should_fail(
     const rd_kafka_conf_t *base_conf) {
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
-        rd_kafka_message_t *batch[10];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_error_t *err;
         char errstr[512];
 
@@ -274,7 +274,8 @@ static void do_test_produce_share_consumer_with_OIDC_expired_token_should_fail(
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
         /* Poll — should trigger auth error callback, no messages expected */
-        err = rd_kafka_share_consume_batch(sc1, 10 * 1000, batch, &rcvd);
+        err  = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
 
@@ -384,8 +385,8 @@ do_test_produce_share_consumer_with_OIDC_should_fail_invalid_token_endpoint(
     const rd_kafka_conf_t *base_conf) {
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
-        rd_kafka_message_t *batch[10];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_error_t *err;
         char errstr[512];
 
@@ -413,7 +414,8 @@ do_test_produce_share_consumer_with_OIDC_should_fail_invalid_token_endpoint(
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
         /* Poll — should trigger auth error callback, no messages expected */
-        err = rd_kafka_share_consume_batch(sc1, 10 * 1000, batch, &rcvd);
+        err  = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
 
@@ -565,8 +567,8 @@ static void do_test_produce_share_consumer_with_OIDC_should_fail(
     const rd_kafka_conf_t *base_conf) {
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
-        rd_kafka_message_t *batch[10];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_error_t *err;
         char errstr[512];
 
@@ -591,7 +593,8 @@ static void do_test_produce_share_consumer_with_OIDC_should_fail(
         sc1 = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
-        err = rd_kafka_share_consume_batch(sc1, 5 * 1000, batch, &rcvd);
+        err  = rd_kafka_share_poll(sc1, 5 * 1000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
 

--- a/tests/0126-oauthbearer_oidc.c
+++ b/tests/0126-oauthbearer_oidc.c
@@ -157,18 +157,23 @@ do_test_produce_share_consumer_with_OIDC(const char *test_name,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(sc1, 3000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+
+                err = rd_kafka_share_poll(sc1, 3000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
                         if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == msg_cnt, "Expected %d messages, consumed %d",
                     msg_cnt, consumed);
@@ -274,10 +279,10 @@ static void do_test_produce_share_consumer_with_OIDC_expired_token_should_fail(
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
         /* Poll — should trigger auth error callback, no messages expected */
-        err  = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        err = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
         if (err)
                 rd_kafka_error_destroy(err);
+        rcvd = rd_kafka_messages_count(batch);
 
         TEST_ASSERT(rcvd == 0,
                     "Expected no messages with expired token, got %zu", rcvd);
@@ -285,6 +290,8 @@ static void do_test_produce_share_consumer_with_OIDC_expired_token_should_fail(
                     "Expected authentication error for share consumer "
                     "with expired token");
 
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         rd_kafka_share_consumer_close(sc1);
         rd_kafka_share_destroy(sc1);
         SUB_TEST_PASS();
@@ -414,10 +421,10 @@ do_test_produce_share_consumer_with_OIDC_should_fail_invalid_token_endpoint(
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
         /* Poll — should trigger auth error callback, no messages expected */
-        err  = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        err = rd_kafka_share_poll(sc1, 10 * 1000, &batch);
         if (err)
                 rd_kafka_error_destroy(err);
+        rcvd = rd_kafka_messages_count(batch);
 
         TEST_ASSERT(rcvd == 0,
                     "Expected no messages with invalid token endpoint, "
@@ -427,6 +434,8 @@ do_test_produce_share_consumer_with_OIDC_should_fail_invalid_token_endpoint(
                     "Expected authentication error for share consumer "
                     "with invalid token endpoint");
 
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         rd_kafka_share_consumer_close(sc1);
         rd_kafka_share_destroy(sc1);
         SUB_TEST_PASS();
@@ -593,16 +602,18 @@ static void do_test_produce_share_consumer_with_OIDC_should_fail(
         sc1 = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(sc1, "Failed to create share consumer: %s", errstr);
 
-        err  = rd_kafka_share_poll(sc1, 5 * 1000, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        err = rd_kafka_share_poll(sc1, 5 * 1000, &batch);
         if (err)
                 rd_kafka_error_destroy(err);
+        rcvd = rd_kafka_messages_count(batch);
 
         TEST_ASSERT(rcvd == 0, "Expected no messages on auth failure, got %zu",
                     rcvd);
         TEST_ASSERT(error_seen,
                     "Expected authentication error for share consumer");
 
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         rd_kafka_share_consumer_close(sc1);
         rd_kafka_share_destroy(sc1);
         SUB_TEST_PASS();

--- a/tests/0128-sasl_callback_queue.cpp
+++ b/tests/0128-sasl_callback_queue.cpp
@@ -177,13 +177,14 @@ static void do_test_share_consumer(bool use_background_queue) {
       rd_kafka_topic_partition_list_destroy(sub);
 
   } else {
-    /* Poll via share_poll — this serves the main queue which should
-     * trigger the OAUTHBEARER refresh callback. */
-    rd_kafka_messages_t *msgs = NULL;
-    rd_kafka_error_t *err     = rd_kafka_share_poll(rkshare, 1000, &msgs);
+    /* Poll via share_poll — this serves the main queue
+     * which should trigger the OAUTHBEARER refresh callback. */
+    rd_kafka_messages_t *batch = NULL;
+    rd_kafka_error_t *err      = rd_kafka_share_poll(rkshare, 1000, &batch);
     if (err)
       rd_kafka_error_destroy(err);
-    rd_kafka_messages_destroy(msgs);
+    rd_kafka_messages_destroy(batch);
+    batch = NULL;
   }
 
   Test::Say(tostr() << "share_cb_called = " << rd_atomic32_get(&share_cb_called)

--- a/tests/0128-sasl_callback_queue.cpp
+++ b/tests/0128-sasl_callback_queue.cpp
@@ -179,10 +179,10 @@ static void do_test_share_consumer(bool use_background_queue) {
   } else {
     /* Poll via share_consume_batch — this serves the main queue
      * which should trigger the OAUTHBEARER refresh callback. */
-    rd_kafka_message_t *msgs[1];
-    size_t rcvd = 0;
-    rd_kafka_error_t *err =
-        rd_kafka_share_consume_batch(rkshare, 1000, msgs, &rcvd);
+    rd_kafka_messages_t *msgs = NULL;
+    size_t rcvd               = 0;
+    rd_kafka_error_t *err     = rd_kafka_share_poll(rkshare, 1000, &msgs);
+    rcvd                      = rd_kafka_messages_count(msgs);
     if (err)
       rd_kafka_error_destroy(err);
   }

--- a/tests/0128-sasl_callback_queue.cpp
+++ b/tests/0128-sasl_callback_queue.cpp
@@ -177,14 +177,13 @@ static void do_test_share_consumer(bool use_background_queue) {
       rd_kafka_topic_partition_list_destroy(sub);
 
   } else {
-    /* Poll via share_consume_batch — this serves the main queue
-     * which should trigger the OAUTHBEARER refresh callback. */
+    /* Poll via share_poll — this serves the main queue which should
+     * trigger the OAUTHBEARER refresh callback. */
     rd_kafka_messages_t *msgs = NULL;
-    size_t rcvd               = 0;
     rd_kafka_error_t *err     = rd_kafka_share_poll(rkshare, 1000, &msgs);
-    rcvd                      = rd_kafka_messages_count(msgs);
     if (err)
       rd_kafka_error_destroy(err);
+    rd_kafka_messages_destroy(msgs);
   }
 
   Test::Say(tostr() << "share_cb_called = " << rd_atomic32_get(&share_cb_called)

--- a/tests/0135-sasl_credentials.cpp
+++ b/tests/0135-sasl_credentials.cpp
@@ -161,7 +161,7 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
   rd_kafka_t *p1;
   rd_kafka_share_t *sc;
   rd_kafka_topic_partition_list_t *subs;
-  rd_kafka_message_t *batch[10];
+  rd_kafka_messages_t *batch = NULL;
   rd_kafka_error_t *err;
   char errstr[512];
   char *username, *password;
@@ -215,13 +215,16 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
   if (set_after_auth_failure) {
     Test::Say("Awaiting share consumer auth failure\n");
     while (!share_error_seen) {
-      rcvd = 0;
-      err  = rd_kafka_share_consume_batch(sc, 1000, batch, &rcvd);
+      rd_kafka_messages_destroy(batch);
+      batch = NULL;
+      err   = rd_kafka_share_poll(sc, 1000, &batch);
+      rcvd  = rd_kafka_messages_count(batch);
+      (void)rcvd;
       if (err)
         rd_kafka_error_destroy(err);
-      for (size_t i = 0; i < rcvd; i++)
-        rd_kafka_message_destroy(batch[i]);
     }
+    rd_kafka_messages_destroy(batch);
+    batch = NULL;
     Test::Say("Share consumer authentication error seen\n");
   }
 
@@ -235,7 +238,8 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
   attempts = 100;
   rcvd     = 0;
   while (rcvd == 0 && attempts-- > 0) {
-    err = rd_kafka_share_consume_batch(sc, 3000, batch, &rcvd);
+    err  = rd_kafka_share_poll(sc, 3000, &batch);
+    rcvd = rd_kafka_messages_count(batch);
     if (err)
       rd_kafka_error_destroy(err);
   }
@@ -243,9 +247,7 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
               "Share consumer failed to consume message after "
               "credential update");
   for (size_t i = 0; i < rcvd; i++)
-    rd_kafka_message_destroy(batch[i]);
-
-  Test::Say("Share consumer successfully consumed after credential update\n");
+    Test::Say("Share consumer successfully consumed after credential update\n");
 
   rd_kafka_share_consumer_close(sc);
   rd_kafka_share_destroy(sc);

--- a/tests/0135-sasl_credentials.cpp
+++ b/tests/0135-sasl_credentials.cpp
@@ -215,16 +215,12 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
   if (set_after_auth_failure) {
     Test::Say("Awaiting share consumer auth failure\n");
     while (!share_error_seen) {
-      rd_kafka_messages_destroy(batch);
-      batch = NULL;
-      err   = rd_kafka_share_poll(sc, 1000, &batch);
-      rcvd  = rd_kafka_messages_count(batch);
-      (void)rcvd;
+      err = rd_kafka_share_poll(sc, 1000, &batch);
       if (err)
         rd_kafka_error_destroy(err);
+      rd_kafka_messages_destroy(batch);
+      batch = NULL;
     }
-    rd_kafka_messages_destroy(batch);
-    batch = NULL;
     Test::Say("Share consumer authentication error seen\n");
   }
 
@@ -238,16 +234,22 @@ static void do_test_share_consumer(bool set_after_auth_failure) {
   attempts = 100;
   rcvd     = 0;
   while (rcvd == 0 && attempts-- > 0) {
-    err  = rd_kafka_share_poll(sc, 3000, &batch);
-    rcvd = rd_kafka_messages_count(batch);
+    err = rd_kafka_share_poll(sc, 3000, &batch);
     if (err)
       rd_kafka_error_destroy(err);
+    rcvd = rd_kafka_messages_count(batch);
+    if (rcvd == 0) {
+      rd_kafka_messages_destroy(batch);
+      batch = NULL;
+    }
   }
   TEST_ASSERT(rcvd > 0,
               "Share consumer failed to consume message after "
               "credential update");
-  for (size_t i = 0; i < rcvd; i++)
-    Test::Say("Share consumer successfully consumed after credential update\n");
+  rd_kafka_messages_destroy(batch);
+  batch = NULL;
+
+  Test::Say("Share consumer successfully consumed after credential update\n");
 
   rd_kafka_share_consumer_close(sc);
   rd_kafka_share_destroy(sc);

--- a/tests/0142-reauthentication.c
+++ b/tests/0142-reauthentication.c
@@ -117,7 +117,7 @@ void do_test_share_consumer(int64_t reauth_time) {
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[500];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         const char *group      = "share-reauth-test";
@@ -158,15 +158,15 @@ void do_test_share_consumer(int64_t reauth_time) {
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err = rd_kafka_share_consume_batch(sc1, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to join group "
                     "and consume warmup message");
-        for (m = 0; m < rcvd; m++)
-                rd_kafka_message_destroy(batch[m]);
+        rd_kafka_messages_destroy(batch);
         TEST_SAY("Share consumer joined group, starting reauth test\n");
 
         start_time = test_clock();
@@ -177,15 +177,15 @@ void do_test_share_consumer(int64_t reauth_time) {
                 test_produce_msgs2(p1, topic, 0, 0, 0, 1, NULL, 0);
                 sent_cnt++;
 
-                err = rd_kafka_share_consume_batch(sc1, 100, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 100, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         rd_kafka_flush(p1, 50);
                 } else {
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err)
+                                if (!rd_kafka_messages_get(batch, m)->err)
                                         recv_cnt++;
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
 
@@ -200,16 +200,16 @@ void do_test_share_consumer(int64_t reauth_time) {
         while (recv_cnt < sent_cnt && attempts-- > 0) {
                 rcvd = 0;
 
-                err = rd_kafka_share_consume_batch(sc1, 3000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 3000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 recv_cnt++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -382,7 +382,7 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[500];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         const char *grp_conf[] = {"share.auto.offset.reset", "SET", "earliest"};
         const char *group      = "share-oauthbearer-reauth-test";
@@ -470,15 +470,15 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err = rd_kafka_share_consume_batch(sc1, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to join group "
                     "and consume warmup message");
-        for (m = 0; m < rcvd; m++)
-                rd_kafka_message_destroy(batch[m]);
+        rd_kafka_messages_destroy(batch);
         TEST_SAY(
             "Share consumer joined group, starting oauthbearer "
             "reauth test\n");
@@ -490,15 +490,15 @@ void do_test_share_oauthbearer(int64_t reauth_time,
                 test_produce_msgs2(p1, topic, 0, 0, 0, 1, NULL, 0);
                 sent_cnt++;
 
-                err = rd_kafka_share_consume_batch(sc1, 100, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 100, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         rd_kafka_flush(p1, 50);
                 } else {
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err)
+                                if (!rd_kafka_messages_get(batch, m)->err)
                                         recv_cnt++;
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
 
@@ -511,16 +511,16 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         while (recv_cnt < sent_cnt && attempts-- > 0) {
                 rcvd = 0;
 
-                err = rd_kafka_share_consume_batch(sc1, 3000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 3000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 recv_cnt++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -689,7 +689,7 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         rd_kafka_share_t *sc1;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[500];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         const char *group = "share-reauth-failure-test";
         const char *topic = test_mk_topic_name("share_reauth_fail", 1);
@@ -738,15 +738,15 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err = rd_kafka_share_consume_batch(sc1, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(sc1, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to consume warmup message");
         for (m = 0; m < rcvd; m++)
-                rd_kafka_message_destroy(batch[m]);
-        TEST_SAY("Share consumer connected, producing messages\n");
+                TEST_SAY("Share consumer connected, producing messages\n");
 
         test_produce_msgs_simple(p1, topic, 0, 200);
         TEST_SAY("Produced messages\n");
@@ -763,13 +763,14 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         while ((test_clock() - start_time) <= wait_time) {
                 rcvd = 0;
 
-                err = rd_kafka_share_consume_batch(sc1, 100, batch, &rcvd);
+                batch = NULL;
+                err   = rd_kafka_share_poll(sc1, 100, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
+                (void)rcvd;
                 if (err) {
                         rd_kafka_error_destroy(err);
-                } else {
-                        for (m = 0; m < rcvd; m++)
-                                rd_kafka_message_destroy(batch[m]);
                 }
+                rd_kafka_messages_destroy(batch);
         }
 
         TEST_ASSERT(error_seen, "should have had an authentication error");

--- a/tests/0142-reauthentication.c
+++ b/tests/0142-reauthentication.c
@@ -158,35 +158,44 @@ void do_test_share_consumer(int64_t reauth_time) {
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err  = rd_kafka_share_poll(sc1, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(sc1, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to join group "
                     "and consume warmup message");
         rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_SAY("Share consumer joined group, starting reauth test\n");
 
         start_time = test_clock();
         while ((test_clock() - start_time) <= wait_time) {
                 rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 /* Produce one message. */
                 test_produce_msgs2(p1, topic, 0, 0, 0, 1, NULL, 0);
                 sent_cnt++;
 
-                err  = rd_kafka_share_poll(sc1, 100, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(sc1, 100, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         rd_kafka_flush(p1, 50);
                 } else {
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err)
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!rkm->err)
                                         recv_cnt++;
                         }
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                 }
 
                 /* Maintain the message rate at ~200 msg/s regardless
@@ -199,18 +208,24 @@ void do_test_share_consumer(int64_t reauth_time) {
         attempts = 100;
         while (recv_cnt < sent_cnt && attempts-- > 0) {
                 rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
-                err  = rd_kafka_share_poll(sc1, 3000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(sc1, 3000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, m);
+                        if (!rkm->err)
                                 recv_cnt++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         rd_kafka_share_consumer_close(sc1);
@@ -470,15 +485,18 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err  = rd_kafka_share_poll(sc1, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(sc1, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to join group "
                     "and consume warmup message");
         rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_SAY(
             "Share consumer joined group, starting oauthbearer "
             "reauth test\n");
@@ -486,20 +504,26 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         start_time = test_clock();
         while ((test_clock() - start_time) <= wait_time) {
                 rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 test_produce_msgs2(p1, topic, 0, 0, 0, 1, NULL, 0);
                 sent_cnt++;
 
-                err  = rd_kafka_share_poll(sc1, 100, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(sc1, 100, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         rd_kafka_flush(p1, 50);
                 } else {
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err)
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!rkm->err)
                                         recv_cnt++;
                         }
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                 }
 
                 rd_usleep(1000 * 50, NULL);
@@ -510,18 +534,24 @@ void do_test_share_oauthbearer(int64_t reauth_time,
         attempts = 100;
         while (recv_cnt < sent_cnt && attempts-- > 0) {
                 rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
-                err  = rd_kafka_share_poll(sc1, 3000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(sc1, 3000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, m);
+                        if (!rkm->err)
                                 recv_cnt++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         rd_kafka_share_consumer_close(sc1);
@@ -698,7 +728,7 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         int64_t start_time = 0;
         int64_t wait_time  = reauth_time * 1.2 * 1000;
         int attempts;
-        size_t rcvd, m;
+        size_t rcvd;
 
         error_seen = 0;
         expect_err = 0;
@@ -738,15 +768,18 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         attempts = 50;
         rcvd     = 0;
         while (rcvd == 0 && attempts-- > 0) {
-                err  = rd_kafka_share_poll(sc1, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(sc1, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd > 0,
                     "Share consumer failed to consume warmup message");
-        for (m = 0; m < rcvd; m++)
-                TEST_SAY("Share consumer connected, producing messages\n");
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        TEST_SAY("Share consumer connected, producing messages\n");
 
         test_produce_msgs_simple(p1, topic, 0, 200);
         TEST_SAY("Produced messages\n");
@@ -762,15 +795,16 @@ void do_test_share_reauth_failure(int64_t reauth_time) {
         start_time = test_clock();
         while ((test_clock() - start_time) <= wait_time) {
                 rcvd = 0;
-
+                rd_kafka_messages_destroy(batch);
                 batch = NULL;
-                err   = rd_kafka_share_poll(sc1, 100, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
-                (void)rcvd;
+
+                err = rd_kafka_share_poll(sc1, 100, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
+                } else {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                 }
-                rd_kafka_messages_destroy(batch);
         }
 
         TEST_ASSERT(error_seen, "should have had an authentication error");

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -51,7 +51,7 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
 }
 
 /**
- * @brief Poll rd_kafka_share_consume_batch() until it returns a fatal
+ * @brief Poll rd_kafka_share_poll() until it returns a fatal
  *        error or \p timeout_ms elapses.
  *
  * While waiting for the fatal error no records are expected, and any

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -51,7 +51,7 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
 }
 
 /**
- * @brief Poll rd_kafka_share_consume_batch() until it returns a fatal
+ * @brief Poll rd_kafka_share_poll() until it returns a fatal
  *        error or \p timeout_ms elapses.
  *
  * While waiting for the fatal error no records are expected, and any
@@ -63,14 +63,14 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
 static rd_kafka_error_t *wait_fatal_error(rd_kafka_share_t *share_c,
                                           int timeout_ms) {
         int64_t deadline = test_clock() + (int64_t)timeout_ms * 1000;
-        rd_kafka_message_t *rkmessages[10];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         rd_kafka_error_t *error;
 
         while (test_clock() < deadline) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(share_c, 100, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(share_c, 100, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
 
                 TEST_ASSERT(rcvd == 0,
                             "Expected no records while waiting for fatal "

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -51,7 +51,7 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
 }
 
 /**
- * @brief Poll rd_kafka_share_poll() until it returns a fatal
+ * @brief Poll rd_kafka_share_consume_batch() until it returns a fatal
  *        error or \p timeout_ms elapses.
  *
  * While waiting for the fatal error no records are expected, and any
@@ -62,20 +62,22 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
  */
 static rd_kafka_error_t *wait_fatal_error(rd_kafka_share_t *share_c,
                                           int timeout_ms) {
-        int64_t deadline = test_clock() + (int64_t)timeout_ms * 1000;
-        rd_kafka_messages_t *rkmessages = NULL;
+        int64_t deadline           = test_clock() + (int64_t)timeout_ms * 1000;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         rd_kafka_error_t *error;
 
         while (test_clock() < deadline) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(share_c, 100, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(share_c, 100, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
 
                 TEST_ASSERT(rcvd == 0,
                             "Expected no records while waiting for fatal "
                             "error, got %d",
                             (int)rcvd);
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (error) {
                         TEST_ASSERT(rd_kafka_error_is_fatal(error),

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -863,8 +863,8 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         rd_kafka_share_poll(consumer, 2000, &batch);
         rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
-                if (rkm && !rkm->err)
+                rd_kafka_message_t *msg = rd_kafka_messages_get(batch, i);
+                if (!msg->err)
                         consumed++;
         }
         rd_kafka_messages_destroy(batch);
@@ -961,8 +961,8 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         rd_kafka_share_poll(consumer, 2000, &batch);
         rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
-                if (rkm && !rkm->err)
+                rd_kafka_message_t *msg = rd_kafka_messages_get(batch, i);
+                if (!msg->err)
                         consumed++;
         }
         rd_kafka_messages_destroy(batch);

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -844,7 +844,7 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         const char *topic = "kip932_fetch_error";
         test_ctx_t ctx    = test_ctx_new();
         rd_kafka_share_t *consumer;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd  = 0;
         int consumed = 0;
         size_t i;
@@ -860,12 +860,15 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-fetch-error");
         subscribe_topics(consumer, &topic, 1);
 
-        rd_kafka_share_poll(consumer, 2000, &rkmessages);
-            rcvd = rd_kafka_messages_count(rkmessages);
+        rd_kafka_share_poll(consumer, 2000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                if (!rd_kafka_messages_get(rkmessages, i)->err)
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+                if (rkm && !rkm->err)
                         consumed++;
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("fetch_error(%s): consumed=%d rcvd=%zu\n",
                  rd_kafka_err2name(err), consumed, rcvd);
@@ -935,7 +938,7 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         const char *topic = "kip932_disconnect";
         test_ctx_t ctx;
         rd_kafka_share_t *consumer;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd  = 0;
         int consumed = 0;
         size_t i;
@@ -955,12 +958,15 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-disconnect");
         subscribe_topics(consumer, &topic, 1);
 
-        rd_kafka_share_poll(consumer, 2000, &rkmessages);
-            rcvd = rd_kafka_messages_count(rkmessages);
+        rd_kafka_share_poll(consumer, 2000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                if (!rd_kafka_messages_get(rkmessages, i)->err)
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+                if (rkm && !rkm->err)
                         consumed++;
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("fetch_disconnected: consumed=%d rcvd=%zu\n", consumed, rcvd);
 

--- a/tests/0156-share_consumer_fetch_mock.c
+++ b/tests/0156-share_consumer_fetch_mock.c
@@ -844,7 +844,7 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         const char *topic = "kip932_fetch_error";
         test_ctx_t ctx    = test_ctx_new();
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *rkmessages[10];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd  = 0;
         int consumed = 0;
         size_t i;
@@ -860,11 +860,11 @@ static void do_test_sharefetch_fetch_error(rd_kafka_resp_err_t err) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-fetch-error");
         subscribe_topics(consumer, &topic, 1);
 
-        rd_kafka_share_consume_batch(consumer, 2000, rkmessages, &rcvd);
+        rd_kafka_share_poll(consumer, 2000, &rkmessages);
+            rcvd = rd_kafka_messages_count(rkmessages);
         for (i = 0; i < rcvd; i++) {
-                if (!rkmessages[i]->err)
+                if (!rd_kafka_messages_get(rkmessages, i)->err)
                         consumed++;
-                rd_kafka_message_destroy(rkmessages[i]);
         }
 
         TEST_SAY("fetch_error(%s): consumed=%d rcvd=%zu\n",
@@ -935,7 +935,7 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         const char *topic = "kip932_disconnect";
         test_ctx_t ctx;
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *rkmessages[10];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd  = 0;
         int consumed = 0;
         size_t i;
@@ -955,11 +955,11 @@ static void do_test_sharefetch_fetch_disconnected(void) {
         consumer = new_share_consumer(ctx.bootstraps, "sg-disconnect");
         subscribe_topics(consumer, &topic, 1);
 
-        rd_kafka_share_consume_batch(consumer, 2000, rkmessages, &rcvd);
+        rd_kafka_share_poll(consumer, 2000, &rkmessages);
+            rcvd = rd_kafka_messages_count(rkmessages);
         for (i = 0; i < rcvd; i++) {
-                if (!rkmessages[i]->err)
+                if (!rd_kafka_messages_get(rkmessages, i)->err)
                         consumed++;
-                rd_kafka_message_destroy(rkmessages[i]);
         }
 
         TEST_SAY("fetch_disconnected: consumed=%d rcvd=%zu\n", consumed, rcvd);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -574,15 +574,15 @@ static void exec_create_consumer(sub_test_state_t *state, const test_op_t *op) {
  * subscribed" message when no subscription is active.
  */
 static void exec_poll_no_sub(sub_test_state_t *state, const test_op_t *op) {
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         size_t rcvd = 0;
         int cidx    = op->consumer_idx;
 
         TEST_SAY("  POLL_NO_SUB: consumer=%d\n", cidx);
 
-        err = rd_kafka_share_consume_batch(state->consumers[cidx], 2000, batch,
-                                           &rcvd);
+        err  = rd_kafka_share_poll(state->consumers[cidx], 2000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "POLL_NO_SUB consumer=%d: expected error, got NULL", cidx);
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -919,7 +919,7 @@ static void test_topic_deletion_does_not_surface_error(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         char errstr[512];
         char *topic_dup;
@@ -970,19 +970,19 @@ static void test_topic_deletion_does_not_surface_error(void) {
          * record so the rktp materialises on rkt_desp (precondition
          * for the metadata-error propagation path to fire). */
         while (consumed < 1 && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                rd_kafka_share_acknowledge(consumer, batch[j]);
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    consumer, rd_kafka_messages_get(batch, j));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
         TEST_ASSERT(consumed >= 1,
@@ -1004,9 +1004,9 @@ static void test_topic_deletion_does_not_surface_error(void) {
          * (no more records); only the metadata-derived topic codes
          * must not surface. */
         for (post_attempts = 0; post_attempts < 30; post_attempts++) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 500, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         TEST_SAY("Post-delete consume_batch: %s\n",
@@ -1023,9 +1023,9 @@ static void test_topic_deletion_does_not_surface_error(void) {
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err)
-                                rd_kafka_share_acknowledge(consumer, batch[j]);
-                        rd_kafka_message_destroy(batch[j]);
+                        if (!rd_kafka_messages_get(batch, j)->err)
+                                rd_kafka_share_acknowledge(
+                                    consumer, rd_kafka_messages_get(batch, j));
                 }
         }
 
@@ -1058,8 +1058,8 @@ static void do_test_subscribe_15_topics(void) {
         char *topics[15];
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[10000];
-        int consumed = 0;
+        rd_kafka_messages_t *batch = NULL;
+        int consumed               = 0;
         int attempts;
         int t;
 
@@ -1103,16 +1103,16 @@ static void do_test_subscribe_15_topics(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
 
                 if (rcvd > 0)
@@ -1143,7 +1143,7 @@ static void do_test_subscribe_15_topics(void) {
  */
 static void do_test_auto_offset_reset_earliest(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-offset-earliest-test";
         rd_kafka_topic_partition_list_t *subs;
@@ -1181,17 +1181,16 @@ static void do_test_auto_offset_reset_earliest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
 
                 if (rcvd > 0)
@@ -1219,7 +1218,7 @@ static void do_test_auto_offset_reset_earliest(void) {
  */
 static void do_test_auto_offset_reset_default_latest(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-offset-default-test";
         rd_kafka_topic_partition_list_t *subs;
@@ -1259,17 +1258,16 @@ static void do_test_auto_offset_reset_default_latest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed_before++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -1294,17 +1292,16 @@ static void do_test_auto_offset_reset_default_latest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed_after++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -1416,7 +1413,7 @@ static void do_test_subscribe_input_validation(void) {
 static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-caret-literal-e2e";
         const int msg_cnt = 50;
@@ -1462,15 +1459,14 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 records_phase1++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_ASSERT(records_phase1 == 0,
@@ -1507,15 +1503,14 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 records_phase2++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_ASSERT(records_phase2 == (size_t)msg_cnt,
@@ -1543,7 +1538,7 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
 static void do_test_consume_batch_without_subscription(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         size_t rcvd = 0;
         size_t i;
@@ -1559,7 +1554,8 @@ static void do_test_consume_batch_without_subscription(void) {
 
         /* Case 1: never subscribed. */
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 1 (never subscribed): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1578,7 +1574,8 @@ static void do_test_consume_batch_without_subscription(void) {
         rd_kafka_topic_partition_list_destroy(subs);
 
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err) {
                 TEST_ASSERT(rd_kafka_error_code(err) !=
                                 RD_KAFKA_RESP_ERR__STATE,
@@ -1587,13 +1584,12 @@ static void do_test_consume_batch_without_subscription(void) {
                 rd_kafka_error_destroy(err);
         }
         for (i = 0; i < rcvd; i++)
-                rd_kafka_message_destroy(batch[i]);
-
-        /* Case 3: unsubscribed -> __STATE again. */
-        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
+                /* Case 3: unsubscribed -> __STATE again. */
+                TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
 
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 3 (after unsubscribe): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1613,7 +1609,8 @@ static void do_test_consume_batch_without_subscription(void) {
         rd_kafka_topic_partition_list_destroy(subs);
 
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err) {
                 TEST_ASSERT(rd_kafka_error_code(err) !=
                                 RD_KAFKA_RESP_ERR__STATE,
@@ -1621,9 +1618,7 @@ static void do_test_consume_batch_without_subscription(void) {
                             rd_kafka_error_string(err));
                 rd_kafka_error_destroy(err);
         }
-        for (i = 0; i < rcvd; i++)
-                rd_kafka_message_destroy(batch[i]);
-
+        rd_kafka_messages_destroy(batch);
         /* Case 5: subscribe([]) is equivalent to unsubscribe — must
          * return NO_ERROR and clear the F_SUBSCRIPTION flag, so the
          * next consume_batch returns __STATE. */
@@ -1638,7 +1633,8 @@ static void do_test_consume_batch_without_subscription(void) {
         rd_kafka_topic_partition_list_destroy(subs);
 
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 5 (after subscribe([])): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1717,7 +1713,7 @@ static void do_test_subscription_change_acks_pending(void) {
         char *t2;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         subchg_ack_state_t state = {0};
         size_t rcvd              = 0;
@@ -1758,16 +1754,14 @@ static void do_test_subscription_change_acks_pending(void) {
         /* Poll until the t1 record arrives */
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
+                rcvd += rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record from t1, got %zu", rcvd);
-        rd_kafka_message_destroy(batch[0]);
-
         TEST_ASSERT(state.base.callback_cnt == 0,
                     "Did not expect callback before subscription change, "
                     "got %d",
@@ -1789,12 +1783,12 @@ static void do_test_subscription_change_acks_pending(void) {
         rcvd     = 0;
         attempts = 30;
         while ((rcvd < 1 || state.base.callback_cnt < 1) && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 1000, batch + rcvd,
-                                                   &batch_rcvd);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 1000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
+                rcvd += rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
         }
 
         TEST_ASSERT(rcvd == 1, "Expected 1 record from t2, got %zu", rcvd);
@@ -1810,8 +1804,6 @@ static void do_test_subscription_change_acks_pending(void) {
         TEST_ASSERT(strcmp(state.first_callback_topic, t1) == 0,
                     "Expected first ack callback to be for t1 (%s), got %s", t1,
                     state.first_callback_topic);
-
-        rd_kafka_message_destroy(batch[0]);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1956,7 +1948,7 @@ static void do_test_delete_records_advances_lso(void) {
         rd_kafka_topic_partition_list_t *offsets;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err_obj;
         rd_kafka_resp_err_t err;
         int64_t first_offset = -1;
@@ -2005,19 +1997,20 @@ static void do_test_delete_records_advances_lso(void) {
         attempts = 30;
         while (consumed < 5 && attempts-- > 0) {
                 batch_cnt = 0;
-                err_obj   = rd_kafka_share_consume_batch(rkshare, 2000, batch,
-                                                         &batch_cnt);
+                err_obj   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                batch_cnt = rd_kafka_messages_count(batch);
                 if (err_obj) {
                         rd_kafka_error_destroy(err_obj);
                         continue;
                 }
                 for (k = 0; k < batch_cnt; k++) {
-                        if (!batch[k]->err) {
+                        if (!rd_kafka_messages_get(batch, k)->err) {
                                 if (first_offset == -1)
-                                        first_offset = batch[k]->offset;
+                                        first_offset =
+                                            rd_kafka_messages_get(batch, k)
+                                                ->offset;
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[k]);
                 }
         }
         TEST_ASSERT(consumed == 5,
@@ -2031,13 +2024,13 @@ static void do_test_delete_records_advances_lso(void) {
 
         /* Verify no additional records show up */
         batch_cnt = 0;
-        err_obj =
-            rd_kafka_share_consume_batch(rkshare, 1000, batch, &batch_cnt);
+        err_obj   = rd_kafka_share_poll(rkshare, 1000, &batch);
+        batch_cnt = rd_kafka_messages_count(batch);
         if (err_obj)
                 rd_kafka_error_destroy(err_obj);
         for (k = 0; k < batch_cnt; k++)
-                rd_kafka_message_destroy(batch[k]);
-        TEST_ASSERT(batch_cnt == 0,
+                TEST_ASSERT(
+                    batch_cnt == 0,
                     "Did not expect more records after consuming 5, got %zu",
                     batch_cnt);
 

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -596,6 +596,7 @@ static void exec_poll_no_sub(sub_test_state_t *state, const test_op_t *op) {
                     "POLL_NO_SUB consumer=%d: expected 0 messages, got %zu",
                     cidx, rcvd);
         rd_kafka_error_destroy(err);
+        rd_kafka_messages_destroy(batch);
 }
 
 /**
@@ -970,7 +971,8 @@ static void test_topic_deletion_does_not_surface_error(void) {
          * record so the rktp materialises on rkt_desp (precondition
          * for the metadata-error propagation path to fire). */
         while (consumed < 1 && attempts++ < 30) {
-                rcvd  = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 error = rd_kafka_share_poll(consumer, 1000, &batch);
                 rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
@@ -978,13 +980,16 @@ static void test_topic_deletion_does_not_surface_error(void) {
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    consumer, rd_kafka_messages_get(batch, j));
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                rd_kafka_share_acknowledge(consumer, msg);
                                 consumed++;
                         }
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(consumed >= 1,
                     "Pre-condition: expected to consume + ack at least one "
                     "record before deleting the topic");
@@ -1004,7 +1009,8 @@ static void test_topic_deletion_does_not_surface_error(void) {
          * (no more records); only the metadata-derived topic codes
          * must not surface. */
         for (post_attempts = 0; post_attempts < 30; post_attempts++) {
-                rcvd  = 0;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 error = rd_kafka_share_poll(consumer, 500, &batch);
                 rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
@@ -1023,11 +1029,14 @@ static void test_topic_deletion_does_not_surface_error(void) {
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err)
-                                rd_kafka_share_acknowledge(
-                                    consumer, rd_kafka_messages_get(batch, j));
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err)
+                                rd_kafka_share_acknowledge(consumer, msg);
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(!surfaced_topic_err,
                     "Topic-level metadata errors must not surface to "
@@ -1103,21 +1112,27 @@ static void do_test_subscribe_15_topics(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(rkshare, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
 
                 if (rcvd > 0)
                         TEST_SAY("Progress: %d/%d\n", consumed, total_expected);
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == total_expected,
                     "Expected %d messages, consumed %d", total_expected,
@@ -1181,21 +1196,27 @@ static void do_test_auto_offset_reset_earliest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
 
                 if (rcvd > 0)
                         TEST_SAY("Progress: %d/%d\n", consumed, msg_cnt);
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == msg_cnt, "Expected %d messages, got %d",
                     msg_cnt, consumed);
@@ -1258,18 +1279,24 @@ static void do_test_auto_offset_reset_default_latest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed_before++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY(
             "Consumed %d messages from before subscription (expected: 0)\n",
@@ -1292,18 +1319,24 @@ static void do_test_auto_offset_reset_default_latest(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed_after++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumed %d messages after subscription (expected: %d)\n",
                  consumed_after, later_msgs);
@@ -1459,16 +1492,22 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 records_phase1++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(records_phase1 == 0,
                     "Phase 1: expected 0 records for '%s' literal "
                     "subscription, got %zu",
@@ -1503,16 +1542,22 @@ static void do_test_subscribe_caret_treated_as_literal_e2e(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 records_phase2++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(records_phase2 == (size_t)msg_cnt,
                     "Phase 2: expected %d records, got %zu", msg_cnt,
                     records_phase2);
@@ -1540,8 +1585,7 @@ static void do_test_consume_batch_without_subscription(void) {
         rd_kafka_topic_partition_list_t *subs;
         rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
-        size_t rcvd = 0;
-        size_t i;
+        size_t rcvd       = 0;
         const char *group = "share-no-subscription";
         const char *topic;
 
@@ -1553,9 +1597,10 @@ static void do_test_consume_batch_without_subscription(void) {
         consumer = test_create_share_consumer(group, NULL);
 
         /* Case 1: never subscribed. */
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 500, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 1 (never subscribed): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1573,9 +1618,10 @@ static void do_test_consume_batch_without_subscription(void) {
         TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
         rd_kafka_topic_partition_list_destroy(subs);
 
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 500, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         if (err) {
                 TEST_ASSERT(rd_kafka_error_code(err) !=
                                 RD_KAFKA_RESP_ERR__STATE,
@@ -1583,13 +1629,14 @@ static void do_test_consume_batch_without_subscription(void) {
                             rd_kafka_error_string(err));
                 rd_kafka_error_destroy(err);
         }
-        for (i = 0; i < rcvd; i++)
-                /* Case 3: unsubscribed -> __STATE again. */
-                TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
 
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 500, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        /* Case 3: unsubscribed -> __STATE again. */
+        TEST_CALL_ERR__(rd_kafka_share_unsubscribe(consumer));
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 3 (after unsubscribe): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1608,9 +1655,10 @@ static void do_test_consume_batch_without_subscription(void) {
         TEST_CALL_ERR__(rd_kafka_share_subscribe(consumer, subs));
         rd_kafka_topic_partition_list_destroy(subs);
 
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 500, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         if (err) {
                 TEST_ASSERT(rd_kafka_error_code(err) !=
                                 RD_KAFKA_RESP_ERR__STATE,
@@ -1618,7 +1666,7 @@ static void do_test_consume_batch_without_subscription(void) {
                             rd_kafka_error_string(err));
                 rd_kafka_error_destroy(err);
         }
-        rd_kafka_messages_destroy(batch);
+
         /* Case 5: subscribe([]) is equivalent to unsubscribe — must
          * return NO_ERROR and clear the F_SUBSCRIPTION flag, so the
          * next consume_batch returns __STATE. */
@@ -1632,9 +1680,10 @@ static void do_test_consume_batch_without_subscription(void) {
                     rd_kafka_err2name(empty_err));
         rd_kafka_topic_partition_list_destroy(subs);
 
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 500, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 500, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_ASSERT(err != NULL,
                     "Case 5 (after subscribe([])): expected error, got NULL");
         TEST_ASSERT(rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__STATE,
@@ -1645,6 +1694,8 @@ static void do_test_consume_batch_without_subscription(void) {
                     rd_kafka_error_string(err));
         TEST_ASSERT(rcvd == 0, "Case 5: expected 0 msgs, got %zu", rcvd);
         rd_kafka_error_destroy(err);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -1754,14 +1805,19 @@ static void do_test_subscription_change_acks_pending(void) {
         /* Poll until the t1 record arrives */
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
-                batch = NULL;
-                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                size_t batch_rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch      = NULL;
+                err        = rd_kafka_share_poll(rkshare, 2000, &batch);
+                batch_rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += rd_kafka_messages_count(batch);
-                rd_kafka_messages_destroy(batch);
+                rcvd += batch_rcvd;
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record from t1, got %zu", rcvd);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
         TEST_ASSERT(state.base.callback_cnt == 0,
                     "Did not expect callback before subscription change, "
                     "got %d",
@@ -1783,12 +1839,14 @@ static void do_test_subscription_change_acks_pending(void) {
         rcvd     = 0;
         attempts = 30;
         while ((rcvd < 1 || state.base.callback_cnt < 1) && attempts-- > 0) {
-                batch = NULL;
-                err   = rd_kafka_share_poll(rkshare, 1000, &batch);
+                size_t batch_rcvd = 0;
+                rd_kafka_messages_destroy(batch);
+                batch      = NULL;
+                err        = rd_kafka_share_poll(rkshare, 1000, &batch);
+                batch_rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += rd_kafka_messages_count(batch);
-                rd_kafka_messages_destroy(batch);
+                rcvd += batch_rcvd;
         }
 
         TEST_ASSERT(rcvd == 1, "Expected 1 record from t2, got %zu", rcvd);
@@ -1804,6 +1862,9 @@ static void do_test_subscription_change_acks_pending(void) {
         TEST_ASSERT(strcmp(state.first_callback_topic, t1) == 0,
                     "Expected first ack callback to be for t1 (%s), got %s", t1,
                     state.first_callback_topic);
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1996,7 +2057,8 @@ static void do_test_delete_records_advances_lso(void) {
 
         attempts = 30;
         while (consumed < 5 && attempts-- > 0) {
-                batch_cnt = 0;
+                rd_kafka_messages_destroy(batch);
+                batch     = NULL;
                 err_obj   = rd_kafka_share_poll(rkshare, 2000, &batch);
                 batch_cnt = rd_kafka_messages_count(batch);
                 if (err_obj) {
@@ -2004,15 +2066,17 @@ static void do_test_delete_records_advances_lso(void) {
                         continue;
                 }
                 for (k = 0; k < batch_cnt; k++) {
-                        if (!rd_kafka_messages_get(batch, k)->err) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, k);
+                        if (!msg->err) {
                                 if (first_offset == -1)
-                                        first_offset =
-                                            rd_kafka_messages_get(batch, k)
-                                                ->offset;
+                                        first_offset = msg->offset;
                                 consumed++;
                         }
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(consumed == 5,
                     "Expected 5 records (offsets 5..9) after DeleteRecords, "
                     "consumed %d",
@@ -2023,16 +2087,17 @@ static void do_test_delete_records_advances_lso(void) {
                     first_offset);
 
         /* Verify no additional records show up */
-        batch_cnt = 0;
+        rd_kafka_messages_destroy(batch);
+        batch     = NULL;
         err_obj   = rd_kafka_share_poll(rkshare, 1000, &batch);
         batch_cnt = rd_kafka_messages_count(batch);
         if (err_obj)
                 rd_kafka_error_destroy(err_obj);
-        for (k = 0; k < batch_cnt; k++)
-                TEST_ASSERT(
-                    batch_cnt == 0,
+        TEST_ASSERT(batch_cnt == 0,
                     "Did not expect more records after consuming 5, got %zu",
                     batch_cnt);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);

--- a/tests/0170-share_consumer_subscription.c
+++ b/tests/0170-share_consumer_subscription.c
@@ -872,14 +872,12 @@ static void do_test_multi_consumer_overlap(void) {
                 int batch_cnt = 0;
                 int ret;
 
-                ret = test_share_consume_batch(rkshare0, 2000, c0_topics, 2,
-                                               &batch_cnt);
+                ret = test_share_poll(rkshare0, 2000, c0_topics, 2, &batch_cnt);
                 TEST_ASSERT(ret >= 0, "C0 wrong topic");
                 c0_cnt += batch_cnt;
 
                 batch_cnt = 0;
-                ret = test_share_consume_batch(rkshare1, 2000, c1_topics, 2,
-                                               &batch_cnt);
+                ret = test_share_poll(rkshare1, 2000, c1_topics, 2, &batch_cnt);
                 TEST_ASSERT(ret >= 0, "C1 wrong topic");
                 c1_cnt += batch_cnt;
         }
@@ -1945,11 +1943,11 @@ static void do_test_two_groups_earliest_vs_latest(void) {
         attempts = 30;
         while (attempts-- > 0 && countA < 5) {
                 int batch_cnt = 0;
-                test_share_consume_batch(consA, 1000, NULL, 0, &batch_cnt);
+                test_share_poll(consA, 1000, NULL, 0, &batch_cnt);
                 countA += batch_cnt;
 
                 batch_cnt = 0;
-                test_share_consume_batch(consB, 500, NULL, 0, &batch_cnt);
+                test_share_poll(consB, 500, NULL, 0, &batch_cnt);
                 countB += batch_cnt;
         }
         TEST_ASSERT(countA == 5, "groupA (earliest) expected 5 records, got %d",
@@ -1967,11 +1965,11 @@ static void do_test_two_groups_earliest_vs_latest(void) {
         attempts = 30;
         while (attempts-- > 0 && countB < 3) {
                 int batch_cnt = 0;
-                test_share_consume_batch(consA, 500, NULL, 0, &batch_cnt);
+                test_share_poll(consA, 500, NULL, 0, &batch_cnt);
                 countA += batch_cnt;
 
                 batch_cnt = 0;
-                test_share_consume_batch(consB, 1000, NULL, 0, &batch_cnt);
+                test_share_poll(consB, 1000, NULL, 0, &batch_cnt);
                 countB += batch_cnt;
         }
         TEST_ASSERT(countA == 8, "groupA expected 8 records total, got %d",

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -893,17 +893,16 @@ typedef struct {
 static int consume_blocker_thread(void *arg) {
         blocker_arg_t *ba          = arg;
         rd_kafka_messages_t *batch = NULL;
-        size_t rcvd                = 0;
         rd_kafka_error_t *err;
 
         rd_atomic32_set(&ba->entering, 1);
 
         /* Blocks for ~5s waiting for messages that never arrive.
          * The share access gate is held for the full duration. */
-        err  = rd_kafka_share_poll(ba->consumer, 5000, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        err = rd_kafka_share_poll(ba->consumer, 5000, &batch);
         if (err)
                 rd_kafka_error_destroy(err);
+        rd_kafka_messages_destroy(batch);
         return 0;
 }
 
@@ -920,7 +919,6 @@ static void do_test_concurrent_thread_access_rejected(void) {
         thrd_t blocker;
         blocker_arg_t ba;
         rd_kafka_messages_t *batch = NULL;
-        size_t rcvd                = 0;
         rd_kafka_error_t *err      = NULL;
         int probe_attempt;
         const int probe_max_attempts = 50; /* 50 × 100ms = 5 s budget */
@@ -975,9 +973,9 @@ static void do_test_concurrent_thread_access_rejected(void) {
          * single-shot assertion flakes. */
         for (probe_attempt = 0; probe_attempt < probe_max_attempts;
              probe_attempt++) {
-                rcvd = 0;
-                err  = rd_kafka_share_poll(consumer, 0, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 0, &batch);
                 if (err &&
                     rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__CONFLICT)
                         break; /* observed the conflict — done */
@@ -1004,14 +1002,15 @@ static void do_test_concurrent_thread_access_rejected(void) {
         /* Sequential ownership transfer: gate is now free, the same
          * main thread should be able to call consume_batch without
          * hitting the gate. */
-        rcvd = 0;
-        err  = rd_kafka_share_poll(consumer, 0, &batch);
-        rcvd = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+        err   = rd_kafka_share_poll(consumer, 0, &batch);
         TEST_ASSERT(!err, "After blocker returned, gate should be free; got %s",
                     err ? rd_kafka_err2str(rd_kafka_error_code(err))
                         : "no error");
         if (err)
                 rd_kafka_error_destroy(err);
+        rd_kafka_messages_destroy(batch);
 
         TEST_SAY("Sequential ownership transfer works after release\n");
 
@@ -1574,7 +1573,6 @@ static void do_test_zero_byte_payload_and_key(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         size_t rcvd = 0;
         int attempts;
@@ -1816,7 +1814,6 @@ static void do_test_many_and_large_headers(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         const int hdr_cnt         = 100;
         const size_t big_hdr_size = 64 * 1024;

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -210,17 +210,21 @@ static void consume_messages(share_test_config_t *config,
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err  = rd_kafka_share_poll(state->consumers[i],
-                                                   poll_timeout, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                        err   = rd_kafka_share_poll(state->consumers[i],
+                                                    poll_timeout, &batch);
 
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
                         }
 
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err) {
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!msg->err) {
                                         state->per_consumer_count[i]++;
                                         state->total_consumed++;
                                 }
@@ -250,6 +254,9 @@ static void consume_messages(share_test_config_t *config,
                                  dist);
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 }
 
 /**
@@ -606,15 +613,19 @@ static void do_test_rapid_produce_consume_cycles(void) {
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                        err   = rd_kafka_share_poll(consumer, 1000, &batch);
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
                         }
 
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err)
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!msg->err)
                                         round_consumed++;
                         }
                 }
@@ -624,6 +635,9 @@ static void do_test_rapid_produce_consume_cycles(void) {
                          round_consumed, msgs_per_round, total_consumed,
                          (round + 1) * msgs_per_round);
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(total_consumed == total_expected,
                     "Expected %d messages, consumed %d", total_expected,
@@ -672,10 +686,12 @@ static void do_test_empty_then_produce(void) {
                 size_t rcvd = 0;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                rcvd = rd_kafka_messages_count(batch);
                 TEST_SAY("Empty poll %d: received %zu\n", attempts + 1, rcvd);
         }
 
@@ -690,18 +706,25 @@ static void do_test_empty_then_produce(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == 100, "Expected 100 messages, consumed %d",
                     consumed);
@@ -760,20 +783,27 @@ static void do_test_sparse_partitions(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
 
                 TEST_SAY("Progress: %d/%d\n", consumed, expected);
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == expected, "Expected %d messages, consumed %d",
                     expected, consumed);
@@ -833,18 +863,25 @@ static void do_test_poll_callback_piggybacked_acks(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 2000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumed %d messages\n", consumed);
         TEST_ASSERT(consumed > 0, "Expected to consume some messages");
@@ -988,7 +1025,7 @@ static void do_test_concurrent_thread_access_rejected(void) {
 
         TEST_ASSERT(
             err && rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__CONFLICT,
-            "Expected __CONFLICT from concurrent consume_batch while blocker "
+            "Expected __CONFLICT from concurrent share_poll while blocker "
             "thread holds the gate after %d probe attempts; got: %s",
             probe_attempt + 1,
             err ? rd_kafka_err2name(rd_kafka_error_code(err)) : "no error");
@@ -1000,7 +1037,7 @@ static void do_test_concurrent_thread_access_rejected(void) {
         thrd_join(blocker, NULL);
 
         /* Sequential ownership transfer: gate is now free, the same
-         * main thread should be able to call consume_batch without
+         * main thread should be able to call share_poll without
          * hitting the gate. */
         rd_kafka_messages_destroy(batch);
         batch = NULL;
@@ -1011,6 +1048,7 @@ static void do_test_concurrent_thread_access_rejected(void) {
         if (err)
                 rd_kafka_error_destroy(err);
         rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Sequential ownership transfer works after release\n");
 
@@ -1033,6 +1071,7 @@ static void do_test_concurrent_thread_access_rejected(void) {
 static void do_test_headers_preserved(void) {
         rd_kafka_share_t *consumer;
         rd_kafka_messages_t *batch = NULL;
+        rd_kafka_message_t *msg0;
         const char *topic;
         const char *group = "share-headers";
         rd_kafka_topic_partition_list_t *subs;
@@ -1072,17 +1111,18 @@ static void do_test_headers_preserved(void) {
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
                 rd_kafka_error_t *e;
+
                 rd_kafka_messages_destroy(batch);
                 batch = NULL;
-
-                e = rd_kafka_share_poll(consumer, 2000, &batch);
+                e     = rd_kafka_share_poll(consumer, 2000, &batch);
                 if (e)
                         rd_kafka_error_destroy(e);
                 rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
 
-        herr = rd_kafka_message_headers(rd_kafka_messages_get(batch, 0), &hdrs);
+        msg0 = rd_kafka_messages_get(batch, 0);
+        herr = rd_kafka_message_headers(msg0, &hdrs);
         TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && hdrs,
                     "Failed to get headers: %s", rd_kafka_err2name(herr));
 
@@ -1100,6 +1140,9 @@ static void do_test_headers_preserved(void) {
         TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR, "h3 not present: %s",
                     rd_kafka_err2name(herr));
         TEST_ASSERT(vsz == 2 && memcmp(val, "v3", 2) == 0, "h3 value mismatch");
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -1345,18 +1388,25 @@ static void do_test_consumer_close_releases_to_group(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumers[0], 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumers[0], 2000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 c0_fetched++;
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(c0_fetched > 0,
                     "Consumer 0 should have fetched some records, got %d",
                     c0_fetched);
@@ -1376,21 +1426,28 @@ static void do_test_consumer_close_releases_to_group(void) {
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err  = rd_kafka_share_poll(consumers[i], 1000, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                        err   = rd_kafka_share_poll(consumers[i], 1000, &batch);
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
                         }
 
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err) {
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!msg->err) {
                                         per_consumer[i]++;
                                         total_consumed++;
                                 }
                         }
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY(
             "Distribution: c0=%d (lost on close), c1=%d, c2=%d, c3=%d "
@@ -1488,15 +1545,19 @@ static void do_test_partition_increase_during_consume(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
         }
@@ -1533,18 +1594,25 @@ static void do_test_partition_increase_during_consume(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 1000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 consumed++;
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == total_expected,
                     "Expected exactly %d total records after partition grow, "
@@ -1573,6 +1641,7 @@ static void do_test_zero_byte_payload_and_key(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         size_t rcvd = 0;
         int attempts;
@@ -1633,24 +1702,26 @@ static void do_test_zero_byte_payload_and_key(void) {
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
-        {
-                test_share_batch_t acc;
-                test_share_batch_init(&acc, 4);
-                attempts = 30;
-                while (acc.cnt < 4 && attempts-- > 0) {
-                        rd_kafka_error_t *e =
-                            test_share_batch_poll(&acc, consumer, 2000);
-                        if (e)
-                                rd_kafka_error_destroy(e);
-                }
-                rcvd = acc.cnt;
-                TEST_ASSERT(rcvd == 4, "Expected 4 records, got %zu", rcvd);
+        attempts = 30;
+        while (rcvd < 4 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                rd_kafka_error_t *e;
 
-                for (i = 0; i < rcvd; i++) {
-                        key_null  = acc.msgs[i]->key == NULL;
-                        key_empty = acc.msgs[i]->key_len == 0 && !key_null;
-                        val_null  = acc.msgs[i]->payload == NULL;
-                        val_empty = acc.msgs[i]->len == 0 && !val_null;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                e     = rd_kafka_share_poll(consumer, 2000, &batch);
+                if (e)
+                        rd_kafka_error_destroy(e);
+                batch_rcvd = rd_kafka_messages_count(batch);
+
+                for (i = 0; i < batch_rcvd; i++) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+
+                        key_null  = msg->key == NULL;
+                        key_empty = msg->key_len == 0 && !key_null;
+                        val_null  = msg->payload == NULL;
+                        val_empty = msg->len == 0 && !val_null;
 
                         /* Brokers may normalize empty buffers to NULL; accept
                          * either. */
@@ -1666,23 +1737,26 @@ static void do_test_zero_byte_payload_and_key(void) {
                                         saw_empty_kv++;
                         } else if (!key_is_empty_or_null &&
                                    val_is_empty_or_null) {
-                                TEST_ASSERT(
-                                    acc.msgs[i]->key_len == 1 &&
-                                        memcmp(acc.msgs[i]->key, "k", 1) == 0,
-                                    "key-only record: key mismatch");
+                                TEST_ASSERT(msg->key_len == 1 &&
+                                                memcmp(msg->key, "k", 1) == 0,
+                                            "key-only record: key mismatch");
                                 saw_key_only++;
                         } else if (key_is_empty_or_null &&
                                    !val_is_empty_or_null) {
                                 TEST_ASSERT(
-                                    acc.msgs[i]->len == 1 &&
-                                        memcmp(acc.msgs[i]->payload, "v", 1) ==
-                                            0,
+                                    msg->len == 1 &&
+                                        memcmp(msg->payload, "v", 1) == 0,
                                     "value-only record: value mismatch");
                                 saw_value_only++;
                         }
                 }
-                test_share_batch_destroy(&acc);
+                rcvd += batch_rcvd;
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        TEST_ASSERT(rcvd == 4, "Expected 4 records, got %zu", rcvd);
 
         TEST_SAY("Counts: empty_kv=%d null_kv=%d key_only=%d value_only=%d\n",
                  saw_empty_kv, saw_null_kv, saw_key_only, saw_value_only);
@@ -1757,25 +1831,29 @@ static void do_test_compression_codec(const char *codec) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(consumer, 2000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err) {
-                                TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, m)->len ==
-                                        (size_t)msg_sz,
-                                    "[%s] msg size %zu != expected %d", codec,
-                                    rd_kafka_messages_get(batch, m)->len,
-                                    msg_sz);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err) {
+                                TEST_ASSERT(msg->len == (size_t)msg_sz,
+                                            "[%s] msg size %zu != expected %d",
+                                            codec, msg->len, msg_sz);
                                 consumed++;
                         }
                 }
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_ASSERT(consumed == msg_cnt,
                     "[%s] expected %d records, consumed %d", codec, msg_cnt,
@@ -1814,6 +1892,7 @@ static void do_test_many_and_large_headers(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         const int hdr_cnt         = 100;
         const size_t big_hdr_size = 64 * 1024;
@@ -1887,79 +1966,92 @@ static void do_test_many_and_large_headers(void) {
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
-        test_share_batch_t acc;
-        test_share_batch_init(&acc, 2);
         attempts = 30;
-        while (acc.cnt < 2 && attempts-- > 0) {
-                rd_kafka_error_t *e =
-                    test_share_batch_poll(&acc, consumer, 2000);
+        while (rcvd < 2 && attempts-- > 0) {
+                size_t batch_rcvd = 0;
+                rd_kafka_error_t *e;
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                e     = rd_kafka_share_poll(consumer, 2000, &batch);
                 if (e)
                         rd_kafka_error_destroy(e);
-        }
-        rcvd = acc.cnt;
+                batch_rcvd = rd_kafka_messages_count(batch);
 
-        TEST_ASSERT(rcvd == 2, "Expected 2 records, got %zu", rcvd);
+                for (i = 0; i < batch_rcvd; i++) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+                        msg_hdrs = NULL;
+                        herr     = rd_kafka_message_headers(msg, &msg_hdrs);
+                        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR &&
+                                        msg_hdrs,
+                                    "headers not available: %s",
+                                    rd_kafka_err2name(herr));
 
-        for (i = 0; i < rcvd; i++) {
-                msg_hdrs = NULL;
-                herr     = rd_kafka_message_headers(acc.msgs[i], &msg_hdrs);
-                TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && msg_hdrs,
-                            "headers not available: %s",
-                            rd_kafka_err2name(herr));
+                        if (msg->key_len == 4 &&
+                            memcmp(msg->key, "many", 4) == 0) {
+                                n = rd_kafka_header_cnt(msg_hdrs);
 
-                if (acc.msgs[i]->key_len == 4 &&
-                    memcmp(acc.msgs[i]->key, "many", 4) == 0) {
-                        n = rd_kafka_header_cnt(msg_hdrs);
+                                TEST_ASSERT(n == (size_t)hdr_cnt,
+                                            "many-headers record: expected %d "
+                                            "headers, got %zu",
+                                            hdr_cnt, n);
 
-                        TEST_ASSERT(n == (size_t)hdr_cnt,
-                                    "many-headers record: expected %d "
-                                    "headers, got %zu",
-                                    hdr_cnt, n);
-
-                        /* Verify every header name+value present. */
-                        for (j = 0; j < (size_t)hdr_cnt; j++) {
-                                rd_snprintf(name, sizeof(name), "h-%zu", j);
-                                rd_snprintf(expected, sizeof(expected), "v-%zu",
-                                            j);
-                                herr = rd_kafka_header_get_last(msg_hdrs, name,
-                                                                &val, &vsz);
-                                TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                /* Verify every header name+value present. */
+                                for (j = 0; j < (size_t)hdr_cnt; j++) {
+                                        rd_snprintf(name, sizeof(name), "h-%zu",
+                                                    j);
+                                        rd_snprintf(expected, sizeof(expected),
+                                                    "v-%zu", j);
+                                        herr = rd_kafka_header_get_last(
+                                            msg_hdrs, name, &val, &vsz);
+                                        TEST_ASSERT(
+                                            herr == RD_KAFKA_RESP_ERR_NO_ERROR,
                                             "%s missing: %s", name,
                                             rd_kafka_err2name(herr));
-                                TEST_ASSERT(vsz == strlen(expected) &&
+                                        TEST_ASSERT(
+                                            vsz == strlen(expected) &&
                                                 memcmp(val, expected, vsz) == 0,
                                             "%s value mismatch", name);
-                        }
-                        verified_many = rd_true;
-                } else if (acc.msgs[i]->key_len == 3 &&
-                           memcmp(acc.msgs[i]->key, "big", 3) == 0) {
-                        herr = rd_kafka_header_get_last(msg_hdrs, "big-hdr",
-                                                        &val, &vsz);
-                        TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
-                                    "big-hdr missing: %s",
-                                    rd_kafka_err2name(herr));
-                        TEST_ASSERT(vsz == big_hdr_size,
-                                    "big-hdr size mismatch: expected %zu, "
-                                    "got %zu",
-                                    big_hdr_size, vsz);
+                                }
+                                verified_many = rd_true;
+                        } else if (msg->key_len == 3 &&
+                                   memcmp(msg->key, "big", 3) == 0) {
+                                herr = rd_kafka_header_get_last(
+                                    msg_hdrs, "big-hdr", &val, &vsz);
+                                TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                            "big-hdr missing: %s",
+                                            rd_kafka_err2name(herr));
+                                TEST_ASSERT(vsz == big_hdr_size,
+                                            "big-hdr size mismatch: expected "
+                                            "%zu, got %zu",
+                                            big_hdr_size, vsz);
 
-                        /* Spot-check the content pattern at a few offsets. */
-                        bytes = (const char *)val;
-                        for (k = 0; k < vsz; k += vsz / 16) {
-                                expected_byte = (char)('A' + (k % 26));
-                                TEST_ASSERT(bytes[k] == expected_byte,
+                                /* Spot-check the content pattern at a few
+                                 * offsets. */
+                                bytes = (const char *)val;
+                                for (k = 0; k < vsz; k += vsz / 16) {
+                                        expected_byte = (char)('A' + (k % 26));
+                                        TEST_ASSERT(
+                                            bytes[k] == expected_byte,
                                             "big-hdr byte %zu: expected %c, "
                                             "got %c",
                                             k, expected_byte, bytes[k]);
+                                }
+                                verified_big = rd_true;
                         }
-                        verified_big = rd_true;
                 }
+                rcvd += batch_rcvd;
         }
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        TEST_ASSERT(rcvd == 2, "Expected 2 records, got %zu", rcvd);
 
         TEST_ASSERT(verified_many, "many-headers record was not verified");
         TEST_ASSERT(verified_big, "big-header record was not verified");
 
-        test_share_batch_destroy(&acc);
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
 

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -1227,7 +1227,7 @@ static void do_test_fetch_max_bytes_small(void) {
         attempts = 30;
         while (consumed < msgcnt && attempts-- > 0) {
                 int batch_cnt = 0;
-                test_share_consume_batch(consumer, 2000, NULL, 0, &batch_cnt);
+                test_share_poll(consumer, 2000, NULL, 0, &batch_cnt);
                 consumed += batch_cnt;
                 if (batch_cnt > 0) {
                         TEST_ASSERT(batch_cnt == 1,
@@ -1319,7 +1319,7 @@ static void do_test_record_larger_than_fetch_max_bytes(void) {
         attempts = 30;
         while (consumed < total && attempts-- > 0) {
                 int batch_cnt = 0;
-                test_share_consume_batch(consumer, 3000, NULL, 0, &batch_cnt);
+                test_share_poll(consumer, 3000, NULL, 0, &batch_cnt);
                 consumed += batch_cnt;
                 if (batch_cnt > 0)
                         TEST_SAY("Progress: %d/%d\n", consumed, total);

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -172,7 +172,7 @@ static void subscribe_consumers(share_test_config_t *config,
  */
 static void consume_messages(share_test_config_t *config,
                              share_test_state_t *state) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         int attempts;
         int poll_timeout;
         int i;
@@ -210,8 +210,9 @@ static void consume_messages(share_test_config_t *config,
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err = rd_kafka_share_consume_batch(
-                            state->consumers[i], poll_timeout, batch, &rcvd);
+                        err  = rd_kafka_share_poll(state->consumers[i],
+                                                   poll_timeout, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
 
                         if (err) {
                                 rd_kafka_error_destroy(err);
@@ -219,11 +220,10 @@ static void consume_messages(share_test_config_t *config,
                         }
 
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err) {
+                                if (!rd_kafka_messages_get(batch, m)->err) {
                                         state->per_consumer_count[i]++;
                                         state->total_consumed++;
                                 }
-                                rd_kafka_message_destroy(batch[m]);
                         }
 
                         /* Early exit if we've consumed everything */
@@ -562,7 +562,7 @@ static void do_test_many_topics_10_multi_partition(void) {
  */
 static void do_test_rapid_produce_consume_cycles(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-rapid-cycles";
         rd_kafka_topic_partition_list_t *subs;
@@ -606,17 +606,16 @@ static void do_test_rapid_produce_consume_cycles(void) {
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err = rd_kafka_share_consume_batch(consumer, 1000,
-                                                           batch, &rcvd);
+                        err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
                         }
 
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err)
+                                if (!rd_kafka_messages_get(batch, m)->err)
                                         round_consumed++;
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
 
@@ -644,7 +643,7 @@ static void do_test_rapid_produce_consume_cycles(void) {
  */
 static void do_test_empty_then_produce(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-empty-then-produce";
         rd_kafka_topic_partition_list_t *subs;
@@ -673,8 +672,8 @@ static void do_test_empty_then_produce(void) {
                 size_t rcvd = 0;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
                 TEST_SAY("Empty poll %d: received %zu\n", attempts + 1, rcvd);
@@ -691,17 +690,16 @@ static void do_test_empty_then_produce(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -721,7 +719,7 @@ static void do_test_empty_then_produce(void) {
  */
 static void do_test_sparse_partitions(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-sparse-partitions";
         rd_kafka_topic_partition_list_t *subs;
@@ -762,17 +760,16 @@ static void do_test_sparse_partitions(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
 
                 TEST_SAY("Progress: %d/%d\n", consumed, expected);
@@ -799,7 +796,7 @@ static void do_test_sparse_partitions(void) {
  */
 static void do_test_poll_callback_piggybacked_acks(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-poll-callback";
         rd_kafka_topic_partition_list_t *subs;
@@ -836,17 +833,16 @@ static void do_test_poll_callback_piggybacked_acks(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -895,16 +891,17 @@ typedef struct {
 } blocker_arg_t;
 
 static int consume_blocker_thread(void *arg) {
-        blocker_arg_t *ba = arg;
-        rd_kafka_message_t *batch[1];
-        size_t rcvd = 0;
+        blocker_arg_t *ba          = arg;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_error_t *err;
 
         rd_atomic32_set(&ba->entering, 1);
 
         /* Blocks for ~5s waiting for messages that never arrive.
          * The share access gate is held for the full duration. */
-        err = rd_kafka_share_consume_batch(ba->consumer, 5000, batch, &rcvd);
+        err  = rd_kafka_share_poll(ba->consumer, 5000, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
         return 0;
@@ -922,9 +919,9 @@ static void do_test_concurrent_thread_access_rejected(void) {
         rd_kafka_topic_partition_list_t *subs;
         thrd_t blocker;
         blocker_arg_t ba;
-        rd_kafka_message_t *batch[1];
-        size_t rcvd           = 0;
-        rd_kafka_error_t *err = NULL;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
+        rd_kafka_error_t *err      = NULL;
         int probe_attempt;
         const int probe_max_attempts = 50; /* 50 × 100ms = 5 s budget */
 
@@ -979,7 +976,8 @@ static void do_test_concurrent_thread_access_rejected(void) {
         for (probe_attempt = 0; probe_attempt < probe_max_attempts;
              probe_attempt++) {
                 rcvd = 0;
-                err  = rd_kafka_share_consume_batch(consumer, 0, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 0, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err &&
                     rd_kafka_error_code(err) == RD_KAFKA_RESP_ERR__CONFLICT)
                         break; /* observed the conflict — done */
@@ -1007,7 +1005,8 @@ static void do_test_concurrent_thread_access_rejected(void) {
          * main thread should be able to call consume_batch without
          * hitting the gate. */
         rcvd = 0;
-        err  = rd_kafka_share_consume_batch(consumer, 0, batch, &rcvd);
+        err  = rd_kafka_share_poll(consumer, 0, &batch);
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(!err, "After blocker returned, gate should be free; got %s",
                     err ? rd_kafka_err2str(rd_kafka_error_code(err))
                         : "no error");
@@ -1034,7 +1033,7 @@ static void do_test_concurrent_thread_access_rejected(void) {
  */
 static void do_test_headers_preserved(void) {
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         const char *topic;
         const char *group = "share-headers";
         rd_kafka_topic_partition_list_t *subs;
@@ -1073,18 +1072,18 @@ static void do_test_headers_preserved(void) {
 
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
                 rd_kafka_error_t *e;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
-                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
-                                                 &batch_rcvd);
+                e = rd_kafka_share_poll(consumer, 2000, &batch);
                 if (e)
                         rd_kafka_error_destroy(e);
-                rcvd += batch_rcvd;
+                rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
 
-        herr = rd_kafka_message_headers(batch[0], &hdrs);
+        herr = rd_kafka_message_headers(rd_kafka_messages_get(batch, 0), &hdrs);
         TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && hdrs,
                     "Failed to get headers: %s", rd_kafka_err2name(herr));
 
@@ -1102,8 +1101,6 @@ static void do_test_headers_preserved(void) {
         TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR, "h3 not present: %s",
                     rd_kafka_err2name(herr));
         TEST_ASSERT(vsz == 2 && memcmp(val, "v3", 2) == 0, "h3 value mismatch");
-
-        rd_kafka_message_destroy(batch[0]);
 
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
@@ -1313,11 +1310,11 @@ static void do_test_consumer_close_releases_to_group(void) {
         const char *topic;
         rd_kafka_share_t *consumers[4];
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        const int total_msgs = 200;
-        int c0_fetched       = 0;
-        int total_consumed   = 0;
-        int per_consumer[4]  = {0};
+        rd_kafka_messages_t *batch = NULL;
+        const int total_msgs       = 200;
+        int c0_fetched             = 0;
+        int total_consumed         = 0;
+        int per_consumer[4]        = {0};
         int attempts;
         int i;
 
@@ -1349,17 +1346,16 @@ static void do_test_consumer_close_releases_to_group(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(consumers[0], 2000, batch,
-                                                   &rcvd);
+                err  = rd_kafka_share_poll(consumers[0], 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 c0_fetched++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_ASSERT(c0_fetched > 0,
@@ -1381,19 +1377,18 @@ static void do_test_consumer_close_releases_to_group(void) {
                         size_t m;
                         rd_kafka_error_t *err;
 
-                        err = rd_kafka_share_consume_batch(consumers[i], 1000,
-                                                           batch, &rcvd);
+                        err  = rd_kafka_share_poll(consumers[i], 1000, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
                         if (err) {
                                 rd_kafka_error_destroy(err);
                                 continue;
                         }
 
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err) {
+                                if (!rd_kafka_messages_get(batch, m)->err) {
                                         per_consumer[i]++;
                                         total_consumed++;
                                 }
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
         }
@@ -1435,7 +1430,7 @@ static void do_test_partition_increase_during_consume(void) {
         rd_kafka_conf_t *prod_conf;
         rd_kafka_t *producer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch   = NULL;
         const int msgs_per_partition = 200;
         const int initial_partitions = 2;
         const int grown_partitions   = 5;
@@ -1494,17 +1489,16 @@ static void do_test_partition_increase_during_consume(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_SAY("Pre-grow consumed: %d/%d\n", consumed, initial_expected);
@@ -1540,17 +1534,16 @@ static void do_test_partition_increase_during_consume(void) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -1581,7 +1574,7 @@ static void do_test_zero_byte_payload_and_key(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[16];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         size_t rcvd = 0;
         int attempts;
@@ -1642,51 +1635,55 @@ static void do_test_zero_byte_payload_and_key(void) {
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
-        attempts = 30;
-        while (rcvd < 4 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                rd_kafka_error_t *e;
-
-                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
-                                                 &batch_rcvd);
-                if (e)
-                        rd_kafka_error_destroy(e);
-                rcvd += batch_rcvd;
-        }
-
-        TEST_ASSERT(rcvd == 4, "Expected 4 records, got %zu", rcvd);
-
-        for (i = 0; i < rcvd; i++) {
-                key_null  = batch[i]->key == NULL;
-                key_empty = batch[i]->key_len == 0 && !key_null;
-                val_null  = batch[i]->payload == NULL;
-                val_empty = batch[i]->len == 0 && !val_null;
-
-                /* Brokers may normalize empty buffers to NULL; accept either.
-                 */
-                key_is_empty_or_null = key_null || key_empty;
-                val_is_empty_or_null = val_null || val_empty;
-
-                if (key_is_empty_or_null && val_is_empty_or_null) {
-                        /* Could be "empty kv" or "null kv" record - count both
-                         * as the "no content" class. */
-                        if (key_null && val_null)
-                                saw_null_kv++;
-                        else
-                                saw_empty_kv++;
-                } else if (!key_is_empty_or_null && val_is_empty_or_null) {
-                        TEST_ASSERT(batch[i]->key_len == 1 &&
-                                        memcmp(batch[i]->key, "k", 1) == 0,
-                                    "key-only record: key mismatch");
-                        saw_key_only++;
-                } else if (key_is_empty_or_null && !val_is_empty_or_null) {
-                        TEST_ASSERT(batch[i]->len == 1 &&
-                                        memcmp(batch[i]->payload, "v", 1) == 0,
-                                    "value-only record: value mismatch");
-                        saw_value_only++;
+        {
+                test_share_batch_t acc;
+                test_share_batch_init(&acc, 4);
+                attempts = 30;
+                while (acc.cnt < 4 && attempts-- > 0) {
+                        rd_kafka_error_t *e =
+                            test_share_batch_poll(&acc, consumer, 2000);
+                        if (e)
+                                rd_kafka_error_destroy(e);
                 }
+                rcvd = acc.cnt;
+                TEST_ASSERT(rcvd == 4, "Expected 4 records, got %zu", rcvd);
 
-                rd_kafka_message_destroy(batch[i]);
+                for (i = 0; i < rcvd; i++) {
+                        key_null  = acc.msgs[i]->key == NULL;
+                        key_empty = acc.msgs[i]->key_len == 0 && !key_null;
+                        val_null  = acc.msgs[i]->payload == NULL;
+                        val_empty = acc.msgs[i]->len == 0 && !val_null;
+
+                        /* Brokers may normalize empty buffers to NULL; accept
+                         * either. */
+                        key_is_empty_or_null = key_null || key_empty;
+                        val_is_empty_or_null = val_null || val_empty;
+
+                        if (key_is_empty_or_null && val_is_empty_or_null) {
+                                /* Could be "empty kv" or "null kv" record -
+                                 * count both as the "no content" class. */
+                                if (key_null && val_null)
+                                        saw_null_kv++;
+                                else
+                                        saw_empty_kv++;
+                        } else if (!key_is_empty_or_null &&
+                                   val_is_empty_or_null) {
+                                TEST_ASSERT(
+                                    acc.msgs[i]->key_len == 1 &&
+                                        memcmp(acc.msgs[i]->key, "k", 1) == 0,
+                                    "key-only record: key mismatch");
+                                saw_key_only++;
+                        } else if (key_is_empty_or_null &&
+                                   !val_is_empty_or_null) {
+                                TEST_ASSERT(
+                                    acc.msgs[i]->len == 1 &&
+                                        memcmp(acc.msgs[i]->payload, "v", 1) ==
+                                            0,
+                                    "value-only record: value mismatch");
+                                saw_value_only++;
+                        }
+                }
+                test_share_batch_destroy(&acc);
         }
 
         TEST_SAY("Counts: empty_kv=%d null_kv=%d key_only=%d value_only=%d\n",
@@ -1721,10 +1718,10 @@ static void do_test_compression_codec(const char *codec) {
         rd_kafka_conf_t *conf;
         rd_kafka_t *producer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        const int msg_cnt = 200;
-        const int msg_sz  = 256;
-        int consumed      = 0;
+        rd_kafka_messages_t *batch = NULL;
+        const int msg_cnt          = 200;
+        const int msg_sz           = 256;
+        int consumed               = 0;
         int attempts;
 
         TEST_SAY("\n");
@@ -1762,21 +1759,23 @@ static void do_test_compression_codec(const char *codec) {
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err) {
-                                TEST_ASSERT(batch[m]->len == (size_t)msg_sz,
-                                            "[%s] msg size %zu != expected %d",
-                                            codec, batch[m]->len, msg_sz);
+                        if (!rd_kafka_messages_get(batch, m)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_messages_get(batch, m)->len ==
+                                        (size_t)msg_sz,
+                                    "[%s] msg size %zu != expected %d", codec,
+                                    rd_kafka_messages_get(batch, m)->len,
+                                    msg_sz);
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -1817,7 +1816,7 @@ static void do_test_many_and_large_headers(void) {
         const char *topic;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[8];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_resp_err_t err;
         const int hdr_cnt         = 100;
         const size_t big_hdr_size = 64 * 1024;
@@ -1891,29 +1890,28 @@ static void do_test_many_and_large_headers(void) {
         rd_kafka_share_subscribe(consumer, subs);
         rd_kafka_topic_partition_list_destroy(subs);
 
+        test_share_batch_t acc;
+        test_share_batch_init(&acc, 2);
         attempts = 30;
-        while (rcvd < 2 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                rd_kafka_error_t *e;
-
-                e = rd_kafka_share_consume_batch(consumer, 2000, batch + rcvd,
-                                                 &batch_rcvd);
+        while (acc.cnt < 2 && attempts-- > 0) {
+                rd_kafka_error_t *e =
+                    test_share_batch_poll(&acc, consumer, 2000);
                 if (e)
                         rd_kafka_error_destroy(e);
-                rcvd += batch_rcvd;
         }
+        rcvd = acc.cnt;
 
         TEST_ASSERT(rcvd == 2, "Expected 2 records, got %zu", rcvd);
 
         for (i = 0; i < rcvd; i++) {
                 msg_hdrs = NULL;
-                herr     = rd_kafka_message_headers(batch[i], &msg_hdrs);
+                herr     = rd_kafka_message_headers(acc.msgs[i], &msg_hdrs);
                 TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR && msg_hdrs,
                             "headers not available: %s",
                             rd_kafka_err2name(herr));
 
-                if (batch[i]->key_len == 4 &&
-                    memcmp(batch[i]->key, "many", 4) == 0) {
+                if (acc.msgs[i]->key_len == 4 &&
+                    memcmp(acc.msgs[i]->key, "many", 4) == 0) {
                         n = rd_kafka_header_cnt(msg_hdrs);
 
                         TEST_ASSERT(n == (size_t)hdr_cnt,
@@ -1936,8 +1934,8 @@ static void do_test_many_and_large_headers(void) {
                                             "%s value mismatch", name);
                         }
                         verified_many = rd_true;
-                } else if (batch[i]->key_len == 3 &&
-                           memcmp(batch[i]->key, "big", 3) == 0) {
+                } else if (acc.msgs[i]->key_len == 3 &&
+                           memcmp(acc.msgs[i]->key, "big", 3) == 0) {
                         herr = rd_kafka_header_get_last(msg_hdrs, "big-hdr",
                                                         &val, &vsz);
                         TEST_ASSERT(herr == RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1959,13 +1957,12 @@ static void do_test_many_and_large_headers(void) {
                         }
                         verified_big = rd_true;
                 }
-
-                rd_kafka_message_destroy(batch[i]);
         }
 
         TEST_ASSERT(verified_many, "many-headers record was not verified");
         TEST_ASSERT(verified_big, "big-header record was not verified");
 
+        test_share_batch_destroy(&acc);
         test_share_consumer_close(consumer);
         test_share_destroy(consumer);
 

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -968,10 +968,9 @@ static void do_test_concurrent_thread_access_rejected(void) {
          * waiting indefinitely (see logs.txt: subtest ran ~4000s
          * before the suite watchdog killed it). */
         if (!strcmp(test_mode, "valgrind")) {
-                TEST_SKIP(
+                SUB_TEST_SKIP(
                     "Concurrent-thread gate test is scheduling-sensitive "
                     "under Valgrind\n");
-                SUB_TEST_PASS();
                 return;
         }
 

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -294,31 +294,29 @@ static void consume_and_acknowledge(ack_test_config_t *config,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(state->consumers[0], poll_timeout,
-                                           &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(state->consumers[0], poll_timeout,
+                                          &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (m = 0; m < rcvd; m++) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
                         rd_kafka_share_AcknowledgeType_t ack_type;
                         rd_kafka_resp_err_t ack_err;
                         int16_t delivery_count =
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(batch, m));
+                            rd_kafka_message_delivery_count(msg);
 
                         /* Error messages must use acknowledge_offset API */
-                        if (rd_kafka_messages_get(batch, m)->err) {
+                        if (msg->err) {
                                 ack_type = determine_ack_type(config);
                                 ack_err  = rd_kafka_share_acknowledge_offset(
                                     state->consumers[0],
-                                    rd_kafka_topic_name(
-                                        rd_kafka_messages_get(batch, m)->rkt),
-                                    rd_kafka_messages_get(batch, m)->partition,
-                                    rd_kafka_messages_get(batch, m)->offset,
-                                    ack_type);
+                                    rd_kafka_topic_name(msg->rkt),
+                                    msg->partition, msg->offset, ack_type);
                                 TEST_ASSERT(
                                     ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                                     "acknowledge_offset failed for error msg: "
@@ -329,8 +327,7 @@ static void consume_and_acknowledge(ack_test_config_t *config,
 
                         /* Redelivered message (delivery_count == 2) */
                         if (delivery_count == 2) {
-                                handle_redelivered_message(
-                                    state, rd_kafka_messages_get(batch, m));
+                                handle_redelivered_message(state, msg);
                                 continue;
                         }
 
@@ -340,28 +337,27 @@ static void consume_and_acknowledge(ack_test_config_t *config,
                                     delivery_count);
 
                         ack_type = determine_ack_type(config);
-                        track_ack_type(state, rd_kafka_messages_get(batch, m),
-                                       ack_type);
+                        track_ack_type(state, msg, ack_type);
 
                         ack_err = rd_kafka_share_acknowledge_type(
-                            state->consumers[0],
-                            rd_kafka_messages_get(batch, m), ack_type);
+                            state->consumers[0], msg, ack_type);
                         TEST_ASSERT(
                             ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "Acknowledge failed: %s (topic=%s, partition=%d, "
                             "offset=%" PRId64 ", type=%d)",
                             rd_kafka_err2str(ack_err),
-                            rd_kafka_topic_name(
-                                rd_kafka_messages_get(batch, m)->rkt),
-                            rd_kafka_messages_get(batch, m)->partition,
-                            rd_kafka_messages_get(batch, m)->offset, ack_type);
+                            rd_kafka_topic_name(msg->rkt), msg->partition,
+                            msg->offset, ack_type);
 
                         if (state->original_cnt < 1000)
                                 state->original_offsets[state->original_cnt++] =
-                                    rd_kafka_messages_get(batch, m)->offset;
+                                    msg->offset;
 
                         total_consumed++;
                 }
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (config->use_random_acks) {
                         if (total_consumed % 500 == 0 || rcvd > 0)
@@ -427,26 +423,25 @@ static void poll_for_redelivery(ack_test_config_t *config,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(state->consumers[0], poll_timeout,
-                                           &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(state->consumers[0], poll_timeout,
+                                          &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err) {
                                 rd_kafka_topic_partition_t *rktpar;
                                 int16_t delivery_count =
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(batch, m));
-                                const char *msg_topic = rd_kafka_topic_name(
-                                    rd_kafka_messages_get(batch, m)->rkt);
-                                int32_t msg_partition =
-                                    rd_kafka_messages_get(batch, m)->partition;
-                                int64_t msg_offset =
-                                    rd_kafka_messages_get(batch, m)->offset;
+                                    rd_kafka_message_delivery_count(msg);
+                                const char *msg_topic =
+                                    rd_kafka_topic_name(msg->rkt);
+                                int32_t msg_partition = msg->partition;
+                                int64_t msg_offset    = msg->offset;
                                 int released_idx;
 
                                 /* Verify delivery_count >= 2 on redelivery */
@@ -481,11 +476,13 @@ static void poll_for_redelivery(ack_test_config_t *config,
                                 state->msgs_redelivered++;
 
                                 rd_kafka_share_acknowledge_type(
-                                    state->consumers[0],
-                                    rd_kafka_messages_get(batch, m),
+                                    state->consumers[0], msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                         }
                 }
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (rcvd > 0) {
                         TEST_SAY("Redelivered so far: %d/%d\n",
@@ -749,6 +746,7 @@ static void do_test_ack_invalid_type(void) {
         const char *topic;
         size_t rcvd = 0;
         int attempts;
+        rd_kafka_message_t *msg0;
 
         SUB_TEST();
 
@@ -769,34 +767,40 @@ static void do_test_ack_invalid_type(void) {
 
         attempts = 20;
         while (rcvd == 0 && attempts-- > 0) {
-                err  = rd_kafka_share_poll(rkshare, 2000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                if (batch) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                }
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                rcvd = rd_kafka_messages_count(batch);
         }
 
         TEST_ASSERT(rcvd == 1, "Expected exactly 1 message, got %zu", rcvd);
 
+        msg0 = rd_kafka_messages_get(batch, 0);
+
         /* Try invalid type (99) */
         ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, rd_kafka_messages_get(batch, 0),
-            (rd_kafka_share_AcknowledgeType_t)99);
+            rkshare, msg0, (rd_kafka_share_AcknowledgeType_t)99);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG for type 99, got %s",
                     rd_kafka_err2str(ack_err));
 
         /* Try GAP type (0) - internal only */
         ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, rd_kafka_messages_get(batch, 0),
-            (rd_kafka_share_AcknowledgeType_t)0);
+            rkshare, msg0, (rd_kafka_share_AcknowledgeType_t)0);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG for type 0 (GAP), got %s",
                     rd_kafka_err2str(ack_err));
 
         /* Clean up with valid acknowledge */
-        rd_kafka_share_acknowledge_type(rkshare,
-                                        rd_kafka_messages_get(batch, 0),
+        rd_kafka_share_acknowledge_type(rkshare, msg0,
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
 
@@ -810,7 +814,9 @@ static void do_test_ack_invalid_type(void) {
  */
 static void do_test_release_then_reject_no_redelivery(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_messages_t *batch = NULL;
+        rd_kafka_messages_t *batches[30] = {NULL};
+        int batch_cnt                    = 0;
+        rd_kafka_messages_t *batch       = NULL;
         rd_kafka_error_t *err;
         rd_kafka_resp_err_t ack_err;
         rd_kafka_topic_partition_list_t *subs;
@@ -820,6 +826,8 @@ static void do_test_release_then_reject_no_redelivery(void) {
         size_t m;
         int attempts;
         int redelivered = 0;
+        int i;
+        rd_kafka_message_t *first_msg = NULL;
 
         SUB_TEST();
 
@@ -839,61 +847,88 @@ static void do_test_release_then_reject_no_redelivery(void) {
         rd_kafka_topic_partition_list_destroy(subs);
 
         /* Consume all messages */
-        {
-                test_share_batch_t acc;
-                test_share_batch_init(&acc, 5);
-                attempts = 30;
-                while (acc.cnt < 5 && attempts-- > 0) {
-                        err = test_share_batch_poll(&acc, rkshare, 2000);
-                        if (err)
-                                rd_kafka_error_destroy(err);
+        attempts = 30;
+        while (rcvd < 5 && attempts-- > 0 && batch_cnt < 30) {
+                rd_kafka_messages_t *b = NULL;
+                size_t batch_rcvd;
+                err = rd_kafka_share_poll(rkshare, 2000, &b);
+                if (err)
+                        rd_kafka_error_destroy(err);
+                batch_rcvd = rd_kafka_messages_count(b);
+                if (batch_rcvd > 0) {
+                        batches[batch_cnt++] = b;
+                        rcvd += batch_rcvd;
+                } else {
+                        rd_kafka_messages_destroy(b);
                 }
-                rcvd = acc.cnt;
-
-                TEST_ASSERT(rcvd == 5, "Expected 5 messages, got %zu", rcvd);
-
-                /* First RELEASE offset 0, then override with REJECT */
-                ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, acc.msgs[0],
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
-                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "RELEASE failed: %s", rd_kafka_err2str(ack_err));
-
-                ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, acc.msgs[0],
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
-                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "REJECT failed: %s", rd_kafka_err2str(ack_err));
-
-                /* ACCEPT remaining messages */
-                for (m = 1; m < rcvd; m++) {
-                        rd_kafka_share_acknowledge_type(
-                            rkshare, acc.msgs[m],
-                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                }
-                test_share_batch_destroy(&acc);
         }
 
-        /* Destroy batch */
+        TEST_ASSERT(rcvd == 5, "Expected 5 messages, got %zu", rcvd);
+
+        /* Locate the first message across batches */
+        first_msg = rd_kafka_messages_get(batches[0], 0);
+
+        /* First RELEASE offset 0, then override with REJECT */
+        ack_err = rd_kafka_share_acknowledge_type(
+            rkshare, first_msg, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "RELEASE failed: %s",
+                    rd_kafka_err2str(ack_err));
+
+        ack_err = rd_kafka_share_acknowledge_type(
+            rkshare, first_msg, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "REJECT failed: %s",
+                    rd_kafka_err2str(ack_err));
+
+        /* ACCEPT remaining messages - skip the very first one (index 0 of
+         * batches[0]) which is already REJECT'd above */
+        {
+                rd_bool_t skipped_first = rd_false;
+                for (i = 0; i < batch_cnt; i++) {
+                        size_t bcnt = rd_kafka_messages_count(batches[i]);
+                        for (m = 0; m < bcnt; m++) {
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batches[i], m);
+                                if (!skipped_first) {
+                                        skipped_first = rd_true;
+                                        continue;
+                                }
+                                rd_kafka_share_acknowledge_type(
+                                    rkshare, msg,
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                        }
+                }
+        }
+
+        /* Destroy batches */
+        for (i = 0; i < batch_cnt; i++) {
+                rd_kafka_messages_destroy(batches[i]);
+                batches[i] = NULL;
+        }
+        batch_cnt = 0;
+
         /* Poll for redelivery - should get 0 */
         TEST_SAY("Polling for redelivery (expecting 0)...\n");
         attempts = 5;
         while (attempts-- > 0) {
-                size_t redeliv_rcvd = 0;
-                err          = rd_kafka_share_poll(rkshare, 2000, &batch);
-                redeliv_rcvd = rd_kafka_messages_count(batch);
+                size_t redeliv_rcvd;
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                redeliv_rcvd = rd_kafka_messages_count(batch);
 
                 for (m = 0; m < redeliv_rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err)
                                 redelivered++;
                         rd_kafka_share_acknowledge_type(
-                            rkshare, rd_kafka_messages_get(batch, m),
+                            rkshare, msg,
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(redelivered == 0,
@@ -949,9 +984,11 @@ static void do_test_change_ack_type_before_commit(void) {
         /* Consume one message */
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                rd_kafka_messages_destroy(batch);
-                batch = NULL;
-                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                if (batch) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                }
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
                 rcvd = rd_kafka_messages_count(batch);
@@ -972,6 +1009,9 @@ static void do_test_change_ack_type_before_commit(void) {
                     "RELEASE (changing from ACCEPT) failed: %s",
                     rd_kafka_err2str(ack_err));
 
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
         /* Commit async - should succeed with RELEASE as final ack type */
         err = rd_kafka_share_commit_async(rkshare);
         TEST_ASSERT(!err, "commit_async failed: %s",
@@ -982,9 +1022,11 @@ static void do_test_change_ack_type_before_commit(void) {
         rcvd     = 0;
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                rd_kafka_messages_destroy(batch);
-                batch = NULL;
-                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                if (batch) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                }
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
                 rcvd = rd_kafka_messages_count(batch);
@@ -992,6 +1034,8 @@ static void do_test_change_ack_type_before_commit(void) {
                         rd_kafka_share_acknowledge_type(
                             rkshare, rd_kafka_messages_get(batch, 0),
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                 }
         }
 
@@ -1051,6 +1095,7 @@ static void do_test_ack_after_commit(void) {
         int32_t saved_partition   = -1;
         int64_t saved_offset      = -1;
         test_ack_cb_state_t state = {0};
+        rd_kafka_message_t *msg0;
 
         SUB_TEST();
 
@@ -1074,9 +1119,11 @@ static void do_test_ack_after_commit(void) {
         /* Consume and acknowledge messages, save first message info */
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                rd_kafka_messages_destroy(batch);
-                batch = NULL;
-                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
+                if (batch) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                }
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
                 rcvd = rd_kafka_messages_count(batch);
@@ -1090,9 +1137,13 @@ static void do_test_ack_after_commit(void) {
         TEST_ASSERT(rcvd == 1, "Expected 1 message, got %zu", rcvd);
 
         /* Save first message info and acknowledge all */
+        msg0            = rd_kafka_messages_get(batch, 0);
         saved_topic     = topic;
-        saved_partition = rd_kafka_messages_get(batch, 0)->partition;
-        saved_offset    = rd_kafka_messages_get(batch, 0)->offset;
+        saved_partition = msg0->partition;
+        saved_offset    = msg0->offset;
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         /* Explicit commit */
         err = rd_kafka_share_commit_async(rkshare);
@@ -1151,6 +1202,7 @@ static void do_test_max_delivery_attempts(void) {
         int delivery_attempt;
         int attempts;
         const int max_deliveries = 5;
+        rd_kafka_message_t *msg0;
 
         SUB_TEST();
 
@@ -1181,36 +1233,39 @@ static void do_test_max_delivery_attempts(void) {
                 attempts = 30;
 
                 while (rcvd == 0 && attempts-- > 0) {
-                        err  = rd_kafka_share_poll(rkshare, 2000, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        if (batch) {
+                                rd_kafka_messages_destroy(batch);
+                                batch = NULL;
+                        }
+                        err = rd_kafka_share_poll(rkshare, 2000, &batch);
                         if (err)
                                 rd_kafka_error_destroy(err);
+                        rcvd = rd_kafka_messages_count(batch);
                 }
 
                 TEST_ASSERT(rcvd == 1,
                             "Delivery attempt %d: expected 1 message, got %zu",
                             delivery_attempt, rcvd);
 
+                msg0 = rd_kafka_messages_get(batch, 0);
+
                 /* Verify delivery_count matches attempt number */
                 TEST_ASSERT(
-                    rd_kafka_message_delivery_count(
-                        rd_kafka_messages_get(batch, 0)) == delivery_attempt,
+                    rd_kafka_message_delivery_count(msg0) == delivery_attempt,
                     "Delivery attempt %d: expected delivery_count=%d, got %d",
                     delivery_attempt, delivery_attempt,
-                    rd_kafka_message_delivery_count(
-                        rd_kafka_messages_get(batch, 0)));
+                    rd_kafka_message_delivery_count(msg0));
 
                 TEST_SAY(
                     "Delivery attempt %d: received message "
                     "(delivery_count=%d), sending RELEASE\n",
-                    delivery_attempt,
-                    rd_kafka_message_delivery_count(
-                        rd_kafka_messages_get(batch, 0)));
+                    delivery_attempt, rd_kafka_message_delivery_count(msg0));
 
                 /* RELEASE to trigger redelivery */
                 rd_kafka_share_acknowledge_type(
-                    rkshare, rd_kafka_messages_get(batch, 0),
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                    rkshare, msg0, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Now poll again - message should NOT be redelivered (max attempts
@@ -1219,19 +1274,23 @@ static void do_test_max_delivery_attempts(void) {
         rcvd     = 0;
         attempts = 5;
         while (attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err               = rd_kafka_share_poll(rkshare, 2000, &batch);
-                batch_rcvd        = rd_kafka_messages_count(batch);
+                size_t batch_rcvd;
+                err = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
+                batch_rcvd = rd_kafka_messages_count(batch);
 
                 if (batch_rcvd > 0) {
                         size_t m;
                         for (m = 0; m < batch_rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err)
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!msg->err)
                                         rcvd++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(rcvd == 0,
@@ -1443,6 +1502,7 @@ static void do_test_ack_message_from_earlier_batch(void) {
         size_t r       = 0;
         rd_kafka_error_t *e;
         int attempts;
+        rd_kafka_message_t *b1_msg0;
 
         SUB_TEST();
 
@@ -1463,9 +1523,11 @@ static void do_test_ack_message_from_earlier_batch(void) {
         /* Poll batch 1 */
         attempts = 30;
         while (b1_rcvd < 1 && attempts-- > 0) {
-                rd_kafka_messages_destroy(batch1);
-                batch1 = NULL;
-                e      = rd_kafka_share_poll(rkshare, 2000, &batch1);
+                if (batch1) {
+                        rd_kafka_messages_destroy(batch1);
+                        batch1 = NULL;
+                }
+                e = rd_kafka_share_poll(rkshare, 2000, &batch1);
                 if (e)
                         rd_kafka_error_destroy(e);
                 b1_rcvd = rd_kafka_messages_count(batch1);
@@ -1473,29 +1535,33 @@ static void do_test_ack_message_from_earlier_batch(void) {
         TEST_ASSERT(b1_rcvd == 1, "Expected 1 record in batch1, got %zu",
                     b1_rcvd);
 
-        ack_err = rd_kafka_share_acknowledge(rkshare,
-                                             rd_kafka_messages_get(batch1, 0));
+        b1_msg0 = rd_kafka_messages_get(batch1, 0);
+
+        ack_err = rd_kafka_share_acknowledge(rkshare, b1_msg0);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "First ack failed: %s", rd_kafka_err2name(ack_err));
 
         /* Poll batch 2 - must be empty (we already consumed and acked
          * the only record). */
-        r = 0;
         e = rd_kafka_share_poll(rkshare, 2000, &batch2);
-        r = rd_kafka_messages_count(batch2);
         if (e)
                 rd_kafka_error_destroy(e);
+        r = rd_kafka_messages_count(batch2);
         TEST_ASSERT(r == 0,
                     "Expected batch 2 to be empty after acking the only "
                     "record, got %zu records",
                     r);
+        rd_kafka_messages_destroy(batch2);
+        batch2 = NULL;
 
         /* Re-acknowledge from batch1 - should fail with _STATE */
-        ack_err = rd_kafka_share_acknowledge(rkshare,
-                                             rd_kafka_messages_get(batch1, 0));
+        ack_err = rd_kafka_share_acknowledge(rkshare, b1_msg0);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__STATE,
                     "Expected _STATE for re-ack across batches, got %s",
                     rd_kafka_err2name(ack_err));
+
+        rd_kafka_messages_destroy(batch1);
+        batch1 = NULL;
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1571,6 +1637,7 @@ static void do_test_ack_offset_wrong_params(void) {
         int attempts;
         int32_t partition;
         int64_t offset;
+        rd_kafka_message_t *msg0;
 
         SUB_TEST();
 
@@ -1590,18 +1657,21 @@ static void do_test_ack_offset_wrong_params(void) {
 
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
-                rd_kafka_messages_destroy(batch);
-                batch = NULL;
-                rd_kafka_error_t *e =
-                    rd_kafka_share_poll(rkshare, 2000, &batch);
+                rd_kafka_error_t *e;
+                if (batch) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                }
+                e = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (e)
                         rd_kafka_error_destroy(e);
                 rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
 
-        partition = rd_kafka_messages_get(batch, 0)->partition;
-        offset    = rd_kafka_messages_get(batch, 0)->offset;
+        msg0      = rd_kafka_messages_get(batch, 0);
+        partition = msg0->partition;
+        offset    = msg0->offset;
 
         /* Wrong offset */
         err = rd_kafka_share_acknowledge_offset(
@@ -1634,6 +1704,9 @@ static void do_test_ack_offset_wrong_params(void) {
         TEST_ASSERT(err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Expected success for correct params, got %s",
                     rd_kafka_err2name(err));
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1704,31 +1777,36 @@ static void do_test_mixed_ack_mode_same_group(void) {
                 rd_kafka_error_t *err;
 
                 /* Implicit consumer */
-                err  = rd_kafka_share_poll(implicit_c, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(implicit_c, 1000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                 } else {
+                        rcvd = rd_kafka_messages_count(batch);
                         for (m = 0; m < rcvd; m++) {
-                                if (!rd_kafka_messages_get(batch, m)->err)
+                                rd_kafka_message_t *msg =
+                                    rd_kafka_messages_get(batch, m);
+                                if (!msg->err)
                                         implicit_cnt++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 /* Explicit consumer */
                 rcvd = 0;
                 err  = rd_kafka_share_poll(explicit_c, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (!msg->err) {
                                 rd_kafka_resp_err_t ack_err =
                                     rd_kafka_share_acknowledge_type(
-                                        explicit_c,
-                                        rd_kafka_messages_get(batch, m),
+                                        explicit_c, msg,
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(!ack_err,
                                             "explicit ACCEPT failed: %s",
@@ -1736,6 +1814,8 @@ static void do_test_mixed_ack_mode_same_group(void) {
                                 explicit_cnt++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed: implicit=%d explicit=%d total=%d/%d\n",
@@ -1757,15 +1837,13 @@ static void do_test_mixed_ack_mode_same_group(void) {
 
         /* Final flush poll on the implicit consumer so the last batch's
          * piggybacked acks reach the broker. */
-        size_t rcvd = 0;
-        size_t m;
         rd_kafka_error_t *err = rd_kafka_share_poll(implicit_c, 1000, &batch);
-        rcvd                  = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
-        for (m = 0; m < rcvd; m++)
-                TEST_ASSERT(
-                    implicit_cnt + explicit_cnt == total_msgs,
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        TEST_ASSERT(implicit_cnt + explicit_cnt == total_msgs,
                     "Expected exactly %d total records across both consumers, "
                     "got %d (implicit=%d explicit=%d)",
                     total_msgs, implicit_cnt + explicit_cnt, implicit_cnt,

--- a/tests/0172-share_consumer_acknowledge.c
+++ b/tests/0172-share_consumer_acknowledge.c
@@ -268,7 +268,7 @@ static void track_ack_type(ack_test_state_t *state,
  */
 static void consume_and_acknowledge(ack_test_config_t *config,
                                     ack_test_state_t *state) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         int poll_timeout =
             config->poll_timeout_ms > 0 ? config->poll_timeout_ms : 3000;
         int attempts = config->max_attempts > 0 ? config->max_attempts : 50;
@@ -294,8 +294,9 @@ static void consume_and_acknowledge(ack_test_config_t *config,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(state->consumers[0],
-                                                   poll_timeout, batch, &rcvd);
+                err  = rd_kafka_share_poll(state->consumers[0], poll_timeout,
+                                           &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
@@ -305,29 +306,31 @@ static void consume_and_acknowledge(ack_test_config_t *config,
                         rd_kafka_share_AcknowledgeType_t ack_type;
                         rd_kafka_resp_err_t ack_err;
                         int16_t delivery_count =
-                            rd_kafka_message_delivery_count(batch[m]);
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(batch, m));
 
                         /* Error messages must use acknowledge_offset API */
-                        if (batch[m]->err) {
+                        if (rd_kafka_messages_get(batch, m)->err) {
                                 ack_type = determine_ack_type(config);
                                 ack_err  = rd_kafka_share_acknowledge_offset(
                                     state->consumers[0],
-                                    rd_kafka_topic_name(batch[m]->rkt),
-                                    batch[m]->partition, batch[m]->offset,
+                                    rd_kafka_topic_name(
+                                        rd_kafka_messages_get(batch, m)->rkt),
+                                    rd_kafka_messages_get(batch, m)->partition,
+                                    rd_kafka_messages_get(batch, m)->offset,
                                     ack_type);
                                 TEST_ASSERT(
                                     ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                                     "acknowledge_offset failed for error msg: "
                                     "%s",
                                     rd_kafka_err2str(ack_err));
-                                rd_kafka_message_destroy(batch[m]);
                                 continue;
                         }
 
                         /* Redelivered message (delivery_count == 2) */
                         if (delivery_count == 2) {
-                                handle_redelivered_message(state, batch[m]);
-                                rd_kafka_message_destroy(batch[m]);
+                                handle_redelivered_message(
+                                    state, rd_kafka_messages_get(batch, m));
                                 continue;
                         }
 
@@ -337,24 +340,27 @@ static void consume_and_acknowledge(ack_test_config_t *config,
                                     delivery_count);
 
                         ack_type = determine_ack_type(config);
-                        track_ack_type(state, batch[m], ack_type);
+                        track_ack_type(state, rd_kafka_messages_get(batch, m),
+                                       ack_type);
 
                         ack_err = rd_kafka_share_acknowledge_type(
-                            state->consumers[0], batch[m], ack_type);
+                            state->consumers[0],
+                            rd_kafka_messages_get(batch, m), ack_type);
                         TEST_ASSERT(
                             ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "Acknowledge failed: %s (topic=%s, partition=%d, "
                             "offset=%" PRId64 ", type=%d)",
                             rd_kafka_err2str(ack_err),
-                            rd_kafka_topic_name(batch[m]->rkt),
-                            batch[m]->partition, batch[m]->offset, ack_type);
+                            rd_kafka_topic_name(
+                                rd_kafka_messages_get(batch, m)->rkt),
+                            rd_kafka_messages_get(batch, m)->partition,
+                            rd_kafka_messages_get(batch, m)->offset, ack_type);
 
                         if (state->original_cnt < 1000)
                                 state->original_offsets[state->original_cnt++] =
-                                    batch[m]->offset;
+                                    rd_kafka_messages_get(batch, m)->offset;
 
                         total_consumed++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
 
                 if (config->use_random_acks) {
@@ -391,7 +397,7 @@ static void consume_and_acknowledge(ack_test_config_t *config,
  */
 static void poll_for_redelivery(ack_test_config_t *config,
                                 ack_test_state_t *state) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         int poll_timeout =
             config->poll_timeout_ms > 0 ? config->poll_timeout_ms : 3000;
         int attempts       = 10;
@@ -421,22 +427,26 @@ static void poll_for_redelivery(ack_test_config_t *config,
                 size_t m;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(state->consumers[0],
-                                                   poll_timeout, batch, &rcvd);
+                err  = rd_kafka_share_poll(state->consumers[0], poll_timeout,
+                                           &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err) {
+                        if (!rd_kafka_messages_get(batch, m)->err) {
                                 rd_kafka_topic_partition_t *rktpar;
                                 int16_t delivery_count =
-                                    rd_kafka_message_delivery_count(batch[m]);
-                                const char *msg_topic =
-                                    rd_kafka_topic_name(batch[m]->rkt);
-                                int32_t msg_partition = batch[m]->partition;
-                                int64_t msg_offset    = batch[m]->offset;
+                                    rd_kafka_message_delivery_count(
+                                        rd_kafka_messages_get(batch, m));
+                                const char *msg_topic = rd_kafka_topic_name(
+                                    rd_kafka_messages_get(batch, m)->rkt);
+                                int32_t msg_partition =
+                                    rd_kafka_messages_get(batch, m)->partition;
+                                int64_t msg_offset =
+                                    rd_kafka_messages_get(batch, m)->offset;
                                 int released_idx;
 
                                 /* Verify delivery_count >= 2 on redelivery */
@@ -471,10 +481,10 @@ static void poll_for_redelivery(ack_test_config_t *config,
                                 state->msgs_redelivered++;
 
                                 rd_kafka_share_acknowledge_type(
-                                    state->consumers[0], batch[m],
+                                    state->consumers[0],
+                                    rd_kafka_messages_get(batch, m),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                         }
-                        rd_kafka_message_destroy(batch[m]);
                 }
 
                 if (rcvd > 0) {
@@ -731,7 +741,7 @@ static void do_test_ack_null_rkshare(void) {
  */
 static void do_test_ack_invalid_type(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         rd_kafka_resp_err_t ack_err;
         rd_kafka_topic_partition_list_t *subs;
@@ -759,7 +769,8 @@ static void do_test_ack_invalid_type(void) {
 
         attempts = 20;
         while (rcvd == 0 && attempts-- > 0) {
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 2000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
         }
@@ -768,23 +779,24 @@ static void do_test_ack_invalid_type(void) {
 
         /* Try invalid type (99) */
         ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], (rd_kafka_share_AcknowledgeType_t)99);
+            rkshare, rd_kafka_messages_get(batch, 0),
+            (rd_kafka_share_AcknowledgeType_t)99);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG for type 99, got %s",
                     rd_kafka_err2str(ack_err));
 
         /* Try GAP type (0) - internal only */
         ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], (rd_kafka_share_AcknowledgeType_t)0);
+            rkshare, rd_kafka_messages_get(batch, 0),
+            (rd_kafka_share_AcknowledgeType_t)0);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__INVALID_ARG,
                     "Expected INVALID_ARG for type 0 (GAP), got %s",
                     rd_kafka_err2str(ack_err));
 
         /* Clean up with valid acknowledge */
-        rd_kafka_share_acknowledge_type(rkshare, batch[0],
+        rd_kafka_share_acknowledge_type(rkshare,
+                                        rd_kafka_messages_get(batch, 0),
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-        rd_kafka_message_destroy(batch[0]);
-
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
 
@@ -798,7 +810,7 @@ static void do_test_ack_invalid_type(void) {
  */
 static void do_test_release_then_reject_no_redelivery(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[100];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         rd_kafka_resp_err_t ack_err;
         rd_kafka_topic_partition_list_t *subs;
@@ -827,59 +839,60 @@ static void do_test_release_then_reject_no_redelivery(void) {
         rd_kafka_topic_partition_list_destroy(subs);
 
         /* Consume all messages */
-        attempts = 30;
-        while (rcvd < 5 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
-                if (err)
-                        rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
-        }
+        {
+                test_share_batch_t acc;
+                test_share_batch_init(&acc, 5);
+                attempts = 30;
+                while (acc.cnt < 5 && attempts-- > 0) {
+                        err = test_share_batch_poll(&acc, rkshare, 2000);
+                        if (err)
+                                rd_kafka_error_destroy(err);
+                }
+                rcvd = acc.cnt;
 
-        TEST_ASSERT(rcvd == 5, "Expected 5 messages, got %zu", rcvd);
+                TEST_ASSERT(rcvd == 5, "Expected 5 messages, got %zu", rcvd);
 
-        /* First RELEASE offset 0, then override with REJECT */
-        ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
-        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "RELEASE failed: %s",
-                    rd_kafka_err2str(ack_err));
+                /* First RELEASE offset 0, then override with REJECT */
+                ack_err = rd_kafka_share_acknowledge_type(
+                    rkshare, acc.msgs[0],
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "RELEASE failed: %s", rd_kafka_err2str(ack_err));
 
-        ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
-        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR, "REJECT failed: %s",
-                    rd_kafka_err2str(ack_err));
+                ack_err = rd_kafka_share_acknowledge_type(
+                    rkshare, acc.msgs[0],
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "REJECT failed: %s", rd_kafka_err2str(ack_err));
 
-        /* ACCEPT remaining messages */
-        for (m = 1; m < rcvd; m++) {
-                rd_kafka_share_acknowledge_type(
-                    rkshare, batch[m], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                /* ACCEPT remaining messages */
+                for (m = 1; m < rcvd; m++) {
+                        rd_kafka_share_acknowledge_type(
+                            rkshare, acc.msgs[m],
+                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                }
+                test_share_batch_destroy(&acc);
         }
 
         /* Destroy batch */
-        for (m = 0; m < rcvd; m++) {
-                rd_kafka_message_destroy(batch[m]);
-        }
-
         /* Poll for redelivery - should get 0 */
         TEST_SAY("Polling for redelivery (expecting 0)...\n");
         attempts = 5;
         while (attempts-- > 0) {
                 size_t redeliv_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch,
-                                                   &redeliv_rcvd);
+                err          = rd_kafka_share_poll(rkshare, 2000, &batch);
+                redeliv_rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (m = 0; m < redeliv_rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 redelivered++;
                         rd_kafka_share_acknowledge_type(
-                            rkshare, batch[m],
+                            rkshare, rd_kafka_messages_get(batch, m),
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -904,7 +917,7 @@ static void do_test_release_then_reject_no_redelivery(void) {
  */
 static void do_test_change_ack_type_before_commit(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         rd_kafka_resp_err_t ack_err;
         rd_kafka_topic_partition_list_t *subs;
@@ -936,15 +949,15 @@ static void do_test_change_ack_type_before_commit(void) {
         /* Consume one message */
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
+                rcvd = rd_kafka_messages_count(batch);
                 if (rcvd > 0) {
                         rd_kafka_share_acknowledge_type(
-                            rkshare, batch[0],
+                            rkshare, rd_kafka_messages_get(batch, 0),
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 }
         }
@@ -953,12 +966,11 @@ static void do_test_change_ack_type_before_commit(void) {
 
         /* Second: Change to RELEASE for first message before commit */
         ack_err = rd_kafka_share_acknowledge_type(
-            rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+            rkshare, rd_kafka_messages_get(batch, 0),
+            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "RELEASE (changing from ACCEPT) failed: %s",
                     rd_kafka_err2str(ack_err));
-
-        rd_kafka_message_destroy(batch[0]);
 
         /* Commit async - should succeed with RELEASE as final ack type */
         err = rd_kafka_share_commit_async(rkshare);
@@ -970,17 +982,16 @@ static void do_test_change_ack_type_before_commit(void) {
         rcvd     = 0;
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
+                rcvd = rd_kafka_messages_count(batch);
                 if (rcvd > 0) {
                         rd_kafka_share_acknowledge_type(
-                            rkshare, batch[0],
+                            rkshare, rd_kafka_messages_get(batch, 0),
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                        rd_kafka_message_destroy(batch[0]);
                 }
         }
 
@@ -1028,7 +1039,7 @@ static void do_test_change_ack_type_before_commit(void) {
  */
 static void do_test_ack_after_commit(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         rd_kafka_resp_err_t ack_err;
         rd_kafka_topic_partition_list_t *subs;
@@ -1063,15 +1074,15 @@ static void do_test_ack_after_commit(void) {
         /* Consume and acknowledge messages, save first message info */
         attempts = 30;
         while (rcvd == 0 && attempts-- > 0) {
-                size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch + rcvd,
-                                                   &batch_rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (err)
                         rd_kafka_error_destroy(err);
-                rcvd += batch_rcvd;
+                rcvd = rd_kafka_messages_count(batch);
                 if (rcvd > 0) {
                         rd_kafka_share_acknowledge_type(
-                            rkshare, batch[0],
+                            rkshare, rd_kafka_messages_get(batch, 0),
                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 }
         }
@@ -1080,10 +1091,8 @@ static void do_test_ack_after_commit(void) {
 
         /* Save first message info and acknowledge all */
         saved_topic     = topic;
-        saved_partition = batch[0]->partition;
-        saved_offset    = batch[0]->offset;
-
-        rd_kafka_message_destroy(batch[0]);
+        saved_partition = rd_kafka_messages_get(batch, 0)->partition;
+        saved_offset    = rd_kafka_messages_get(batch, 0)->offset;
 
         /* Explicit commit */
         err = rd_kafka_share_commit_async(rkshare);
@@ -1133,7 +1142,7 @@ static void do_test_ack_after_commit(void) {
  */
 static void do_test_max_delivery_attempts(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[100];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         rd_kafka_topic_partition_list_t *subs;
         const char *group = "share-max-delivery-attempts";
@@ -1172,8 +1181,8 @@ static void do_test_max_delivery_attempts(void) {
                 attempts = 30;
 
                 while (rcvd == 0 && attempts-- > 0) {
-                        err = rd_kafka_share_consume_batch(rkshare, 2000, batch,
-                                                           &rcvd);
+                        err  = rd_kafka_share_poll(rkshare, 2000, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
                         if (err)
                                 rd_kafka_error_destroy(err);
                 }
@@ -1184,22 +1193,24 @@ static void do_test_max_delivery_attempts(void) {
 
                 /* Verify delivery_count matches attempt number */
                 TEST_ASSERT(
-                    rd_kafka_message_delivery_count(batch[0]) ==
-                        delivery_attempt,
+                    rd_kafka_message_delivery_count(
+                        rd_kafka_messages_get(batch, 0)) == delivery_attempt,
                     "Delivery attempt %d: expected delivery_count=%d, got %d",
                     delivery_attempt, delivery_attempt,
-                    rd_kafka_message_delivery_count(batch[0]));
+                    rd_kafka_message_delivery_count(
+                        rd_kafka_messages_get(batch, 0)));
 
                 TEST_SAY(
                     "Delivery attempt %d: received message "
                     "(delivery_count=%d), sending RELEASE\n",
                     delivery_attempt,
-                    rd_kafka_message_delivery_count(batch[0]));
+                    rd_kafka_message_delivery_count(
+                        rd_kafka_messages_get(batch, 0)));
 
                 /* RELEASE to trigger redelivery */
                 rd_kafka_share_acknowledge_type(
-                    rkshare, batch[0], RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
-                rd_kafka_message_destroy(batch[0]);
+                    rkshare, rd_kafka_messages_get(batch, 0),
+                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
         }
 
         /* Now poll again - message should NOT be redelivered (max attempts
@@ -1209,17 +1220,16 @@ static void do_test_max_delivery_attempts(void) {
         attempts = 5;
         while (attempts-- > 0) {
                 size_t batch_rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 2000, batch,
-                                                   &batch_rcvd);
+                err               = rd_kafka_share_poll(rkshare, 2000, &batch);
+                batch_rcvd        = rd_kafka_messages_count(batch);
                 if (err)
                         rd_kafka_error_destroy(err);
 
                 if (batch_rcvd > 0) {
                         size_t m;
                         for (m = 0; m < batch_rcvd; m++) {
-                                if (!batch[m]->err)
+                                if (!rd_kafka_messages_get(batch, m)->err)
                                         rcvd++;
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
         }
@@ -1423,8 +1433,8 @@ static void do_test_scale_10_topics_3_partitions(void) {
  */
 static void do_test_ack_message_from_earlier_batch(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch1[10];
-        rd_kafka_message_t *batch2[10];
+        rd_kafka_messages_t *batch1 = NULL;
+        rd_kafka_messages_t *batch2 = NULL;
         rd_kafka_topic_partition_list_t *subs;
         rd_kafka_resp_err_t ack_err;
         const char *group = "share-cross-batch-ack";
@@ -1453,24 +1463,26 @@ static void do_test_ack_message_from_earlier_batch(void) {
         /* Poll batch 1 */
         attempts = 30;
         while (b1_rcvd < 1 && attempts-- > 0) {
-                r = 0;
-                e = rd_kafka_share_consume_batch(rkshare, 2000,
-                                                 batch1 + b1_rcvd, &r);
+                rd_kafka_messages_destroy(batch1);
+                batch1 = NULL;
+                e      = rd_kafka_share_poll(rkshare, 2000, &batch1);
                 if (e)
                         rd_kafka_error_destroy(e);
-                b1_rcvd += r;
+                b1_rcvd = rd_kafka_messages_count(batch1);
         }
         TEST_ASSERT(b1_rcvd == 1, "Expected 1 record in batch1, got %zu",
                     b1_rcvd);
 
-        ack_err = rd_kafka_share_acknowledge(rkshare, batch1[0]);
+        ack_err = rd_kafka_share_acknowledge(rkshare,
+                                             rd_kafka_messages_get(batch1, 0));
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                     "First ack failed: %s", rd_kafka_err2name(ack_err));
 
         /* Poll batch 2 - must be empty (we already consumed and acked
          * the only record). */
         r = 0;
-        e = rd_kafka_share_consume_batch(rkshare, 2000, batch2, &r);
+        e = rd_kafka_share_poll(rkshare, 2000, &batch2);
+        r = rd_kafka_messages_count(batch2);
         if (e)
                 rd_kafka_error_destroy(e);
         TEST_ASSERT(r == 0,
@@ -1479,12 +1491,11 @@ static void do_test_ack_message_from_earlier_batch(void) {
                     r);
 
         /* Re-acknowledge from batch1 - should fail with _STATE */
-        ack_err = rd_kafka_share_acknowledge(rkshare, batch1[0]);
+        ack_err = rd_kafka_share_acknowledge(rkshare,
+                                             rd_kafka_messages_get(batch1, 0));
         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR__STATE,
                     "Expected _STATE for re-ack across batches, got %s",
                     rd_kafka_err2name(ack_err));
-
-        rd_kafka_message_destroy(batch1[0]);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1551,7 +1562,7 @@ static void do_test_ack_offset_before_consume(void) {
  */
 static void do_test_ack_offset_wrong_params(void) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[10];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_topic_partition_list_t *subs;
         rd_kafka_resp_err_t err;
         const char *group = "share-ack-wrong-params";
@@ -1579,17 +1590,18 @@ static void do_test_ack_offset_wrong_params(void) {
 
         attempts = 30;
         while (rcvd < 1 && attempts-- > 0) {
-                size_t r            = 0;
-                rd_kafka_error_t *e = rd_kafka_share_consume_batch(
-                    rkshare, 2000, batch + rcvd, &r);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                rd_kafka_error_t *e =
+                    rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (e)
                         rd_kafka_error_destroy(e);
-                rcvd += r;
+                rcvd = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(rcvd == 1, "Expected 1 record, got %zu", rcvd);
 
-        partition = batch[0]->partition;
-        offset    = batch[0]->offset;
+        partition = rd_kafka_messages_get(batch, 0)->partition;
+        offset    = rd_kafka_messages_get(batch, 0)->offset;
 
         /* Wrong offset */
         err = rd_kafka_share_acknowledge_offset(
@@ -1623,8 +1635,6 @@ static void do_test_ack_offset_wrong_params(void) {
                     "Expected success for correct params, got %s",
                     rd_kafka_err2name(err));
 
-        rd_kafka_message_destroy(batch[0]);
-
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
 
@@ -1652,10 +1662,10 @@ static void do_test_mixed_ack_mode_same_group(void) {
         rd_kafka_share_t *implicit_c;
         rd_kafka_share_t *explicit_c;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        const int total_msgs = 400;
-        int implicit_cnt     = 0;
-        int explicit_cnt     = 0;
+        rd_kafka_messages_t *batch = NULL;
+        const int total_msgs       = 400;
+        int implicit_cnt           = 0;
+        int explicit_cnt           = 0;
         int attempts;
         rd_kafka_error_t *cerr;
         test_ack_cb_state_t exp_state = {0};
@@ -1694,38 +1704,37 @@ static void do_test_mixed_ack_mode_same_group(void) {
                 rd_kafka_error_t *err;
 
                 /* Implicit consumer */
-                err = rd_kafka_share_consume_batch(implicit_c, 1000, batch,
-                                                   &rcvd);
+                err  = rd_kafka_share_poll(implicit_c, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                 } else {
                         for (m = 0; m < rcvd; m++) {
-                                if (!batch[m]->err)
+                                if (!rd_kafka_messages_get(batch, m)->err)
                                         implicit_cnt++;
-                                rd_kafka_message_destroy(batch[m]);
                         }
                 }
 
                 /* Explicit consumer */
                 rcvd = 0;
-                err  = rd_kafka_share_consume_batch(explicit_c, 1000, batch,
-                                                    &rcvd);
+                err  = rd_kafka_share_poll(explicit_c, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err) {
+                        if (!rd_kafka_messages_get(batch, m)->err) {
                                 rd_kafka_resp_err_t ack_err =
                                     rd_kafka_share_acknowledge_type(
-                                        explicit_c, batch[m],
+                                        explicit_c,
+                                        rd_kafka_messages_get(batch, m),
                                         RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(!ack_err,
                                             "explicit ACCEPT failed: %s",
                                             rd_kafka_err2str(ack_err));
                                 explicit_cnt++;
                         }
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
 
@@ -1750,14 +1759,13 @@ static void do_test_mixed_ack_mode_same_group(void) {
          * piggybacked acks reach the broker. */
         size_t rcvd = 0;
         size_t m;
-        rd_kafka_error_t *err =
-            rd_kafka_share_consume_batch(implicit_c, 1000, batch, &rcvd);
+        rd_kafka_error_t *err = rd_kafka_share_poll(implicit_c, 1000, &batch);
+        rcvd                  = rd_kafka_messages_count(batch);
         if (err)
                 rd_kafka_error_destroy(err);
         for (m = 0; m < rcvd; m++)
-                rd_kafka_message_destroy(batch[m]);
-
-        TEST_ASSERT(implicit_cnt + explicit_cnt == total_msgs,
+                TEST_ASSERT(
+                    implicit_cnt + explicit_cnt == total_msgs,
                     "Expected exactly %d total records across both consumers, "
                     "got %d (implicit=%d explicit=%d)",
                     total_msgs, implicit_cnt + explicit_cnt, implicit_cnt,

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -2007,8 +2007,7 @@ static void do_test_lock_expiry_callback_err(void) {
                     "expiry, got %s",
                     rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
 
-        for (j = 0; j < consumed; j++)
-                test_share_consumer_close(rkshare);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&state);
 

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -115,7 +115,7 @@ static void do_test_implicit_second_consumer(void) {
         const char *group = "commit-async-implicit-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -138,17 +138,18 @@ static void do_test_implicit_second_consumer(void) {
         /* Wait for first batch of records */
         while (consumed1 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                c1_offsets[consumed1++] = rkmessages[j]->offset;
-                        rd_kafka_message_destroy(rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                                c1_offsets[consumed1++] =
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset;
                 }
         }
 
@@ -175,7 +176,8 @@ static void do_test_implicit_second_consumer(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -183,16 +185,17 @@ static void do_test_implicit_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer 2 got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         consumed2++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", consumed2);
@@ -220,7 +223,7 @@ static void do_test_explicit_second_consumer(void) {
         const char *group = "commit-async-explicit-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -243,20 +246,22 @@ static void do_test_explicit_second_consumer(void) {
         /* Wait for first batch of records */
         while (consumed1 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                c1_offsets[consumed1++] = rkmessages[j]->offset;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                c1_offsets[consumed1++] =
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset;
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -283,7 +288,8 @@ static void do_test_explicit_second_consumer(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -291,16 +297,17 @@ static void do_test_explicit_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer 2 got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         consumed2++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", consumed2);
@@ -330,7 +337,7 @@ static void do_test_mixed_acks_second_consumer(void) {
         const char *group = "commit-async-mixed-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, redelivered = 0;
@@ -354,24 +361,27 @@ static void do_test_mixed_acks_second_consumer(void) {
         while ((consumed < MAX_MSGS || redelivered < released_cnt) &&
                attempts++ < 100) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 if (rd_kafka_message_delivery_count(
-                                        rkmessages[j]) > 1) {
+                                        rd_kafka_messages_get(rkmessages, j)) >
+                                    1) {
                                         /* Redelivered — verify it was
                                          * RELEASE'd and ACCEPT it */
                                         int k;
                                         rd_bool_t found = rd_false;
 
                                         for (k = 0; k < released_cnt; k++) {
-                                                if (rkmessages[j]->offset ==
+                                                if (rd_kafka_messages_get(
+                                                        rkmessages, j)
+                                                        ->offset ==
                                                     released_offsets[k]) {
                                                         found = rd_true;
                                                         released_offsets[k] =
@@ -383,10 +393,12 @@ static void do_test_mixed_acks_second_consumer(void) {
                                             found,
                                             "Redelivered offset %" PRId64
                                             " was not RELEASE'd",
-                                            rkmessages[j]->offset);
+                                            rd_kafka_messages_get(rkmessages, j)
+                                                ->offset);
 
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[j]);
+                                            rkshare, rd_kafka_messages_get(
+                                                         rkmessages, j));
                                         redelivered++;
                                 } else {
                                         /* New record — ack with random type */
@@ -396,22 +408,27 @@ static void do_test_mixed_acks_second_consumer(void) {
                                         if (ack_type ==
                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT) {
                                                 rd_kafka_share_acknowledge(
-                                                    rkshare, rkmessages[j]);
+                                                    rkshare,
+                                                    rd_kafka_messages_get(
+                                                        rkmessages, j));
                                         } else {
                                                 if (ack_type ==
                                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE)
                                                         released_offsets
                                                             [released_cnt++] =
-                                                                rkmessages[j]
+                                                                rd_kafka_messages_get(
+                                                                    rkmessages,
+                                                                    j)
                                                                     ->offset;
                                                 rd_kafka_share_acknowledge_type(
-                                                    rkshare, rkmessages[j],
+                                                    rkshare,
+                                                    rd_kafka_messages_get(
+                                                        rkmessages, j),
                                                     ack_type);
                                         }
                                         consumed++;
                                 }
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
 
                 error = rd_kafka_share_commit_async(rkshare);
@@ -483,21 +500,20 @@ static void do_test_multi_topic_partition(void) {
                 }
 
                 while (consumed < msgs_per_round && attempts++ < 100) {
-                        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                        size_t rcvd = 0;
+                        rd_kafka_messages_t *rkmessages = NULL;
+                        size_t rcvd                     = 0;
                         size_t j;
 
-                        error = rd_kafka_share_consume_batch(rkshare, 5000,
-                                                             rkmessages, &rcvd);
+                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
+                        rcvd  = rd_kafka_messages_count(rkmessages);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rkmessages[j]->err)
+                                if (!rd_kafka_messages_get(rkmessages, j)->err)
                                         consumed++;
-                                rd_kafka_message_destroy(rkmessages[j]);
                         }
                 }
 
@@ -564,21 +580,20 @@ static void do_test_produce_consume_loop(void) {
                          msgs_per_round);
 
                 while (consumed < msgs_per_round && attempts++ < 100) {
-                        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                        size_t rcvd = 0;
+                        rd_kafka_messages_t *rkmessages = NULL;
+                        size_t rcvd                     = 0;
                         size_t j;
 
-                        error = rd_kafka_share_consume_batch(rkshare, 5000,
-                                                             rkmessages, &rcvd);
+                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
+                        rcvd  = rd_kafka_messages_count(rkmessages);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rkmessages[j]->err)
+                                if (!rd_kafka_messages_get(rkmessages, j)->err)
                                         consumed++;
-                                rd_kafka_message_destroy(rkmessages[j]);
                         }
                 }
 
@@ -656,23 +671,27 @@ static void do_test_multi_round_mixed_second_consumer(void) {
                 while (
                     (consumed < msgs_per_round || redelivered < released_cnt) &&
                     attempts++ < 100) {
-                        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                        size_t rcvd = 0;
+                        rd_kafka_messages_t *rkmessages = NULL;
+                        size_t rcvd                     = 0;
                         size_t j;
 
-                        error = rd_kafka_share_consume_batch(rkshare, 5000,
-                                                             rkmessages, &rcvd);
+                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
+                        rcvd  = rd_kafka_messages_count(rkmessages);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rkmessages[j]->err) {
+                                if (!rd_kafka_messages_get(rkmessages, j)
+                                         ->err) {
                                         if (rd_kafka_message_delivery_count(
-                                                rkmessages[j]) > 1) {
+                                                rd_kafka_messages_get(
+                                                    rkmessages, j)) > 1) {
                                                 rd_kafka_share_acknowledge(
-                                                    rkshare, rkmessages[j]);
+                                                    rkshare,
+                                                    rd_kafka_messages_get(
+                                                        rkmessages, j));
                                                 redelivered++;
                                         } else {
                                                 rd_kafka_share_AcknowledgeType_t
@@ -683,20 +702,21 @@ static void do_test_multi_round_mixed_second_consumer(void) {
                                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT) {
                                                         rd_kafka_share_acknowledge(
                                                             rkshare,
-                                                            rkmessages[j]);
+                                                            rd_kafka_messages_get(
+                                                                rkmessages, j));
                                                 } else {
                                                         if (ack_type ==
                                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE)
                                                                 released_cnt++;
                                                         rd_kafka_share_acknowledge_type(
                                                             rkshare,
-                                                            rkmessages[j],
+                                                            rd_kafka_messages_get(
+                                                                rkmessages, j),
                                                             ack_type);
                                                 }
                                                 consumed++;
                                         }
                                 }
-                                rd_kafka_message_destroy(rkmessages[j]);
                         }
 
                         error = rd_kafka_share_commit_async(rkshare);
@@ -786,21 +806,20 @@ static void do_test_multiple_commit_async_calls(void) {
         test_produce_msgs_simple(common_producer, topic, 0, first_produce);
 
         while (consumed < first_produce && attempts++ < 100) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd                     = 0;
                 size_t j;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -821,21 +840,20 @@ static void do_test_multiple_commit_async_calls(void) {
 
         attempts = 0;
         while (consumed2 < second_produce && attempts++ < 100) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd                     = 0;
                 size_t j;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed2++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -864,7 +882,7 @@ static void do_test_commit_between_produces(void) {
         const char *group = "commit-async-between-produces";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         const int half = MAX_MSGS / 2;
@@ -886,26 +904,27 @@ static void do_test_commit_between_produces(void) {
 
         while (consumed1 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                TEST_ASSERT(rd_kafka_message_delivery_count(
-                                                rkmessages[j]) == 1,
-                                            "First half: redelivered record at "
-                                            "offset %" PRId64
-                                            " (delivery_count=%d)",
-                                            rkmessages[j]->offset,
-                                            rd_kafka_message_delivery_count(
-                                                rkmessages[j]));
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_message_delivery_count(
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        1,
+                                    "First half: redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
+                                    rd_kafka_message_delivery_count(
+                                        rd_kafka_messages_get(rkmessages, j)));
                                 consumed1++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -928,26 +947,27 @@ static void do_test_commit_between_produces(void) {
         attempts = 0;
         while (consumed2 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_ASSERT(
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]) == 1,
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        1,
                                     "Second half: redelivered record at "
                                     "offset %" PRId64 " (delivery_count=%d)",
-                                    rkmessages[j]->offset,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]));
+                                        rd_kafka_messages_get(rkmessages, j)));
                                 consumed2++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -974,7 +994,8 @@ static void do_test_commit_between_produces(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -982,16 +1003,17 @@ static void do_test_commit_between_produces(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer 2 got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         received++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
@@ -1036,32 +1058,35 @@ static void do_test_all_release_second_consumer(void) {
          * redeliveries are received. */
         while ((consumed < MAX_MSGS || redelivered < consumed) &&
                attempts++ < 200) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd                     = 0;
                 size_t j;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 if (rd_kafka_message_delivery_count(
-                                        rkmessages[j]) > 1) {
+                                        rd_kafka_messages_get(rkmessages, j)) >
+                                    1) {
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[j]);
+                                            rkshare, rd_kafka_messages_get(
+                                                         rkmessages, j));
                                         redelivered++;
                                 } else {
                                         rd_kafka_share_acknowledge_type(
-                                            rkshare, rkmessages[j],
+                                            rkshare,
+                                            rd_kafka_messages_get(rkmessages,
+                                                                  j),
                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                         consumed++;
                                 }
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
 
                 error = rd_kafka_share_commit_async(rkshare);
@@ -1095,7 +1120,7 @@ static void do_test_all_reject_second_consumer(void) {
         const char *group = "commit-async-all-reject-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, received = 0;
@@ -1115,21 +1140,21 @@ static void do_test_all_reject_second_consumer(void) {
         while (consumed < MAX_MSGS && attempts++ < 100) {
                 size_t rcvd_inner = 0;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd_inner);
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd_inner = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd_inner; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 rd_kafka_share_acknowledge_type(
-                                    rkshare, rkmessages[j],
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
 
                 error = rd_kafka_share_commit_async(rkshare);
@@ -1163,7 +1188,8 @@ static void do_test_all_reject_second_consumer(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -1171,16 +1197,17 @@ static void do_test_all_reject_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer 2 got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         received++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
@@ -1206,7 +1233,7 @@ static void do_test_per_record_commit_async(void) {
         const char *group = "commit-async-per-record";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, received = 0;
@@ -1228,17 +1255,18 @@ static void do_test_per_record_commit_async(void) {
         while (consumed < MAX_MSGS && attempts++ < 100) {
                 size_t rcvd_inner = 0;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd_inner);
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd_inner = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd_inner; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
 
                                 error = rd_kafka_share_commit_async(rkshare);
@@ -1247,7 +1275,6 @@ static void do_test_per_record_commit_async(void) {
                                     consumed,
                                     error ? rd_kafka_error_string(error) : "");
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1279,7 +1306,8 @@ static void do_test_per_record_commit_async(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -1287,16 +1315,17 @@ static void do_test_per_record_commit_async(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer 2 got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         received++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
@@ -1448,12 +1477,12 @@ static void do_test_mock_inflight_caching(void) {
          * cache the acks in rkb_share_async_ack_details instead of
          * sending a new ShareFetch request. */
         while (consumed < msgcnt && i < 30) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd                     = 0;
                 size_t j;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 i++;
                 if (error) {
                         rd_kafka_error_destroy(error);
@@ -1461,9 +1490,10 @@ static void do_test_mock_inflight_caching(void) {
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
 
                                 error = rd_kafka_share_commit_async(rkshare);
@@ -1473,7 +1503,6 @@ static void do_test_mock_inflight_caching(void) {
                                     error ? rd_kafka_error_string(error) : "");
                                 commit_cnt++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_SAY("Mock: consumed %d/%d\n", consumed, msgcnt);
@@ -1531,7 +1560,7 @@ static void do_test_lock_timeout_redelivery(void) {
         const char *group = "commit-async-lock-timeout";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -1554,26 +1583,27 @@ static void do_test_lock_timeout_redelivery(void) {
         attempts = 0;
         while (consumed1 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_ASSERT(
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]) == 1,
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        1,
                                     "First consume: expected delivery_count=1, "
                                     "got %d at offset %" PRId64,
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]),
-                                    rkmessages[j]->offset);
+                                        rd_kafka_messages_get(rkmessages, j)),
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset);
                                 consumed1++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1590,26 +1620,28 @@ static void do_test_lock_timeout_redelivery(void) {
         attempts = 0;
         while (consumed2 == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                TEST_ASSERT(rd_kafka_message_delivery_count(
-                                                rkmessages[j]) == 2,
-                                            "Second consume: expected "
-                                            "delivery_count=2, got %d at "
-                                            "offset %" PRId64,
-                                            rd_kafka_message_delivery_count(
-                                                rkmessages[j]),
-                                            rkmessages[j]->offset);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_message_delivery_count(
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        2,
+                                    "Second consume: expected "
+                                    "delivery_count=2, got %d at "
+                                    "offset %" PRId64,
+                                    rd_kafka_message_delivery_count(
+                                        rd_kafka_messages_get(rkmessages, j)),
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset);
                                 consumed2++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1635,7 +1667,7 @@ static void do_test_commit_async_callback(void) {
         const char *group = "commit-async-callback";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         int consumed              = 0;
@@ -1657,16 +1689,15 @@ static void do_test_commit_async_callback(void) {
         /* Consume some messages */
         while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1713,9 +1744,9 @@ static void do_test_partial_batch_commit_async(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_message_t *dummy[16];
-        size_t rcvd, total = 0, j;
+        rd_kafka_messages_t *dummy = NULL;
+        test_share_batch_t acc;
+        size_t j;
         test_ack_cb_state_t state = {0};
         const int msg_cnt         = 5;
         int attempts              = 0;
@@ -1732,25 +1763,22 @@ static void do_test_partial_batch_commit_async(void) {
         test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
+        test_share_batch_init(&acc, msg_cnt);
+
         /* Consume all msg_cnt records (may take multiple polls) */
-        while (total < (size_t)msg_cnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000,
-                                                     rkmessages + total, &rcvd);
-                if (error) {
+        while (acc.cnt < (size_t)msg_cnt && attempts++ < 30) {
+                error = test_share_batch_poll(&acc, rkshare, 3000);
+                if (error)
                         rd_kafka_error_destroy(error);
-                        continue;
-                }
-                total += rcvd;
         }
-        TEST_ASSERT(total == (size_t)msg_cnt,
-                    "Expected exactly %d records, got %zu", msg_cnt, total);
+        TEST_ASSERT(acc.cnt == (size_t)msg_cnt,
+                    "Expected exactly %d records, got %zu", msg_cnt, acc.cnt);
 
         /* Acknowledge first 3 records; leave the remainder un-acked. */
         to_ack_first = 3;
         for (j = 0; j < to_ack_first; j++) {
                 ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, rkmessages[j],
+                    rkshare, acc.msgs[j],
                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "First-half ACCEPT %zu failed: %s", j,
@@ -1762,30 +1790,29 @@ static void do_test_partial_batch_commit_async(void) {
         TEST_ASSERT(!error, "First commit_async failed: %s",
                     error ? rd_kafka_error_string(error) : "");
 
-        /* While un-acked records remain in the batch, consume_batch must
+        /* While un-acked records remain in the batch, share_poll must
          * return _STATE rather than proceed. */
-        size_t r = 0;
-        rd_kafka_error_t *e =
-            rd_kafka_share_consume_batch(rkshare, 1000, dummy, &r);
+        rd_kafka_error_t *e = rd_kafka_share_poll(rkshare, 1000, &dummy);
+        rd_kafka_messages_destroy(dummy);
         TEST_ASSERT(e != NULL,
-                    "Expected consume_batch to return _STATE while "
+                    "Expected share_poll to return _STATE while "
                     "un-acked records remain, got NULL error");
         TEST_ASSERT(rd_kafka_error_code(e) == RD_KAFKA_RESP_ERR__STATE,
                     "Expected _STATE, got %s",
                     rd_kafka_err2name(rd_kafka_error_code(e)));
-        TEST_SAY("Got expected _STATE from consume_batch: %s\n",
+        TEST_SAY("Got expected _STATE from share_poll: %s\n",
                  rd_kafka_error_string(e));
         rd_kafka_error_destroy(e);
 
         /* Acknowledge the remaining records */
-        for (j = to_ack_first; j < total; j++) {
+        for (j = to_ack_first; j < acc.cnt; j++) {
                 ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, rkmessages[j],
+                    rkshare, acc.msgs[j],
                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                TEST_ASSERT(
-                    ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                    "Second-half ACCEPT %zu (offset=%" PRId64 ") failed: %s", j,
-                    rkmessages[j]->offset, rd_kafka_err2str(ack_err));
+                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                            "Second-half ACCEPT %zu (offset=%" PRId64
+                            ") failed: %s",
+                            j, acc.msgs[j]->offset, rd_kafka_err2str(ack_err));
         }
 
         /* Second commit_async commits the remaining acks */
@@ -1793,7 +1820,7 @@ static void do_test_partial_batch_commit_async(void) {
         TEST_ASSERT(!error, "Second commit_async failed: %s",
                     error ? rd_kafka_error_string(error) : "");
 
-        /* Now consume_batch can proceed and drive piggybacked acks; the
+        /* Now share_poll can proceed and drive piggybacked acks; the
          * callback should fire at least once and report all acked
          * offsets across the two commits. */
         test_wait_for_cb_with_poll(&state, rkshare, 1, 15000);
@@ -1805,15 +1832,13 @@ static void do_test_partial_batch_commit_async(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Callback errored: %s",
                     rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
-        TEST_ASSERT(state.total_offsets >= (size_t)total,
-                    "Expected callback to report %zu offsets, got %zu", total,
+        TEST_ASSERT(state.total_offsets >= acc.cnt,
+                    "Expected callback to report %zu offsets, got %zu", acc.cnt,
                     state.total_offsets);
         TEST_SAY("Partial commit callbacks=%d, total_offsets=%zu\n",
                  state.callback_cnt, state.total_offsets);
 
-        for (j = 0; j < total; j++)
-                rd_kafka_message_destroy(rkmessages[j]);
-
+        test_share_batch_destroy(&acc);
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&state);
@@ -1831,7 +1856,7 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
         const char *group = "commit-async-implicit-no-commit";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         test_ack_cb_state_t state = {0};
         const int msg_cnt         = 20;
@@ -1849,21 +1874,21 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
         test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
-        /* First poll: drain all produced records. consume_batch typically
+        /* First poll: drain all produced records. share_poll typically
          * returns the whole broker-side RecordBatch (so all msg_cnt records
          * arrive in one call), but the loop tolerates split deliveries. */
         while (consumed < msg_cnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd       = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed == msg_cnt,
@@ -1874,14 +1899,16 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
          * fire via piggybacked acks on the next ShareFetch. */
         attempts = 10;
         while (attempts-- > 0 && state.callback_cnt == 0) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd       = rd_kafka_messages_count(rkmessages);
+                (void)rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
-                for (j = 0; j < rcvd; j++)
-                        rd_kafka_message_destroy(rkmessages[j]);
         }
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
 
         TEST_ASSERT(state.callback_cnt >= 1,
                     "Expected callback from implicit piggybacked acks (no "
@@ -1914,7 +1941,7 @@ static void do_test_lock_expiry_callback_err(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         size_t consumed           = 0;
         int attempts              = 0;
@@ -1935,8 +1962,8 @@ static void do_test_lock_expiry_callback_err(void) {
         /* Consume records (acquires lock) */
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -1948,7 +1975,7 @@ static void do_test_lock_expiry_callback_err(void) {
         /* Acknowledge all consumed records explicitly */
         for (j = 0; j < consumed; j++) {
                 ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, rkmessages[j],
+                    rkshare, rd_kafka_messages_get(rkmessages, j),
                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "ACCEPT failed: %s", rd_kafka_err2str(ack_err));
@@ -1981,9 +2008,7 @@ static void do_test_lock_expiry_callback_err(void) {
                     rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
 
         for (j = 0; j < consumed; j++)
-                rd_kafka_message_destroy(rkmessages[j]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&state);
 
@@ -2028,7 +2053,7 @@ static void do_test_safe_api_from_callback(void) {
         const char *group = "commit-async-safe-api-cb";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         int consumed     = 0;
         int second_round = 0;
@@ -2049,16 +2074,15 @@ static void do_test_safe_api_from_callback(void) {
         /* First-round consumption */
         while (consumed < 5 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2078,16 +2102,15 @@ static void do_test_safe_api_from_callback(void) {
         attempts = 0;
         while (second_round < 5 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 second_round++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(second_round > 0,
@@ -2135,7 +2158,7 @@ static void do_test_callback_side_effects_dont_break(void) {
         const char *group = "commit-async-side-effect-cb";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         int consumed   = 0;
         int post_count = 0;
@@ -2156,16 +2179,15 @@ static void do_test_callback_side_effects_dont_break(void) {
         /* Consume the produced records */
         while (consumed < 10 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
@@ -2197,16 +2219,15 @@ static void do_test_callback_side_effects_dont_break(void) {
         attempts = 0;
         while (post_count == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 post_count++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(post_count > 0,
@@ -2225,7 +2246,7 @@ static void do_test_change_callback(void) {
         const char *group = "change-callback";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         int consumed                = 0;
         int attempts                = 0;
@@ -2251,19 +2272,19 @@ static void do_test_change_callback(void) {
         /* Phase 1: consume the first batch and commit with callback A */
         while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2303,19 +2324,19 @@ static void do_test_change_callback(void) {
         attempts = 0;
         while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2363,19 +2384,19 @@ static void do_test_change_callback(void) {
         attempts = 0;
         while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed > 0,
@@ -2391,17 +2412,17 @@ static void do_test_change_callback(void) {
         int poll_iters = 20;
         while (poll_iters-- > 0) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 200, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error)
                         rd_kafka_error_destroy(error);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2452,8 +2473,8 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
         reentrancy_check_state_t *st = (reentrancy_check_state_t *)opaque;
         rd_kafka_error_t *error_obj;
         rd_kafka_resp_err_t resp_err;
-        rd_kafka_message_t *batch[8];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_topic_partition_list_t *subs;
 
         /* Update base state for callback tracking */
@@ -2466,8 +2487,9 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
                             rd_kafka_share_partition_offsets_offsets_cnt(p);
         }
 
-        /* Try rd_kafka_share_consume_batch - should fail with _STATE */
-        error_obj = rd_kafka_share_consume_batch(rkshare, 100, batch, &rcvd);
+        /* Try rd_kafka_share_poll - should fail with _STATE */
+        error_obj = rd_kafka_share_poll(rkshare, 100, &batch);
+        rcvd      = rd_kafka_messages_count(batch);
         if (error_obj &&
             rd_kafka_error_code(error_obj) == RD_KAFKA_RESP_ERR__STATE) {
                 st->rejections++;
@@ -2536,7 +2558,7 @@ static void do_test_reentrancy_protection(void) {
         const char *group = "reentrancy-protection";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd, j;
         int consumed                   = 0;
         int attempts                   = 0;
@@ -2566,19 +2588,19 @@ static void do_test_reentrancy_protection(void) {
          */
         while (consumed < 50 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed > 0, "Expected to consume some messages");

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -2473,7 +2473,6 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
         rd_kafka_error_t *error_obj;
         rd_kafka_resp_err_t resp_err;
         rd_kafka_messages_t *batch = NULL;
-        size_t rcvd                = 0;
         rd_kafka_topic_partition_list_t *subs;
 
         /* Update base state for callback tracking */
@@ -2488,7 +2487,7 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
 
         /* Try rd_kafka_share_poll - should fail with _STATE */
         error_obj = rd_kafka_share_poll(rkshare, 100, &batch);
-        rcvd      = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
         if (error_obj &&
             rd_kafka_error_code(error_obj) == RD_KAFKA_RESP_ERR__STATE) {
                 st->rejections++;

--- a/tests/0173-share_consumer_commit_async.c
+++ b/tests/0173-share_consumer_commit_async.c
@@ -115,7 +115,7 @@ static void do_test_implicit_second_consumer(void) {
         const char *group = "commit-async-implicit-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -137,20 +137,21 @@ static void do_test_implicit_second_consumer(void) {
 
         /* Wait for first batch of records */
         while (consumed1 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
-                                c1_offsets[consumed1++] =
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
+                                c1_offsets[consumed1++] = rkm->offset;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumer 1 consumed %d messages in first batch\n", consumed1);
@@ -175,9 +176,8 @@ static void do_test_implicit_second_consumer(void) {
         rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -185,18 +185,18 @@ static void do_test_implicit_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer 2 got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer 2 got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         consumed2++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", consumed2);
         TEST_ASSERT(consumed2 == 5, "Expected 5 verification records, got %d",
@@ -223,7 +223,7 @@ static void do_test_explicit_second_consumer(void) {
         const char *group = "commit-async-explicit-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -245,24 +245,23 @@ static void do_test_explicit_second_consumer(void) {
 
         /* Wait for first batch of records */
         while (consumed1 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                c1_offsets[consumed1++] =
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                c1_offsets[consumed1++] = rkm->offset;
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumer 1 consumed %d messages in first batch\n", consumed1);
@@ -287,9 +286,8 @@ static void do_test_explicit_second_consumer(void) {
         rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -297,18 +295,18 @@ static void do_test_explicit_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer 2 got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer 2 got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         consumed2++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", consumed2);
         TEST_ASSERT(consumed2 == 5, "Expected 5 verification records, got %d",
@@ -337,7 +335,7 @@ static void do_test_mixed_acks_second_consumer(void) {
         const char *group = "commit-async-mixed-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, redelivered = 0;
@@ -360,28 +358,25 @@ static void do_test_mixed_acks_second_consumer(void) {
         /* Consume all records and handle redeliveries in the same loop */
         while ((consumed < MAX_MSGS || redelivered < released_cnt) &&
                attempts++ < 100) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                if (rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) >
-                                    1) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                if (rd_kafka_message_delivery_count(rkm) > 1) {
                                         /* Redelivered — verify it was
                                          * RELEASE'd and ACCEPT it */
                                         int k;
                                         rd_bool_t found = rd_false;
 
                                         for (k = 0; k < released_cnt; k++) {
-                                                if (rd_kafka_messages_get(
-                                                        rkmessages, j)
-                                                        ->offset ==
+                                                if (rkm->offset ==
                                                     released_offsets[k]) {
                                                         found = rd_true;
                                                         released_offsets[k] =
@@ -393,12 +388,10 @@ static void do_test_mixed_acks_second_consumer(void) {
                                             found,
                                             "Redelivered offset %" PRId64
                                             " was not RELEASE'd",
-                                            rd_kafka_messages_get(rkmessages, j)
-                                                ->offset);
+                                            rkm->offset);
 
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rd_kafka_messages_get(
-                                                         rkmessages, j));
+                                        rd_kafka_share_acknowledge(rkshare,
+                                                                   rkm);
                                         redelivered++;
                                 } else {
                                         /* New record — ack with random type */
@@ -408,28 +401,22 @@ static void do_test_mixed_acks_second_consumer(void) {
                                         if (ack_type ==
                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT) {
                                                 rd_kafka_share_acknowledge(
-                                                    rkshare,
-                                                    rd_kafka_messages_get(
-                                                        rkmessages, j));
+                                                    rkshare, rkm);
                                         } else {
                                                 if (ack_type ==
                                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE)
                                                         released_offsets
                                                             [released_cnt++] =
-                                                                rd_kafka_messages_get(
-                                                                    rkmessages,
-                                                                    j)
-                                                                    ->offset;
+                                                                rkm->offset;
                                                 rd_kafka_share_acknowledge_type(
-                                                    rkshare,
-                                                    rd_kafka_messages_get(
-                                                        rkmessages, j),
-                                                    ack_type);
+                                                    rkshare, rkm, ack_type);
                                         }
                                         consumed++;
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 error = rd_kafka_share_commit_async(rkshare);
                 TEST_ASSERT(!error, "commit_async failed: %s",
@@ -500,21 +487,24 @@ static void do_test_multi_topic_partition(void) {
                 }
 
                 while (consumed < msgs_per_round && attempts++ < 100) {
-                        rd_kafka_messages_t *rkmessages = NULL;
-                        size_t rcvd                     = 0;
+                        rd_kafka_messages_t *batch = NULL;
+                        size_t rcvd;
                         size_t j;
 
-                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
-                        rcvd  = rd_kafka_messages_count(rkmessages);
+                        error = rd_kafka_share_poll(rkshare, 5000, &batch);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
+                        rcvd = rd_kafka_messages_count(batch);
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rd_kafka_messages_get(rkmessages, j)->err)
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, j);
+                                if (!rkm->err)
                                         consumed++;
                         }
+                        rd_kafka_messages_destroy(batch);
                 }
 
                 TEST_SAY("Round %d: consumed %d/%d messages\n", round, consumed,
@@ -580,21 +570,24 @@ static void do_test_produce_consume_loop(void) {
                          msgs_per_round);
 
                 while (consumed < msgs_per_round && attempts++ < 100) {
-                        rd_kafka_messages_t *rkmessages = NULL;
-                        size_t rcvd                     = 0;
+                        rd_kafka_messages_t *batch = NULL;
+                        size_t rcvd;
                         size_t j;
 
-                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
-                        rcvd  = rd_kafka_messages_count(rkmessages);
+                        error = rd_kafka_share_poll(rkshare, 5000, &batch);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
+                        rcvd = rd_kafka_messages_count(batch);
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rd_kafka_messages_get(rkmessages, j)->err)
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, j);
+                                if (!rkm->err)
                                         consumed++;
                         }
+                        rd_kafka_messages_destroy(batch);
                 }
 
                 TEST_SAY("Round %d: consumed %d/%d messages\n", round, consumed,
@@ -671,27 +664,25 @@ static void do_test_multi_round_mixed_second_consumer(void) {
                 while (
                     (consumed < msgs_per_round || redelivered < released_cnt) &&
                     attempts++ < 100) {
-                        rd_kafka_messages_t *rkmessages = NULL;
-                        size_t rcvd                     = 0;
+                        rd_kafka_messages_t *batch = NULL;
+                        size_t rcvd;
                         size_t j;
 
-                        error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
-                        rcvd  = rd_kafka_messages_count(rkmessages);
+                        error = rd_kafka_share_poll(rkshare, 5000, &batch);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
+                        rcvd = rd_kafka_messages_count(batch);
 
                         for (j = 0; j < rcvd; j++) {
-                                if (!rd_kafka_messages_get(rkmessages, j)
-                                         ->err) {
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, j);
+                                if (!rkm->err) {
                                         if (rd_kafka_message_delivery_count(
-                                                rd_kafka_messages_get(
-                                                    rkmessages, j)) > 1) {
+                                                rkm) > 1) {
                                                 rd_kafka_share_acknowledge(
-                                                    rkshare,
-                                                    rd_kafka_messages_get(
-                                                        rkmessages, j));
+                                                    rkshare, rkm);
                                                 redelivered++;
                                         } else {
                                                 rd_kafka_share_AcknowledgeType_t
@@ -701,23 +692,20 @@ static void do_test_multi_round_mixed_second_consumer(void) {
                                                 if (ack_type ==
                                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT) {
                                                         rd_kafka_share_acknowledge(
-                                                            rkshare,
-                                                            rd_kafka_messages_get(
-                                                                rkmessages, j));
+                                                            rkshare, rkm);
                                                 } else {
                                                         if (ack_type ==
                                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE)
                                                                 released_cnt++;
                                                         rd_kafka_share_acknowledge_type(
-                                                            rkshare,
-                                                            rd_kafka_messages_get(
-                                                                rkmessages, j),
+                                                            rkshare, rkm,
                                                             ack_type);
                                                 }
                                                 consumed++;
                                         }
                                 }
                         }
+                        rd_kafka_messages_destroy(batch);
 
                         error = rd_kafka_share_commit_async(rkshare);
                         TEST_ASSERT(!error, "Round %d: commit_async failed: %s",
@@ -806,21 +794,24 @@ static void do_test_multiple_commit_async_calls(void) {
         test_produce_msgs_simple(common_producer, topic, 0, first_produce);
 
         while (consumed < first_produce && attempts++ < 100) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd                     = 0;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd;
                 size_t j;
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
         }
 
         TEST_SAY("First set: consumed %d/%d messages\n", consumed,
@@ -840,21 +831,24 @@ static void do_test_multiple_commit_async_calls(void) {
 
         attempts = 0;
         while (consumed2 < second_produce && attempts++ < 100) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd                     = 0;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd;
                 size_t j;
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed2++;
                 }
+                rd_kafka_messages_destroy(batch);
         }
 
         TEST_SAY("After multiple commits: consumed %d/%d messages\n", consumed2,
@@ -882,7 +876,7 @@ static void do_test_commit_between_produces(void) {
         const char *group = "commit-async-between-produces";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         const int half = MAX_MSGS / 2;
@@ -903,29 +897,28 @@ static void do_test_commit_between_produces(void) {
         test_produce_msgs_simple(common_producer, topic, 0, half);
 
         while (consumed1 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        1,
+                                    rd_kafka_message_delivery_count(rkm) == 1,
                                     "First half: redelivered record at "
                                     "offset %" PRId64 " (delivery_count=%d)",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)));
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                                 consumed1++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("First half: consumed %d messages\n", consumed1);
@@ -946,29 +939,28 @@ static void do_test_commit_between_produces(void) {
 
         attempts = 0;
         while (consumed2 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        1,
+                                    rd_kafka_message_delivery_count(rkm) == 1,
                                     "Second half: redelivered record at "
                                     "offset %" PRId64 " (delivery_count=%d)",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)));
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                                 consumed2++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Second half: consumed %d messages\n", consumed2);
@@ -993,9 +985,8 @@ static void do_test_commit_between_produces(void) {
         rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -1003,18 +994,18 @@ static void do_test_commit_between_produces(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer 2 got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer 2 got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         received++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
@@ -1058,36 +1049,34 @@ static void do_test_all_release_second_consumer(void) {
          * redeliveries are received. */
         while ((consumed < MAX_MSGS || redelivered < consumed) &&
                attempts++ < 200) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd                     = 0;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd;
                 size_t j;
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                if (rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) >
-                                    1) {
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rd_kafka_messages_get(
-                                                         rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                if (rd_kafka_message_delivery_count(rkm) > 1) {
+                                        rd_kafka_share_acknowledge(rkshare,
+                                                                   rkm);
                                         redelivered++;
                                 } else {
                                         rd_kafka_share_acknowledge_type(
-                                            rkshare,
-                                            rd_kafka_messages_get(rkmessages,
-                                                                  j),
+                                            rkshare, rkm,
                                             RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                         consumed++;
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(batch);
 
                 error = rd_kafka_share_commit_async(rkshare);
                 TEST_ASSERT(!error, "commit_async failed: %s",
@@ -1120,7 +1109,7 @@ static void do_test_all_reject_second_consumer(void) {
         const char *group = "commit-async-all-reject-second";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, received = 0;
@@ -1138,24 +1127,27 @@ static void do_test_all_reject_second_consumer(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed < MAX_MSGS && attempts++ < 100) {
-                size_t rcvd_inner = 0;
+                size_t rcvd_inner;
 
-                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd_inner = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd_inner = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd_inner; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 rd_kafka_share_acknowledge_type(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j),
+                                    rkshare, rkm,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 error = rd_kafka_share_commit_async(rkshare);
                 TEST_ASSERT(!error, "commit_async failed: %s",
@@ -1187,9 +1179,8 @@ static void do_test_all_reject_second_consumer(void) {
         rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -1197,18 +1188,18 @@ static void do_test_all_reject_second_consumer(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer 2 got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer 2 got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         received++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
@@ -1233,7 +1224,7 @@ static void do_test_per_record_commit_async(void) {
         const char *group = "commit-async-per-record";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0, received = 0;
@@ -1253,20 +1244,20 @@ static void do_test_per_record_commit_async(void) {
         /* Consume all records, ACCEPT each individually with
          * commit_async after every record */
         while (consumed < MAX_MSGS && attempts++ < 100) {
-                size_t rcvd_inner = 0;
+                size_t rcvd_inner;
 
-                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd_inner = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd_inner = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd_inner; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
 
                                 error = rd_kafka_share_commit_async(rkshare);
@@ -1276,6 +1267,8 @@ static void do_test_per_record_commit_async(void) {
                                     error ? rd_kafka_error_string(error) : "");
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed %d/%d messages with per-record commit_async\n",
@@ -1305,9 +1298,8 @@ static void do_test_per_record_commit_async(void) {
         rkshare = test_create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         TEST_SAY("Consumer 2 consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error) {
@@ -1315,18 +1307,18 @@ static void do_test_per_record_commit_async(void) {
         }
 
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer 2 got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer 2 got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         received++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer 2 got %d messages (expected 5)\n", received);
         TEST_ASSERT(received == 5, "Expected 5 verification records, got %d",
@@ -1477,23 +1469,23 @@ static void do_test_mock_inflight_caching(void) {
          * cache the acks in rkb_share_async_ack_details instead of
          * sending a new ShareFetch request. */
         while (consumed < msgcnt && i < 30) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd                     = 0;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd;
                 size_t j;
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 i++;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
 
                                 error = rd_kafka_share_commit_async(rkshare);
@@ -1504,6 +1496,7 @@ static void do_test_mock_inflight_caching(void) {
                                 commit_cnt++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
         }
         TEST_SAY("Mock: consumed %d/%d\n", consumed, msgcnt);
         TEST_ASSERT(consumed == msgcnt, "Expected %d, got %d", msgcnt,
@@ -1560,7 +1553,7 @@ static void do_test_lock_timeout_redelivery(void) {
         const char *group = "commit-async-lock-timeout";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed1 = 0, consumed2 = 0;
@@ -1582,29 +1575,28 @@ static void do_test_lock_timeout_redelivery(void) {
          * Do NOT call commit_async — records stay ACQUIRED. */
         attempts = 0;
         while (consumed1 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        1,
+                                    rd_kafka_message_delivery_count(rkm) == 1,
                                     "First consume: expected delivery_count=1, "
                                     "got %d at offset %" PRId64,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)),
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset);
+                                    rd_kafka_message_delivery_count(rkm),
+                                    rkm->offset);
                                 consumed1++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("First consume: got %d/%d records (not acknowledged)\n",
@@ -1619,30 +1611,29 @@ static void do_test_lock_timeout_redelivery(void) {
          * redelivered with delivery_count == 2. */
         attempts = 0;
         while (consumed2 == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        2,
+                                    rd_kafka_message_delivery_count(rkm) == 2,
                                     "Second consume: expected "
                                     "delivery_count=2, got %d at "
                                     "offset %" PRId64,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)),
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset);
+                                    rd_kafka_message_delivery_count(rkm),
+                                    rkm->offset);
                                 consumed2++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Second consume: got %d/%d redelivered records\n", consumed2,
@@ -1667,7 +1658,7 @@ static void do_test_commit_async_callback(void) {
         const char *group = "commit-async-callback";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         int consumed              = 0;
@@ -1688,17 +1679,20 @@ static void do_test_commit_async_callback(void) {
 
         /* Consume some messages */
         while (consumed < 20 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed %d messages\n", consumed);
@@ -1744,13 +1738,15 @@ static void do_test_partial_batch_commit_async(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
-        rd_kafka_messages_t *dummy = NULL;
-        test_share_batch_t acc;
+        rd_kafka_messages_t *batches[CONSUME_ARRAY] = {NULL};
+        size_t batch_cnt                            = 0;
+        size_t total                                = 0;
         size_t j;
         test_ack_cb_state_t state = {0};
         const int msg_cnt         = 5;
         int attempts              = 0;
         size_t to_ack_first;
+        size_t acked = 0;
 
         SUB_TEST();
 
@@ -1763,26 +1759,40 @@ static void do_test_partial_batch_commit_async(void) {
         test_share_set_auto_offset_reset(group, "earliest");
         subscribe_consumer(rkshare, &topic, 1);
 
-        test_share_batch_init(&acc, msg_cnt);
+        /* Consume all msg_cnt records (may take multiple polls). Keep each
+         * returned batch alive so the message pointers remain valid for
+         * later acknowledgement. */
+        while (total < (size_t)msg_cnt && attempts++ < 30) {
+                rd_kafka_messages_t *poll_batch = NULL;
 
-        /* Consume all msg_cnt records (may take multiple polls) */
-        while (acc.cnt < (size_t)msg_cnt && attempts++ < 30) {
-                error = test_share_batch_poll(&acc, rkshare, 3000);
-                if (error)
+                error = rd_kafka_share_poll(rkshare, 3000, &poll_batch);
+                if (error) {
                         rd_kafka_error_destroy(error);
+                        continue;
+                }
+                batches[batch_cnt++] = poll_batch;
+                total += rd_kafka_messages_count(poll_batch);
         }
-        TEST_ASSERT(acc.cnt == (size_t)msg_cnt,
-                    "Expected exactly %d records, got %zu", msg_cnt, acc.cnt);
+        TEST_ASSERT(total == (size_t)msg_cnt,
+                    "Expected exactly %d records, got %zu", msg_cnt, total);
 
-        /* Acknowledge first 3 records; leave the remainder un-acked. */
+        /* Acknowledge first 3 records across the accumulated batches; leave
+         * the remainder un-acked. */
         to_ack_first = 3;
-        for (j = 0; j < to_ack_first; j++) {
-                ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, acc.msgs[j],
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "First-half ACCEPT %zu failed: %s", j,
-                            rd_kafka_err2str(ack_err));
+        acked        = 0;
+        for (j = 0; j < batch_cnt && acked < to_ack_first; j++) {
+                size_t k, n = rd_kafka_messages_count(batches[j]);
+                for (k = 0; k < n && acked < to_ack_first; k++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batches[j], k);
+                        ack_err = rd_kafka_share_acknowledge_type(
+                            rkshare, rkm,
+                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                        TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                    "First-half ACCEPT %zu failed: %s", acked,
+                                    rd_kafka_err2str(ack_err));
+                        acked++;
+                }
         }
 
         /* commit_async itself succeeds — it just schedules. */
@@ -1792,8 +1802,8 @@ static void do_test_partial_batch_commit_async(void) {
 
         /* While un-acked records remain in the batch, share_poll must
          * return _STATE rather than proceed. */
-        rd_kafka_error_t *e = rd_kafka_share_poll(rkshare, 1000, &dummy);
-        rd_kafka_messages_destroy(dummy);
+        rd_kafka_messages_t *dummy = NULL;
+        rd_kafka_error_t *e        = rd_kafka_share_poll(rkshare, 1000, &dummy);
         TEST_ASSERT(e != NULL,
                     "Expected share_poll to return _STATE while "
                     "un-acked records remain, got NULL error");
@@ -1803,16 +1813,32 @@ static void do_test_partial_batch_commit_async(void) {
         TEST_SAY("Got expected _STATE from share_poll: %s\n",
                  rd_kafka_error_string(e));
         rd_kafka_error_destroy(e);
+        rd_kafka_messages_destroy(dummy);
 
-        /* Acknowledge the remaining records */
-        for (j = to_ack_first; j < acc.cnt; j++) {
-                ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, acc.msgs[j],
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
-                TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
-                            "Second-half ACCEPT %zu (offset=%" PRId64
-                            ") failed: %s",
-                            j, acc.msgs[j]->offset, rd_kafka_err2str(ack_err));
+        /* Acknowledge the remaining records across the batches. */
+        {
+                size_t seen = 0;
+                for (j = 0; j < batch_cnt; j++) {
+                        size_t k, n = rd_kafka_messages_count(batches[j]);
+                        for (k = 0; k < n; k++) {
+                                rd_kafka_message_t *rkm;
+                                if (seen < to_ack_first) {
+                                        seen++;
+                                        continue;
+                                }
+                                rkm     = rd_kafka_messages_get(batches[j], k);
+                                ack_err = rd_kafka_share_acknowledge_type(
+                                    rkshare, rkm,
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                                TEST_ASSERT(
+                                    ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
+                                    "Second-half ACCEPT %zu (offset=%" PRId64
+                                    ") failed: %s",
+                                    seen, rkm->offset,
+                                    rd_kafka_err2str(ack_err));
+                                seen++;
+                        }
+                }
         }
 
         /* Second commit_async commits the remaining acks */
@@ -1832,13 +1858,15 @@ static void do_test_partial_batch_commit_async(void) {
                         RD_KAFKA_RESP_ERR_NO_ERROR,
                     "Callback errored: %s",
                     rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
-        TEST_ASSERT(state.total_offsets >= acc.cnt,
-                    "Expected callback to report %zu offsets, got %zu", acc.cnt,
+        TEST_ASSERT(state.total_offsets >= (size_t)total,
+                    "Expected callback to report %zu offsets, got %zu", total,
                     state.total_offsets);
         TEST_SAY("Partial commit callbacks=%d, total_offsets=%zu\n",
                  state.callback_cnt, state.total_offsets);
 
-        test_share_batch_destroy(&acc);
+        for (j = 0; j < batch_cnt; j++)
+                rd_kafka_messages_destroy(batches[j]);
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&state);
@@ -1856,7 +1884,7 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
         const char *group = "commit-async-implicit-no-commit";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd, j;
         test_ack_cb_state_t state = {0};
         const int msg_cnt         = 20;
@@ -1878,18 +1906,20 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
          * returns the whole broker-side RecordBatch (so all msg_cnt records
          * arrive in one call), but the loop tolerates split deliveries. */
         while (consumed < msg_cnt && attempts++ < 30) {
-                rd_kafka_messages_destroy(rkmessages);
-                rkmessages = NULL;
-                error      = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd       = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed == msg_cnt,
                     "Expected to consume %d messages, got %d", msg_cnt,
@@ -1899,16 +1929,12 @@ static void do_test_implicit_callback_no_explicit_commit(void) {
          * fire via piggybacked acks on the next ShareFetch. */
         attempts = 10;
         while (attempts-- > 0 && state.callback_cnt == 0) {
-                rd_kafka_messages_destroy(rkmessages);
-                rkmessages = NULL;
-                error      = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd       = rd_kafka_messages_count(rkmessages);
-                (void)rcvd;
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
-        rd_kafka_messages_destroy(rkmessages);
-        rkmessages = NULL;
 
         TEST_ASSERT(state.callback_cnt >= 1,
                     "Expected callback from implicit piggybacked acks (no "
@@ -1941,8 +1967,8 @@ static void do_test_lock_expiry_callback_err(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
-        rd_kafka_messages_t *rkmessages = NULL;
-        size_t rcvd, j;
+        rd_kafka_messages_t *batch = NULL;
+        size_t j;
         size_t consumed           = 0;
         int attempts              = 0;
         test_ack_cb_state_t state = {0};
@@ -1961,22 +1987,20 @@ static void do_test_lock_expiry_callback_err(void) {
 
         /* Consume records (acquires lock) */
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
-                consumed = rcvd;
+                consumed = rd_kafka_messages_count(batch);
         }
         TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
 
         /* Acknowledge all consumed records explicitly */
         for (j = 0; j < consumed; j++) {
-                ack_err = rd_kafka_share_acknowledge_type(
-                    rkshare, rd_kafka_messages_get(rkmessages, j),
-                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                ack_err                 = rd_kafka_share_acknowledge_type(
+                    rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                 TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "ACCEPT failed: %s", rd_kafka_err2str(ack_err));
         }
@@ -2006,6 +2030,9 @@ static void do_test_lock_expiry_callback_err(void) {
                     "Expected INVALID_RECORD_STATE in callback after lock "
                     "expiry, got %s",
                     rd_kafka_err2name(test_ack_cb_state_first_err(&state)));
+
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2052,7 +2079,7 @@ static void do_test_safe_api_from_callback(void) {
         const char *group = "commit-async-safe-api-cb";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd, j;
         int consumed     = 0;
         int second_round = 0;
@@ -2072,17 +2099,20 @@ static void do_test_safe_api_from_callback(void) {
 
         /* First-round consumption */
         while (consumed < 5 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Drive piggyback acks - this fires the callback */
@@ -2100,17 +2130,20 @@ static void do_test_safe_api_from_callback(void) {
         test_produce_msgs_simple(common_producer, topic, 0, 5);
         attempts = 0;
         while (second_round < 5 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 second_round++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(second_round > 0,
                     "Consumer stopped working after callback invocation");
@@ -2157,7 +2190,7 @@ static void do_test_callback_side_effects_dont_break(void) {
         const char *group = "commit-async-side-effect-cb";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd, j;
         int consumed   = 0;
         int post_count = 0;
@@ -2177,17 +2210,20 @@ static void do_test_callback_side_effects_dont_break(void) {
 
         /* Consume the produced records */
         while (consumed < 10 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
 
@@ -2217,17 +2253,20 @@ static void do_test_callback_side_effects_dont_break(void) {
         test_produce_msgs_simple(common_producer, topic, 0, 5);
         attempts = 0;
         while (post_count == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 2000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 post_count++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(post_count > 0,
                     "Consumer stopped working after side-effect callback");
@@ -2245,7 +2284,7 @@ static void do_test_change_callback(void) {
         const char *group = "change-callback";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd, j;
         int consumed                = 0;
         int attempts                = 0;
@@ -2270,21 +2309,22 @@ static void do_test_change_callback(void) {
 
         /* Phase 1: consume the first batch and commit with callback A */
         while (consumed < 20 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed > 0, "Expected to consume some messages");
@@ -2322,21 +2362,22 @@ static void do_test_change_callback(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < 20 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed > 0,
@@ -2382,21 +2423,22 @@ static void do_test_change_callback(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < 20 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed > 0,
                     "Expected to consume some messages after unregister");
@@ -2410,19 +2452,20 @@ static void do_test_change_callback(void) {
          * callback - so we poll manually with a fixed budget. */
         int poll_iters = 20;
         while (poll_iters-- > 0) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 200, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 200, &batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Critical assertion: neither callback should have been invoked
@@ -2487,7 +2530,6 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
 
         /* Try rd_kafka_share_poll - should fail with _STATE */
         error_obj = rd_kafka_share_poll(rkshare, 100, &batch);
-        rd_kafka_messages_destroy(batch);
         if (error_obj &&
             rd_kafka_error_code(error_obj) == RD_KAFKA_RESP_ERR__STATE) {
                 st->rejections++;
@@ -2497,6 +2539,7 @@ reentrancy_check_cb(rd_kafka_share_t *rkshare,
                 if (error_obj)
                         rd_kafka_error_destroy(error_obj);
         }
+        rd_kafka_messages_destroy(batch);
 
         /* Try rd_kafka_share_commit_async - should fail with _STATE */
         error_obj = rd_kafka_share_commit_async(rkshare);
@@ -2556,7 +2599,7 @@ static void do_test_reentrancy_protection(void) {
         const char *group = "reentrancy-protection";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd, j;
         int consumed                   = 0;
         int attempts                   = 0;
@@ -2585,21 +2628,22 @@ static void do_test_reentrancy_protection(void) {
         /* Consume messages to trigger acknowledgement and callback invocation
          */
         while (consumed < 50 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 consumed++;
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed > 0, "Expected to consume some messages");
 

--- a/tests/0174-share_consumer_concurrency.c
+++ b/tests/0174-share_consumer_concurrency.c
@@ -266,16 +266,16 @@ static int consumer_thread_func(void *arg) {
                 if (!keep_running)
                         break;
 
-                rcvd = 0;
-                err  = rd_kafka_share_poll(consumer, 500, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(consumer, 500, &batch);
                 if (err) {
-                        TEST_SAY(
-                            "Consumer thread %d: consume_batch error: %s\n",
-                            args->consumer_id, rd_kafka_error_string(err));
+                        TEST_SAY("Consumer thread %d: share_poll error: %s\n",
+                                 args->consumer_id, rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 /* Per-record atomic step:
                  *   ACK → process (count into shared state under lock) →
@@ -289,6 +289,9 @@ static int consumer_thread_func(void *arg) {
                         rd_kafka_message_t *msg =
                             rd_kafka_messages_get(batch, m);
 
+                        if (!msg)
+                                continue;
+
                         if (msg->err) {
                                 const char *msg_topic =
                                     msg->rkt ? rd_kafka_topic_name(msg->rkt)
@@ -300,7 +303,6 @@ static int consumer_thread_func(void *arg) {
                                     args->consumer_id, msg_topic,
                                     msg->partition, msg->offset,
                                     rd_kafka_err2name(msg->err));
-                                rd_kafka_message_destroy(msg);
                                 continue;
                         }
 
@@ -317,7 +319,6 @@ static int consumer_thread_func(void *arg) {
                                             "for this record\n",
                                             args->consumer_id, msg->offset,
                                             rd_kafka_err2name(ack_err));
-                                        rd_kafka_message_destroy(msg);
                                         continue;
                                 }
                                 acked_in_batch++;
@@ -336,9 +337,10 @@ static int consumer_thread_func(void *arg) {
                                 state->total_consumed++;
                                 mtx_unlock(&state->lock);
                         }
-
-                        rd_kafka_message_destroy(msg);
                 }
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 /* Flush the per-record acks to the broker before the
                  * next consume_batch or stop check. Per-partition

--- a/tests/0174-share_consumer_concurrency.c
+++ b/tests/0174-share_consumer_concurrency.c
@@ -235,7 +235,7 @@ static int consumer_thread_func(void *arg) {
         concurrent_test_state_t *state = args->state;
         rd_kafka_share_t *consumer;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         int t;
         size_t m;
@@ -267,7 +267,8 @@ static int consumer_thread_func(void *arg) {
                         break;
 
                 rcvd = 0;
-                err = rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                err  = rd_kafka_share_poll(consumer, 500, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY(
                             "Consumer thread %d: consume_batch error: %s\n",
@@ -285,7 +286,8 @@ static int consumer_thread_func(void *arg) {
                  *   total_duplicates. The per-batch commit_sync below
                  *   flushes the acks to the broker. */
                 for (m = 0; m < rcvd; m++) {
-                        rd_kafka_message_t *msg = batch[m];
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
 
                         if (msg->err) {
                                 const char *msg_topic =

--- a/tests/0175-share_consumer_groups.c
+++ b/tests/0175-share_consumer_groups.c
@@ -144,7 +144,7 @@ static void subscribe_all_consumers(groups_test_config_t *config,
  */
 static void consume_from_all_groups(groups_test_config_t *config,
                                     groups_test_state_t *state) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         int attempts;
         int g, c;
@@ -175,8 +175,9 @@ static void consume_from_all_groups(groups_test_config_t *config,
                         for (c = 0; c < config->consumers_per_group[g]; c++) {
                                 rcvd = 0;
 
-                                err = rd_kafka_share_consume_batch(
-                                    state->consumers[g][c], 500, batch, &rcvd);
+                                err = rd_kafka_share_poll(
+                                    state->consumers[g][c], 500, &batch);
+                                rcvd = rd_kafka_messages_count(batch);
                                 if (err) {
                                         TEST_SAY(
                                             "Group %d consumer %d: "
@@ -187,9 +188,9 @@ static void consume_from_all_groups(groups_test_config_t *config,
                                 }
 
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!batch[m]->err)
+                                        if (!rd_kafka_messages_get(batch, m)
+                                                 ->err)
                                                 state->consumed[g]++;
-                                        rd_kafka_message_destroy(batch[m]);
                                 }
                                 round_consumed += (int)rcvd;
                         }
@@ -424,7 +425,7 @@ static void do_test_five_groups_same_topic(void) {
 static void do_test_groups_staggered_join(void) {
         rd_kafka_share_t *consumer_a, *consumer_b;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         const char *topic;
         const char *group_a = "share-stagger-A";
@@ -466,8 +467,8 @@ static void do_test_groups_staggered_join(void) {
         while (consumed_a < msg_cnt / 2 && attempts-- > 0) {
                 rcvd = 0;
 
-                err = rd_kafka_share_consume_batch(consumer_a, 1000, batch,
-                                                   &rcvd);
+                err  = rd_kafka_share_poll(consumer_a, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY("Group A: share_consume_batch failed: %s\n",
                                  rd_kafka_error_string(err));
@@ -475,9 +476,8 @@ static void do_test_groups_staggered_join(void) {
                         continue;
                 }
                 for (m = 0; m < rcvd; m++) {
-                        if (!batch[m]->err)
+                        if (!rd_kafka_messages_get(batch, m)->err)
                                 consumed_a++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_SAY("Group A consumed %d so far\n", consumed_a);
@@ -496,13 +496,13 @@ static void do_test_groups_staggered_join(void) {
                 rcvd = 0;
 
                 if (consumed_a < msg_cnt) {
-                        err = rd_kafka_share_consume_batch(consumer_a, 500,
-                                                           batch, &rcvd);
+                        err  = rd_kafka_share_poll(consumer_a, 500, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
                         if (!err) {
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!batch[m]->err)
+                                        if (!rd_kafka_messages_get(batch, m)
+                                                 ->err)
                                                 consumed_a++;
-                                        rd_kafka_message_destroy(batch[m]);
                                 }
                         } else {
                                 TEST_SAY(
@@ -515,13 +515,13 @@ static void do_test_groups_staggered_join(void) {
 
                 rcvd = 0;
                 if (consumed_b < msg_cnt) {
-                        err = rd_kafka_share_consume_batch(consumer_b, 500,
-                                                           batch, &rcvd);
+                        err  = rd_kafka_share_poll(consumer_b, 500, &batch);
+                        rcvd = rd_kafka_messages_count(batch);
                         if (!err) {
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!batch[m]->err)
+                                        if (!rd_kafka_messages_get(batch, m)
+                                                 ->err)
                                                 consumed_b++;
-                                        rd_kafka_message_destroy(batch[m]);
                                 }
                         } else {
                                 TEST_SAY(

--- a/tests/0175-share_consumer_groups.c
+++ b/tests/0175-share_consumer_groups.c
@@ -173,25 +173,26 @@ static void consume_from_all_groups(groups_test_config_t *config,
                         all_done = 0;
 
                         for (c = 0; c < config->consumers_per_group[g]; c++) {
-                                rcvd = 0;
-
                                 err = rd_kafka_share_poll(
                                     state->consumers[g][c], 500, &batch);
-                                rcvd = rd_kafka_messages_count(batch);
                                 if (err) {
                                         TEST_SAY(
                                             "Group %d consumer %d: "
-                                            "share_consume_batch failed: %s\n",
+                                            "share_poll failed: %s\n",
                                             g, c, rd_kafka_error_string(err));
                                         rd_kafka_error_destroy(err);
                                         continue;
                                 }
 
+                                rcvd = rd_kafka_messages_count(batch);
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!rd_kafka_messages_get(batch, m)
-                                                 ->err)
+                                        rd_kafka_message_t *msg =
+                                            rd_kafka_messages_get(batch, m);
+                                        if (msg && !msg->err)
                                                 state->consumed[g]++;
                                 }
+                                rd_kafka_messages_destroy(batch);
+                                batch = NULL;
                                 round_consumed += (int)rcvd;
                         }
                 }
@@ -465,20 +466,22 @@ static void do_test_groups_staggered_join(void) {
         /* Group A consumes half */
         attempts = 30;
         while (consumed_a < msg_cnt / 2 && attempts-- > 0) {
-                rcvd = 0;
-
-                err  = rd_kafka_share_poll(consumer_a, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(consumer_a, 1000, &batch);
                 if (err) {
-                        TEST_SAY("Group A: share_consume_batch failed: %s\n",
+                        TEST_SAY("Group A: share_poll failed: %s\n",
                                  rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (m = 0; m < rcvd; m++) {
-                        if (!rd_kafka_messages_get(batch, m)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
+                        if (msg && !msg->err)
                                 consumed_a++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_SAY("Group A consumed %d so far\n", consumed_a);
 
@@ -493,39 +496,42 @@ static void do_test_groups_staggered_join(void) {
         attempts = 50;
         while ((consumed_a < msg_cnt || consumed_b < msg_cnt) &&
                attempts-- > 0) {
-                rcvd = 0;
-
                 if (consumed_a < msg_cnt) {
-                        err  = rd_kafka_share_poll(consumer_a, 500, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        err = rd_kafka_share_poll(consumer_a, 500, &batch);
                         if (!err) {
+                                rcvd = rd_kafka_messages_count(batch);
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!rd_kafka_messages_get(batch, m)
-                                                 ->err)
+                                        rd_kafka_message_t *msg =
+                                            rd_kafka_messages_get(batch, m);
+                                        if (msg && !msg->err)
                                                 consumed_a++;
                                 }
+                                rd_kafka_messages_destroy(batch);
+                                batch = NULL;
                         } else {
                                 TEST_SAY(
-                                    "Group A: share_consume_batch failed: "
+                                    "Group A: share_poll failed: "
                                     "%s\n",
                                     rd_kafka_error_string(err));
                                 rd_kafka_error_destroy(err);
                         }
                 }
 
-                rcvd = 0;
                 if (consumed_b < msg_cnt) {
-                        err  = rd_kafka_share_poll(consumer_b, 500, &batch);
-                        rcvd = rd_kafka_messages_count(batch);
+                        err = rd_kafka_share_poll(consumer_b, 500, &batch);
                         if (!err) {
+                                rcvd = rd_kafka_messages_count(batch);
                                 for (m = 0; m < rcvd; m++) {
-                                        if (!rd_kafka_messages_get(batch, m)
-                                                 ->err)
+                                        rd_kafka_message_t *msg =
+                                            rd_kafka_messages_get(batch, m);
+                                        if (msg && !msg->err)
                                                 consumed_b++;
                                 }
+                                rd_kafka_messages_destroy(batch);
+                                batch = NULL;
                         } else {
                                 TEST_SAY(
-                                    "Group B: share_consume_batch failed: "
+                                    "Group B: share_poll failed: "
                                     "%s\n",
                                     rd_kafka_error_string(err));
                                 rd_kafka_error_destroy(err);

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -118,7 +118,7 @@ static void do_test_basic_implicit_commit_sync(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -137,18 +137,21 @@ static void do_test_basic_implicit_commit_sync(void) {
 
         /* Consume records */
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed %d messages\n", consumed);
@@ -191,29 +194,28 @@ static void do_test_basic_implicit_commit_sync(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < 5 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 5000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        1,
+                                    rd_kafka_message_delivery_count(rkm) == 1,
                                     "Got redelivered record at offset %" PRId64
                                     " (delivery_count=%d)",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)));
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Verification: got %d messages (expected 5)\n", consumed);
@@ -240,7 +242,7 @@ static void do_test_basic_explicit_commit_sync(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -259,22 +261,23 @@ static void do_test_basic_explicit_commit_sync(void) {
 
         /* Consume records and explicitly ACCEPT each */
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed and acknowledged %d messages\n", consumed);
@@ -317,29 +320,28 @@ static void do_test_basic_explicit_commit_sync(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < 5 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 5000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_ASSERT(
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)) ==
-                                        1,
+                                    rd_kafka_message_delivery_count(rkm) == 1,
                                     "Got redelivered record at offset %" PRId64
                                     " (delivery_count=%d)",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)));
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Verification: got %d messages (expected 5)\n", consumed);
@@ -407,7 +409,7 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -425,18 +427,21 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumer A consumed %d messages\n", consumed);
@@ -459,28 +464,27 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
-        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
-                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
+        TEST_SAY("Consumer B share_poll returned: rcvd=%zu, error=%s\n", rcvd,
+                 error ? rd_kafka_error_string(error) : "none");
         if (error)
                 rd_kafka_error_destroy(error);
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer B got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer B got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         consumed++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
@@ -506,7 +510,7 @@ static void do_test_mixed_ack_types(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -527,47 +531,43 @@ static void do_test_mixed_ack_types(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 /* Skip partial batches — wait for all 10 in one call */
                 if (rcvd < 10) {
-                        for (j = 0; j < rcvd; j++)
-                                continue;
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                        continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
                         rd_kafka_resp_err_t err;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
 
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        if (rkm->err)
                                 continue;
-                        }
 
                         if (consumed < 5) {
                                 /* ACCEPT first 5 */
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j),
+                                    rkshare, rkm,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                         } else if (consumed < 8) {
                                 /* RELEASE next 3 */
-                                released_offsets[released_cnt++] =
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset;
+                                released_offsets[released_cnt++] = rkm->offset;
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j),
+                                    rkshare, rkm,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                         } else {
                                 /* REJECT last 2 */
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j),
+                                    rkshare, rkm,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                         }
 
@@ -575,6 +575,8 @@ static void do_test_mixed_ack_types(void) {
                                     rd_kafka_err2str(err));
                         consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY(
@@ -618,34 +620,31 @@ static void do_test_mixed_ack_types(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < 3 && attempts++ < 10) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 int16_t dc;
                                 int k;
                                 rd_bool_t found = rd_false;
 
-                                dc = rd_kafka_message_delivery_count(
-                                    rd_kafka_messages_get(rkmessages, j));
+                                dc = rd_kafka_message_delivery_count(rkm);
                                 TEST_ASSERT(
                                     dc >= 2,
                                     "Consumer B got record at offset %" PRId64
                                     " with delivery_count=%d, expected >= 2",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    (int)dc);
+                                    rkm->offset, (int)dc);
 
                                 /* Verify it is one of the released offsets */
                                 for (k = 0; k < released_cnt; k++) {
-                                        if (rd_kafka_messages_get(rkmessages, j)
-                                                ->offset ==
+                                        if (rkm->offset ==
                                             released_offsets[k]) {
                                                 found = rd_true;
                                                 break;
@@ -654,12 +653,13 @@ static void do_test_mixed_ack_types(void) {
                                 TEST_ASSERT(found,
                                             "Consumer B got offset %" PRId64
                                             " which was not RELEASE'd",
-                                            rd_kafka_messages_get(rkmessages, j)
-                                                ->offset);
+                                            rkm->offset);
 
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumer B consumed %d messages (expected 3 RELEASE'd)\n",
@@ -690,7 +690,7 @@ static void do_test_multiple_commit_sync_calls(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed                = 0;
@@ -710,22 +710,22 @@ static void do_test_multiple_commit_sync_calls(void) {
 
         /* Consume all 50, commit_sync every 10 records */
         while (consumed < 50 && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                                 acked_since_last_commit++;
                         }
+
                         /* commit_sync every 10 records */
                         if (acked_since_last_commit == 10) {
                                 partitions = NULL;
@@ -796,6 +796,8 @@ static void do_test_multiple_commit_sync_calls(void) {
                                     commit_cnt);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumer A consumed %d messages, %d commit_sync calls\n",
@@ -814,28 +816,27 @@ static void do_test_multiple_commit_sync_calls(void) {
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
-        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
-                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
+        TEST_SAY("Consumer B share_poll returned: rcvd=%zu, error=%s\n", rcvd,
+                 error ? rd_kafka_error_string(error) : "none");
         if (error)
                 rd_kafka_error_destroy(error);
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer B got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer B got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         consumed++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
@@ -882,7 +883,7 @@ static void do_test_multi_topic_partition(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         char *topics[MULTI_TP_TOPICS];
         size_t rcvd;
         size_t j;
@@ -918,13 +919,12 @@ static void do_test_multi_topic_partition(void) {
                 rd_kafka_topic_partition_list_t *batch_tps;
                 int batch_cnt = 0;
 
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 /* Track unique topic-partitions in this batch */
                 batch_tps = rd_kafka_topic_partition_list_new(
@@ -935,26 +935,21 @@ static void do_test_multi_topic_partition(void) {
                         rd_kafka_resp_err_t err;
                         int16_t dc;
                         const char *msg_topic;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
 
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        if (rkm->err)
                                 continue;
-                        }
 
-                        msg_topic = rd_kafka_topic_name(
-                            rd_kafka_messages_get(rkmessages, j)->rkt);
+                        msg_topic = rd_kafka_topic_name(rkm->rkt);
 
                         /* Add to batch TPs if not already present */
                         if (!rd_kafka_topic_partition_list_find(
-                                batch_tps, msg_topic,
-                                rd_kafka_messages_get(rkmessages, j)
-                                    ->partition))
+                                batch_tps, msg_topic, rkm->partition))
                                 rd_kafka_topic_partition_list_add(
-                                    batch_tps, msg_topic,
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->partition);
+                                    batch_tps, msg_topic, rkm->partition);
 
-                        dc = rd_kafka_message_delivery_count(
-                            rd_kafka_messages_get(rkmessages, j));
+                        dc = rd_kafka_message_delivery_count(rkm);
                         if (dc > max_dc_seen)
                                 max_dc_seen = dc;
 
@@ -965,9 +960,8 @@ static void do_test_multi_topic_partition(void) {
                         else
                                 ack_type = get_ack_type(total_consumed);
 
-                        err = rd_kafka_share_acknowledge_type(
-                            rkshare, rd_kafka_messages_get(rkmessages, j),
-                            ack_type);
+                        err = rd_kafka_share_acknowledge_type(rkshare, rkm,
+                                                              ack_type);
                         TEST_ASSERT(!err, "acknowledge_type failed: %s",
                                     rd_kafka_err2str(err));
 
@@ -982,6 +976,8 @@ static void do_test_multi_topic_partition(void) {
                         total_consumed++;
                         batch_cnt++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (batch_cnt == 0) {
                         rd_kafka_topic_partition_list_destroy(batch_tps);
@@ -1225,67 +1221,54 @@ static void do_test_mock_uses_share_acknowledge(void) {
 
         /* Consume all records, ACCEPT each, commit_sync every 10 */
         while (consumed < msgcnt && attempts++ < 30) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd                     = 0;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd;
                 size_t j;
 
                 TEST_SAY(
-                    "Iter %d: calling share_consume_batch "
+                    "Iter %d: calling share_poll "
                     "(consumed=%d/%d, acked_since_last=%d)\n",
                     attempts, consumed, msgcnt, acked_since_last_commit);
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         TEST_SAY(
-                            "Iter %d: share_consume_batch error: %s "
+                            "Iter %d: share_poll error: %s "
                             "(rcvd=%zu)\n",
-                            attempts, rd_kafka_error_string(error), rcvd);
+                            attempts, rd_kafka_error_string(error),
+                            rd_kafka_messages_count(batch));
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
-                TEST_SAY("Iter %d: share_consume_batch returned %zu msg(s)\n",
-                         attempts, rcvd);
+                TEST_SAY("Iter %d: share_poll returned %zu msg(s)\n", attempts,
+                         rcvd);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
                                 TEST_SAY(
                                     "  ACK %s [%" PRId32 "] @ offset %" PRId64
                                     " (delivery_count=%d)\n",
-                                    rd_kafka_topic_name(
-                                        rd_kafka_messages_get(rkmessages, j)
-                                            ->rkt),
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->partition,
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset,
-                                    (int)rd_kafka_message_delivery_count(
-                                        rd_kafka_messages_get(rkmessages, j)));
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                                    rd_kafka_topic_name(rkm->rkt),
+                                    rkm->partition, rkm->offset,
+                                    (int)rd_kafka_message_delivery_count(rkm));
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                                 acked_since_last_commit++;
                         } else {
                                 TEST_SAY(
                                     "  msg #%zu carries error %s on "
                                     "%s [%" PRId32 "] @ %" PRId64 "\n",
-                                    j,
-                                    rd_kafka_err2name(
-                                        rd_kafka_messages_get(rkmessages, j)
-                                            ->err),
-                                    rd_kafka_messages_get(rkmessages, j)->rkt
-                                        ? rd_kafka_topic_name(
-                                              rd_kafka_messages_get(rkmessages,
-                                                                    j)
-                                                  ->rkt)
-                                        : "(no-rkt)",
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->partition,
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset);
+                                    j, rd_kafka_err2name(rkm->err),
+                                    rkm->rkt ? rd_kafka_topic_name(rkm->rkt)
+                                             : "(no-rkt)",
+                                    rkm->partition, rkm->offset);
                         }
+
                         if (acked_since_last_commit == 10) {
                                 partitions = NULL;
                                 TEST_SAY(
@@ -1350,6 +1333,7 @@ static void do_test_mock_uses_share_acknowledge(void) {
                                 acked_since_last_commit = 0;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
         }
 
         TEST_SAY(
@@ -1417,7 +1401,7 @@ static void do_test_mock_commit_sync_timeout(void) {
         const char *topic                           = "mock-cs-timeout";
         const char *t                               = topic;
         const int msgcnt                            = 10;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed;
@@ -1444,22 +1428,23 @@ static void do_test_mock_commit_sync_timeout(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < msgcnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Phase 1: consumed and acknowledged %d messages\n", consumed);
@@ -1537,18 +1522,21 @@ static void do_test_mock_commit_sync_timeout(void) {
         consumed = 0;
         attempts = 0;
         while (attempts++ < 5) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Phase 2: second consumer got %d records (expected 0)\n",
@@ -1573,22 +1561,23 @@ static void do_test_mock_commit_sync_timeout(void) {
         consumed = 0;
         attempts = 0;
         while (consumed < msgcnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Phase 3: consumed %d messages\n", consumed);
@@ -1641,7 +1630,7 @@ static void do_test_mixed_commit_types(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed              = 0;
@@ -1666,19 +1655,18 @@ static void do_test_mixed_commit_types(void) {
         /* Consume all 50 records, ACCEPT each, alternate between
          * commit_async (10 times) and commit_sync (1 time) */
         while (consumed < 50 && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                                 acked_since_last_sync++;
 
@@ -1752,6 +1740,8 @@ static void do_test_mixed_commit_types(void) {
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Final commit_sync for any remaining acks */
@@ -1796,28 +1786,27 @@ static void do_test_mixed_commit_types(void) {
         rkshare = create_share_consumer(group, "implicit");
         subscribe_consumer(rkshare, &topic, 1);
 
-        rcvd  = 0;
-        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
-        TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
-                 rcvd, error ? rd_kafka_error_string(error) : "none");
+        error = rd_kafka_share_poll(rkshare, 15000, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
+        TEST_SAY("Consumer B share_poll returned: rcvd=%zu, error=%s\n", rcvd,
+                 error ? rd_kafka_error_string(error) : "none");
         if (error)
                 rd_kafka_error_destroy(error);
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                        TEST_ASSERT(
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)) == 1,
-                            "Consumer B got redelivered record at "
-                            "offset %" PRId64 " (delivery_count=%d)",
-                            rd_kafka_messages_get(rkmessages, j)->offset,
-                            rd_kafka_message_delivery_count(
-                                rd_kafka_messages_get(rkmessages, j)));
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, j);
+                if (!rkm->err) {
+                        TEST_ASSERT(rd_kafka_message_delivery_count(rkm) == 1,
+                                    "Consumer B got redelivered record at "
+                                    "offset %" PRId64 " (delivery_count=%d)",
+                                    rkm->offset,
+                                    rd_kafka_message_delivery_count(rkm));
                         consumed++;
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
         TEST_ASSERT(consumed == 5, "Expected 5 verification records, got %d",
@@ -1859,8 +1848,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
         const char *topic                           = "mock-cs-dispatch-prio";
         const char *t                               = topic;
         const int msgcnt                            = 30;
-        rd_kafka_messages_t *rkmessages             = NULL;
-        rd_kafka_message_t *msg_handles[30];
+        rd_kafka_messages_t *batch                  = NULL;
+        rd_kafka_messages_t *all_batch              = NULL;
         size_t rcvd;
         size_t j;
         int consumed;
@@ -1886,24 +1875,33 @@ static void do_test_mock_broker_dispatch_priority(void) {
                                              "explicit");
         subscribe_consumer(rkshare, &t, 1);
 
-        /* Consume all 30 records in one batch, keep handles */
+        /* Consume all 30 records in one batch, keep batch alive for
+         * later acknowledge calls. */
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rd_kafka_messages_destroy(rkmessages);
-                rkmessages = NULL;
-                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd       = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        rd_kafka_message_t *m =
-                            rd_kafka_messages_get(rkmessages, j);
-                        if (!m->err && consumed < msgcnt)
-                                msg_handles[consumed++] = m;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err && consumed < msgcnt)
+                                consumed++;
+                }
+
+                if (consumed == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                } else {
+                        all_batch = batch;
+                        batch     = NULL;
                 }
         }
 
@@ -1924,7 +1922,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
         /* ACCEPT first 10, commit_async → sends first
          * ShareAcknowledge (inflight, push entry 1: 2s RTT) */
         for (i = 0; i < 10; i++)
-                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+                rd_kafka_share_acknowledge(rkshare,
+                                           rd_kafka_messages_get(all_batch, i));
 
         error = rd_kafka_share_commit_async(rkshare);
         TEST_ASSERT(!error, "commit_async #1 failed: %s",
@@ -1938,7 +1937,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
         /* ACCEPT next 10, commit_async → broker busy,
          * cached in async_ack_details */
         for (i = 10; i < 20; i++)
-                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+                rd_kafka_share_acknowledge(rkshare,
+                                           rd_kafka_messages_get(all_batch, i));
 
         error = rd_kafka_share_commit_async(rkshare);
         TEST_ASSERT(!error, "commit_async #2 failed: %s",
@@ -1959,7 +1959,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
          *   t=4s:  async completes, sync dispatched (entry 3)
          *   t=5s:  sync timeout fires → TIMED_OUT (5s < 6s) */
         for (i = 20; i < 30; i++)
-                rd_kafka_share_acknowledge(rkshare, msg_handles[i]);
+                rd_kafka_share_acknowledge(rkshare,
+                                           rd_kafka_messages_get(all_batch, i));
 
         TEST_SAY("Calling commit_sync(5000ms)\n");
         t_start      = test_clock();
@@ -2010,8 +2011,9 @@ static void do_test_mock_broker_dispatch_priority(void) {
 
         rd_kafka_topic_partition_list_destroy(partitions);
 
-        /* msg_handles[] elements are owned by rkmessages; that handle is
-         * destroyed at the end of the function. */
+        /* Destroy the held batch (frees all message handles) */
+        rd_kafka_messages_destroy(all_batch);
+        all_batch = NULL;
 
         /* Wait for remaining async to complete */
         rd_sleep(3);
@@ -2028,18 +2030,21 @@ static void do_test_mock_broker_dispatch_priority(void) {
         consumed = 0;
         attempts = 0;
         while (attempts++ < 5) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Second consumer got %d records (expected 0)\n", consumed);
@@ -2048,7 +2053,6 @@ static void do_test_mock_broker_dispatch_priority(void) {
                     "(all acks should have been processed)",
                     consumed);
 
-        rd_kafka_messages_destroy(rkmessages);
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
@@ -2108,7 +2112,7 @@ static void do_test_commit_sync_callback(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         size_t consumed           = 0;
@@ -2129,21 +2133,22 @@ static void do_test_commit_sync_callback(void) {
 
         /* Consume and acknowledge messages */
         while (consumed < 20 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("Consumed and acknowledged %zu messages\n", consumed);
@@ -2192,7 +2197,7 @@ static void do_test_commit_sync_after_topic_deletion(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         rd_kafka_resp_err_t del_err;
         size_t rcvd;
         size_t j;
@@ -2222,17 +2227,20 @@ static void do_test_commit_sync_after_topic_deletion(void) {
 
         /* Consume records (so there's something to commit) */
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
 
@@ -2305,7 +2313,7 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed         = 0;
@@ -2328,22 +2336,22 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed < total_msgs && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (rkm->err)
                                 continue;
-                        }
 
-                        rd_kafka_share_acknowledge(
-                            rkshare, rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_share_acknowledge(rkshare, rkm);
                         consumed++;
+
                         if (consumed <= phase_a) {
                                 /* Phase A: ack 1 -> commit alternates */
                                 if (consumed % 2 == 1) {
@@ -2402,6 +2410,8 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
@@ -2448,7 +2458,7 @@ static void do_test_chaos_alternating_commits(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed         = 0;
@@ -2470,21 +2480,21 @@ static void do_test_chaos_alternating_commits(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed < total_msgs && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (rkm->err)
                                 continue;
-                        }
-                        rd_kafka_share_acknowledge(
-                            rkshare, rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_share_acknowledge(rkshare, rkm);
                         consumed++;
+
                         if (consumed % 2 == 1) {
                                 error = rd_kafka_share_commit_sync(
                                     rkshare, 30000, &partitions);
@@ -2505,6 +2515,8 @@ static void do_test_chaos_alternating_commits(void) {
                                 async_cnt++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
@@ -2550,7 +2562,7 @@ static void do_test_chaos_random_ack_random_commit(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int processed         = 0;
@@ -2582,13 +2594,12 @@ static void do_test_chaos_random_ack_random_commit(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (processed < target && attempts++ < 80) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 /* Drain the entire batch every iteration. Past `target`,
                  * stop driving chaos but still ACCEPT every record so
@@ -2599,17 +2610,17 @@ static void do_test_chaos_random_ack_random_commit(void) {
                         rd_kafka_share_AcknowledgeType_t at;
                         rd_kafka_resp_err_t aerr;
                         int r;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
 
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        if (rkm->err)
                                 continue;
-                        }
 
                         if (processed >= target) {
                                 /* Drain-only path: ACCEPT to release the
                                  * lock without affecting chaos stats. */
                                 aerr = rd_kafka_share_acknowledge_type(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j),
+                                    rkshare, rkm,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(!aerr, "drain ACCEPT failed: %s",
                                             rd_kafka_err2str(aerr));
@@ -2628,8 +2639,8 @@ static void do_test_chaos_random_ack_random_commit(void) {
                                 rejected++;
                         }
 
-                        aerr = rd_kafka_share_acknowledge_type(
-                            rkshare, rd_kafka_messages_get(rkmessages, j), at);
+                        aerr =
+                            rd_kafka_share_acknowledge_type(rkshare, rkm, at);
                         TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
                                     (int)at, rd_kafka_err2str(aerr));
                         processed++;
@@ -2662,6 +2673,8 @@ static void do_test_chaos_random_ack_random_commit(void) {
                                 }
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Final flush. */
@@ -2711,7 +2724,7 @@ static void do_test_chaos_burst_commits(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed  = 0;
@@ -2735,21 +2748,21 @@ static void do_test_chaos_burst_commits(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed < total_msgs && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (rkm->err)
                                 continue;
-                        }
-                        rd_kafka_share_acknowledge(
-                            rkshare, rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_share_acknowledge(rkshare, rkm);
                         consumed++;
+
                         for (b = 0; b < burst_size; b++) {
                                 error = rd_kafka_share_commit_async(rkshare);
                                 TEST_ASSERT(
@@ -2769,6 +2782,8 @@ static void do_test_chaos_burst_commits(void) {
                         partitions = NULL;
                         sync_cnt++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed == total_msgs, "Expected %d records, consumed %d",
@@ -2810,7 +2825,7 @@ static void do_test_chaos_callback_receipt_match(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_messages_t *rkmessages             = NULL;
+        rd_kafka_messages_t *batch                  = NULL;
         size_t rcvd;
         size_t j;
         int consumed           = 0;
@@ -2834,22 +2849,22 @@ static void do_test_chaos_callback_receipt_match(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         while (consumed < total_msgs && attempts++ < 60) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (rkm->err)
                                 continue;
-                        }
-                        rd_kafka_share_acknowledge(
-                            rkshare, rd_kafka_messages_get(rkmessages, j));
+                        rd_kafka_share_acknowledge(rkshare, rkm);
                         consumed++;
                         acked_since_commit++;
+
                         if (acked_since_commit < batch_target)
                                 continue;
 
@@ -2877,6 +2892,8 @@ static void do_test_chaos_callback_receipt_match(void) {
                         acked_since_commit = 0;
                         batch_target       = (batch_target % 5) + 1;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Drain any leftover acked-but-not-committed records. */

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -2010,9 +2010,8 @@ static void do_test_mock_broker_dispatch_priority(void) {
 
         rd_kafka_topic_partition_list_destroy(partitions);
 
-        /* Destroy message handles */
-        for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(msg_handles[i]);
+        /* msg_handles[] elements are owned by rkmessages; that handle is
+         * destroyed at the end of the function. */
 
         /* Wait for remaining async to complete */
         rd_sleep(3);

--- a/tests/0176-share_consumer_commit_sync.c
+++ b/tests/0176-share_consumer_commit_sync.c
@@ -118,7 +118,7 @@ static void do_test_basic_implicit_commit_sync(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -138,17 +138,16 @@ static void do_test_basic_implicit_commit_sync(void) {
         /* Consume records */
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -193,26 +192,27 @@ static void do_test_basic_implicit_commit_sync(void) {
         attempts = 0;
         while (consumed < 5 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 5000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_ASSERT(
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]) == 1,
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        1,
                                     "Got redelivered record at offset %" PRId64
                                     " (delivery_count=%d)",
-                                    rkmessages[j]->offset,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]));
+                                        rd_kafka_messages_get(rkmessages, j)));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -240,7 +240,7 @@ static void do_test_basic_explicit_commit_sync(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -260,20 +260,20 @@ static void do_test_basic_explicit_commit_sync(void) {
         /* Consume records and explicitly ACCEPT each */
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -318,26 +318,27 @@ static void do_test_basic_explicit_commit_sync(void) {
         attempts = 0;
         while (consumed < 5 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 5000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 5000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_ASSERT(
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]) == 1,
+                                        rd_kafka_messages_get(rkmessages, j)) ==
+                                        1,
                                     "Got redelivered record at offset %" PRId64
                                     " (delivery_count=%d)",
-                                    rkmessages[j]->offset,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
                                     rd_kafka_message_delivery_count(
-                                        rkmessages[j]));
+                                        rd_kafka_messages_get(rkmessages, j)));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -406,7 +407,7 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -425,17 +426,16 @@ static void do_test_commit_sync_prevents_redelivery(void) {
 
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -460,7 +460,8 @@ static void do_test_commit_sync_prevents_redelivery(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error)
@@ -468,16 +469,17 @@ static void do_test_commit_sync_prevents_redelivery(void) {
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer B got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         consumed++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
@@ -504,7 +506,7 @@ static void do_test_mixed_ack_types(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed = 0;
@@ -526,8 +528,8 @@ static void do_test_mixed_ack_types(void) {
 
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -536,41 +538,42 @@ static void do_test_mixed_ack_types(void) {
                 /* Skip partial batches — wait for all 10 in one call */
                 if (rcvd < 10) {
                         for (j = 0; j < rcvd; j++)
-                                rd_kafka_message_destroy(rkmessages[j]);
-                        continue;
+                                continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
                         rd_kafka_resp_err_t err;
 
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
 
                         if (consumed < 5) {
                                 /* ACCEPT first 5 */
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare, rkmessages[j],
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                         } else if (consumed < 8) {
                                 /* RELEASE next 3 */
                                 released_offsets[released_cnt++] =
-                                    rkmessages[j]->offset;
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset;
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare, rkmessages[j],
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                         } else {
                                 /* REJECT last 2 */
                                 err = rd_kafka_share_acknowledge_type(
-                                    rkshare, rkmessages[j],
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                         }
 
                         TEST_ASSERT(!err, "acknowledge_type failed: %s",
                                     rd_kafka_err2str(err));
                         consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -616,30 +619,33 @@ static void do_test_mixed_ack_types(void) {
         attempts = 0;
         while (consumed < 3 && attempts++ < 10) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 int16_t dc;
                                 int k;
                                 rd_bool_t found = rd_false;
 
                                 dc = rd_kafka_message_delivery_count(
-                                    rkmessages[j]);
+                                    rd_kafka_messages_get(rkmessages, j));
                                 TEST_ASSERT(
                                     dc >= 2,
                                     "Consumer B got record at offset %" PRId64
                                     " with delivery_count=%d, expected >= 2",
-                                    rkmessages[j]->offset, (int)dc);
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
+                                    (int)dc);
 
                                 /* Verify it is one of the released offsets */
                                 for (k = 0; k < released_cnt; k++) {
-                                        if (rkmessages[j]->offset ==
+                                        if (rd_kafka_messages_get(rkmessages, j)
+                                                ->offset ==
                                             released_offsets[k]) {
                                                 found = rd_true;
                                                 break;
@@ -648,11 +654,11 @@ static void do_test_mixed_ack_types(void) {
                                 TEST_ASSERT(found,
                                             "Consumer B got offset %" PRId64
                                             " which was not RELEASE'd",
-                                            rkmessages[j]->offset);
+                                            rd_kafka_messages_get(rkmessages, j)
+                                                ->offset);
 
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -684,7 +690,7 @@ static void do_test_multiple_commit_sync_calls(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed                = 0;
@@ -705,22 +711,21 @@ static void do_test_multiple_commit_sync_calls(void) {
         /* Consume all 50, commit_sync every 10 records */
         while (consumed < 50 && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                                 acked_since_last_commit++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         /* commit_sync every 10 records */
                         if (acked_since_last_commit == 10) {
                                 partitions = NULL;
@@ -810,7 +815,8 @@ static void do_test_multiple_commit_sync_calls(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error)
@@ -818,16 +824,17 @@ static void do_test_multiple_commit_sync_calls(void) {
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer B got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         consumed++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
@@ -875,7 +882,7 @@ static void do_test_multi_topic_partition(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         char *topics[MULTI_TP_TOPICS];
         size_t rcvd;
         size_t j;
@@ -912,8 +919,8 @@ static void do_test_multi_topic_partition(void) {
                 int batch_cnt = 0;
 
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -929,21 +936,25 @@ static void do_test_multi_topic_partition(void) {
                         int16_t dc;
                         const char *msg_topic;
 
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
 
-                        msg_topic = rd_kafka_topic_name(rkmessages[j]->rkt);
+                        msg_topic = rd_kafka_topic_name(
+                            rd_kafka_messages_get(rkmessages, j)->rkt);
 
                         /* Add to batch TPs if not already present */
                         if (!rd_kafka_topic_partition_list_find(
-                                batch_tps, msg_topic, rkmessages[j]->partition))
+                                batch_tps, msg_topic,
+                                rd_kafka_messages_get(rkmessages, j)
+                                    ->partition))
                                 rd_kafka_topic_partition_list_add(
                                     batch_tps, msg_topic,
-                                    rkmessages[j]->partition);
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->partition);
 
-                        dc = rd_kafka_message_delivery_count(rkmessages[j]);
+                        dc = rd_kafka_message_delivery_count(
+                            rd_kafka_messages_get(rkmessages, j));
                         if (dc > max_dc_seen)
                                 max_dc_seen = dc;
 
@@ -955,7 +966,8 @@ static void do_test_multi_topic_partition(void) {
                                 ack_type = get_ack_type(total_consumed);
 
                         err = rd_kafka_share_acknowledge_type(
-                            rkshare, rkmessages[j], ack_type);
+                            rkshare, rd_kafka_messages_get(rkmessages, j),
+                            ack_type);
                         TEST_ASSERT(!err, "acknowledge_type failed: %s",
                                     rd_kafka_err2str(err));
 
@@ -969,7 +981,6 @@ static void do_test_multi_topic_partition(void) {
 
                         total_consumed++;
                         batch_cnt++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
 
                 if (batch_cnt == 0) {
@@ -1214,8 +1225,8 @@ static void do_test_mock_uses_share_acknowledge(void) {
 
         /* Consume all records, ACCEPT each, commit_sync every 10 */
         while (consumed < msgcnt && attempts++ < 30) {
-                rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-                size_t rcvd = 0;
+                rd_kafka_messages_t *rkmessages = NULL;
+                size_t rcvd                     = 0;
                 size_t j;
 
                 TEST_SAY(
@@ -1223,8 +1234,8 @@ static void do_test_mock_uses_share_acknowledge(void) {
                     "(consumed=%d/%d, acked_since_last=%d)\n",
                     attempts, consumed, msgcnt, acked_since_last_commit);
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         TEST_SAY(
                             "Iter %d: share_consume_batch error: %s "
@@ -1238,32 +1249,43 @@ static void do_test_mock_uses_share_acknowledge(void) {
                          attempts, rcvd);
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_SAY(
                                     "  ACK %s [%" PRId32 "] @ offset %" PRId64
                                     " (delivery_count=%d)\n",
-                                    rd_kafka_topic_name(rkmessages[j]->rkt),
-                                    rkmessages[j]->partition,
-                                    rkmessages[j]->offset,
+                                    rd_kafka_topic_name(
+                                        rd_kafka_messages_get(rkmessages, j)
+                                            ->rkt),
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->partition,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset,
                                     (int)rd_kafka_message_delivery_count(
-                                        rkmessages[j]));
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                                        rd_kafka_messages_get(rkmessages, j)));
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                                 acked_since_last_commit++;
                         } else {
                                 TEST_SAY(
                                     "  msg #%zu carries error %s on "
                                     "%s [%" PRId32 "] @ %" PRId64 "\n",
-                                    j, rd_kafka_err2name(rkmessages[j]->err),
-                                    rkmessages[j]->rkt ? rd_kafka_topic_name(
-                                                             rkmessages[j]->rkt)
-                                                       : "(no-rkt)",
-                                    rkmessages[j]->partition,
-                                    rkmessages[j]->offset);
+                                    j,
+                                    rd_kafka_err2name(
+                                        rd_kafka_messages_get(rkmessages, j)
+                                            ->err),
+                                    rd_kafka_messages_get(rkmessages, j)->rkt
+                                        ? rd_kafka_topic_name(
+                                              rd_kafka_messages_get(rkmessages,
+                                                                    j)
+                                                  ->rkt)
+                                        : "(no-rkt)",
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->partition,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset);
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         if (acked_since_last_commit == 10) {
                                 partitions = NULL;
                                 TEST_SAY(
@@ -1395,7 +1417,7 @@ static void do_test_mock_commit_sync_timeout(void) {
         const char *topic                           = "mock-cs-timeout";
         const char *t                               = topic;
         const int msgcnt                            = 10;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed;
@@ -1423,20 +1445,20 @@ static void do_test_mock_commit_sync_timeout(void) {
         attempts = 0;
         while (consumed < msgcnt && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1516,17 +1538,16 @@ static void do_test_mock_commit_sync_timeout(void) {
         attempts = 0;
         while (attempts++ < 5) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1553,20 +1574,20 @@ static void do_test_mock_commit_sync_timeout(void) {
         attempts = 0;
         while (consumed < msgcnt && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1620,7 +1641,7 @@ static void do_test_mixed_commit_types(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed              = 0;
@@ -1646,17 +1667,18 @@ static void do_test_mixed_commit_types(void) {
          * commit_async (10 times) and commit_sync (1 time) */
         while (consumed < 50 && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                                 acked_since_last_sync++;
 
@@ -1729,7 +1751,6 @@ static void do_test_mixed_commit_types(void) {
                                         acked_since_last_sync = 0;
                                 }
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -1776,7 +1797,8 @@ static void do_test_mixed_commit_types(void) {
         subscribe_consumer(rkshare, &topic, 1);
 
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 15000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 15000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_SAY("Consumer B consume_batch returned: rcvd=%zu, error=%s\n",
                  rcvd, error ? rd_kafka_error_string(error) : "none");
         if (error)
@@ -1784,16 +1806,17 @@ static void do_test_mixed_commit_types(void) {
 
         consumed = 0;
         for (j = 0; j < rcvd; j++) {
-                if (!rkmessages[j]->err) {
+                if (!rd_kafka_messages_get(rkmessages, j)->err) {
                         TEST_ASSERT(
-                            rd_kafka_message_delivery_count(rkmessages[j]) == 1,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)) == 1,
                             "Consumer B got redelivered record at "
                             "offset %" PRId64 " (delivery_count=%d)",
-                            rkmessages[j]->offset,
-                            rd_kafka_message_delivery_count(rkmessages[j]));
+                            rd_kafka_messages_get(rkmessages, j)->offset,
+                            rd_kafka_message_delivery_count(
+                                rd_kafka_messages_get(rkmessages, j)));
                         consumed++;
                 }
-                rd_kafka_message_destroy(rkmessages[j]);
         }
 
         TEST_SAY("Consumer B got %d messages (expected 5)\n", consumed);
@@ -1836,7 +1859,7 @@ static void do_test_mock_broker_dispatch_priority(void) {
         const char *topic                           = "mock-cs-dispatch-prio";
         const char *t                               = topic;
         const int msgcnt                            = 30;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         rd_kafka_message_t *msg_handles[30];
         size_t rcvd;
         size_t j;
@@ -1867,19 +1890,20 @@ static void do_test_mock_broker_dispatch_priority(void) {
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd       = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err && consumed < msgcnt)
-                                msg_handles[consumed++] = rkmessages[j];
-                        else
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        rd_kafka_message_t *m =
+                            rd_kafka_messages_get(rkmessages, j);
+                        if (!m->err && consumed < msgcnt)
+                                msg_handles[consumed++] = m;
                 }
         }
 
@@ -2006,17 +2030,16 @@ static void do_test_mock_broker_dispatch_priority(void) {
         attempts = 0;
         while (attempts++ < 5) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2026,6 +2049,7 @@ static void do_test_mock_broker_dispatch_priority(void) {
                     "(all acks should have been processed)",
                     consumed);
 
+        rd_kafka_messages_destroy(rkmessages);
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
@@ -2085,7 +2109,7 @@ static void do_test_commit_sync_callback(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         size_t consumed           = 0;
@@ -2107,19 +2131,19 @@ static void do_test_commit_sync_callback(void) {
         /* Consume and acknowledge messages */
         while (consumed < 20 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
 
@@ -2169,7 +2193,7 @@ static void do_test_commit_sync_after_topic_deletion(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         rd_kafka_resp_err_t del_err;
         size_t rcvd;
         size_t j;
@@ -2200,16 +2224,15 @@ static void do_test_commit_sync_after_topic_deletion(void) {
         /* Consume records (so there's something to commit) */
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed > 0, "Expected to consume records, got 0");
@@ -2283,7 +2306,7 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed         = 0;
@@ -2307,23 +2330,21 @@ static void do_test_chaos_111_ack_commit_interleave(void) {
 
         while (consumed < total_msgs && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
 
-                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        rd_kafka_share_acknowledge(
+                            rkshare, rd_kafka_messages_get(rkmessages, j));
                         consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         if (consumed <= phase_a) {
                                 /* Phase A: ack 1 -> commit alternates */
                                 if (consumed % 2 == 1) {
@@ -2428,7 +2449,7 @@ static void do_test_chaos_alternating_commits(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed         = 0;
@@ -2451,22 +2472,20 @@ static void do_test_chaos_alternating_commits(void) {
 
         while (consumed < total_msgs && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
-                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        rd_kafka_share_acknowledge(
+                            rkshare, rd_kafka_messages_get(rkmessages, j));
                         consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         if (consumed % 2 == 1) {
                                 error = rd_kafka_share_commit_sync(
                                     rkshare, 30000, &partitions);
@@ -2532,7 +2551,7 @@ static void do_test_chaos_random_ack_random_commit(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int processed         = 0;
@@ -2565,8 +2584,8 @@ static void do_test_chaos_random_ack_random_commit(void) {
 
         while (processed < target && attempts++ < 80) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -2582,8 +2601,7 @@ static void do_test_chaos_random_ack_random_commit(void) {
                         rd_kafka_resp_err_t aerr;
                         int r;
 
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
 
@@ -2591,11 +2609,11 @@ static void do_test_chaos_random_ack_random_commit(void) {
                                 /* Drain-only path: ACCEPT to release the
                                  * lock without affecting chaos stats. */
                                 aerr = rd_kafka_share_acknowledge_type(
-                                    rkshare, rkmessages[j],
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(!aerr, "drain ACCEPT failed: %s",
                                             rd_kafka_err2str(aerr));
-                                rd_kafka_message_destroy(rkmessages[j]);
                                 continue;
                         }
 
@@ -2612,10 +2630,9 @@ static void do_test_chaos_random_ack_random_commit(void) {
                         }
 
                         aerr = rd_kafka_share_acknowledge_type(
-                            rkshare, rkmessages[j], at);
+                            rkshare, rd_kafka_messages_get(rkmessages, j), at);
                         TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
                                     (int)at, rd_kafka_err2str(aerr));
-                        rd_kafka_message_destroy(rkmessages[j]);
                         processed++;
 
                         /* ~1 in 3 records: issue a commit. Sync vs async
@@ -2695,7 +2712,7 @@ static void do_test_chaos_burst_commits(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed  = 0;
@@ -2720,22 +2737,20 @@ static void do_test_chaos_burst_commits(void) {
 
         while (consumed < total_msgs && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
-                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        rd_kafka_share_acknowledge(
+                            rkshare, rd_kafka_messages_get(rkmessages, j));
                         consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         for (b = 0; b < burst_size; b++) {
                                 error = rd_kafka_share_commit_async(rkshare);
                                 TEST_ASSERT(
@@ -2796,7 +2811,7 @@ static void do_test_chaos_callback_receipt_match(void) {
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages             = NULL;
         size_t rcvd;
         size_t j;
         int consumed           = 0;
@@ -2821,23 +2836,21 @@ static void do_test_chaos_callback_receipt_match(void) {
 
         while (consumed < total_msgs && attempts++ < 60) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
                 for (j = 0; j < rcvd && consumed < total_msgs; j++) {
-                        if (rkmessages[j]->err) {
-                                rd_kafka_message_destroy(rkmessages[j]);
+                        if (rd_kafka_messages_get(rkmessages, j)->err) {
                                 continue;
                         }
-                        rd_kafka_share_acknowledge(rkshare, rkmessages[j]);
+                        rd_kafka_share_acknowledge(
+                            rkshare, rd_kafka_messages_get(rkmessages, j));
                         consumed++;
                         acked_since_commit++;
-                        rd_kafka_message_destroy(rkmessages[j]);
-
                         if (acked_since_commit < batch_target)
                                 continue;
 

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -108,26 +108,25 @@ static int consume_share_messages(rd_kafka_share_t *rkshare,
                                   int expected_cnt,
                                   int max_attempts,
                                   int poll_timeout_ms) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        int consumed = 0;
-        int attempts = max_attempts;
+        rd_kafka_messages_t *batch = NULL;
+        int consumed               = 0;
+        int attempts               = max_attempts;
 
         while (consumed < expected_cnt && attempts-- > 0) {
                 size_t rcvd = 0;
                 size_t i;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(rkshare, poll_timeout_ms,
-                                                   batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
+                        if (!rd_kafka_messages_get(batch, i)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[i]);
                 }
         }
 
@@ -144,26 +143,25 @@ static int consume_share_messages(rd_kafka_share_t *rkshare,
 static int consume_share_no_msgs(rd_kafka_share_t *rkshare,
                                  int poll_attempts,
                                  int poll_timeout_ms) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        int consumed = 0;
-        int attempts = poll_attempts;
+        rd_kafka_messages_t *batch = NULL;
+        int consumed               = 0;
+        int attempts               = poll_attempts;
 
         while (attempts-- > 0) {
                 size_t rcvd = 0;
                 size_t i;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(rkshare, poll_timeout_ms,
-                                                   batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
+                        if (!rd_kafka_messages_get(batch, i)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[i]);
                 }
         }
 
@@ -192,8 +190,8 @@ static void consume_and_verify_offsets(rd_kafka_share_t *rkshare,
                                        const int64_t *forbidden_offsets,
                                        int forbidden_cnt,
                                        const char *isolation_level) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        int attempts = 50;
+        rd_kafka_messages_t *batch = NULL;
+        int attempts               = 50;
         int64_t received_offsets[10];
         int consumed = 0;
         int i, j;
@@ -206,20 +204,24 @@ static void consume_and_verify_offsets(rd_kafka_share_t *rkshare,
                 size_t rcvd = 0;
                 rd_kafka_error_t *err;
 
-                err = rd_kafka_share_consume_batch(rkshare, 3000, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 3000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
                 for (i = 0; i < (int)rcvd; i++) {
-                        if (!batch[i]->err && consumed < 10) {
-                                received_offsets[consumed] = batch[i]->offset;
-                                TEST_SAY("  Message %d: offset=%" PRId64 "\n",
-                                         consumed, batch[i]->offset);
+                        if (!rd_kafka_messages_get(batch, i)->err &&
+                            consumed < 10) {
+                                received_offsets[consumed] =
+                                    rd_kafka_messages_get(batch, i)->offset;
+                                TEST_SAY(
+                                    "  Message %d: offset=%" PRId64 "\n",
+                                    consumed,
+                                    rd_kafka_messages_get(batch, i)->offset);
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[i]);
                 }
         }
 
@@ -1140,7 +1142,7 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         const char *txn_id = "txn-dynamic-c-uc-release";
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
         size_t rcvd, j;
@@ -1167,21 +1169,23 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                TEST_ASSERT(batch[j]->offset == 0,
-                                            "Phase 1: expected offset 0, "
-                                            "got %" PRId64,
-                                            batch[j]->offset);
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_messages_get(batch, j)->offset ==
+                                        0,
+                                    "Phase 1: expected offset 0, "
+                                    "got %" PRId64,
+                                    rd_kafka_messages_get(batch, j)->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1189,7 +1193,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                             rd_kafka_err2name(ack_err));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
         TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
@@ -1203,16 +1206,17 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         produce_msg_txn(producer, topic, "Message 2", rd_false);
         attempts = 10;
         while (attempts-- > 0) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 500, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
                 for (j = 0; j < rcvd; j++) {
-                        TEST_ASSERT(batch[j]->err || batch[j]->offset != 2,
-                                    "Phase 2: aborted Msg2 leaked at "
-                                    "offset 2 in read_committed");
-                        rd_kafka_message_destroy(batch[j]);
+                        TEST_ASSERT(
+                            rd_kafka_messages_get(batch, j)->err ||
+                                rd_kafka_messages_get(batch, j)->offset != 2,
+                            "Phase 2: aborted Msg2 leaked at "
+                            "offset 2 in read_committed");
                 }
         }
 
@@ -1222,21 +1226,23 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                TEST_ASSERT(batch[j]->offset == 4,
-                                            "Phase 3: expected offset 4 "
-                                            "(Msg3), got %" PRId64,
-                                            batch[j]->offset);
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_messages_get(batch, j)->offset ==
+                                        4,
+                                    "Phase 3: expected offset 4 "
+                                    "(Msg3), got %" PRId64,
+                                    rd_kafka_messages_get(batch, j)->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1244,7 +1250,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                             rd_kafka_err2name(ack_err));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
         TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
@@ -1263,32 +1268,32 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         produce_msg_txn(producer, topic, "Message 4", rd_false);
         attempts = 3;
         while (attempts-- > 0) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 1000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 1000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
+                        if (!rd_kafka_messages_get(batch, j)->err) {
                                 /* Should only be Msg3 (offset 4) re-delivered;
                                  * Msg4 at offset 6 is aborted in
                                  * read_committed.
                                  */
                                 TEST_ASSERT(
-                                    batch[j]->offset == 4,
+                                    rd_kafka_messages_get(batch, j)->offset ==
+                                        4,
                                     "Phase 4: unexpected offset %" PRId64,
-                                    batch[j]->offset);
+                                    rd_kafka_messages_get(batch, j)->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
                                             "Phase 4 RELEASE failed: %s",
                                             rd_kafka_err2name(ack_err));
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
                 if (rcvd > 0) {
                         error = rd_kafka_share_commit_async(consumer);
@@ -1315,20 +1320,21 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         while (attempts++ < 60) {
                 int new_acks = 0;
                 rd_bool_t all_seen;
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                int64_t off = batch[j]->offset;
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                int64_t off =
+                                    rd_kafka_messages_get(batch, j)->offset;
                                 if (off >= 0 && off < 20)
                                         seen[off] = rd_true;
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1336,7 +1342,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                             rd_kafka_err2name(ack_err));
                                 new_acks++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
                 if (new_acks > 0) {
                         error = rd_kafka_share_commit_async(consumer);
@@ -1392,7 +1397,7 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         const char *txn_id = "txn-dynamic-c-uc-reject";
         rd_kafka_t *producer;
         rd_kafka_share_t *consumer;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t ack_err;
         size_t rcvd, j;
@@ -1419,21 +1424,23 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                TEST_ASSERT(batch[j]->offset == 0,
-                                            "Phase 1: expected offset 0, "
-                                            "got %" PRId64,
-                                            batch[j]->offset);
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_messages_get(batch, j)->offset ==
+                                        0,
+                                    "Phase 1: expected offset 0, "
+                                    "got %" PRId64,
+                                    rd_kafka_messages_get(batch, j)->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1441,7 +1448,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                             rd_kafka_err2name(ack_err));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
         TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
@@ -1454,16 +1460,17 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         produce_msg_txn(producer, topic, "Message 2", rd_false);
         attempts = 10;
         while (attempts-- > 0) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 500, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
                 for (j = 0; j < rcvd; j++) {
-                        TEST_ASSERT(batch[j]->err || batch[j]->offset != 2,
-                                    "Phase 2: aborted Msg2 leaked at "
-                                    "offset 2 in read_committed");
-                        rd_kafka_message_destroy(batch[j]);
+                        TEST_ASSERT(
+                            rd_kafka_messages_get(batch, j)->err ||
+                                rd_kafka_messages_get(batch, j)->offset != 2,
+                            "Phase 2: aborted Msg2 leaked at "
+                            "offset 2 in read_committed");
                 }
         }
 
@@ -1473,21 +1480,23 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         consumed = 0;
         attempts = 0;
         while (consumed == 0 && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                TEST_ASSERT(batch[j]->offset == 4,
-                                            "Phase 3: expected offset 4 "
-                                            "(Msg3), got %" PRId64,
-                                            batch[j]->offset);
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                TEST_ASSERT(
+                                    rd_kafka_messages_get(batch, j)->offset ==
+                                        4,
+                                    "Phase 3: expected offset 4 "
+                                    "(Msg3), got %" PRId64,
+                                    rd_kafka_messages_get(batch, j)->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1495,7 +1504,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                             rd_kafka_err2name(ack_err));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
         TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
@@ -1509,21 +1517,20 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         produce_msg_txn(producer, topic, "Message 4", rd_false);
         attempts = 20;
         while (attempts-- > 0) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 500, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 500, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
+                        if (!rd_kafka_messages_get(batch, j)->err) {
                                 TEST_FAIL(
                                     "Phase 4: unexpected record at "
                                     "offset %" PRId64
                                     " (Msg3 was REJECTed, Msg4 is "
                                     "aborted in read_committed)",
-                                    batch[j]->offset);
+                                    rd_kafka_messages_get(batch, j)->offset);
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
         }
 
@@ -1545,16 +1552,17 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         while (attempts++ < 60) {
                 int new_acks = 0;
                 rd_bool_t all_seen;
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 2000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!batch[j]->err) {
-                                int64_t off = batch[j]->offset;
+                        if (!rd_kafka_messages_get(batch, j)->err) {
+                                int64_t off =
+                                    rd_kafka_messages_get(batch, j)->offset;
                                 TEST_ASSERT(off != 4,
                                             "Phase 7: Msg3 (offset 4) "
                                             "should not be redelivered "
@@ -1562,7 +1570,7 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                 if (off >= 0 && off < 20)
                                         seen[off] = rd_true;
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, batch[j],
+                                    consumer, rd_kafka_messages_get(batch, j),
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1570,7 +1578,6 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                             rd_kafka_err2name(ack_err));
                                 new_acks++;
                         }
-                        rd_kafka_message_destroy(batch[j]);
                 }
                 if (new_acks > 0) {
                         error = rd_kafka_share_commit_async(consumer);

--- a/tests/0177-share_consumer_transactions.c
+++ b/tests/0177-share_consumer_transactions.c
@@ -117,17 +117,21 @@ static int consume_share_messages(rd_kafka_share_t *rkshare,
                 size_t i;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
-                        if (!rd_kafka_messages_get(batch, i)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+                        if (!msg->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         return consumed;
@@ -152,17 +156,21 @@ static int consume_share_no_msgs(rd_kafka_share_t *rkshare,
                 size_t i;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, poll_timeout_ms, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
-                        if (!rd_kafka_messages_get(batch, i)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+                        if (!msg->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         return consumed;
@@ -204,25 +212,25 @@ static void consume_and_verify_offsets(rd_kafka_share_t *rkshare,
                 size_t rcvd = 0;
                 rd_kafka_error_t *err;
 
-                err  = rd_kafka_share_poll(rkshare, 3000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < (int)rcvd; i++) {
-                        if (!rd_kafka_messages_get(batch, i)->err &&
-                            consumed < 10) {
-                                received_offsets[consumed] =
-                                    rd_kafka_messages_get(batch, i)->offset;
-                                TEST_SAY(
-                                    "  Message %d: offset=%" PRId64 "\n",
-                                    consumed,
-                                    rd_kafka_messages_get(batch, i)->offset);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+                        if (!msg->err && consumed < 10) {
+                                received_offsets[consumed] = msg->offset;
+                                TEST_SAY("  Message %d: offset=%" PRId64 "\n",
+                                         consumed, msg->offset);
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Verify no forbidden offsets were received */
@@ -1171,21 +1179,21 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, j)->offset ==
-                                        0,
-                                    "Phase 1: expected offset 0, "
-                                    "got %" PRId64,
-                                    rd_kafka_messages_get(batch, j)->offset);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                TEST_ASSERT(msg->offset == 0,
+                                            "Phase 1: expected offset 0, "
+                                            "got %" PRId64,
+                                            msg->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1194,6 +1202,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
                     consumed);
@@ -1208,16 +1218,18 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         while (attempts-- > 0) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 500, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        TEST_ASSERT(
-                            rd_kafka_messages_get(batch, j)->err ||
-                                rd_kafka_messages_get(batch, j)->offset != 2,
-                            "Phase 2: aborted Msg2 leaked at "
-                            "offset 2 in read_committed");
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        TEST_ASSERT(msg->err || msg->offset != 2,
+                                    "Phase 2: aborted Msg2 leaked at "
+                                    "offset 2 in read_committed");
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Phase 3: committed Msg3 -> RELEASE */
@@ -1228,21 +1240,21 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, j)->offset ==
-                                        4,
-                                    "Phase 3: expected offset 4 "
-                                    "(Msg3), got %" PRId64,
-                                    rd_kafka_messages_get(batch, j)->offset);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                TEST_ASSERT(msg->offset == 4,
+                                            "Phase 3: expected offset 4 "
+                                            "(Msg3), got %" PRId64,
+                                            msg->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1251,6 +1263,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
                     consumed);
@@ -1270,24 +1284,25 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
         while (attempts-- > 0) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 1000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
                                 /* Should only be Msg3 (offset 4) re-delivered;
                                  * Msg4 at offset 6 is aborted in
                                  * read_committed.
                                  */
                                 TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, j)->offset ==
-                                        4,
+                                    msg->offset == 4,
                                     "Phase 4: unexpected offset %" PRId64,
-                                    rd_kafka_messages_get(batch, j)->offset);
+                                    msg->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1295,6 +1310,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                             rd_kafka_err2name(ack_err));
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (rcvd > 0) {
                         error = rd_kafka_share_commit_async(consumer);
                         if (error)
@@ -1322,19 +1339,20 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                 rd_bool_t all_seen;
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                int64_t off =
-                                    rd_kafka_messages_get(batch, j)->offset;
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                int64_t off = msg->offset;
                                 if (off >= 0 && off < 20)
                                         seen[off] = rd_true;
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1343,6 +1361,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_release(void) {
                                 new_acks++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (new_acks > 0) {
                         error = rd_kafka_share_commit_async(consumer);
                         if (error)
@@ -1426,21 +1446,21 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, j)->offset ==
-                                        0,
-                                    "Phase 1: expected offset 0, "
-                                    "got %" PRId64,
-                                    rd_kafka_messages_get(batch, j)->offset);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                TEST_ASSERT(msg->offset == 0,
+                                            "Phase 1: expected offset 0, "
+                                            "got %" PRId64,
+                                            msg->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1449,6 +1469,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed == 1, "Phase 1: expected 1 record, got %d",
                     consumed);
@@ -1462,16 +1484,18 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         while (attempts-- > 0) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 500, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        TEST_ASSERT(
-                            rd_kafka_messages_get(batch, j)->err ||
-                                rd_kafka_messages_get(batch, j)->offset != 2,
-                            "Phase 2: aborted Msg2 leaked at "
-                            "offset 2 in read_committed");
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        TEST_ASSERT(msg->err || msg->offset != 2,
+                                    "Phase 2: aborted Msg2 leaked at "
+                                    "offset 2 in read_committed");
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Phase 3: committed Msg3 -> REJECT */
@@ -1482,21 +1506,21 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         while (consumed == 0 && attempts++ < 30) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                TEST_ASSERT(
-                                    rd_kafka_messages_get(batch, j)->offset ==
-                                        4,
-                                    "Phase 3: expected offset 4 "
-                                    "(Msg3), got %" PRId64,
-                                    rd_kafka_messages_get(batch, j)->offset);
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                TEST_ASSERT(msg->offset == 4,
+                                            "Phase 3: expected offset 4 "
+                                            "(Msg3), got %" PRId64,
+                                            msg->offset);
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1505,6 +1529,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed == 1, "Phase 3: expected 1 record, got %d",
                     consumed);
@@ -1519,19 +1545,23 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
         while (attempts-- > 0) {
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 500, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
                                 TEST_FAIL(
                                     "Phase 4: unexpected record at "
                                     "offset %" PRId64
                                     " (Msg3 was REJECTed, Msg4 is "
                                     "aborted in read_committed)",
-                                    rd_kafka_messages_get(batch, j)->offset);
+                                    msg->offset);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         /* Phase 5: alter isolation level to read_uncommitted */
@@ -1554,15 +1584,16 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                 rd_bool_t all_seen;
                 rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 2000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(batch, j)->err) {
-                                int64_t off =
-                                    rd_kafka_messages_get(batch, j)->offset;
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, j);
+                        if (!msg->err) {
+                                int64_t off = msg->offset;
                                 TEST_ASSERT(off != 4,
                                             "Phase 7: Msg3 (offset 4) "
                                             "should not be redelivered "
@@ -1570,7 +1601,7 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                 if (off >= 0 && off < 20)
                                         seen[off] = rd_true;
                                 ack_err = rd_kafka_share_acknowledge_type(
-                                    consumer, rd_kafka_messages_get(batch, j),
+                                    consumer, msg,
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
                                 TEST_ASSERT(ack_err ==
                                                 RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1579,6 +1610,8 @@ static void do_test_dynamic_committed_to_uncommitted_with_reject(void) {
                                 new_acks++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (new_acks > 0) {
                         error = rd_kafka_share_commit_async(consumer);
                         if (error)

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -403,8 +403,7 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                 size_t rcvd_msgs = 0;
                 int i;
 
-                error     = rd_kafka_share_poll(rkshare, 3000, &batch);
-                rcvd_msgs = rd_kafka_messages_count(batch);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
@@ -415,8 +414,13 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                         continue;
                 }
 
-                if (rcvd_msgs == 0)
+                rcvd_msgs = rd_kafka_messages_count(batch);
+
+                if (rcvd_msgs == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
+                }
 
                 TEST_SAY("%s: Attempt %d/%d: Received %d messages\n",
                          consumer_name, attempt + 1, MAX_CONSUME_ATTEMPTS,
@@ -431,7 +435,6 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                                     "%s: Skipping message %d with error: %s\n",
                                     consumer_name, i,
                                     rd_kafka_message_errstr(rkm));
-                                rd_kafka_message_destroy(rkm);
                                 continue;
                         }
 
@@ -452,12 +455,11 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
 
                         if (do_acknowledge)
                                 rd_kafka_share_acknowledge(rkshare, rkm);
-                        rd_kafka_message_destroy(rkm);
                         tracked++;
                 }
 
-                for (; i < (int)rcvd_msgs; i++) {
-                }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (tracked >= target_count) {
                         TEST_SAY("%s: Reached target of %d tracked messages\n",
@@ -582,16 +584,14 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                                     int tracked_cnt,
                                     rd_bool_t expect_redelivery,
                                     const char *context_label) {
-        test_share_batch_t batch;
-        size_t total_rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t total_rcvd          = 0;
         int attempt;
         rd_kafka_error_t *error;
         int matched_count = 0;
         rd_bool_t *tracked_seen =
             tracked_cnt > 0 ? rd_calloc(tracked_cnt, sizeof(*tracked_seen))
                             : NULL;
-
-        test_share_batch_init(&batch, (size_t)max_total_msgs);
 
         TEST_SAY(
             "%s: Consuming for verification (up to %d messages, max %d "
@@ -606,7 +606,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                 size_t rcvd_msgs = 0;
                 size_t i;
 
-                error = test_share_batch_poll(&batch, rkshare, 3000);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
@@ -616,10 +616,14 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                         rd_kafka_error_destroy(error);
                         continue;
                 }
-                rcvd_msgs = batch.cnt - total_rcvd;
 
-                if (rcvd_msgs == 0)
+                rcvd_msgs = rd_kafka_messages_count(batch);
+
+                if (rcvd_msgs == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
+                }
 
                 TEST_SAY(
                     "%s: Attempt %d/%d: Received %d messages (total: %d)\n",
@@ -627,14 +631,15 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                     (int)rcvd_msgs, (int)(total_rcvd + rcvd_msgs));
 
                 /* Match each new message against the tracked list */
-                for (i = total_rcvd; i < total_rcvd + rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkm = batch.msgs[i];
+                for (i = 0; i < rcvd_msgs; i++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, i);
                         const char *topic;
                         int32_t partition;
                         int64_t offset;
                         int j;
 
-                        if (rkm->err)
+                        if (!rkm || rkm->err)
                                 continue;
 
                         topic     = rd_kafka_topic_name(rkm->rkt);
@@ -673,6 +678,8 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                 }
 
                 total_rcvd += rcvd_msgs;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_SAY("%s: Received %d messages, matched %d/%d tracked\n",
@@ -717,7 +724,6 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                     consumer_name);
         }
 
-        test_share_batch_destroy(&batch);
         if (tracked_seen)
                 rd_free(tracked_seen);
 }
@@ -766,10 +772,13 @@ static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
         rd_kafka_topic_partition_list_t *commit_results = NULL;
         rd_kafka_queue_t *queue                         = NULL;
 
-        /* 1. consume_batch */
+        /* 1. share_poll */
         error = rd_kafka_share_poll(consumer, 100, &batch);
-        rd_kafka_messages_destroy(batch);
-        assert_state_error(error, "consume_batch");
+        assert_state_error(error, "share_poll");
+        if (batch) {
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+        }
 
         /* 2. commit_async */
         error = rd_kafka_share_commit_async(consumer);
@@ -893,17 +902,20 @@ static void setup_3broker_share_consumer(const char *test_name,
         TEST_SAY("Consuming %d messages across %d partitions...\n", total_msgs,
                  partition_cnt);
         while (consumed < total_msgs && attempts++ < 30) {
-                rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
-                        if (!rd_kafka_messages_get(batch, i)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, i);
+                        if (rkm && !rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(consumed == total_msgs, "Expected %d messages, got %d",
@@ -1576,17 +1588,20 @@ static void do_test_close_with_broker_busy(void) {
 
                 TEST_SAY("Iteration %d: consuming %d msgs\n", iter, total_msgs);
                 while (consumed < total_msgs && attempts++ < 30) {
-                        rcvd  = 0;
                         error = rd_kafka_share_poll(consumer, 3000, &batch);
-                        rcvd  = rd_kafka_messages_count(batch);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
+                        rcvd = rd_kafka_messages_count(batch);
                         for (i = 0; i < (int)rcvd; i++) {
-                                if (!rd_kafka_messages_get(batch, i)->err)
+                                rd_kafka_message_t *rkm =
+                                    rd_kafka_messages_get(batch, i);
+                                if (rkm && !rkm->err)
                                         consumed++;
                         }
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         TEST_ASSERT(rd_kafka_share_commit_async(consumer) ==
                                         NULL,
                                     "fail to call commit async");
@@ -1630,15 +1645,16 @@ static void do_test_close_with_broker_busy(void) {
 
         TEST_SAY("c2: verifying no msgs redelivered (5 fetch attempts)\n");
         for (i = 0; i < 5; i++) {
-                rcvd  = 0;
                 error = rd_kafka_share_poll(c2, 2000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         TEST_SAY("c2 attempt %d: error: %s\n", i + 1,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 TEST_ASSERT(
                     rcvd == 0,
                     "c2 attempt %d: received %d msgs (expected 0 — close "
@@ -1680,7 +1696,6 @@ static void do_test_close_with_broker_down(void) {
         size_t rcvd;
         int attempts       = 0;
         rd_bool_t got_msgs = rd_false;
-        size_t i;
         rd_ts_t t_start, t_elapsed_ms;
         char errstr[512];
 
@@ -1727,20 +1742,22 @@ static void do_test_close_with_broker_down(void) {
          */
         TEST_SAY("Consuming until first non-empty batch...\n");
         while (!got_msgs && attempts++ < 30) {
-                rcvd  = 0;
                 error = rd_kafka_share_poll(consumer, 3000, &batch);
-                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 if (rcvd > 0) {
                         TEST_SAY("Received %d messages\n", (int)rcvd);
-                        for (i = 0; i < rcvd; i++)
-                                got_msgs = rd_true;
+                        rd_kafka_messages_destroy(batch);
+                        batch    = NULL;
+                        got_msgs = rd_true;
                         break;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(got_msgs, "Expected to receive at least one message");
@@ -1894,14 +1911,21 @@ static void do_test_api_calls_during_closing(void) {
                 int attempts               = 0;
                 rd_kafka_error_t *cerr     = NULL;
                 while (attempts++ < 20 && rcvd == 0) {
+                        cerr = rd_kafka_share_poll(consumer, 500, &batch);
+                        if (cerr) {
+                                rd_kafka_error_destroy(cerr);
+                                continue;
+                        }
+                        rcvd = rd_kafka_messages_count(batch);
+                        if (rcvd == 0) {
+                                rd_kafka_messages_destroy(batch);
+                                batch = NULL;
+                        }
+                }
+                if (batch) {
                         rd_kafka_messages_destroy(batch);
                         batch = NULL;
-                        cerr  = rd_kafka_share_poll(consumer, 500, &batch);
-                        rcvd  = rd_kafka_messages_count(batch);
-                        if (cerr)
-                                rd_kafka_error_destroy(cerr);
                 }
-                rd_kafka_messages_destroy(batch);
         }
 
         /* Inject 5s delay on ShareAcknowledge so close() stays in flight. */
@@ -1984,33 +2008,32 @@ static void do_test_implicit_ack_callback_fires_on_close(void) {
 
         /* First poll: fetch the record (auto-ack pending for next poll) */
         while (consumed < 1 && attempts++ < 30) {
-                rcvd  = 0;
                 error = rd_kafka_share_poll(rkshare, 2000, &raw_batch);
-                rcvd  = rd_kafka_messages_count(raw_batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(raw_batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(raw_batch, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(raw_batch, j);
+                        if (rkm && !rkm->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(raw_batch);
+                raw_batch = NULL;
         }
         TEST_ASSERT(consumed == 1, "Expected 1 record, got %d", consumed);
 
         /* Second poll: drives the piggybacked implicit ack to the broker */
         attempts = 5;
         while (attempts-- > 0) {
-                rd_kafka_messages_destroy(raw_batch);
-                raw_batch = NULL;
-                error     = rd_kafka_share_poll(rkshare, 1000, &raw_batch);
-                rcvd      = rd_kafka_messages_count(raw_batch);
-                (void)rcvd;
+                error = rd_kafka_share_poll(rkshare, 1000, &raw_batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rd_kafka_messages_destroy(raw_batch);
+                raw_batch = NULL;
         }
-        rd_kafka_messages_destroy(raw_batch);
-        raw_batch = NULL;
 
         /* Close - any pending ack-completion callbacks must be flushed */
         TEST_SAY("Closing share consumer without explicit commit\n");

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -387,7 +387,7 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                              rd_bool_t do_acknowledge,
                              tracked_msg_t *tracked_msgs,
                              int *tracked_cnt) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         int attempt;
         rd_kafka_error_t *error;
         int tracked = 0;
@@ -403,8 +403,8 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                 size_t rcvd_msgs = 0;
                 int i;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, batch,
-                                                     &rcvd_msgs);
+                error     = rd_kafka_share_poll(rkshare, 3000, &batch);
+                rcvd_msgs = rd_kafka_messages_count(batch);
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
@@ -423,7 +423,8 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                          (int)rcvd_msgs);
 
                 for (i = 0; i < (int)rcvd_msgs && tracked < target_count; i++) {
-                        rd_kafka_message_t *rkm = batch[i];
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, i);
 
                         if (rkm->err) {
                                 TEST_SAY(
@@ -456,7 +457,6 @@ static int consume_and_track(rd_kafka_share_t *rkshare,
                 }
 
                 for (; i < (int)rcvd_msgs; i++) {
-                        rd_kafka_message_destroy(batch[i]);
                 }
 
                 if (tracked >= target_count) {
@@ -582,7 +582,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                                     int tracked_cnt,
                                     rd_bool_t expect_redelivery,
                                     const char *context_label) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        test_share_batch_t batch;
         size_t total_rcvd = 0;
         int attempt;
         rd_kafka_error_t *error;
@@ -590,6 +590,8 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
         rd_bool_t *tracked_seen =
             tracked_cnt > 0 ? rd_calloc(tracked_cnt, sizeof(*tracked_seen))
                             : NULL;
+
+        test_share_batch_init(&batch, (size_t)max_total_msgs);
 
         TEST_SAY(
             "%s: Consuming for verification (up to %d messages, max %d "
@@ -604,8 +606,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                 size_t rcvd_msgs = 0;
                 size_t i;
 
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, batch + total_rcvd, &rcvd_msgs);
+                error = test_share_batch_poll(&batch, rkshare, 3000);
 
                 if (error) {
                         TEST_SAY("%s: Attempt %d/%d: error: %s\n",
@@ -615,6 +616,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd_msgs = batch.cnt - total_rcvd;
 
                 if (rcvd_msgs == 0)
                         continue;
@@ -626,7 +628,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
 
                 /* Match each new message against the tracked list */
                 for (i = total_rcvd; i < total_rcvd + rcvd_msgs; i++) {
-                        rd_kafka_message_t *rkm = batch[i];
+                        rd_kafka_message_t *rkm = batch.msgs[i];
                         const char *topic;
                         int32_t partition;
                         int64_t offset;
@@ -715,10 +717,7 @@ static void verify_tracked_messages(rd_kafka_share_t *rkshare,
                     consumer_name);
         }
 
-        /* Destroy all consumed messages */
-        for (size_t i = 0; i < total_rcvd; i++)
-                rd_kafka_message_destroy(batch[i]);
-
+        test_share_batch_destroy(&batch);
         if (tracked_seen)
                 rd_free(tracked_seen);
 }
@@ -762,14 +761,15 @@ static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
                                          const char *topic) {
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
-        rd_kafka_message_t *batch[4];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         rd_kafka_topic_partition_list_t *subs, *sub_result = NULL;
         rd_kafka_topic_partition_list_t *commit_results = NULL;
         rd_kafka_queue_t *queue                         = NULL;
 
         /* 1. consume_batch */
-        error = rd_kafka_share_consume_batch(consumer, 100, batch, &rcvd);
+        error = rd_kafka_share_poll(consumer, 100, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         assert_state_error(error, "consume_batch");
 
         /* 2. commit_async */
@@ -849,7 +849,7 @@ static void setup_3broker_share_consumer(const char *test_name,
         rd_kafka_share_t *consumer;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         char topic[64], group[64], errstr[512];
         int p, consumed = 0, attempts = 0;
@@ -894,17 +894,16 @@ static void setup_3broker_share_consumer(const char *test_name,
         TEST_SAY("Consuming %d messages across %d partitions...\n", total_msgs,
                  partition_cnt);
         while (consumed < total_msgs && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
+                        if (!rd_kafka_messages_get(batch, i)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[i]);
                 }
         }
 
@@ -1504,7 +1503,7 @@ static void do_test_close_with_broker_busy(void) {
         rd_kafka_share_t *consumer, *c2;
         rd_kafka_conf_t *conf;
         rd_kafka_topic_partition_list_t *subs;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error, *close_err;
         char topic[64], group[64], errstr[512];
         int iter, p, i;
@@ -1579,16 +1578,15 @@ static void do_test_close_with_broker_busy(void) {
                 TEST_SAY("Iteration %d: consuming %d msgs\n", iter, total_msgs);
                 while (consumed < total_msgs && attempts++ < 30) {
                         rcvd  = 0;
-                        error = rd_kafka_share_consume_batch(consumer, 3000,
-                                                             batch, &rcvd);
+                        error = rd_kafka_share_poll(consumer, 3000, &batch);
+                        rcvd  = rd_kafka_messages_count(batch);
                         if (error) {
                                 rd_kafka_error_destroy(error);
                                 continue;
                         }
                         for (i = 0; i < (int)rcvd; i++) {
-                                if (!batch[i]->err)
+                                if (!rd_kafka_messages_get(batch, i)->err)
                                         consumed++;
-                                rd_kafka_message_destroy(batch[i]);
                         }
                         TEST_ASSERT(rd_kafka_share_commit_async(consumer) ==
                                         NULL,
@@ -1634,7 +1632,8 @@ static void do_test_close_with_broker_busy(void) {
         TEST_SAY("c2: verifying no msgs redelivered (5 fetch attempts)\n");
         for (i = 0; i < 5; i++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(c2, 2000, batch, &rcvd);
+                error = rd_kafka_share_poll(c2, 2000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         TEST_SAY("c2 attempt %d: error: %s\n", i + 1,
                                  rd_kafka_error_string(error));
@@ -1676,7 +1675,7 @@ static void do_test_close_with_broker_down(void) {
         const char *group           = "sg-close-broker-down";
         const int msgcnt            = 10;
         const int socket_timeout_ms = 20000;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch  = NULL;
         rd_kafka_error_t *error;
         rd_kafka_error_t *close_err;
         size_t rcvd;
@@ -1729,9 +1728,9 @@ static void do_test_close_with_broker_down(void) {
          */
         TEST_SAY("Consuming until first non-empty batch...\n");
         while (!got_msgs && attempts++ < 30) {
-                rcvd = 0;
-                error =
-                    rd_kafka_share_consume_batch(consumer, 3000, batch, &rcvd);
+                rcvd  = 0;
+                error = rd_kafka_share_poll(consumer, 3000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -1740,8 +1739,7 @@ static void do_test_close_with_broker_down(void) {
                 if (rcvd > 0) {
                         TEST_SAY("Received %d messages\n", (int)rcvd);
                         for (i = 0; i < rcvd; i++)
-                                rd_kafka_message_destroy(batch[i]);
-                        got_msgs = rd_true;
+                                got_msgs = rd_true;
                         break;
                 }
         }
@@ -1892,18 +1890,19 @@ static void do_test_api_calls_during_closing(void) {
 
         /* Consume one batch so there's state to flush on close. */
         {
-                rd_kafka_message_t *batch[4];
-                size_t rcvd            = 0;
-                int attempts           = 0;
-                rd_kafka_error_t *cerr = NULL;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd                = 0;
+                int attempts               = 0;
+                rd_kafka_error_t *cerr     = NULL;
                 while (attempts++ < 20 && rcvd == 0) {
-                        cerr = rd_kafka_share_consume_batch(consumer, 500,
-                                                            batch, &rcvd);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
+                        cerr  = rd_kafka_share_poll(consumer, 500, &batch);
+                        rcvd  = rd_kafka_messages_count(batch);
                         if (cerr)
                                 rd_kafka_error_destroy(cerr);
                 }
-                for (size_t i = 0; i < rcvd; i++)
-                        rd_kafka_message_destroy(batch[i]);
+                rd_kafka_messages_destroy(batch);
         }
 
         /* Inject 5s delay on ShareAcknowledge so close() stays in flight. */
@@ -1953,7 +1952,7 @@ static void do_test_implicit_ack_callback_fires_on_close(void) {
         const char *group;
         char group_id[64];
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *raw_batch[16];
+        rd_kafka_messages_t *raw_batch = NULL;
         rd_kafka_topic_partition_list_t *subs;
         rd_kafka_error_t *error;
         ack_receipts_t receipts;
@@ -1987,16 +1986,15 @@ static void do_test_implicit_ack_callback_fires_on_close(void) {
         /* First poll: fetch the record (auto-ack pending for next poll) */
         while (consumed < 1 && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, raw_batch,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 2000, &raw_batch);
+                rcvd  = rd_kafka_messages_count(raw_batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!raw_batch[j]->err)
+                        if (!rd_kafka_messages_get(raw_batch, j)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(raw_batch[j]);
                 }
         }
         TEST_ASSERT(consumed == 1, "Expected 1 record, got %d", consumed);
@@ -2004,14 +2002,16 @@ static void do_test_implicit_ack_callback_fires_on_close(void) {
         /* Second poll: drives the piggybacked implicit ack to the broker */
         attempts = 5;
         while (attempts-- > 0) {
-                rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 1000, raw_batch,
-                                                     &rcvd);
+                rd_kafka_messages_destroy(raw_batch);
+                raw_batch = NULL;
+                error     = rd_kafka_share_poll(rkshare, 1000, &raw_batch);
+                rcvd      = rd_kafka_messages_count(raw_batch);
+                (void)rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
-                for (j = 0; j < rcvd; j++)
-                        rd_kafka_message_destroy(raw_batch[j]);
         }
+        rd_kafka_messages_destroy(raw_batch);
+        raw_batch = NULL;
 
         /* Close - any pending ack-completion callbacks must be flushed */
         TEST_SAY("Closing share consumer without explicit commit\n");

--- a/tests/0178-share_consumer_close.c
+++ b/tests/0178-share_consumer_close.c
@@ -762,14 +762,13 @@ static void verify_all_apis_return_error(rd_kafka_share_t *consumer,
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
         rd_kafka_messages_t *batch = NULL;
-        size_t rcvd                = 0;
         rd_kafka_topic_partition_list_t *subs, *sub_result = NULL;
         rd_kafka_topic_partition_list_t *commit_results = NULL;
         rd_kafka_queue_t *queue                         = NULL;
 
         /* 1. consume_batch */
         error = rd_kafka_share_poll(consumer, 100, &batch);
-        rcvd  = rd_kafka_messages_count(batch);
+        rd_kafka_messages_destroy(batch);
         assert_state_error(error, "consume_batch");
 
         /* 2. commit_async */

--- a/tests/0179-share_consumer_destroy.c
+++ b/tests/0179-share_consumer_destroy.c
@@ -425,7 +425,8 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         rd_kafka_topic_partition_list_t *commit_result = NULL;
         const char *topic         = "0179-destroy-cached-acks-delayed-broker";
         const char *group         = "0179-destroy-cached-acks";
@@ -460,8 +461,8 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < 10 && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -497,7 +498,7 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         /* Step 1: Acknowledge first 2 messages and commit async */
         TEST_SAY(
             "Step 1: Acknowledging messages 0-1 and calling commit_async\n");
-        ack_range_logged(rkshare, rkmessages, 0, 2, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages_acc.msgs, 0, 2, (int)rcvd);
         /* The below call should keep the broker busy */
         rd_kafka_share_commit_async(rkshare);
 
@@ -505,14 +506,14 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         TEST_SAY(
             "Step 2: Acknowledging messages 2-5 and calling commit_async "
             "(should cache)\n");
-        ack_range_logged(rkshare, rkmessages, 2, 6, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages_acc.msgs, 2, 6, (int)rcvd);
         rd_kafka_share_commit_async(rkshare);
 
         /* Step 3: Acknowledge next 4 messages and commit sync */
         TEST_SAY(
             "Step 3: Acknowledging messages 6-9 and calling "
             "commit_sync (should cache)\n");
-        ack_range_logged(rkshare, rkmessages, 6, 10, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages_acc.msgs, 6, 10, (int)rcvd);
 
         rd_kafka_share_commit_sync(rkshare, 1000, &commit_result);
         TEST_ASSERT(commit_result != NULL,
@@ -532,9 +533,7 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
 
         /* Destroy all consumed messages */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        TEST_SAY("Calling destroy with flags 0x%x\n", destroy_flags);
+                TEST_SAY("Calling destroy with flags 0x%x\n", destroy_flags);
         t_start = test_clock();
         destroy_share_consumer(rkshare, destroy_flags);
         t_elapsed_ms = (test_clock() - t_start) / 1000;
@@ -700,7 +699,8 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         rd_kafka_topic_partition_list_t *result = NULL;
         const char *topic;
         const char *group           = "0179-decommission-commit-sync";
@@ -755,8 +755,8 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
 
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -771,7 +771,7 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
                                 size_t k;
                                 for (k = rcvd - batch_rcvd; k < rcvd; k++)
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[k]);
+                                            rkshare, rkmessages_acc.msgs[k]);
                         }
                 }
                 attempts++;
@@ -784,7 +784,7 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
 
         /* The last message of the last batch tells us which broker
          * holds the unacked records that commit_sync will ship to. */
-        target_partition    = rkmessages[rcvd - 1]->partition;
+        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -835,9 +835,7 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
 
         /* Cleanup */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        destroy_share_consumer(rkshare, destroy_flags);
+                destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         /* Restore the default fatal-error handler. */
@@ -874,7 +872,8 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic;
         const char *group           = "0179-decommission-consume-batch";
         int32_t target_broker_id    = -1;
@@ -933,8 +932,8 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
 
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -956,7 +955,7 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         /* The last message of the last batch tells us which broker
          * holds the unacked records — that's the broker the next
          * consume_batch's piggybacked ShareAck will target. */
-        target_partition    = rkmessages[rcvd - 1]->partition;
+        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -964,8 +963,7 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
                  target_partition, target_broker_id, surviving_broker_id);
 
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-        rcvd = 0;
+                rcvd = 0;
 
         rd_kafka_mock_broker_push_request_error_rtts(
             mcluster, target_broker_id, RD_KAFKAP_ShareFetch, 1,
@@ -985,9 +983,8 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         TEST_SAY(
             "Calling consume_batch — expecting no messages and no "
             "app-visible error\n");
-        fetch_rcvd = CONSUME_ARRAY;
-        error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages + rcvd,
-                                             &fetch_rcvd);
+        error      = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+        fetch_rcvd = rkmessages_acc.cnt - rcvd;
 
         TEST_ASSERT(error == NULL,
                     "Expected consume_batch to return NULL error, got %s",
@@ -1032,6 +1029,7 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         /* Restore the default fatal-error handler. */
         test_curr->is_fatal_cb = NULL;
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1062,7 +1060,8 @@ static void test_broker_decommission_during_close(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic;
         const char *group           = "0179-decommission-close";
         int32_t target_broker_id    = -1;
@@ -1123,8 +1122,8 @@ static void test_broker_decommission_during_close(int destroy_flags,
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
 
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -1139,7 +1138,7 @@ static void test_broker_decommission_during_close(int destroy_flags,
                                 size_t k;
                                 for (k = rcvd - batch_rcvd; k < rcvd; k++)
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[k]);
+                                            rkshare, rkmessages_acc.msgs[k]);
                         }
                 }
                 attempts++;
@@ -1155,7 +1154,7 @@ static void test_broker_decommission_during_close(int destroy_flags,
          * holds the unacked records — that's the broker close()'s
          * ShareAck will target. Decommission that broker; the other
          * survives. */
-        target_partition    = rkmessages[rcvd - 1]->partition;
+        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -1218,9 +1217,7 @@ static void test_broker_decommission_during_close(int destroy_flags,
 
         /* Cleanup */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        destroy_share_consumer(rkshare, destroy_flags);
+                destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         ack_receipts_destroy(&receipts);
@@ -1255,7 +1252,8 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic;
         const char *group           = "0179-decommission-commit-async";
         int32_t target_broker_id    = -1;
@@ -1319,8 +1317,8 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
 
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -1335,7 +1333,7 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
                                 size_t k;
                                 for (k = rcvd - batch_rcvd; k < rcvd; k++)
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[k]);
+                                            rkshare, rkmessages_acc.msgs[k]);
                         }
                 }
                 attempts++;
@@ -1351,7 +1349,7 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
          * holds the unacked records — that's the broker the
          * commit_async ShareAck will target. Decommission that broker;
          * the other survives. */
-        target_partition    = rkmessages[rcvd - 1]->partition;
+        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -1377,9 +1375,7 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
 
         /* Cleanup messages before destroy. */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        destroy_share_consumer(rkshare, destroy_flags);
+                destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         /* Assert ack callback receipts.
@@ -1420,7 +1416,8 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic        = "0179-leader-migration-mid-session";
         const char *group        = "0179-leader-migration-mid-session";
         const int msgs_per_round = 5;
@@ -1457,8 +1454,8 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         while (rcvd < (size_t)msgs_per_round &&
                attempts++ < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
@@ -1491,8 +1488,8 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         while (rcvd < (size_t)(2 * msgs_per_round) &&
                attempts++ < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
@@ -1504,14 +1501,14 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         TEST_SAY("Round 2: consumed %d total messages\n", (int)rcvd);
 
         for (i = 0; i < rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        /* Close + destroy. Without the leader-migration fix, broker 1's
-         * destroy_final would assert on non-empty toppars_in_session. */
-        TEST_SAY("Calling destroy (flags 0x%x)\n", destroy_flags);
+                /* Close + destroy. Without the leader-migration fix, broker 1's
+                 * destroy_final would assert on non-empty toppars_in_session.
+                 */
+                TEST_SAY("Calling destroy (flags 0x%x)\n", destroy_flags);
         destroy_share_consumer(rkshare, destroy_flags);
 
         test_mock_cluster_destroy(mcluster);
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1534,7 +1531,8 @@ static void test_destroy_during_rebalance(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic            = "0179-destroy-during-rebalance";
         const char *group            = "0179-destroy-during-rebalance";
         const int heartbeat_delay_ms = 10000;
@@ -1564,9 +1562,9 @@ static void test_destroy_during_rebalance(int destroy_flags) {
 
         TEST_SAY("Waiting for first batch (signals assignment is live)\n");
         while (rcvd == 0 && attempts++ < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &batch_rcvd);
+                size_t batch_rcvd;
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
@@ -1577,13 +1575,11 @@ static void test_destroy_during_rebalance(int destroy_flags) {
                     "got %d after %d attempts",
                     (int)rcvd, attempts);
         for (i = 0; i < rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        /* Block all subsequent ShareGroupHeartbeats. The next heartbeat
-         * sent by the cgrp (including the leave-group heartbeat) will be
-         * stuck in flight for heartbeat_delay_ms. */
-        TEST_SAY("Injecting %dms RTT delay on ShareGroupHeartbeat\n",
-                 heartbeat_delay_ms);
+                /* Block all subsequent ShareGroupHeartbeats. The next heartbeat
+                 * sent by the cgrp (including the leave-group heartbeat) will
+                 * be stuck in flight for heartbeat_delay_ms. */
+                TEST_SAY("Injecting %dms RTT delay on ShareGroupHeartbeat\n",
+                         heartbeat_delay_ms);
         TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
                         mcluster, 1, RD_KAFKAP_ShareGroupHeartbeat, 1,
                         RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1622,6 +1618,7 @@ static void test_destroy_during_rebalance(int destroy_flags) {
         }
 
         test_mock_cluster_destroy(mcluster);
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1649,7 +1646,8 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
         rd_kafka_t *rk;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         const char *topic            = "0179-destroy-fatal-error";
         const char *group            = "0179-destroy-fatal-error";
         const int total_msgs         = 10;
@@ -1679,8 +1677,8 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
         TEST_SAY("Consuming %d msgs\n", total_msgs);
         while (rcvd < (size_t)total_msgs && attempts++ < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
@@ -1693,7 +1691,7 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
         TEST_SAY("Acknowledging %d/%d messages (no commit)\n", (int)(rcvd / 2),
                  (int)rcvd);
         for (i = 0; i < rcvd / 2; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         /* Inject a long delay on the next ShareAcknowledge so a normal
          * close path would block on it. The fatal-error path must NOT
@@ -1715,10 +1713,8 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
 
         /* Destroy all consumed messages before share_destroy. */
         for (i = 0; i < rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        TEST_SAY("Calling destroy with flags 0x%x (fatal-error path)\n",
-                 destroy_flags);
+                TEST_SAY("Calling destroy with flags 0x%x (fatal-error path)\n",
+                         destroy_flags);
         t_start = test_clock();
         destroy_share_consumer(rkshare, destroy_flags);
         t_elapsed_ms = (test_clock() - t_start) / 1000;
@@ -1731,6 +1727,7 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
                     t_elapsed_ms);
 
         test_mock_cluster_destroy(mcluster);
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1754,7 +1751,8 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
         const char *group = "0179-destroy-explicit-ack";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         size_t rcvd               = 0;
         size_t first_batch_cnt    = 0;
         int32_t first_batch_part  = -1;
@@ -1801,8 +1799,8 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -1819,7 +1817,8 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
                                 first_batch_cnt = batch_rcvd;
                                 for (k = 0; k < batch_rcvd; k++)
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[rcvd + k]);
+                                            rkshare,
+                                            rkmessages_acc.msgs[rcvd + k]);
                         }
                         rcvd += batch_rcvd;
                 }
@@ -1834,7 +1833,7 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
                     TEST_MSGS / 2, (int)first_batch_cnt);
 
         drain_ack_callbacks(rkshare);
-        first_batch_part  = rkmessages[0]->partition;
+        first_batch_part  = rkmessages_acc.msgs[0]->partition;
         second_batch_part = (first_batch_part == 0) ? 1 : 0;
         TEST_SAY("Consumed %d messages (first batch on partition %" PRId32
                  ", second batch on partition %" PRId32 ")\n",
@@ -1852,7 +1851,7 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
                 int k;
                 for (k = 0; k < second_to_ack; k++)
                         rd_kafka_share_acknowledge(
-                            rkshare, rkmessages[first_batch_cnt + k]);
+                            rkshare, rkmessages_acc.msgs[first_batch_cnt + k]);
                 ack_cnt = (int)first_batch_cnt + second_to_ack;
                 TEST_SAY(
                     "Acked first batch (%d) + second batch (%d) = %d / "
@@ -1862,9 +1861,7 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
 
         /* Destroy all consumed messages (acked and unacked alike). */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        destroy_share_consumer(rkshare, destroy_flags);
+                destroy_share_consumer(rkshare, destroy_flags);
 
         /* Assert ack callback receipts.
          *
@@ -1918,7 +1915,8 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         const char *group = "0179-destroy-implicit-ack";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
         size_t rcvd               = 0;
         size_t first_batch_cnt    = 0;
         int32_t first_batch_part  = -1;
@@ -1961,8 +1959,8 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
                 size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error             = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
@@ -1984,7 +1982,7 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         TEST_ASSERT(first_batch_cnt == TEST_MSGS / 2,
                     "Expected first batch == TEST_MSGS/2 (%d), got %d",
                     TEST_MSGS / 2, (int)first_batch_cnt);
-        first_batch_part  = rkmessages[0]->partition;
+        first_batch_part  = rkmessages_acc.msgs[0]->partition;
         second_batch_part = (first_batch_part == 0) ? 1 : 0;
         TEST_SAY("Consumed %d messages (first batch on partition %" PRId32
                  ", second batch on partition %" PRId32 ")\n",
@@ -1996,9 +1994,7 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
 
         /* Destroy all consumed messages before share_destroy. */
         for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        destroy_share_consumer(rkshare, destroy_flags);
+                destroy_share_consumer(rkshare, destroy_flags);
 
         /* Assert ack callback receipts.
          *
@@ -2020,6 +2016,7 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
 
         ack_receipts_destroy(&receipts);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2086,7 +2083,7 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
         const char *group = "0179-destroy-mixed";
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *partitions = NULL;
-        rd_kafka_message_t *batch[64];
+        rd_kafka_messages_t *batch                  = NULL;
         rd_kafka_error_t *close_err;
         thrd_t destroy_thr;
         destroy_watchdog_arg_t arg;
@@ -2127,7 +2124,8 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
         while (acked < target && attempts++ < 80) {
                 rd_kafka_error_t *err;
                 rcvd = 0;
-                err = rd_kafka_share_consume_batch(rkshare, 3000, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 3000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
@@ -2137,13 +2135,11 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
                         rd_kafka_resp_err_t aerr;
                         rd_kafka_error_t *cerr;
 
-                        if (batch[j]->err) {
-                                rd_kafka_message_destroy(batch[j]);
+                        if (rd_kafka_messages_get(batch, j)->err) {
                                 continue;
                         }
 
                         if (acked >= target) {
-                                rd_kafka_message_destroy(batch[j]);
                                 continue;
                         }
 
@@ -2159,11 +2155,10 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
                                 break;
                         }
 
-                        aerr = rd_kafka_share_acknowledge_type(rkshare,
-                                                               batch[j], at);
+                        aerr = rd_kafka_share_acknowledge_type(
+                            rkshare, rd_kafka_messages_get(batch, j), at);
                         TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
                                     (int)at, rd_kafka_err2str(aerr));
-                        rd_kafka_message_destroy(batch[j]);
                         acked++;
 
                         if (acked % 5 == 0) {

--- a/tests/0179-share_consumer_destroy.c
+++ b/tests/0179-share_consumer_destroy.c
@@ -340,18 +340,20 @@ static void subscribe_topics(rd_kafka_share_t *consumer,
  * @brief Acknowledge messages in [start, end) and log each result.
  */
 static void ack_range_logged(rd_kafka_share_t *rkshare,
-                             rd_kafka_message_t **rkmessages,
+                             rd_kafka_messages_t *batch,
                              int start,
                              int end,
                              int rcvd) {
         int i;
         for (i = start; i < end && i < rcvd; i++) {
-                rd_kafka_resp_err_t ack_err =
-                    rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+                rd_kafka_resp_err_t ack_err;
+                if (!rkm)
+                        continue;
+                ack_err = rd_kafka_share_acknowledge(rkshare, rkm);
                 TEST_SAY("  ack msg[%d] %s[%" PRId32 "]@%" PRId64 " -> %s\n", i,
-                         rd_kafka_topic_name(rkmessages[i]->rkt),
-                         rkmessages[i]->partition, rkmessages[i]->offset,
-                         rd_kafka_err2str(ack_err));
+                         rd_kafka_topic_name(rkm->rkt), rkm->partition,
+                         rkm->offset, rd_kafka_err2str(ack_err));
         }
 }
 
@@ -425,8 +427,7 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
+        rd_kafka_messages_t *rkmessages                = NULL;
         rd_kafka_topic_partition_list_t *commit_result = NULL;
         const char *topic         = "0179-destroy-cached-acks-delayed-broker";
         const char *group         = "0179-destroy-cached-acks";
@@ -460,18 +461,19 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         TEST_SAY("Consuming messages (up to %d attempts)\n",
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < 10 && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
-                        TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
-                                 (int)batch_rcvd);
-                        rcvd += batch_rcvd;
+                } else {
+                        rcvd = rd_kafka_messages_count(rkmessages);
+                        if (rcvd > 0)
+                                TEST_SAY("Attempt %d: consumed %d messages\n",
+                                         attempts, (int)rcvd);
                 }
                 attempts++;
         }
@@ -498,7 +500,7 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         /* Step 1: Acknowledge first 2 messages and commit async */
         TEST_SAY(
             "Step 1: Acknowledging messages 0-1 and calling commit_async\n");
-        ack_range_logged(rkshare, rkmessages_acc.msgs, 0, 2, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages, 0, 2, (int)rcvd);
         /* The below call should keep the broker busy */
         rd_kafka_share_commit_async(rkshare);
 
@@ -506,14 +508,14 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         TEST_SAY(
             "Step 2: Acknowledging messages 2-5 and calling commit_async "
             "(should cache)\n");
-        ack_range_logged(rkshare, rkmessages_acc.msgs, 2, 6, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages, 2, 6, (int)rcvd);
         rd_kafka_share_commit_async(rkshare);
 
         /* Step 3: Acknowledge next 4 messages and commit sync */
         TEST_SAY(
             "Step 3: Acknowledging messages 6-9 and calling "
             "commit_sync (should cache)\n");
-        ack_range_logged(rkshare, rkmessages_acc.msgs, 6, 10, (int)rcvd);
+        ack_range_logged(rkshare, rkmessages, 6, 10, (int)rcvd);
 
         rd_kafka_share_commit_sync(rkshare, 1000, &commit_result);
         TEST_ASSERT(commit_result != NULL,
@@ -532,8 +534,10 @@ test_destroy_with_cached_acks_and_delayed_broker(int destroy_flags) {
         rd_kafka_topic_partition_list_destroy(commit_result);
 
         /* Destroy all consumed messages */
-        for (i = 0; i < (int)rcvd; i++)
-                TEST_SAY("Calling destroy with flags 0x%x\n", destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        TEST_SAY("Calling destroy with flags 0x%x\n", destroy_flags);
         t_start = test_clock();
         destroy_share_consumer(rkshare, destroy_flags);
         t_elapsed_ms = (test_clock() - t_start) / 1000;
@@ -699,8 +703,7 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
+        rd_kafka_messages_t *rkmessages         = NULL;
         rd_kafka_topic_partition_list_t *result = NULL;
         const char *topic;
         const char *group           = "0179-decommission-commit-sync";
@@ -753,25 +756,36 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
         TEST_SAY("Consuming up to %d messages (max %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
+                size_t batch_rcvd;
 
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(rkmessages);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
                         rcvd += batch_rcvd;
 
                         if (explicit_ack) {
                                 size_t k;
-                                for (k = rcvd - batch_rcvd; k < rcvd; k++)
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages_acc.msgs[k]);
+                                for (k = 0; k < batch_rcvd; k++) {
+                                        rd_kafka_message_t *rkm =
+                                            rd_kafka_messages_get(rkmessages,
+                                                                  k);
+                                        if (rkm)
+                                                rd_kafka_share_acknowledge(
+                                                    rkshare, rkm);
+                                }
                         }
                 }
                 attempts++;
@@ -784,7 +798,16 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
 
         /* The last message of the last batch tells us which broker
          * holds the unacked records that commit_sync will ship to. */
-        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
+        {
+                size_t _last_cnt = rd_kafka_messages_count(rkmessages);
+                rd_kafka_message_t *_last_rkm =
+                    _last_cnt > 0
+                        ? rd_kafka_messages_get(rkmessages, _last_cnt - 1)
+                        : NULL;
+                TEST_ASSERT(_last_rkm != NULL,
+                            "Expected last batch to be non-empty");
+                target_partition = _last_rkm->partition;
+        }
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -834,8 +857,10 @@ static void test_broker_decommission_with_commit_sync(int destroy_flags,
         rd_kafka_topic_partition_list_destroy(result);
 
         /* Cleanup */
-        for (i = 0; i < (int)rcvd; i++)
-                destroy_share_consumer(rkshare, destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         /* Restore the default fatal-error handler. */
@@ -872,8 +897,7 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
+        rd_kafka_messages_t *rkmessages = NULL;
         const char *topic;
         const char *group           = "0179-decommission-consume-batch";
         int32_t target_broker_id    = -1;
@@ -882,7 +906,6 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         size_t rcvd                 = 0;
         size_t fetch_rcvd           = 0;
         int attempts                = 0;
-        int i;
         int32_t surviving_part;
         expected_ack_t expected[2];
         ack_receipts_t receipts;
@@ -930,16 +953,22 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         TEST_SAY("Consuming up to %d messages (max %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
+                size_t batch_rcvd;
 
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(rkmessages);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
                         rcvd += batch_rcvd;
@@ -955,15 +984,25 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         /* The last message of the last batch tells us which broker
          * holds the unacked records — that's the broker the next
          * consume_batch's piggybacked ShareAck will target. */
-        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
+        {
+                size_t _last_cnt = rd_kafka_messages_count(rkmessages);
+                rd_kafka_message_t *_last_rkm =
+                    _last_cnt > 0
+                        ? rd_kafka_messages_get(rkmessages, _last_cnt - 1)
+                        : NULL;
+                TEST_ASSERT(_last_rkm != NULL,
+                            "Expected last batch to be non-empty");
+                target_partition = _last_rkm->partition;
+        }
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
                  ", surviving broker = %" PRId32 "\n",
                  target_partition, target_broker_id, surviving_broker_id);
 
-        for (i = 0; i < (int)rcvd; i++)
-                rcvd = 0;
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+        rcvd       = 0;
 
         rd_kafka_mock_broker_push_request_error_rtts(
             mcluster, target_broker_id, RD_KAFKAP_ShareFetch, 1,
@@ -983,8 +1022,10 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         TEST_SAY(
             "Calling consume_batch — expecting no messages and no "
             "app-visible error\n");
-        error      = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-        fetch_rcvd = rkmessages_acc.cnt - rcvd;
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+        error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+        fetch_rcvd = rd_kafka_messages_count(rkmessages);
 
         TEST_ASSERT(error == NULL,
                     "Expected consume_batch to return NULL error, got %s",
@@ -1021,6 +1062,9 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
                               RD_KAFKA_RESP_ERR__DESTROY_BROKER, TEST_MSGS / 2};
         verify_ack_receipts(&receipts, expected, 2, "consume_batch");
 
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
         destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
@@ -1029,7 +1073,6 @@ static void test_broker_decommission_with_consume_batch(int destroy_flags) {
         /* Restore the default fatal-error handler. */
         test_curr->is_fatal_cb = NULL;
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1060,8 +1103,7 @@ static void test_broker_decommission_during_close(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
+        rd_kafka_messages_t *rkmessages = NULL;
         const char *topic;
         const char *group           = "0179-decommission-close";
         int32_t target_broker_id    = -1;
@@ -1069,7 +1111,6 @@ static void test_broker_decommission_during_close(int destroy_flags,
         int32_t target_partition    = -1;
         size_t rcvd                 = 0;
         int attempts                = 0;
-        int i;
         int32_t surviving_part;
         expected_ack_t expected[2];
         ack_receipts_t receipts;
@@ -1120,25 +1161,36 @@ static void test_broker_decommission_during_close(int destroy_flags,
         TEST_SAY("Consuming up to %d messages (max %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
+                size_t batch_rcvd;
 
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(rkmessages);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
                         rcvd += batch_rcvd;
 
                         if (explicit_ack) {
                                 size_t k;
-                                for (k = rcvd - batch_rcvd; k < rcvd; k++)
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages_acc.msgs[k]);
+                                for (k = 0; k < batch_rcvd; k++) {
+                                        rd_kafka_message_t *rkm =
+                                            rd_kafka_messages_get(rkmessages,
+                                                                  k);
+                                        if (rkm)
+                                                rd_kafka_share_acknowledge(
+                                                    rkshare, rkm);
+                                }
                         }
                 }
                 attempts++;
@@ -1154,7 +1206,16 @@ static void test_broker_decommission_during_close(int destroy_flags,
          * holds the unacked records — that's the broker close()'s
          * ShareAck will target. Decommission that broker; the other
          * survives. */
-        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
+        {
+                size_t _last_cnt = rd_kafka_messages_count(rkmessages);
+                rd_kafka_message_t *_last_rkm =
+                    _last_cnt > 0
+                        ? rd_kafka_messages_get(rkmessages, _last_cnt - 1)
+                        : NULL;
+                TEST_ASSERT(_last_rkm != NULL,
+                            "Expected last batch to be non-empty");
+                target_partition = _last_rkm->partition;
+        }
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -1216,8 +1277,10 @@ static void test_broker_decommission_during_close(int destroy_flags,
         }
 
         /* Cleanup */
-        for (i = 0; i < (int)rcvd; i++)
-                destroy_share_consumer(rkshare, destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         ack_receipts_destroy(&receipts);
@@ -1252,8 +1315,7 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
+        rd_kafka_messages_t *rkmessages = NULL;
         const char *topic;
         const char *group           = "0179-decommission-commit-async";
         int32_t target_broker_id    = -1;
@@ -1261,7 +1323,6 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
         int32_t target_partition    = -1;
         size_t rcvd                 = 0;
         int attempts                = 0;
-        int i;
         int32_t surviving_part;
         expected_ack_t expected[2];
         ack_receipts_t receipts;
@@ -1315,25 +1376,36 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
         TEST_SAY("Consuming up to %d messages (max %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
+                size_t batch_rcvd;
 
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(rkmessages);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
                         rcvd += batch_rcvd;
 
                         if (explicit_ack) {
                                 size_t k;
-                                for (k = rcvd - batch_rcvd; k < rcvd; k++)
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages_acc.msgs[k]);
+                                for (k = 0; k < batch_rcvd; k++) {
+                                        rd_kafka_message_t *rkm =
+                                            rd_kafka_messages_get(rkmessages,
+                                                                  k);
+                                        if (rkm)
+                                                rd_kafka_share_acknowledge(
+                                                    rkshare, rkm);
+                                }
                         }
                 }
                 attempts++;
@@ -1349,7 +1421,16 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
          * holds the unacked records — that's the broker the
          * commit_async ShareAck will target. Decommission that broker;
          * the other survives. */
-        target_partition    = rkmessages_acc.msgs[rcvd - 1]->partition;
+        {
+                size_t _last_cnt = rd_kafka_messages_count(rkmessages);
+                rd_kafka_message_t *_last_rkm =
+                    _last_cnt > 0
+                        ? rd_kafka_messages_get(rkmessages, _last_cnt - 1)
+                        : NULL;
+                TEST_ASSERT(_last_rkm != NULL,
+                            "Expected last batch to be non-empty");
+                target_partition = _last_rkm->partition;
+        }
         target_broker_id    = (target_partition == 0) ? 1 : 2;
         surviving_broker_id = (target_broker_id == 1) ? 2 : 1;
         TEST_SAY("Target partition = %" PRId32 ", target broker = %" PRId32
@@ -1374,8 +1455,10 @@ static void test_broker_decommission_with_commit_async(int destroy_flags,
                     error ? rd_kafka_error_string(error) : "(null)");
 
         /* Cleanup messages before destroy. */
-        for (i = 0; i < (int)rcvd; i++)
-                destroy_share_consumer(rkshare, destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        destroy_share_consumer(rkshare, destroy_flags);
         test_mock_cluster_destroy(mcluster);
 
         /* Assert ack callback receipts.
@@ -1416,14 +1499,12 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
-        const char *topic        = "0179-leader-migration-mid-session";
-        const char *group        = "0179-leader-migration-mid-session";
-        const int msgs_per_round = 5;
-        size_t rcvd              = 0;
-        int attempts             = 0;
-        size_t i;
+        rd_kafka_messages_t *rkmessages = NULL;
+        const char *topic               = "0179-leader-migration-mid-session";
+        const char *group               = "0179-leader-migration-mid-session";
+        const int msgs_per_round        = 5;
+        size_t rcvd                     = 0;
+        int attempts                    = 0;
 
         SUB_TEST_QUICK("destroy_flags=0x%x", destroy_flags);
 
@@ -1453,13 +1534,13 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         TEST_SAY("Round 1: consume from broker 1 (initial leader)\n");
         while (rcvd < (size_t)msgs_per_round &&
                attempts++ < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
-                        rcvd += batch_rcvd;
+                        rcvd += rd_kafka_messages_count(rkmessages);
         }
         TEST_ASSERT(rcvd >= (size_t)msgs_per_round,
                     "Round 1: expected %d msgs, got %d", msgs_per_round,
@@ -1487,28 +1568,28 @@ static void test_leader_migration_mid_session_destroy(int destroy_flags) {
         attempts = 0;
         while (rcvd < (size_t)(2 * msgs_per_round) &&
                attempts++ < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
-                        rcvd += batch_rcvd;
+                        rcvd += rd_kafka_messages_count(rkmessages);
         }
         TEST_ASSERT(rcvd >= (size_t)(2 * msgs_per_round),
                     "Round 2: expected %d total msgs, got %d",
                     2 * msgs_per_round, (int)rcvd);
         TEST_SAY("Round 2: consumed %d total messages\n", (int)rcvd);
 
-        for (i = 0; i < rcvd; i++)
-                /* Close + destroy. Without the leader-migration fix, broker 1's
-                 * destroy_final would assert on non-empty toppars_in_session.
-                 */
-                TEST_SAY("Calling destroy (flags 0x%x)\n", destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        /* Close + destroy. Without the leader-migration fix, broker 1's
+         * destroy_final would assert on non-empty toppars_in_session. */
+        TEST_SAY("Calling destroy (flags 0x%x)\n", destroy_flags);
         destroy_share_consumer(rkshare, destroy_flags);
 
         test_mock_cluster_destroy(mcluster);
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1531,15 +1612,13 @@ static void test_destroy_during_rebalance(int destroy_flags) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
-        const char *topic            = "0179-destroy-during-rebalance";
-        const char *group            = "0179-destroy-during-rebalance";
-        const int heartbeat_delay_ms = 10000;
-        size_t rcvd                  = 0;
-        int attempts                 = 0;
+        rd_kafka_messages_t *rkmessages = NULL;
+        const char *topic               = "0179-destroy-during-rebalance";
+        const char *group               = "0179-destroy-during-rebalance";
+        const int heartbeat_delay_ms    = 10000;
+        size_t rcvd                     = 0;
+        int attempts                    = 0;
         rd_ts_t t_start, t_elapsed_ms;
-        size_t i;
 
         SUB_TEST_QUICK("destroy_flags=0x%x", destroy_flags);
 
@@ -1562,24 +1641,26 @@ static void test_destroy_during_rebalance(int destroy_flags) {
 
         TEST_SAY("Waiting for first batch (signals assignment is live)\n");
         while (rcvd == 0 && attempts++ < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
-                        rcvd = batch_rcvd;
+                        rcvd = rd_kafka_messages_count(rkmessages);
         }
         TEST_ASSERT(rcvd > 0,
                     "Expected at least 1 msg before forcing rebalance; "
                     "got %d after %d attempts",
                     (int)rcvd, attempts);
-        for (i = 0; i < rcvd; i++)
-                /* Block all subsequent ShareGroupHeartbeats. The next heartbeat
-                 * sent by the cgrp (including the leave-group heartbeat) will
-                 * be stuck in flight for heartbeat_delay_ms. */
-                TEST_SAY("Injecting %dms RTT delay on ShareGroupHeartbeat\n",
-                         heartbeat_delay_ms);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        /* Block all subsequent ShareGroupHeartbeats. The next heartbeat
+         * sent by the cgrp (including the leave-group heartbeat) will be
+         * stuck in flight for heartbeat_delay_ms. */
+        TEST_SAY("Injecting %dms RTT delay on ShareGroupHeartbeat\n",
+                 heartbeat_delay_ms);
         TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
                         mcluster, 1, RD_KAFKAP_ShareGroupHeartbeat, 1,
                         RD_KAFKA_RESP_ERR_NO_ERROR,
@@ -1618,7 +1699,6 @@ static void test_destroy_during_rebalance(int destroy_flags) {
         }
 
         test_mock_cluster_destroy(mcluster);
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1646,14 +1726,13 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
         rd_kafka_t *rk;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t err;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
-        const char *topic            = "0179-destroy-fatal-error";
-        const char *group            = "0179-destroy-fatal-error";
-        const int total_msgs         = 10;
-        const int share_ack_delay_ms = 30000;
-        size_t rcvd                  = 0;
-        int attempts                 = 0;
+        rd_kafka_messages_t *rkmessages = NULL;
+        const char *topic               = "0179-destroy-fatal-error";
+        const char *group               = "0179-destroy-fatal-error";
+        const int total_msgs            = 10;
+        const int share_ack_delay_ms    = 30000;
+        size_t rcvd                     = 0;
+        int attempts                    = 0;
         size_t i;
         rd_ts_t t_start, t_elapsed_ms;
 
@@ -1676,13 +1755,13 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
 
         TEST_SAY("Consuming %d msgs\n", total_msgs);
         while (rcvd < (size_t)total_msgs && attempts++ < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
                 if (error)
                         rd_kafka_error_destroy(error);
                 else
-                        rcvd += batch_rcvd;
+                        rcvd = rd_kafka_messages_count(rkmessages);
         }
         TEST_ASSERT(rcvd >= (size_t)total_msgs,
                     "Expected %d msgs, got %d after %d attempts", total_msgs,
@@ -1690,8 +1769,11 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
 
         TEST_SAY("Acknowledging %d/%d messages (no commit)\n", (int)(rcvd / 2),
                  (int)rcvd);
-        for (i = 0; i < rcvd / 2; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+        for (i = 0; i < rcvd / 2; i++) {
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(rkmessages, i);
+                if (rkm)
+                        rd_kafka_share_acknowledge(rkshare, rkm);
+        }
 
         /* Inject a long delay on the next ShareAcknowledge so a normal
          * close path would block on it. The fatal-error path must NOT
@@ -1712,9 +1794,11 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
                     "test_fatal_error returned %s", rd_kafka_err2name(err));
 
         /* Destroy all consumed messages before share_destroy. */
-        for (i = 0; i < rcvd; i++)
-                TEST_SAY("Calling destroy with flags 0x%x (fatal-error path)\n",
-                         destroy_flags);
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+
+        TEST_SAY("Calling destroy with flags 0x%x (fatal-error path)\n",
+                 destroy_flags);
         t_start = test_clock();
         destroy_share_consumer(rkshare, destroy_flags);
         t_elapsed_ms = (test_clock() - t_start) / 1000;
@@ -1727,7 +1811,6 @@ static void test_destroy_with_fatal_error(int destroy_flags) {
                     t_elapsed_ms);
 
         test_mock_cluster_destroy(mcluster);
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1751,14 +1834,13 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
         const char *group = "0179-destroy-explicit-ack";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
-        size_t rcvd               = 0;
-        size_t first_batch_cnt    = 0;
-        int32_t first_batch_part  = -1;
-        int32_t second_batch_part = -1;
-        int i;
-        int attempts = 0;
+        rd_kafka_messages_t *first_batch  = NULL;
+        rd_kafka_messages_t *second_batch = NULL;
+        size_t rcvd                       = 0;
+        size_t first_batch_cnt            = 0;
+        int32_t first_batch_part          = -1;
+        int32_t second_batch_part         = -1;
+        int attempts                      = 0;
         int ack_cnt;
         expected_ack_t expected[2];
         int second_part_cnt;
@@ -1798,29 +1880,46 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
         TEST_SAY("Consuming %d messages (up to %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_t *batch = NULL;
+                size_t batch_rcvd;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        rd_kafka_messages_destroy(batch);
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(batch);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
-                        if (first_batch_cnt == 0) {
+                        if (first_batch == NULL) {
                                 size_t k;
                                 /* First non-empty batch: ack ALL. The
                                  * next consume_batch will piggyback
                                  * this ack on a ShareFetch. */
+                                first_batch     = batch;
                                 first_batch_cnt = batch_rcvd;
-                                for (k = 0; k < batch_rcvd; k++)
-                                        rd_kafka_share_acknowledge(
-                                            rkshare,
-                                            rkmessages_acc.msgs[rcvd + k]);
+                                for (k = 0; k < batch_rcvd; k++) {
+                                        rd_kafka_message_t *rkm =
+                                            rd_kafka_messages_get(batch, k);
+                                        if (rkm)
+                                                rd_kafka_share_acknowledge(
+                                                    rkshare, rkm);
+                                }
+                        } else {
+                                /* Second non-empty batch — keep it for
+                                 * out-of-loop acks below. */
+                                rd_kafka_messages_destroy(second_batch);
+                                second_batch = batch;
                         }
                         rcvd += batch_rcvd;
+                } else {
+                        rd_kafka_messages_destroy(batch);
                 }
                 attempts++;
         }
@@ -1831,15 +1930,22 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
         TEST_ASSERT(first_batch_cnt == TEST_MSGS / 2,
                     "Expected first batch == TEST_MSGS/2 (%d), got %d",
                     TEST_MSGS / 2, (int)first_batch_cnt);
+        TEST_ASSERT(second_batch != NULL, "Expected a non-NULL second batch");
 
         drain_ack_callbacks(rkshare);
-        first_batch_part  = rkmessages_acc.msgs[0]->partition;
+        {
+                rd_kafka_message_t *first_rkm =
+                    rd_kafka_messages_get(first_batch, 0);
+                TEST_ASSERT(first_rkm != NULL,
+                            "Expected non-NULL first batch message");
+                first_batch_part = first_rkm->partition;
+        }
         second_batch_part = (first_batch_part == 0) ? 1 : 0;
         TEST_SAY("Consumed %d messages (first batch on partition %" PRId32
                  ", second batch on partition %" PRId32 ")\n",
                  (int)rcvd, first_batch_part, second_batch_part);
 
-        /* Ack the second batch (records rkmessages[first_batch_cnt..rcvd)):
+        /* Ack the second batch:
          *   ack_half=false: ack all TEST_MSGS/2 records.
          *   ack_half=true:  ack TEST_MSGS/4 records (the first half).
          * These acks won't be piggyback-flushed close runs — which is
@@ -1849,9 +1955,12 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
                 int second_to_ack =
                     ack_half ? (TEST_MSGS / 4) : (TEST_MSGS / 2);
                 int k;
-                for (k = 0; k < second_to_ack; k++)
-                        rd_kafka_share_acknowledge(
-                            rkshare, rkmessages_acc.msgs[first_batch_cnt + k]);
+                for (k = 0; k < second_to_ack; k++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(second_batch, k);
+                        if (rkm)
+                                rd_kafka_share_acknowledge(rkshare, rkm);
+                }
                 ack_cnt = (int)first_batch_cnt + second_to_ack;
                 TEST_SAY(
                     "Acked first batch (%d) + second batch (%d) = %d / "
@@ -1860,8 +1969,12 @@ static void do_test_destroy_with_explicit_ack(int destroy_flags,
         }
 
         /* Destroy all consumed messages (acked and unacked alike). */
-        for (i = 0; i < (int)rcvd; i++)
-                destroy_share_consumer(rkshare, destroy_flags);
+        rd_kafka_messages_destroy(first_batch);
+        first_batch = NULL;
+        rd_kafka_messages_destroy(second_batch);
+        second_batch = NULL;
+
+        destroy_share_consumer(rkshare, destroy_flags);
 
         /* Assert ack callback receipts.
          *
@@ -1915,14 +2028,13 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         const char *group = "0179-destroy-implicit-ack";
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, CONSUME_ARRAY);
-        size_t rcvd               = 0;
-        size_t first_batch_cnt    = 0;
-        int32_t first_batch_part  = -1;
-        int32_t second_batch_part = -1;
-        int i;
-        int attempts = 0;
+        rd_kafka_messages_t *first_batch  = NULL;
+        rd_kafka_messages_t *second_batch = NULL;
+        size_t rcvd                       = 0;
+        size_t first_batch_cnt            = 0;
+        int32_t first_batch_part          = -1;
+        int32_t second_batch_part         = -1;
+        int attempts                      = 0;
         expected_ack_t expected[1];
         ack_receipts_t receipts;
 
@@ -1958,20 +2070,33 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         TEST_SAY("Consuming %d messages (up to %d attempts)\n", TEST_MSGS,
                  MAX_CONSUME_ATTEMPTS);
         while (rcvd < TEST_MSGS && attempts < MAX_CONSUME_ATTEMPTS) {
-                size_t batch_rcvd = CONSUME_ARRAY - rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                rd_kafka_messages_t *batch = NULL;
+                size_t batch_rcvd;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
 
                 if (error) {
                         TEST_SAY("Attempt %d: consume error: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        rd_kafka_messages_destroy(batch);
+                        attempts++;
+                        continue;
+                }
+
+                batch_rcvd = rd_kafka_messages_count(batch);
+                if (batch_rcvd > 0) {
                         TEST_SAY("Attempt %d: consumed %d messages\n", attempts,
                                  (int)batch_rcvd);
-                        if (first_batch_cnt == 0)
+                        if (first_batch == NULL) {
+                                first_batch     = batch;
                                 first_batch_cnt = batch_rcvd;
+                        } else {
+                                rd_kafka_messages_destroy(second_batch);
+                                second_batch = batch;
+                        }
                         rcvd += batch_rcvd;
+                } else {
+                        rd_kafka_messages_destroy(batch);
                 }
                 attempts++;
         }
@@ -1982,7 +2107,13 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         TEST_ASSERT(first_batch_cnt == TEST_MSGS / 2,
                     "Expected first batch == TEST_MSGS/2 (%d), got %d",
                     TEST_MSGS / 2, (int)first_batch_cnt);
-        first_batch_part  = rkmessages_acc.msgs[0]->partition;
+        {
+                rd_kafka_message_t *first_rkm =
+                    rd_kafka_messages_get(first_batch, 0);
+                TEST_ASSERT(first_rkm != NULL,
+                            "Expected non-NULL first batch message");
+                first_batch_part = first_rkm->partition;
+        }
         second_batch_part = (first_batch_part == 0) ? 1 : 0;
         TEST_SAY("Consumed %d messages (first batch on partition %" PRId32
                  ", second batch on partition %" PRId32 ")\n",
@@ -1993,8 +2124,12 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
         drain_ack_callbacks(rkshare);
 
         /* Destroy all consumed messages before share_destroy. */
-        for (i = 0; i < (int)rcvd; i++)
-                destroy_share_consumer(rkshare, destroy_flags);
+        rd_kafka_messages_destroy(first_batch);
+        first_batch = NULL;
+        rd_kafka_messages_destroy(second_batch);
+        second_batch = NULL;
+
+        destroy_share_consumer(rkshare, destroy_flags);
 
         /* Assert ack callback receipts.
          *
@@ -2016,7 +2151,6 @@ static void do_test_destroy_with_implicit_ack(int destroy_flags) {
 
         ack_receipts_destroy(&receipts);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2123,25 +2257,29 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
          * with whatever inflight state that leaves the lib in. */
         while (acked < target && attempts++ < 80) {
                 rd_kafka_error_t *err;
-                rcvd = 0;
-                err  = rd_kafka_share_poll(rkshare, 3000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                err   = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (err) {
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
                         rd_kafka_share_AcknowledgeType_t at;
                         rd_kafka_resp_err_t aerr;
                         rd_kafka_error_t *cerr;
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
 
-                        if (rd_kafka_messages_get(batch, j)->err) {
+                        if (!rkm)
                                 continue;
-                        }
 
-                        if (acked >= target) {
+                        if (rkm->err)
                                 continue;
-                        }
+
+                        if (acked >= target)
+                                continue;
 
                         switch (acked % 3) {
                         case 0:
@@ -2155,8 +2293,8 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
                                 break;
                         }
 
-                        aerr = rd_kafka_share_acknowledge_type(
-                            rkshare, rd_kafka_messages_get(batch, j), at);
+                        aerr =
+                            rd_kafka_share_acknowledge_type(rkshare, rkm, at);
                         TEST_ASSERT(!aerr, "acknowledge_type(%d) failed: %s",
                                     (int)at, rd_kafka_err2str(aerr));
                         acked++;
@@ -2182,6 +2320,8 @@ static void do_test_destroy_with_mixed_acks_and_commits(int destroy_flags) {
                         }
                 }
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
         TEST_ASSERT(acked >= target, "expected to ack %d records, got %d",
                     target, acked);
         TEST_SAY(

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -361,7 +361,7 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
                                   int batch_sizes_cap,
                                   int per_call_timeout_ms,
                                   int max_calls) {
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         size_t rcvd;
         size_t j;
         rd_kafka_error_t *error;
@@ -370,26 +370,32 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
         int call;
 
         for (call = 0; call < max_calls && got < target; call++) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, per_call_timeout_ms,
-                                            &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error =
+                    rd_kafka_share_poll(rkshare, per_call_timeout_ms, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
-                if (rcvd == 0)
+                rcvd = rd_kafka_messages_count(batch);
+                if (rcvd == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
+                }
 
                 if (batches < batch_sizes_cap)
                         batch_sizes[batches] = (int)rcvd;
                 batches++;
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 got++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         return batches;
 }

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -349,7 +349,7 @@ static void produce_one_per_batch(rd_kafka_t *producer,
 
 /**
  * @brief Consume \p target records and record how many records came in
- *        each batch returned by rd_kafka_share_consume_batch().
+ *        each batch returned by rd_kafka_share_poll().
  *
  * @returns Number of batches it took to reach \p target records.
  *          Out-param \p batch_sizes is filled with each batch's
@@ -361,7 +361,7 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
                                   int batch_sizes_cap,
                                   int per_call_timeout_ms,
                                   int max_calls) {
-        rd_kafka_message_t *rkmessages[1024];
+        rd_kafka_messages_t *rkmessages = NULL;
         size_t rcvd;
         size_t j;
         rd_kafka_error_t *error;
@@ -371,8 +371,9 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
 
         for (call = 0; call < max_calls && got < target; call++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(
-                    rkshare, per_call_timeout_ms, rkmessages, &rcvd);
+                error = rd_kafka_share_poll(rkshare, per_call_timeout_ms,
+                                            &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -386,9 +387,8 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
                 batches++;
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 got++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         return batches;

--- a/tests/0181-share_consumer_topic_delete.c
+++ b/tests/0181-share_consumer_topic_delete.c
@@ -120,7 +120,7 @@ static rd_kafka_share_t *create_topic_delete_consumer(const char *group,
 
 static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[1024];
+        rd_kafka_messages_t *batch               = NULL;
         rd_kafka_topic_partition_list_t *results = NULL;
         rd_kafka_error_t *error;
         rd_kafka_resp_err_t del_err;
@@ -175,30 +175,36 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
          * records and that every partition is represented. */
         while (total < TD_TOTAL && attempts-- > 0) {
                 size_t n = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 2000, batch, &n);
+                error    = rd_kafka_share_poll(rkshare, 2000, &batch);
+                n        = rd_kafka_messages_count(batch);
                 TEST_ASSERT(!error, "consume_batch failed: %s",
                             rd_kafka_error_string(error));
                 TEST_SAY("Phase 1: got %" PRIusz " record(s), total %d/%d\n", n,
                          total + (int)n, TD_TOTAL);
                 for (m = 0; m < n; m++) {
-                        TEST_ASSERT(!strcmp(rd_kafka_topic_name(batch[m]->rkt),
-                                            topic_del),
-                                    "Phase 1 record from unexpected topic %s",
-                                    rd_kafka_topic_name(batch[m]->rkt));
-                        TEST_ASSERT(batch[m]->partition >= 0 &&
-                                        batch[m]->partition < TD_NPART,
-                                    "Unexpected partition %" PRId32,
-                                    batch[m]->partition);
-                        part_cnt[batch[m]->partition]++;
+                        TEST_ASSERT(
+                            !strcmp(rd_kafka_topic_name(
+                                        rd_kafka_messages_get(batch, m)->rkt),
+                                    topic_del),
+                            "Phase 1 record from unexpected topic %s",
+                            rd_kafka_topic_name(
+                                rd_kafka_messages_get(batch, m)->rkt));
+                        TEST_ASSERT(
+                            rd_kafka_messages_get(batch, m)->partition >= 0 &&
+                                rd_kafka_messages_get(batch, m)->partition <
+                                    TD_NPART,
+                            "Unexpected partition %" PRId32,
+                            rd_kafka_messages_get(batch, m)->partition);
+                        part_cnt[rd_kafka_messages_get(batch, m)->partition]++;
                         if (explicit_ack) {
                                 rd_kafka_resp_err_t ack_err =
-                                    rd_kafka_share_acknowledge(rkshare,
-                                                               batch[m]);
+                                    rd_kafka_share_acknowledge(
+                                        rkshare,
+                                        rd_kafka_messages_get(batch, m));
                                 TEST_ASSERT(!ack_err, "acknowledge failed: %s",
                                             rd_kafka_err2str(ack_err));
                         }
                         total++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_ASSERT(total == TD_TOTAL, "Expected %d records, got %d", TD_TOTAL,
@@ -279,8 +285,8 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
         attempts = 60;
         while (attempts-- > 0) {
                 size_t got = 0;
-                error =
-                    rd_kafka_share_consume_batch(rkshare, 1000, batch, &got);
+                error      = rd_kafka_share_poll(rkshare, 1000, &batch);
+                got        = rd_kafka_messages_count(batch);
                 TEST_ASSERT(!error, "consume_batch failed: %s",
                             rd_kafka_error_string(error));
                 TEST_SAY("Phase 2: got %" PRIusz
@@ -297,15 +303,18 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
                 idle_polls = 0;
                 for (m = 0; m < got; m++) {
                         TEST_ASSERT(
-                            !strcmp(rd_kafka_topic_name(batch[m]->rkt),
+                            !strcmp(rd_kafka_topic_name(
+                                        rd_kafka_messages_get(batch, m)->rkt),
                                     topic_keep),
                             "Phase 2 returned a record from %s; only %s "
                             "should remain",
-                            rd_kafka_topic_name(batch[m]->rkt), topic_keep);
+                            rd_kafka_topic_name(
+                                rd_kafka_messages_get(batch, m)->rkt),
+                            topic_keep);
                         if (explicit_ack)
-                                rd_kafka_share_acknowledge(rkshare, batch[m]);
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rd_kafka_messages_get(batch, m));
                         keep_rcvd++;
-                        rd_kafka_message_destroy(batch[m]);
                 }
         }
         TEST_ASSERT(keep_rcvd == TD_KEEP_MSGS,

--- a/tests/0181-share_consumer_topic_delete.c
+++ b/tests/0181-share_consumer_topic_delete.c
@@ -174,38 +174,34 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
          * also flushes the previous broker's acknowledgements. Verify all
          * records and that every partition is represented. */
         while (total < TD_TOTAL && attempts-- > 0) {
-                size_t n = 0;
-                error    = rd_kafka_share_poll(rkshare, 2000, &batch);
-                n        = rd_kafka_messages_count(batch);
-                TEST_ASSERT(!error, "consume_batch failed: %s",
+                size_t n;
+                error = rd_kafka_share_poll(rkshare, 2000, &batch);
+                TEST_ASSERT(!error, "share_poll failed: %s",
                             rd_kafka_error_string(error));
+                n = rd_kafka_messages_count(batch);
                 TEST_SAY("Phase 1: got %" PRIusz " record(s), total %d/%d\n", n,
                          total + (int)n, TD_TOTAL);
                 for (m = 0; m < n; m++) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
                         TEST_ASSERT(
-                            !strcmp(rd_kafka_topic_name(
-                                        rd_kafka_messages_get(batch, m)->rkt),
-                                    topic_del),
+                            !strcmp(rd_kafka_topic_name(msg->rkt), topic_del),
                             "Phase 1 record from unexpected topic %s",
-                            rd_kafka_topic_name(
-                                rd_kafka_messages_get(batch, m)->rkt));
+                            rd_kafka_topic_name(msg->rkt));
                         TEST_ASSERT(
-                            rd_kafka_messages_get(batch, m)->partition >= 0 &&
-                                rd_kafka_messages_get(batch, m)->partition <
-                                    TD_NPART,
-                            "Unexpected partition %" PRId32,
-                            rd_kafka_messages_get(batch, m)->partition);
-                        part_cnt[rd_kafka_messages_get(batch, m)->partition]++;
+                            msg->partition >= 0 && msg->partition < TD_NPART,
+                            "Unexpected partition %" PRId32, msg->partition);
+                        part_cnt[msg->partition]++;
                         if (explicit_ack) {
                                 rd_kafka_resp_err_t ack_err =
-                                    rd_kafka_share_acknowledge(
-                                        rkshare,
-                                        rd_kafka_messages_get(batch, m));
+                                    rd_kafka_share_acknowledge(rkshare, msg);
                                 TEST_ASSERT(!ack_err, "acknowledge failed: %s",
                                             rd_kafka_err2str(ack_err));
                         }
                         total++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(total == TD_TOTAL, "Expected %d records, got %d", TD_TOTAL,
                     total);
@@ -284,11 +280,11 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
          * Revert to a plain drain loop once the broker is fixed. */
         attempts = 60;
         while (attempts-- > 0) {
-                size_t got = 0;
-                error      = rd_kafka_share_poll(rkshare, 1000, &batch);
-                got        = rd_kafka_messages_count(batch);
-                TEST_ASSERT(!error, "consume_batch failed: %s",
+                size_t got;
+                error = rd_kafka_share_poll(rkshare, 1000, &batch);
+                TEST_ASSERT(!error, "share_poll failed: %s",
                             rd_kafka_error_string(error));
+                got = rd_kafka_messages_count(batch);
                 TEST_SAY("Phase 2: got %" PRIusz
                          " record(s), kept %d/%d (idle %d)\n",
                          got, keep_rcvd, TD_KEEP_MSGS, idle_polls);
@@ -296,26 +292,27 @@ static void do_test_topic_delete_ack(const char *mode, ack_timing_t timing) {
                         /* An empty poll counts as drained only after every
                          * record has arrived; earlier ones are the session
                          * still recovering. */
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         if (keep_rcvd >= TD_KEEP_MSGS && ++idle_polls >= 3)
                                 break;
                         continue;
                 }
                 idle_polls = 0;
                 for (m = 0; m < got; m++) {
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, m);
                         TEST_ASSERT(
-                            !strcmp(rd_kafka_topic_name(
-                                        rd_kafka_messages_get(batch, m)->rkt),
-                                    topic_keep),
+                            !strcmp(rd_kafka_topic_name(msg->rkt), topic_keep),
                             "Phase 2 returned a record from %s; only %s "
                             "should remain",
-                            rd_kafka_topic_name(
-                                rd_kafka_messages_get(batch, m)->rkt),
-                            topic_keep);
+                            rd_kafka_topic_name(msg->rkt), topic_keep);
                         if (explicit_ack)
-                                rd_kafka_share_acknowledge(
-                                    rkshare, rd_kafka_messages_get(batch, m));
+                                rd_kafka_share_acknowledge(rkshare, msg);
                         keep_rcvd++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(keep_rcvd == TD_KEEP_MSGS,
                     "Expected to drain exactly %d records from surviving "

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -175,32 +175,31 @@ static void mock_produce_partition(rd_kafka_t *producer,
  *        actually acknowledged.
  */
 static int consume_and_ack_all(rd_kafka_share_t *rkshare, int msgcnt) {
-        rd_kafka_messages_t *rkmessages = NULL;
-        int acked                       = 0;
-        int attempts                    = 0;
+        rd_kafka_messages_t *batch = NULL;
+        int acked                  = 0;
+        int attempts               = 0;
 
         while (acked < msgcnt && attempts++ < 30) {
                 size_t rcvd = 0;
                 size_t j;
-                rd_kafka_error_t *error;
-                rd_kafka_messages_destroy(rkmessages);
-                rkmessages = NULL;
-                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd       = rd_kafka_messages_count(rkmessages);
+                rd_kafka_error_t *error =
+                    rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        rd_kafka_message_t *m =
-                            rd_kafka_messages_get(rkmessages, j);
-                        if (!m->err) {
-                                rd_kafka_share_acknowledge(rkshare, m);
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 acked++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
-        rd_kafka_messages_destroy(rkmessages);
         return acked;
 }
 
@@ -368,11 +367,11 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
         const int total_msgs         = partition_cnt * msgs_per_partition;
         rd_kafka_resp_err_t injected_err =
             RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        int total_consumed = 0;
-        int acked          = 0;
-        int attempts       = 0;
+        rd_kafka_messages_t *batches[CONSUME_ARRAY] = {0};
+        int batch_cnt                               = 0;
+        int total_consumed                          = 0;
+        int acked                                   = 0;
+        int attempts                                = 0;
         int i;
         test_ack_cb_state_t cb_state = {0};
 
@@ -397,13 +396,21 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
 
         /* Consume messages from all partitions */
         while (total_consumed < total_msgs && attempts++ < 50) {
-                size_t rcvd = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt - total_consumed;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd                = 0;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
+                if (rcvd == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        continue;
+                }
+                TEST_ASSERT(batch_cnt < CONSUME_ARRAY, "batch buffer overflow");
+                batches[batch_cnt++] = batch;
                 total_consumed += (int)rcvd;
         }
 
@@ -413,11 +420,16 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
                     total_msgs, partition_cnt, total_consumed);
 
         /* Acknowledge all messages */
-        for (i = 0; i < total_consumed; i++) {
-                if (!rkmessages_acc.msgs[i]->err) {
-                        rd_kafka_share_acknowledge(rkshare,
-                                                   rkmessages_acc.msgs[i]);
-                        acked++;
+        for (i = 0; i < batch_cnt; i++) {
+                size_t j;
+                size_t rcvd = rd_kafka_messages_count(batches[i]);
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batches[i], j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
+                                acked++;
+                        }
                 }
         }
 
@@ -469,12 +481,14 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
                     "expected callback total_offsets %d, got %zu", total_msgs,
                     cb_state.total_offsets);
 
+        for (i = 0; i < batch_cnt; i++)
+                rd_kafka_messages_destroy(batches[i]);
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -501,10 +515,9 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         const int total_msgs         = partition_cnt * msgs_per_partition;
         rd_kafka_resp_err_t injected_err =
             RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        int total_consumed = 0;
-        int attempts       = 0;
+        rd_kafka_messages_t *batch = NULL;
+        int total_consumed         = 0;
+        int attempts               = 0;
         int i;
         test_ack_cb_state_t cb_state = {0};
 
@@ -531,13 +544,19 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         /* First consume batch - establishes session, consumes messages */
         while (total_consumed < total_msgs && attempts++ < 50) {
                 size_t rcvd = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt - total_consumed;
+                error       = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 total_consumed += (int)rcvd;
+                /* Destroy messages - in implicit mode they're
+                 * auto-acknowledged */
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(total_consumed == total_msgs,
@@ -545,13 +564,11 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
                     "got %d",
                     total_msgs, partition_cnt, total_consumed);
 
-        /* Destroy messages - in implicit mode they're auto-acknowledged */
-        for (i = 0; i < total_consumed; i++)
-                /* Produce more messages to trigger another ShareFetch with
-                 * piggybacked acks from the previous consume */
-                for (i = 0; i < partition_cnt; i++)
-                        mock_produce_partition(ctx.producer, topic, i,
-                                               msgs_per_partition);
+        /* Produce more messages to trigger another ShareFetch with
+         * piggybacked acks from the previous consume */
+        for (i = 0; i < partition_cnt; i++)
+                mock_produce_partition(ctx.producer, topic, i,
+                                       msgs_per_partition);
 
         /* Inject top-level error on next ShareFetch (which will carry
          * piggybacked acks from the previous consume_batch) */
@@ -566,16 +583,21 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         attempts       = 0;
         while (total_consumed < total_msgs && attempts++ < 50) {
                 size_t rcvd = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt;
+                size_t j;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         /* May get errors due to injected error */
                 }
-                for (i = 0; i < (int)rcvd; i++) {
-                        if (!rkmessages_acc.msgs[i]->err)
+                rcvd = rd_kafka_messages_count(batch);
+                for (j = 0; j < rcvd; j++) {
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
                                 total_consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 /* Break after we've given the callback a chance to fire */
                 if (cb_state.callback_cnt > 0)
                         break;
@@ -607,7 +629,6 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -645,10 +666,11 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         const char *topic = "0182-epoch-zero-ack";
         const char *group = "sg-0182-epoch-zero-ack";
         const int msgcnt  = 10;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        int total_consumed = 0;
-        int attempts       = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *batches[CONSUME_ARRAY] = {0};
+        int batch_cnt                               = 0;
+        int total_consumed                          = 0;
+        int attempts                                = 0;
         size_t share_ack_cnt;
         int i;
         test_ack_cb_state_t cb_state = {0};
@@ -670,14 +692,27 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         /* Phase 0: consume all 10 records. Hold message handles for
          * acknowledge in phase 1 and phase 2. */
         while (total_consumed < msgcnt && attempts++ < 30) {
-                size_t rcvd = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt - total_consumed;
+                rd_kafka_messages_t *batch = NULL;
+                size_t rcvd                = 0;
+                size_t j;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
                         continue;
                 }
-                total_consumed += (int)rcvd;
+                rcvd = rd_kafka_messages_count(batch);
+                if (rcvd == 0) {
+                        rd_kafka_messages_destroy(batch);
+                        continue;
+                }
+                /* Flatten message handles into rkmessages for the
+                 * phase-1/phase-2 partial-ack indexing pattern. */
+                for (j = 0; j < rcvd && total_consumed < CONSUME_ARRAY; j++)
+                        rkmessages[total_consumed++] =
+                            rd_kafka_messages_get(batch, j);
+                TEST_ASSERT(batch_cnt < CONSUME_ARRAY, "batch buffer overflow");
+                batches[batch_cnt++] = batch;
         }
         TEST_ASSERT(total_consumed == msgcnt,
                     "Phase 0: expected %d records, got %d", msgcnt,
@@ -688,7 +723,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
          * propagates. The buf reply handler resets the broker session
          * epoch to 0 on this error. */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -746,7 +781,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 1000, &partitions);
@@ -790,6 +825,9 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
                     cb_state.total_offsets);
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
+
+        for (i = 0; i < batch_cnt; i++)
+                rd_kafka_messages_destroy(batches[i]);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -841,11 +879,11 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         const char *topic = "0182-epoch-zero-piggyback";
         const char *group = "sg-0182-epoch-zero-piggyback";
         const int msgcnt  = 10;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        rd_kafka_messages_t *phase2_msgs = NULL;
-        int attempts                     = 0;
-        size_t rcvd                      = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *phase0_batch = NULL;
+        rd_kafka_messages_t *phase2_batch = NULL;
+        int attempts                      = 0;
+        size_t rcvd                       = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
         int i;
@@ -873,21 +911,25 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * below max.poll.records (default 500), so a non-empty call
          * returns the full set. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt;
+                rd_kafka_messages_destroy(phase0_batch);
+                phase0_batch = NULL;
+                error = rd_kafka_share_poll(rkshare, 3000, &phase0_batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(phase0_batch);
         }
         TEST_ASSERT(rcvd == (size_t)msgcnt,
                     "Phase 0: expected %d records in single batch, "
                     "got %" PRIusz,
                     msgcnt, rcvd);
+        for (i = 0; i < msgcnt; i++)
+                rkmessages[i] = rd_kafka_messages_get(phase0_batch, i);
 
         /* Phase 1: ACCEPT first 5 records, inject SHARE_SESSION_NOT_FOUND
          * on next ShareAcknowledge, call commit_sync to trigger session
          * reset on the broker (epoch -> 0). */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -952,7 +994,7 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         /* Single consume_batch triggers the strip-mode FANOUT.
          * Records here may be re-deliveries after lock expiry — we
@@ -960,11 +1002,12 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * test_wait_for_cb_with_poll below tolerates the explicit-mode
          * __STATE the next consume_batch may return for these
          * un-acknowledged records (rcvd stays 0). */
-        error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
-        rcvd  = rd_kafka_messages_count(phase2_msgs);
-        (void)rcvd;
+        error = rd_kafka_share_poll(rkshare, 1000, &phase2_batch);
         if (error)
                 rd_kafka_error_destroy(error);
+        rd_kafka_messages_destroy(phase2_batch);
+        phase2_batch = NULL;
+
         share_fetch_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
@@ -1013,13 +1056,13 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
-        rd_kafka_messages_destroy(phase2_msgs);
+        rd_kafka_messages_destroy(phase0_batch);
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1049,11 +1092,11 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         const char *topic = "0182-epoch-zero-piggyback-fetch-err";
         const char *group = "sg-0182-epoch-zero-piggyback-fetch-err";
         const int msgcnt  = 10;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        rd_kafka_messages_t *phase2_msgs = NULL;
-        int attempts                     = 0;
-        size_t rcvd                      = 0;
+        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *phase0_batch = NULL;
+        rd_kafka_messages_t *phase2_batch = NULL;
+        int attempts                      = 0;
+        size_t rcvd                       = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
         int i;
@@ -1081,21 +1124,25 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * below max.poll.records (default 500), so a non-empty call
          * returns the full set. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                rcvd  = rkmessages_acc.cnt;
+                rd_kafka_messages_destroy(phase0_batch);
+                phase0_batch = NULL;
+                error = rd_kafka_share_poll(rkshare, 3000, &phase0_batch);
                 if (error)
                         rd_kafka_error_destroy(error);
+                rcvd = rd_kafka_messages_count(phase0_batch);
         }
         TEST_ASSERT(rcvd == (size_t)msgcnt,
                     "Phase 0: expected %d records in single batch, "
                     "got %" PRIusz,
                     msgcnt, rcvd);
+        for (i = 0; i < msgcnt; i++)
+                rkmessages[i] = rd_kafka_messages_get(phase0_batch, i);
 
         /* Phase 1: ACCEPT first 5 records, inject SHARE_SESSION_NOT_FOUND
          * on next ShareAcknowledge, call commit_sync to trigger session
          * reset on the broker (epoch -> 0). */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -1136,7 +1183,7 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
                         ctx.mcluster, 1, RD_KAFKAP_ShareFetch, 1,
@@ -1150,11 +1197,12 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * test_wait_for_cb_with_poll below tolerates the explicit-mode
          * __STATE the next consume_batch may return for these
          * un-acknowledged records (rcvd stays 0). */
-        error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
-        rcvd  = rd_kafka_messages_count(phase2_msgs);
-        (void)rcvd;
+        error = rd_kafka_share_poll(rkshare, 1000, &phase2_batch);
         if (error)
                 rd_kafka_error_destroy(error);
+        rd_kafka_messages_destroy(phase2_batch);
+        phase2_batch = NULL;
+
         share_fetch_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
@@ -1196,13 +1244,13 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
-        rd_kafka_messages_destroy(phase2_msgs);
+        rd_kafka_messages_destroy(phase0_batch);
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1292,44 +1340,55 @@ static rd_kafka_share_t *create_share_consumer_socket_timeout(
 
 /**
  * @brief Consume up to \p expected records (across one or more
- *        consume_batch calls), acknowledging the first \p ack_first.
+ *        share_poll calls), acknowledging the first \p ack_first.
  *
- * Caller owns and must destroy every message in \p rkmessages.
- * Asserts that exactly \p expected records were received within the
- * polling budget. Used both for the pre-stage Phase 1 consume (broker
- * has all records ready, typically arrives in a single batch) and for
- * the post-teardown Phase 2 consume (records may trickle in across
- * multiple batches as the new session warms up).
+ * Caller owns the returned batch via \p *out_batch and must
+ * rd_kafka_messages_destroy() it. The flattened \p rkmessages array
+ * is populated with pointers borrowed from the batch (lifetime tied
+ * to the batch). Asserts that exactly \p expected records were
+ * received within the polling budget. Used both for the pre-stage
+ * Phase 1 consume (broker has all records ready, typically arrives
+ * in a single batch) and for the post-teardown Phase 2 consume
+ * (records may trickle in across multiple batches as the new
+ * session warms up).
  */
 static void consume_first_batch(rd_kafka_share_t *rkshare,
-                                test_share_batch_t *acc,
-                                int expected) {
+                                rd_kafka_message_t **rkmessages,
+                                int expected,
+                                rd_kafka_messages_t **out_batch) {
         size_t rcvd  = 0;
         int attempts = 0;
         rd_kafka_error_t *error;
+        rd_kafka_messages_t *batch = NULL;
         int j;
 
         /* Spin until the first non-empty batch arrives. The test
          * pre-stages the broker with all \p expected records so the
          * batch we receive will contain exactly that many. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = test_share_batch_poll(acc, rkshare, 3000);
-                rcvd  = acc->cnt;
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
-                        TEST_SAY("consume_first_batch: err=%s rcvd=%zu\n",
-                                 rd_kafka_err2name(rd_kafka_error_code(error)),
-                                 rcvd);
+                        TEST_SAY("consume_first_batch: err=%s\n",
+                                 rd_kafka_err2name(rd_kafka_error_code(error)));
                         rd_kafka_error_destroy(error);
                 }
+                rcvd = rd_kafka_messages_count(batch);
         }
 
         TEST_ASSERT((int)rcvd == expected,
                     "Expected %d records in first batch, got %zu", expected,
                     rcvd);
 
-        for (j = 0; j < (int)rcvd; j++)
-                TEST_ASSERT(!acc->msgs[j]->err, "Unexpected per-record err: %s",
-                            rd_kafka_err2str(acc->msgs[j]->err));
+        for (j = 0; j < (int)rcvd; j++) {
+                rkmessages[j] = rd_kafka_messages_get(batch, j);
+                TEST_ASSERT(!rkmessages[j]->err,
+                            "Unexpected per-record err: %s",
+                            rd_kafka_err2str(rkmessages[j]->err));
+        }
+
+        *out_batch = batch;
 }
 
 /**
@@ -1405,8 +1464,10 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
         const int partitions_total = SOCKET_TIMEOUT_MATRIX_PARTITIONS;
         const int msgcnt =
             partitions_total * SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION;
-        test_share_batch_t rkmessages_acc;
-        test_ack_cb_state_t cb_state = {0};
+        rd_kafka_message_t **rkmessages;
+        rd_kafka_messages_t *phase1_batch = NULL;
+        rd_kafka_messages_t *phase2_batch = NULL;
+        test_ack_cb_state_t cb_state      = {0};
         rd_ts_t t_p1_end_us, t_callbacks_done_us;
         int actual_wait_ms, expected_wait_ms;
         int min_between_rtt_ms_socket_timeout_ms;
@@ -1578,14 +1639,14 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
             test_share_ack_cb);
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
-        test_share_batch_init(&rkmessages_acc, msgcnt);
+        rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
 
         /* Phase 1: consume the first batch (all msgcnt records
          * given the small partition count and broker readiness),
          * acknowledge everyone, then inject RTT and commit_sync. */
-        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
+        consume_first_batch(rkshare, rkmessages, msgcnt, &phase1_batch);
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, rtt_ms);
 
@@ -1655,12 +1716,13 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
                     SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION);
 
         /* Free phase-1 messages. */
-        test_share_batch_destroy(&rkmessages_acc);
-        test_share_batch_init(&rkmessages_acc, msgcnt);
+        rd_kafka_messages_destroy(phase1_batch);
+        phase1_batch = NULL;
+        memset(rkmessages, 0, msgcnt * sizeof(*rkmessages));
 
-        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
+        consume_first_batch(rkshare, rkmessages, msgcnt, &phase2_batch);
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 5000, &partitions);
@@ -1689,8 +1751,8 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
                     "after=%d",
                     prev_callback_cnt, cb_state.callback_cnt);
 
-        for (i = 0; i < msgcnt; i++)
-                test_share_batch_destroy(&rkmessages_acc);
+        rd_kafka_messages_destroy(phase2_batch);
+        rd_free(rkmessages);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1749,8 +1811,9 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
         const int partitions_total = SOCKET_TIMEOUT_MATRIX_PARTITIONS;
         const int msgcnt =
             partitions_total * SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION;
-        test_share_batch_t rkmessages_acc;
-        test_ack_cb_state_t cb_state = {0};
+        rd_kafka_message_t **rkmessages;
+        rd_kafka_messages_t *phase1_batch = NULL;
+        test_ack_cb_state_t cb_state      = {0};
         rd_ts_t t_p1_end_us, t_callbacks_done_us;
         int actual_wait_ms, expected_wait_ms;
         int min_between_rtt_ms_socket_timeout_ms;
@@ -1842,16 +1905,16 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
             test_share_ack_cb);
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
-        test_share_batch_init(&rkmessages_acc, msgcnt);
+        rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
 
         /* Phase 1: consume the first batch (all msgcnt records),
          * then ack the first half of the batch in receive order.
          * The exact set of partitions covered depends on broker-side
          * record ordering; the assertions below adapt to whatever
          * partitions appear in commit_sync's results. */
-        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
+        consume_first_batch(rkshare, rkmessages, msgcnt, &phase1_batch);
         for (i = 0; i < msgcnt / 2; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, rtt_ms);
 
@@ -1926,7 +1989,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
 
         /* Ack the remaining half of the batch in receive order. */
         for (i = msgcnt / 2; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 5000, &partitions);
@@ -1968,8 +2031,8 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
             rd_kafka_err2name(expected_phase2_commit_err),
             rd_kafka_err2name(cb_state.errs[cb_state.callback_cnt - 1]));
 
-        for (i = 0; i < msgcnt; i++)
-                test_share_batch_destroy(&rkmessages_acc);
+        rd_kafka_messages_destroy(phase1_batch);
+        rd_free(rkmessages);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1999,8 +2062,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
  * is fully materialised before the test injects an error. Records are
  * ACKed inline because the consumer is in explicit-ack mode. */
 static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
@@ -2008,20 +2070,24 @@ static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
         rd_bool_t got_any = rd_false;
 
         for (attempts = 0; attempts < 20; attempts++) {
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 1000);
-                rcvd  = rkmessages_acc.cnt;
+                error = rd_kafka_share_poll(rkshare, 1000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages_acc.msgs[j]->err) {
-                                rd_kafka_share_acknowledge(
-                                    rkshare, rkmessages_acc.msgs[j]);
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                                 got_any = rd_true;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (got_any)
                         return;
         }
@@ -2048,35 +2114,38 @@ static void share_topic_err_force_metadata(rd_kafka_share_t *rkshare) {
 static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
                                               rd_kafka_resp_err_t expected,
                                               int max_attempts) {
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
         int attempts;
 
         for (attempts = 0; attempts < max_attempts; attempts++) {
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 500);
-                rcvd  = rkmessages_acc.cnt;
+                error = rd_kafka_share_poll(rkshare, 500, &batch);
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
-                        TEST_SAY("consume_batch returned %s: %s\n",
+                        TEST_SAY("share_poll returned %s: %s\n",
                                  rd_kafka_err2name(code),
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         if (code == expected)
                                 return rd_true;
                         continue;
                 }
-                /* Ack received records so the next consume_batch can
+                rcvd = rd_kafka_messages_count(batch);
+                /* Ack received records so the next share_poll can
                  * proceed past the explicit-mode "previous poll
                  * unacked" gate. */
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages_acc.msgs[j]->err)
-                                rd_kafka_share_acknowledge(
-                                    rkshare, rkmessages_acc.msgs[j]);
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         return rd_false;
 }
@@ -2087,33 +2156,35 @@ static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
 static void share_topic_err_assert_no_err(rd_kafka_share_t *rkshare,
                                           int n_attempts,
                                           const char *context) {
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
         int attempts;
 
         for (attempts = 0; attempts < n_attempts; attempts++) {
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
-                rcvd  = rkmessages_acc.cnt;
+                error = rd_kafka_share_poll(rkshare, 200, &batch);
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
                         TEST_FAIL(
-                            "[%s] unexpected error from consume_batch: "
+                            "[%s] unexpected error from share_poll: "
                             "%s",
                             context, rd_kafka_err2name(code));
                 }
-                /* Ack received records so the next consume_batch can
+                rcvd = rd_kafka_messages_count(batch);
+                /* Ack received records so the next share_poll can
                  * proceed past the explicit-mode "previous poll
                  * unacked" gate. */
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages_acc.msgs[j]->err)
-                                rd_kafka_share_acknowledge(
-                                    rkshare, rkmessages_acc.msgs[j]);
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 }
 
@@ -2184,11 +2255,10 @@ static void test_share_consumer_surfaces_topic_authorization_failed(void) {
 static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
         test_ctx_t ctx;
         rd_kafka_share_t *rkshare;
-        const char *topic       = "0182-multipart-single-op";
-        const char *group       = "sg-0182-multipart-single-op";
-        const int partition_cnt = 5;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
+        const char *topic          = "0182-multipart-single-op";
+        const char *group          = "sg-0182-multipart-single-op";
+        const int partition_cnt    = 5;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         size_t rcvd, j;
         int err_count = 0;
@@ -2220,9 +2290,7 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
          * short to keep it within one heartbeat interval and count just
          * what this cycle produced. */
         for (attempts = 0; attempts < 3; attempts++) {
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
-                rcvd  = rkmessages_acc.cnt;
+                error = rd_kafka_share_poll(rkshare, 200, &batch);
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         const char *errstr       = rd_kafka_error_string(error);
@@ -2231,13 +2299,19 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
                             errstr && strstr(errstr, topic))
                                 err_count++;
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages_acc.msgs[j]->err)
-                                rd_kafka_share_acknowledge(
-                                    rkshare, rkmessages_acc.msgs[j]);
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err)
+                                rd_kafka_share_acknowledge(rkshare, rkm);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         TEST_ASSERT(err_count == 1,
@@ -2249,7 +2323,6 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2554,14 +2627,13 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         rd_kafka_conf_t *conf;
         rd_atomic32_t broker_not_up_cnt;
         rd_kafka_error_t *error;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
-        const char *topic       = "0182-no_bounce_loop";
-        const char *group       = "sg-0182-no-bounce-loop";
-        const int msgcnt_phase1 = 5;
-        const int msgcnt_phase2 = 5;
+        rd_kafka_messages_t *batch = NULL;
+        const char *topic          = "0182-no_bounce_loop";
+        const char *group          = "sg-0182-no-bounce-loop";
+        const int msgcnt_phase1    = 5;
+        const int msgcnt_phase2    = 5;
         int acked, cnt;
-        size_t rcvd, j;
+        size_t rcvd;
         size_t share_fetch_cnt_before_drain;
         size_t share_fetch_cnt_after_drain;
         rd_ts_t end_ts;
@@ -2632,17 +2704,18 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
 
         end_ts = test_clock() + 1000 * 1000;
         while (test_clock() < end_ts) {
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 100);
-                rcvd  = rkmessages_acc.cnt;
+                error = rd_kafka_share_poll(rkshare, 100, &batch);
                 TEST_ASSERT(!error,
-                            "unexpected error from consume_batch while "
+                            "unexpected error from share_poll while "
                             "broker is down: %s",
                             error ? rd_kafka_error_string(error) : "NULL");
+                rcvd = rd_kafka_messages_count(batch);
                 TEST_ASSERT(rcvd == 0,
                             "expected 0 records while broker is down, "
                             "got %zu",
                             rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         cnt = rd_atomic32_get(&broker_not_up_cnt);
@@ -2673,13 +2746,12 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
                     share_fetch_cnt_before_drain);
 
         /* Drain the pre-fetched records. They're already on the
-         * consumer queue, so consume_batch returns them directly
+         * consumer queue, so share_poll returns them directly
          * without enqueueing a FANOUT and no new ShareFetch fires. */
-        rcvd  = 0;
-        error = test_share_batch_poll(&rkmessages_acc, rkshare, 100);
-        rcvd  = rkmessages_acc.cnt;
-        TEST_ASSERT(!error, "post-recovery consume_batch error: %s",
+        error = rd_kafka_share_poll(rkshare, 100, &batch);
+        TEST_ASSERT(!error, "post-recovery share_poll error: %s",
                     error ? rd_kafka_error_string(error) : "NULL");
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(rcvd == (size_t)msgcnt_phase2,
                     "expected %d records from queue, got %" PRIusz,
                     msgcnt_phase2, rcvd);
@@ -2687,12 +2759,14 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         share_fetch_cnt_after_drain = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_fetch_request, NULL);
         TEST_ASSERT(share_fetch_cnt_after_drain == share_fetch_cnt_before_drain,
-                    "consume_batch should drain the queue without firing "
+                    "share_poll should drain the queue without firing "
                     "a new ShareFetch; pre=%" PRIusz " post=%" PRIusz,
                     share_fetch_cnt_before_drain, share_fetch_cnt_after_drain);
 
-        for (j = 0; j < rcvd; j++)
-                rd_kafka_mock_clear_requests(ctx.mcluster);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        rd_kafka_mock_clear_requests(ctx.mcluster);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2700,7 +2774,6 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
 
         test_curr->is_fatal_cb = NULL;
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2734,8 +2807,7 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         const int msgcnt_recovery     = 5;
         const int n_cycles            = 10;
         const int max_allowed_log_cnt = n_cycles;
-        test_share_batch_t rkmessages_acc;
-        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *batch    = NULL;
         size_t rcvd;
         rd_kafka_error_t *error;
         int i, cnt, acked;
@@ -2792,15 +2864,16 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         /* Reset to drop any noise from cgrp/connection bring-up. */
         rd_atomic32_set(&broker_not_up_cnt, 0);
 
-        /* Kickstart the empty-poll loop: one consume_batch on the now
+        /* Kickstart the empty-poll loop: one share_poll on the now
          * empty topic starts the FANOUT->Step 6 cycle which keeps
-         * firing on the main thread until consume_batch returns. */
-        rcvd  = 0;
-        error = test_share_batch_poll(&rkmessages_acc, rkshare, 500);
-        rcvd  = rkmessages_acc.cnt;
-        TEST_ASSERT(!error, "kickstart consume_batch error: %s",
+         * firing on the main thread until share_poll returns. */
+        error = rd_kafka_share_poll(rkshare, 500, &batch);
+        TEST_ASSERT(!error, "kickstart share_poll error: %s",
                     error ? rd_kafka_error_string(error) : "NULL");
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         /* Chaos: rapidly flip the broker up/down across n_cycles
          * while the consumer's empty-poll loop is hot. Each set_down
@@ -2810,28 +2883,29 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
                 TEST_SAY("Cycle %d/%d: taking broker 1 down\n", i + 1,
                          n_cycles);
                 rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
-                rcvd  = rkmessages_acc.cnt;
-                TEST_ASSERT(!error, "cycle %d down: consume_batch error: %s",
+                error = rd_kafka_share_poll(rkshare, 200, &batch);
+                TEST_ASSERT(!error, "cycle %d down: share_poll error: %s",
                             i + 1,
                             error ? rd_kafka_error_string(error) : "NULL");
+                rcvd = rd_kafka_messages_count(batch);
                 TEST_ASSERT(rcvd == 0,
                             "cycle %d down: expected 0 records, got %zu", i + 1,
                             rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 TEST_SAY("Cycle %d/%d: bringing broker 1 back up\n", i + 1,
                          n_cycles);
                 rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
-                rcvd  = 0;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
-                rcvd  = rkmessages_acc.cnt;
-                TEST_ASSERT(!error, "cycle %d up: consume_batch error: %s",
-                            i + 1,
+                error = rd_kafka_share_poll(rkshare, 200, &batch);
+                TEST_ASSERT(!error, "cycle %d up: share_poll error: %s", i + 1,
                             error ? rd_kafka_error_string(error) : "NULL");
+                rcvd = rd_kafka_messages_count(batch);
                 TEST_ASSERT(rcvd == 0,
                             "cycle %d up: expected 0 records, got %zu", i + 1,
                             rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         cnt = rd_atomic32_get(&broker_not_up_cnt);
@@ -2857,7 +2931,6 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
 
         test_curr->is_fatal_cb = NULL;
 
-        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -175,28 +175,32 @@ static void mock_produce_partition(rd_kafka_t *producer,
  *        actually acknowledged.
  */
 static int consume_and_ack_all(rd_kafka_share_t *rkshare, int msgcnt) {
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        int acked    = 0;
-        int attempts = 0;
+        rd_kafka_messages_t *rkmessages = NULL;
+        int acked                       = 0;
+        int attempts                    = 0;
 
         while (acked < msgcnt && attempts++ < 30) {
                 size_t rcvd = 0;
                 size_t j;
-                rd_kafka_error_t *error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages, &rcvd);
+                rd_kafka_error_t *error;
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd       = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        rd_kafka_message_t *m =
+                            rd_kafka_messages_get(rkmessages, j);
+                        if (!m->err) {
+                                rd_kafka_share_acknowledge(rkshare, m);
                                 acked++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
+        rd_kafka_messages_destroy(rkmessages);
         return acked;
 }
 
@@ -364,7 +368,8 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
         const int total_msgs         = partition_cnt * msgs_per_partition;
         rd_kafka_resp_err_t injected_err =
             RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         int total_consumed = 0;
         int acked          = 0;
         int attempts       = 0;
@@ -393,8 +398,8 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
         /* Consume messages from all partitions */
         while (total_consumed < total_msgs && attempts++ < 50) {
                 size_t rcvd = 0;
-                error       = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + total_consumed, &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt - total_consumed;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -409,8 +414,9 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
 
         /* Acknowledge all messages */
         for (i = 0; i < total_consumed; i++) {
-                if (!rkmessages[i]->err) {
-                        rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                if (!rkmessages_acc.msgs[i]->err) {
+                        rd_kafka_share_acknowledge(rkshare,
+                                                   rkmessages_acc.msgs[i]);
                         acked++;
                 }
         }
@@ -464,13 +470,12 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
                     cb_state.total_offsets);
 
         for (i = 0; i < total_consumed; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -497,7 +502,8 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         const int total_msgs         = partition_cnt * msgs_per_partition;
         rd_kafka_resp_err_t injected_err =
             RD_KAFKA_RESP_ERR_SHARE_SESSION_NOT_FOUND;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         int total_consumed = 0;
         int attempts       = 0;
         int i;
@@ -526,8 +532,8 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         /* First consume batch - establishes session, consumes messages */
         while (total_consumed < total_msgs && attempts++ < 50) {
                 size_t rcvd = 0;
-                error       = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + total_consumed, &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt - total_consumed;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -542,13 +548,11 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
 
         /* Destroy messages - in implicit mode they're auto-acknowledged */
         for (i = 0; i < total_consumed; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        /* Produce more messages to trigger another ShareFetch with
-         * piggybacked acks from the previous consume */
-        for (i = 0; i < partition_cnt; i++)
-                mock_produce_partition(ctx.producer, topic, i,
-                                       msgs_per_partition);
+                /* Produce more messages to trigger another ShareFetch with
+                 * piggybacked acks from the previous consume */
+                for (i = 0; i < partition_cnt; i++)
+                        mock_produce_partition(ctx.producer, topic, i,
+                                               msgs_per_partition);
 
         /* Inject top-level error on next ShareFetch (which will carry
          * piggybacked acks from the previous consume_batch) */
@@ -563,16 +567,15 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         attempts       = 0;
         while (total_consumed < total_msgs && attempts++ < 50) {
                 size_t rcvd = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         /* May get errors due to injected error */
                 }
                 for (i = 0; i < (int)rcvd; i++) {
-                        if (!rkmessages[i]->err)
+                        if (!rkmessages_acc.msgs[i]->err)
                                 total_consumed++;
-                        rd_kafka_message_destroy(rkmessages[i]);
                 }
                 /* Break after we've given the callback a chance to fire */
                 if (cb_state.callback_cnt > 0)
@@ -605,6 +608,7 @@ static void test_consume_batch_multi_partition_top_level_error(void) {
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -642,7 +646,8 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         const char *topic = "0182-epoch-zero-ack";
         const char *group = "sg-0182-epoch-zero-ack";
         const int msgcnt  = 10;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         int total_consumed = 0;
         int attempts       = 0;
         size_t share_ack_cnt;
@@ -667,8 +672,8 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
          * acknowledge in phase 1 and phase 2. */
         while (total_consumed < msgcnt && attempts++ < 30) {
                 size_t rcvd = 0;
-                error       = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + total_consumed, &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt - total_consumed;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
@@ -684,7 +689,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
          * propagates. The buf reply handler resets the broker session
          * epoch to 0 on this error. */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -742,7 +747,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 1000, &partitions);
@@ -788,9 +793,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
@@ -840,10 +843,11 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         const char *topic = "0182-epoch-zero-piggyback";
         const char *group = "sg-0182-epoch-zero-piggyback";
         const int msgcnt  = 10;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_message_t *phase2_msgs[CONSUME_ARRAY];
-        int attempts = 0;
-        size_t rcvd  = 0;
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *phase2_msgs = NULL;
+        int attempts                     = 0;
+        size_t rcvd                      = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
         size_t j;
@@ -872,8 +876,8 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * below max.poll.records (default 500), so a non-empty call
          * returns the full set. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt;
                 if (error)
                         rd_kafka_error_destroy(error);
         }
@@ -886,7 +890,7 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * on next ShareAcknowledge, call commit_sync to trigger session
          * reset on the broker (epoch -> 0). */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -951,7 +955,7 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         /* Single consume_batch triggers the strip-mode FANOUT.
          * Records here may be re-deliveries after lock expiry — we
@@ -959,14 +963,13 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * test_wait_for_cb_with_poll below tolerates the explicit-mode
          * __STATE the next consume_batch may return for these
          * un-acknowledged records (rcvd stays 0). */
-        error = rd_kafka_share_consume_batch(rkshare, 1000, phase2_msgs, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
+        rcvd  = rd_kafka_messages_count(phase2_msgs);
         if (error)
                 rd_kafka_error_destroy(error);
         for (j = 0; j < rcvd; j++)
-                rd_kafka_message_destroy(phase2_msgs[j]);
-
-        share_fetch_cnt = test_mock_get_matching_request_cnt(
-            ctx.mcluster, is_share_fetch_request, NULL);
+                share_fetch_cnt = test_mock_get_matching_request_cnt(
+                    ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_ack_request, NULL);
 
@@ -1014,13 +1017,12 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1050,10 +1052,11 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         const char *topic = "0182-epoch-zero-piggyback-fetch-err";
         const char *group = "sg-0182-epoch-zero-piggyback-fetch-err";
         const int msgcnt  = 10;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        rd_kafka_message_t *phase2_msgs[CONSUME_ARRAY];
-        int attempts = 0;
-        size_t rcvd  = 0;
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
+        rd_kafka_messages_t *phase2_msgs = NULL;
+        int attempts                     = 0;
+        size_t rcvd                      = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
         size_t j;
@@ -1082,8 +1085,8 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * below max.poll.records (default 500), so a non-empty call
          * returns the full set. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                rcvd  = rkmessages_acc.cnt;
                 if (error)
                         rd_kafka_error_destroy(error);
         }
@@ -1096,7 +1099,7 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * on next ShareAcknowledge, call commit_sync to trigger session
          * reset on the broker (epoch -> 0). */
         for (i = 0; i < 5; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         rd_kafka_mock_start_request_tracking(ctx.mcluster);
         rd_kafka_mock_clear_requests(ctx.mcluster);
@@ -1137,7 +1140,7 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         rd_kafka_mock_clear_requests(ctx.mcluster);
 
         for (i = 5; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         TEST_ASSERT(rd_kafka_mock_broker_push_request_error_rtts(
                         ctx.mcluster, 1, RD_KAFKAP_ShareFetch, 1,
@@ -1151,14 +1154,13 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * test_wait_for_cb_with_poll below tolerates the explicit-mode
          * __STATE the next consume_batch may return for these
          * un-acknowledged records (rcvd stays 0). */
-        error = rd_kafka_share_consume_batch(rkshare, 1000, phase2_msgs, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
+        rcvd  = rd_kafka_messages_count(phase2_msgs);
         if (error)
                 rd_kafka_error_destroy(error);
         for (j = 0; j < rcvd; j++)
-                rd_kafka_message_destroy(phase2_msgs[j]);
-
-        share_fetch_cnt = test_mock_get_matching_request_cnt(
-            ctx.mcluster, is_share_fetch_request, NULL);
+                share_fetch_cnt = test_mock_get_matching_request_cnt(
+                    ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_ack_request, NULL);
 
@@ -1199,13 +1201,12 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -1305,7 +1306,7 @@ static rd_kafka_share_t *create_share_consumer_socket_timeout(
  * multiple batches as the new session warms up).
  */
 static void consume_first_batch(rd_kafka_share_t *rkshare,
-                                rd_kafka_message_t **rkmessages,
+                                test_share_batch_t *acc,
                                 int expected) {
         size_t rcvd  = 0;
         int attempts = 0;
@@ -1316,8 +1317,8 @@ static void consume_first_batch(rd_kafka_share_t *rkshare,
          * pre-stages the broker with all \p expected records so the
          * batch we receive will contain exactly that many. */
         while (rcvd == 0 && attempts++ < 30) {
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(acc, rkshare, 3000);
+                rcvd  = acc->cnt;
                 if (error) {
                         TEST_SAY("consume_first_batch: err=%s rcvd=%zu\n",
                                  rd_kafka_err2name(rd_kafka_error_code(error)),
@@ -1331,9 +1332,8 @@ static void consume_first_batch(rd_kafka_share_t *rkshare,
                     rcvd);
 
         for (j = 0; j < (int)rcvd; j++)
-                TEST_ASSERT(!rkmessages[j]->err,
-                            "Unexpected per-record err: %s",
-                            rd_kafka_err2str(rkmessages[j]->err));
+                TEST_ASSERT(!acc->msgs[j]->err, "Unexpected per-record err: %s",
+                            rd_kafka_err2str(acc->msgs[j]->err));
 }
 
 /**
@@ -1409,7 +1409,7 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
         const int partitions_total = SOCKET_TIMEOUT_MATRIX_PARTITIONS;
         const int msgcnt =
             partitions_total * SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION;
-        rd_kafka_message_t **rkmessages;
+        test_share_batch_t rkmessages_acc;
         test_ack_cb_state_t cb_state = {0};
         rd_ts_t t_p1_end_us, t_callbacks_done_us;
         int actual_wait_ms, expected_wait_ms;
@@ -1582,14 +1582,14 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
             test_share_ack_cb);
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
-        rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
+        test_share_batch_init(&rkmessages_acc, msgcnt);
 
         /* Phase 1: consume the first batch (all msgcnt records
          * given the small partition count and broker readiness),
          * acknowledge everyone, then inject RTT and commit_sync. */
-        consume_first_batch(rkshare, rkmessages, msgcnt);
+        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, rtt_ms);
 
@@ -1659,13 +1659,12 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
                     SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION);
 
         /* Free phase-1 messages. */
-        for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-        memset(rkmessages, 0, msgcnt * sizeof(*rkmessages));
+        test_share_batch_destroy(&rkmessages_acc);
+        test_share_batch_init(&rkmessages_acc, msgcnt);
 
-        consume_first_batch(rkshare, rkmessages, msgcnt);
+        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 5000, &partitions);
@@ -1695,8 +1694,7 @@ static void do_test_socket_timeout_full_ack_then_more(int api_timeout_ms,
                     prev_callback_cnt, cb_state.callback_cnt);
 
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-        rd_free(rkmessages);
+                test_share_batch_destroy(&rkmessages_acc);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -1755,7 +1753,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
         const int partitions_total = SOCKET_TIMEOUT_MATRIX_PARTITIONS;
         const int msgcnt =
             partitions_total * SOCKET_TIMEOUT_MATRIX_MSGS_PER_PARTITION;
-        rd_kafka_message_t **rkmessages;
+        test_share_batch_t rkmessages_acc;
         test_ack_cb_state_t cb_state = {0};
         rd_ts_t t_p1_end_us, t_callbacks_done_us;
         int actual_wait_ms, expected_wait_ms;
@@ -1848,16 +1846,16 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
             test_share_ack_cb);
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
-        rkmessages = rd_calloc(msgcnt, sizeof(*rkmessages));
+        test_share_batch_init(&rkmessages_acc, msgcnt);
 
         /* Phase 1: consume the first batch (all msgcnt records),
          * then ack the first half of the batch in receive order.
          * The exact set of partitions covered depends on broker-side
          * record ordering; the assertions below adapt to whatever
          * partitions appear in commit_sync's results. */
-        consume_first_batch(rkshare, rkmessages, msgcnt);
+        consume_first_batch(rkshare, &rkmessages_acc, msgcnt);
         for (i = 0; i < msgcnt / 2; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         rd_kafka_mock_broker_set_rtt(ctx.mcluster, -1, rtt_ms);
 
@@ -1932,7 +1930,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
 
         /* Ack the remaining half of the batch in receive order. */
         for (i = msgcnt / 2; i < msgcnt; i++)
-                rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
 
         partitions = NULL;
         error      = rd_kafka_share_commit_sync(rkshare, 5000, &partitions);
@@ -1975,8 +1973,7 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
             rd_kafka_err2name(cb_state.errs[cb_state.callback_cnt - 1]));
 
         for (i = 0; i < msgcnt; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-        rd_free(rkmessages);
+                test_share_batch_destroy(&rkmessages_acc);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2006,7 +2003,8 @@ do_test_socket_timeout_partial_ack_then_remaining(int api_timeout_ms,
  * is fully materialised before the test injects an error. Records are
  * ACKed inline because the consumer is in explicit-ack mode. */
 static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
@@ -2015,19 +2013,18 @@ static void share_topic_err_prime_assignment(rd_kafka_share_t *rkshare) {
 
         for (attempts = 0; attempts < 20; attempts++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 1000);
+                rcvd  = rkmessages_acc.cnt;
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
+                        if (!rkmessages_acc.msgs[j]->err) {
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rkmessages_acc.msgs[j]);
                                 got_any = rd_true;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
                 if (got_any)
                         return;
@@ -2055,7 +2052,8 @@ static void share_topic_err_force_metadata(rd_kafka_share_t *rkshare) {
 static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
                                               rd_kafka_resp_err_t expected,
                                               int max_attempts) {
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
@@ -2063,8 +2061,8 @@ static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
 
         for (attempts = 0; attempts < max_attempts; attempts++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 500);
+                rcvd  = rkmessages_acc.cnt;
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         TEST_SAY("consume_batch returned %s: %s\n",
@@ -2079,10 +2077,9 @@ static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
                  * proceed past the explicit-mode "previous poll
                  * unacked" gate. */
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
+                        if (!rkmessages_acc.msgs[j]->err)
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rkmessages_acc.msgs[j]);
                 }
         }
         return rd_false;
@@ -2094,7 +2091,8 @@ static rd_bool_t share_topic_err_wait_for_err(rd_kafka_share_t *rkshare,
 static void share_topic_err_assert_no_err(rd_kafka_share_t *rkshare,
                                           int n_attempts,
                                           const char *context) {
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         rd_kafka_error_t *error;
         size_t rcvd;
         size_t j;
@@ -2102,8 +2100,8 @@ static void share_topic_err_assert_no_err(rd_kafka_share_t *rkshare,
 
         for (attempts = 0; attempts < n_attempts; attempts++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
+                rcvd  = rkmessages_acc.cnt;
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         rd_kafka_error_destroy(error);
@@ -2116,10 +2114,9 @@ static void share_topic_err_assert_no_err(rd_kafka_share_t *rkshare,
                  * proceed past the explicit-mode "previous poll
                  * unacked" gate. */
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
+                        if (!rkmessages_acc.msgs[j]->err)
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rkmessages_acc.msgs[j]);
                 }
         }
 }
@@ -2194,7 +2191,8 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
         const char *topic       = "0182-multipart-single-op";
         const char *group       = "sg-0182-multipart-single-op";
         const int partition_cnt = 5;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         rd_kafka_error_t *error;
         size_t rcvd, j;
         int err_count = 0;
@@ -2227,8 +2225,8 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
          * what this cycle produced. */
         for (attempts = 0; attempts < 3; attempts++) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
+                rcvd  = rkmessages_acc.cnt;
                 if (error) {
                         rd_kafka_resp_err_t code = rd_kafka_error_code(error);
                         const char *errstr       = rd_kafka_error_string(error);
@@ -2240,10 +2238,9 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
-                                rd_kafka_share_acknowledge(rkshare,
-                                                           rkmessages[j]);
-                        rd_kafka_message_destroy(rkmessages[j]);
+                        if (!rkmessages_acc.msgs[j]->err)
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rkmessages_acc.msgs[j]);
                 }
         }
 
@@ -2256,6 +2253,7 @@ static void test_share_consumer_multi_partition_single_op_per_cycle(void) {
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2560,7 +2558,8 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         rd_kafka_conf_t *conf;
         rd_atomic32_t broker_not_up_cnt;
         rd_kafka_error_t *error;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         const char *topic       = "0182-no_bounce_loop";
         const char *group       = "sg-0182-no-bounce-loop";
         const int msgcnt_phase1 = 5;
@@ -2638,8 +2637,8 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
         end_ts = test_clock() + 1000 * 1000;
         while (test_clock() < end_ts) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 100);
+                rcvd  = rkmessages_acc.cnt;
                 TEST_ASSERT(!error,
                             "unexpected error from consume_batch while "
                             "broker is down: %s",
@@ -2681,7 +2680,8 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
          * consumer queue, so consume_batch returns them directly
          * without enqueueing a FANOUT and no new ShareFetch fires. */
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 100, rkmessages, &rcvd);
+        error = test_share_batch_poll(&rkmessages_acc, rkshare, 100);
+        rcvd  = rkmessages_acc.cnt;
         TEST_ASSERT(!error, "post-recovery consume_batch error: %s",
                     error ? rd_kafka_error_string(error) : "NULL");
         TEST_ASSERT(rcvd == (size_t)msgcnt_phase2,
@@ -2696,9 +2696,7 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
                     share_fetch_cnt_before_drain, share_fetch_cnt_after_drain);
 
         for (j = 0; j < rcvd; j++)
-                rd_kafka_message_destroy(rkmessages[j]);
-
-        rd_kafka_mock_clear_requests(ctx.mcluster);
+                rd_kafka_mock_clear_requests(ctx.mcluster);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
@@ -2706,6 +2704,7 @@ static void do_test_no_bounce_loop_on_down_broker(void) {
 
         test_curr->is_fatal_cb = NULL;
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 
@@ -2739,7 +2738,8 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
         const int msgcnt_recovery     = 5;
         const int n_cycles            = 10;
         const int max_allowed_log_cnt = n_cycles;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        test_share_batch_t rkmessages_acc;
+        test_share_batch_init(&rkmessages_acc, 200);
         size_t rcvd;
         rd_kafka_error_t *error;
         int i, cnt, acked;
@@ -2800,7 +2800,8 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
          * empty topic starts the FANOUT->Step 6 cycle which keeps
          * firing on the main thread until consume_batch returns. */
         rcvd  = 0;
-        error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages, &rcvd);
+        error = test_share_batch_poll(&rkmessages_acc, rkshare, 500);
+        rcvd  = rkmessages_acc.cnt;
         TEST_ASSERT(!error, "kickstart consume_batch error: %s",
                     error ? rd_kafka_error_string(error) : "NULL");
         TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
@@ -2814,8 +2815,8 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
                          n_cycles);
                 rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
+                rcvd  = rkmessages_acc.cnt;
                 TEST_ASSERT(!error, "cycle %d down: consume_batch error: %s",
                             i + 1,
                             error ? rd_kafka_error_string(error) : "NULL");
@@ -2827,8 +2828,8 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
                          n_cycles);
                 rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 200, rkmessages,
-                                                     &rcvd);
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 200);
+                rcvd  = rkmessages_acc.cnt;
                 TEST_ASSERT(!error, "cycle %d up: consume_batch error: %s",
                             i + 1,
                             error ? rd_kafka_error_string(error) : "NULL");
@@ -2860,6 +2861,7 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
 
         test_curr->is_fatal_cb = NULL;
 
+        test_share_batch_destroy(&rkmessages_acc);
         SUB_TEST_PASS();
 }
 

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -848,7 +848,6 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
         size_t rcvd                      = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
-        size_t j;
         int i;
         test_ack_cb_state_t cb_state = {0};
 
@@ -1057,7 +1056,6 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
         size_t rcvd                      = 0;
         size_t share_ack_cnt;
         size_t share_fetch_cnt;
-        size_t j;
         int i;
         test_ack_cb_state_t cb_state = {0};
 

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -469,8 +469,7 @@ static void test_commit_sync_multi_partition_top_level_error(void) {
                     "expected callback total_offsets %d, got %zu", total_msgs,
                     cb_state.total_offsets);
 
-        for (i = 0; i < total_consumed; i++)
-                test_share_consumer_close(rkshare);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
@@ -792,8 +791,7 @@ test_commit_sync_at_epoch_zero_returns_invalid_session_epoch_error(void) {
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
-        for (i = 0; i < msgcnt; i++)
-                test_share_consumer_close(rkshare);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
@@ -965,11 +963,11 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
          * un-acknowledged records (rcvd stays 0). */
         error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
         rcvd  = rd_kafka_messages_count(phase2_msgs);
+        (void)rcvd;
         if (error)
                 rd_kafka_error_destroy(error);
-        for (j = 0; j < rcvd; j++)
-                share_fetch_cnt = test_mock_get_matching_request_cnt(
-                    ctx.mcluster, is_share_fetch_request, NULL);
+        share_fetch_cnt = test_mock_get_matching_request_cnt(
+            ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_ack_request, NULL);
 
@@ -1016,8 +1014,8 @@ static void test_consume_batch_at_epoch_zero_strips_piggyback_acks(void) {
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
-        for (i = 0; i < msgcnt; i++)
-                test_share_consumer_close(rkshare);
+        rd_kafka_messages_destroy(phase2_msgs);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);
@@ -1156,11 +1154,11 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
          * un-acknowledged records (rcvd stays 0). */
         error = rd_kafka_share_poll(rkshare, 1000, &phase2_msgs);
         rcvd  = rd_kafka_messages_count(phase2_msgs);
+        (void)rcvd;
         if (error)
                 rd_kafka_error_destroy(error);
-        for (j = 0; j < rcvd; j++)
-                share_fetch_cnt = test_mock_get_matching_request_cnt(
-                    ctx.mcluster, is_share_fetch_request, NULL);
+        share_fetch_cnt = test_mock_get_matching_request_cnt(
+            ctx.mcluster, is_share_fetch_request, NULL);
         share_ack_cnt = test_mock_get_matching_request_cnt(
             ctx.mcluster, is_share_ack_request, NULL);
 
@@ -1200,8 +1198,8 @@ static void test_strip_pre_set_survives_sharefetch_err(void) {
 
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
-        for (i = 0; i < msgcnt; i++)
-                test_share_consumer_close(rkshare);
+        rd_kafka_messages_destroy(phase2_msgs);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ack_cb_state_destroy(&cb_state);
         test_ctx_destroy(&ctx);

--- a/tests/0183-share_consumer_leader_change_mock.c
+++ b/tests/0183-share_consumer_leader_change_mock.c
@@ -313,8 +313,8 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
         /* Clean up held message handles. */
-        for (j = 0; j < rcvd; j++)
-                test_share_consumer_close(rkshare);
+        rd_kafka_messages_destroy(rkmessages);
+        test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 

--- a/tests/0183-share_consumer_leader_change_mock.c
+++ b/tests/0183-share_consumer_leader_change_mock.c
@@ -182,14 +182,14 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        const char *topic         = "0183-shareack-nlof";
-        const char *group         = "sg-0183-shareack-nlof";
-        const int broker1         = 1;
-        const int broker2         = 2;
-        const int msgcnt          = 10;
-        const int acks_per_commit = 2;
-        const int commit_rounds   = msgcnt / acks_per_commit;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        const char *topic               = "0183-shareack-nlof";
+        const char *group               = "sg-0183-shareack-nlof";
+        const int broker1               = 1;
+        const int broker2               = 2;
+        const int msgcnt                = 10;
+        const int acks_per_commit       = 2;
+        const int commit_rounds         = msgcnt / acks_per_commit;
+        rd_kafka_messages_t *rkmessages = NULL;
         int round;
         size_t rcvd         = 0;
         size_t consumed_idx = 0;
@@ -222,7 +222,8 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         subscribe_one(rkshare, topic);
 
         /* Consume one batch — expect all 10 records in a single call. */
-        error = rd_kafka_share_consume_batch(rkshare, 10000, rkmessages, &rcvd);
+        error = rd_kafka_share_poll(rkshare, 10000, &rkmessages);
+        rcvd  = rd_kafka_messages_count(rkmessages);
         TEST_ASSERT(!error, "consume_batch failed: %s",
                     error ? rd_kafka_error_string(error) : "");
         TEST_ASSERT(rcvd == (size_t)msgcnt,
@@ -249,7 +250,8 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
                      k++, consumed_idx++) {
                         rd_kafka_resp_err_t ack_err;
                         ack_err = rd_kafka_share_acknowledge(
-                            rkshare, rkmessages[consumed_idx]);
+                            rkshare,
+                            rd_kafka_messages_get(rkmessages, consumed_idx));
                         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                                     "round %d: acknowledge failed: %s", round,
                                     rd_kafka_err2str(ack_err));
@@ -312,9 +314,7 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
 
         /* Clean up held message handles. */
         for (j = 0; j < rcvd; j++)
-                rd_kafka_message_destroy(rkmessages[j]);
-
-        test_share_consumer_close(rkshare);
+                test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
 
@@ -347,17 +347,17 @@ static void test_partition_not_leader_or_follower_silent(void) {
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        const char *topic = "0183-nlof-silent";
-        const char *group = "sg-0183-nlof-silent";
-        const int broker1 = 1;
-        const int broker2 = 2;
-        const int msgcnt  = 5;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        int phase1_consumed = 0;
-        int phase2_consumed = 0;
-        int error_cnt       = 0;
-        int attempts        = 0;
-        size_t rcvd         = 0;
+        const char *topic               = "0183-nlof-silent";
+        const char *group               = "sg-0183-nlof-silent";
+        const int broker1               = 1;
+        const int broker2               = 2;
+        const int msgcnt                = 5;
+        rd_kafka_messages_t *rkmessages = NULL;
+        int phase1_consumed             = 0;
+        int phase2_consumed             = 0;
+        int error_cnt                   = 0;
+        int attempts                    = 0;
+        size_t rcvd                     = 0;
         size_t share_fetch_cnt;
         size_t metadata_cnt;
         size_t j;
@@ -397,16 +397,15 @@ static void test_partition_not_leader_or_follower_silent(void) {
 
         while (phase1_consumed < msgcnt && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 phase1_consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(phase1_consumed == msgcnt,
@@ -438,17 +437,16 @@ static void test_partition_not_leader_or_follower_silent(void) {
         attempts = 0;
         while (phase2_consumed < msgcnt && attempts++ < 30) {
                 rcvd  = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         error_cnt++;
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err)
+                        if (!rd_kafka_messages_get(rkmessages, j)->err)
                                 phase2_consumed++;
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(phase2_consumed >= msgcnt,
@@ -508,10 +506,10 @@ static int consume_phase(rd_kafka_share_t *rkshare,
                          int expected,
                          int post_first_batch_settle_ms,
                          const char *phase_name) {
-        int consumed     = 0;
-        int attempts     = 0;
-        int max_attempts = expected * 3 + 60;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        int consumed                                   = 0;
+        int attempts                                   = 0;
+        int max_attempts                               = expected * 3 + 60;
+        rd_kafka_messages_t *rkmessages                = NULL;
         rd_kafka_topic_partition_list_t *flush_results = NULL;
         rd_kafka_error_t *flush_err;
         rd_bool_t first_batch = rd_true;
@@ -522,8 +520,8 @@ static int consume_phase(rd_kafka_share_t *rkshare,
                 rd_kafka_error_t *error;
                 size_t j;
 
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         TEST_SAY("%s: consume_batch err %s\n", phase_name,
                                  rd_kafka_error_string(error));
@@ -532,20 +530,24 @@ static int consume_phase(rd_kafka_share_t *rkshare,
                 }
 
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 consumed++;
                                 TEST_SAY(
                                     "%s: record #%d: %s [%" PRId32
                                     "] offset %" PRId64 "\n",
                                     phase_name, consumed,
-                                    rd_kafka_topic_name(rkmessages[j]->rkt),
-                                    rkmessages[j]->partition,
-                                    rkmessages[j]->offset);
+                                    rd_kafka_topic_name(
+                                        rd_kafka_messages_get(rkmessages, j)
+                                            ->rkt),
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->partition,
+                                    rd_kafka_messages_get(rkmessages, j)
+                                        ->offset);
                                 if (explicit_mode)
                                         rd_kafka_share_acknowledge(
-                                            rkshare, rkmessages[j]);
+                                            rkshare, rd_kafka_messages_get(
+                                                         rkmessages, j));
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
 
                 if (explicit_mode && rcvd > 0) {
@@ -922,7 +924,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //         const char *topic = "0183-utp-silent";
 //         const char *group = "sg-0183-utp-silent";
 //         const int msgcnt  = 5;
-//         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+//         rd_kafka_messages_t *rkmessages = NULL;
 //         int phase1_consumed = 0;
 //         int error_cnt       = 0;
 //         int attempts        = 0;
@@ -961,7 +963,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 
 //         while (phase1_consumed < msgcnt && attempts++ < 30) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_consume_batch(rkshare, 3000,
+//                 error = rd_kafka_share_poll(rkshare, 3000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {
@@ -969,9 +971,10 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //                         continue;
 //                 }
 //                 for (j = 0; j < rcvd; j++) {
-//                         if (!rkmessages[j]->err)
+//                         if (!rd_kafka_messages_get(rkmessages, j)->err)
 //                                 phase1_consumed++;
-//                         rd_kafka_message_destroy(rkmessages[j]);
+//                         rd_kafka_message_destroy(rd_kafka_messages_get(rkmessages,
+//                         j));
 //                 }
 //         }
 //         TEST_ASSERT(phase1_consumed == msgcnt,
@@ -995,7 +998,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //          * an error (silent handling requires zero). */
 //         while (poll_cnt++ < 5) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_consume_batch(rkshare, 1000,
+//                 error = rd_kafka_share_poll(rkshare, 1000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {
@@ -1004,7 +1007,8 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //                         continue;
 //                 }
 //                 for (j = 0; j < rcvd; j++)
-//                         rd_kafka_message_destroy(rkmessages[j]);
+//                         rd_kafka_message_destroy(rd_kafka_messages_get(rkmessages,
+//                         j));
 //         }
 //         TEST_ASSERT(error_cnt == 0,
 //                     "expected 0 OP_CONSUMER_ERR after topic delete "
@@ -1078,8 +1082,8 @@ do_test_records_survive_leaderless_transit(rd_bool_t explicit_mode) {
         test_ctx_t ctx;
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
-        size_t drain_rcvd = 0;
+        rd_kafka_messages_t *rkmessages = NULL;
+        size_t drain_rcvd               = 0;
         char *topic;
         const int part_cnt  = 1;
         const char *group   = "sg-0183-leaderless-transit";
@@ -1142,16 +1146,18 @@ do_test_records_survive_leaderless_transit(rd_bool_t explicit_mode) {
                                 RD_KAFKA_RESP_ERR_NO_ERROR,
                             "set leader [%d] -> -1 (leader-less)", i);
 
-        /* Mid consume_batch: drive the internal fetch cycle so the
+        /* Mid share_poll: drive the internal fetch cycle so the
          * consumer hits broker 1 with SHAREFETCH, gets
          * NOT_LEADER_OR_FOLLOWER, refreshes metadata, sees
          * leader_id=-1, and delegates the rktp to the :0/internal
          * pseudo-broker. No records expected (leader-less). */
-        TEST_ASSERT(!rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                  &drain_rcvd),
-                    "mid consume_batch unexpected err");
+        rd_kafka_messages_destroy(rkmessages);
+        rkmessages = NULL;
+        TEST_ASSERT(!rd_kafka_share_poll(rkshare, 500, &rkmessages),
+                    "mid share_poll unexpected err");
+        drain_rcvd = rd_kafka_messages_count(rkmessages);
         TEST_ASSERT(drain_rcvd == 0,
-                    "mid consume_batch expected 0 records during the "
+                    "mid share_poll expected 0 records during the "
                     "leader-less window, got %" PRIusz,
                     drain_rcvd);
 

--- a/tests/0183-share_consumer_leader_change_mock.c
+++ b/tests/0183-share_consumer_leader_change_mock.c
@@ -963,7 +963,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 
 //         while (phase1_consumed < msgcnt && attempts++ < 30) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_consume_batch(rkshare, 3000,
+//                 error = rd_kafka_share_poll(rkshare, 3000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {
@@ -997,7 +997,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //          * an error (silent handling requires zero). */
 //         while (poll_cnt++ < 5) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_consume_batch(rkshare, 1000,
+//                 error = rd_kafka_share_poll(rkshare, 1000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {

--- a/tests/0183-share_consumer_leader_change_mock.c
+++ b/tests/0183-share_consumer_leader_change_mock.c
@@ -182,14 +182,14 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        const char *topic               = "0183-shareack-nlof";
-        const char *group               = "sg-0183-shareack-nlof";
-        const int broker1               = 1;
-        const int broker2               = 2;
-        const int msgcnt                = 10;
-        const int acks_per_commit       = 2;
-        const int commit_rounds         = msgcnt / acks_per_commit;
-        rd_kafka_messages_t *rkmessages = NULL;
+        const char *topic          = "0183-shareack-nlof";
+        const char *group          = "sg-0183-shareack-nlof";
+        const int broker1          = 1;
+        const int broker2          = 2;
+        const int msgcnt           = 10;
+        const int acks_per_commit  = 2;
+        const int commit_rounds    = msgcnt / acks_per_commit;
+        rd_kafka_messages_t *batch = NULL;
         int round;
         size_t rcvd         = 0;
         size_t consumed_idx = 0;
@@ -221,10 +221,10 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         subscribe_one(rkshare, topic);
 
         /* Consume one batch — expect all 10 records in a single call. */
-        error = rd_kafka_share_poll(rkshare, 10000, &rkmessages);
-        rcvd  = rd_kafka_messages_count(rkmessages);
-        TEST_ASSERT(!error, "consume_batch failed: %s",
+        error = rd_kafka_share_poll(rkshare, 10000, &batch);
+        TEST_ASSERT(!error, "share_poll failed: %s",
                     error ? rd_kafka_error_string(error) : "");
+        rcvd = rd_kafka_messages_count(batch);
         TEST_ASSERT(rcvd == (size_t)msgcnt,
                     "expected %d records in first batch, got %" PRIusz, msgcnt,
                     rcvd);
@@ -250,7 +250,7 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
                         rd_kafka_resp_err_t ack_err;
                         ack_err = rd_kafka_share_acknowledge(
                             rkshare,
-                            rd_kafka_messages_get(rkmessages, consumed_idx));
+                            rd_kafka_messages_get(batch, consumed_idx));
                         TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                                     "round %d: acknowledge failed: %s", round,
                                     rd_kafka_err2str(ack_err));
@@ -312,7 +312,9 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         rd_kafka_mock_stop_request_tracking(ctx.mcluster);
 
         /* Clean up held message handles. */
-        rd_kafka_messages_destroy(rkmessages);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         test_ctx_destroy(&ctx);
@@ -346,17 +348,17 @@ static void test_partition_not_leader_or_follower_silent(void) {
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
         rd_kafka_error_t *error;
-        const char *topic               = "0183-nlof-silent";
-        const char *group               = "sg-0183-nlof-silent";
-        const int broker1               = 1;
-        const int broker2               = 2;
-        const int msgcnt                = 5;
-        rd_kafka_messages_t *rkmessages = NULL;
-        int phase1_consumed             = 0;
-        int phase2_consumed             = 0;
-        int error_cnt                   = 0;
-        int attempts                    = 0;
-        size_t rcvd                     = 0;
+        const char *topic          = "0183-nlof-silent";
+        const char *group          = "sg-0183-nlof-silent";
+        const int broker1          = 1;
+        const int broker2          = 2;
+        const int msgcnt           = 5;
+        rd_kafka_messages_t *batch = NULL;
+        int phase1_consumed        = 0;
+        int phase2_consumed        = 0;
+        int error_cnt              = 0;
+        int attempts               = 0;
+        size_t rcvd                = 0;
         size_t share_fetch_cnt;
         size_t metadata_cnt;
         size_t j;
@@ -395,17 +397,19 @@ static void test_partition_not_leader_or_follower_silent(void) {
         subscribe_one(rkshare, topic);
 
         while (phase1_consumed < msgcnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, j);
+                        if (m && !m->err)
                                 phase1_consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(phase1_consumed == msgcnt,
                     "Phase 1: expected %d records from broker %d, got %d",
@@ -435,18 +439,20 @@ static void test_partition_not_leader_or_follower_silent(void) {
          * handling must keep that return NULL throughout recovery. */
         attempts = 0;
         while (phase2_consumed < msgcnt && attempts++ < 30) {
-                rcvd  = 0;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         error_cnt++;
                         rd_kafka_error_destroy(error);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err)
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, j);
+                        if (m && !m->err)
                                 phase2_consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(phase2_consumed >= msgcnt,
                     "Phase 2: expected >= %d records from broker %d after "
@@ -508,7 +514,7 @@ static int consume_phase(rd_kafka_share_t *rkshare,
         int consumed                                   = 0;
         int attempts                                   = 0;
         int max_attempts                               = expected * 3 + 60;
-        rd_kafka_messages_t *rkmessages                = NULL;
+        rd_kafka_messages_t *batch                     = NULL;
         rd_kafka_topic_partition_list_t *flush_results = NULL;
         rd_kafka_error_t *flush_err;
         rd_bool_t first_batch = rd_true;
@@ -519,35 +525,30 @@ static int consume_phase(rd_kafka_share_t *rkshare,
                 rd_kafka_error_t *error;
                 size_t j;
 
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
-                        TEST_SAY("%s: consume_batch err %s\n", phase_name,
+                        TEST_SAY("%s: share_poll err %s\n", phase_name,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         continue;
                 }
 
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, j);
+                        if (m && !m->err) {
                                 consumed++;
-                                TEST_SAY(
-                                    "%s: record #%d: %s [%" PRId32
-                                    "] offset %" PRId64 "\n",
-                                    phase_name, consumed,
-                                    rd_kafka_topic_name(
-                                        rd_kafka_messages_get(rkmessages, j)
-                                            ->rkt),
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->partition,
-                                    rd_kafka_messages_get(rkmessages, j)
-                                        ->offset);
+                                TEST_SAY("%s: record #%d: %s [%" PRId32
+                                         "] offset %" PRId64 "\n",
+                                         phase_name, consumed,
+                                         rd_kafka_topic_name(m->rkt),
+                                         m->partition, m->offset);
                                 if (explicit_mode)
-                                        rd_kafka_share_acknowledge(
-                                            rkshare, rd_kafka_messages_get(
-                                                         rkmessages, j));
+                                        rd_kafka_share_acknowledge(rkshare, m);
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
 
                 if (explicit_mode && rcvd > 0) {
                         if (use_commit_sync) {
@@ -923,7 +924,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //         const char *topic = "0183-utp-silent";
 //         const char *group = "sg-0183-utp-silent";
 //         const int msgcnt  = 5;
-//         rd_kafka_messages_t *rkmessages = NULL;
+//         rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
 //         int phase1_consumed = 0;
 //         int error_cnt       = 0;
 //         int attempts        = 0;
@@ -962,7 +963,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 
 //         while (phase1_consumed < msgcnt && attempts++ < 30) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_poll(rkshare, 3000,
+//                 error = rd_kafka_share_consume_batch(rkshare, 3000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {
@@ -970,10 +971,9 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //                         continue;
 //                 }
 //                 for (j = 0; j < rcvd; j++) {
-//                         if (!rd_kafka_messages_get(rkmessages, j)->err)
+//                         if (!rkmessages[j]->err)
 //                                 phase1_consumed++;
-//                         rd_kafka_message_destroy(rd_kafka_messages_get(rkmessages,
-//                         j));
+//                         rd_kafka_message_destroy(rkmessages[j]);
 //                 }
 //         }
 //         TEST_ASSERT(phase1_consumed == msgcnt,
@@ -997,7 +997,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //          * an error (silent handling requires zero). */
 //         while (poll_cnt++ < 5) {
 //                 rcvd  = 0;
-//                 error = rd_kafka_share_poll(rkshare, 1000,
+//                 error = rd_kafka_share_consume_batch(rkshare, 1000,
 //                 rkmessages,
 //                                                      &rcvd);
 //                 if (error) {
@@ -1006,8 +1006,7 @@ do_test_leader_change_consume_recovery(rd_bool_t explicit_mode,
 //                         continue;
 //                 }
 //                 for (j = 0; j < rcvd; j++)
-//                         rd_kafka_message_destroy(rd_kafka_messages_get(rkmessages,
-//                         j));
+//                         rd_kafka_message_destroy(rkmessages[j]);
 //         }
 //         TEST_ASSERT(error_cnt == 0,
 //                     "expected 0 OP_CONSUMER_ERR after topic delete "
@@ -1081,8 +1080,8 @@ do_test_records_survive_leaderless_transit(rd_bool_t explicit_mode) {
         test_ctx_t ctx;
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
-        rd_kafka_messages_t *rkmessages = NULL;
-        size_t drain_rcvd               = 0;
+        rd_kafka_messages_t *drain_batch = NULL;
+        size_t drain_rcvd                = 0;
         char *topic;
         const int part_cnt  = 1;
         const char *group   = "sg-0183-leaderless-transit";
@@ -1145,20 +1144,20 @@ do_test_records_survive_leaderless_transit(rd_bool_t explicit_mode) {
                                 RD_KAFKA_RESP_ERR_NO_ERROR,
                             "set leader [%d] -> -1 (leader-less)", i);
 
-        /* Mid share_poll: drive the internal fetch cycle so the
+        /* Mid consume_batch: drive the internal fetch cycle so the
          * consumer hits broker 1 with SHAREFETCH, gets
          * NOT_LEADER_OR_FOLLOWER, refreshes metadata, sees
          * leader_id=-1, and delegates the rktp to the :0/internal
          * pseudo-broker. No records expected (leader-less). */
-        rd_kafka_messages_destroy(rkmessages);
-        rkmessages = NULL;
-        TEST_ASSERT(!rd_kafka_share_poll(rkshare, 500, &rkmessages),
+        TEST_ASSERT(!rd_kafka_share_poll(rkshare, 500, &drain_batch),
                     "mid share_poll unexpected err");
-        drain_rcvd = rd_kafka_messages_count(rkmessages);
+        drain_rcvd = rd_kafka_messages_count(drain_batch);
         TEST_ASSERT(drain_rcvd == 0,
                     "mid share_poll expected 0 records during the "
                     "leader-less window, got %" PRIusz,
                     drain_rcvd);
+        rd_kafka_messages_destroy(drain_batch);
+        drain_batch = NULL;
 
         /* Settle: pre-fix, :0/internal's broker_internal_serve loop
          * runs consumer_toppars_serve here, which calls fetch_decide

--- a/tests/0183-share_consumer_leader_change_mock.c
+++ b/tests/0183-share_consumer_leader_change_mock.c
@@ -195,7 +195,6 @@ static void test_shareack_leader_change_reduces_rpcs(void) {
         size_t consumed_idx = 0;
         size_t share_ack_cnt;
         size_t metadata_cnt;
-        size_t j;
 
         SUB_TEST_QUICK();
 

--- a/tests/0184-share_consumer_topic_recreate.c
+++ b/tests/0184-share_consumer_topic_recreate.c
@@ -141,16 +141,17 @@ static int consume_into_msgver(rd_kafka_share_t *rkshare,
                                test_msgver_t *mv,
                                int exp_cnt,
                                int timeout_ms) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        rd_ts_t deadline = test_clock() + (rd_ts_t)timeout_ms * 1000;
-        rd_kafka_t *rk   = test_share_consumer_get_rk(rkshare);
+        rd_kafka_messages_t *batch = NULL;
+        rd_ts_t deadline           = test_clock() + (rd_ts_t)timeout_ms * 1000;
+        rd_kafka_t *rk             = test_share_consumer_get_rk(rkshare);
 
         while (mv->msgcnt < exp_cnt && test_clock() < deadline) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
 
-                err = rd_kafka_share_consume_batch(rkshare, 500, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 500, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY("share_consume_batch error: %s\n",
                                  rd_kafka_error_string(err));
@@ -159,7 +160,7 @@ static int consume_into_msgver(rd_kafka_share_t *rkshare,
                 }
 
                 for (i = 0; i < rcvd; i++) {
-                        rd_kafka_message_t *m = batch[i];
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
 
                         if (m->err) {
                                 TEST_SAY(
@@ -624,7 +625,7 @@ static void do_test_recreate_survives_concurrent_producer(void) {
         const int producer_period_ms  = 100; /* ~10 msgs/sec */
         const int phase_duration_ms   = 10000;
         rd_kafka_share_t *rkshare;
-        rd_kafka_message_t *batch[BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         struct producer_thread_args producer_args;
         thrd_t producer_thrd;
         rd_kafka_Uuid_t *id_initial, *id_final;
@@ -667,7 +668,8 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err = rd_kafka_share_consume_batch(rkshare, 200, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 200, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY(
                             "Phase BEFORE: share_consume_batch error: "
@@ -677,7 +679,7 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                         continue;
                 }
                 for (i = 0; i < rcvd; i++) {
-                        rd_kafka_message_t *m = batch[i];
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 7 &&
                             !strncmp((const char *)m->payload, "before:", 7))
                                 before_cnt++;
@@ -702,7 +704,8 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err = rd_kafka_share_consume_batch(rkshare, 200, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 200, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY(
                             "Phase DURING: share_consume_batch error: "
@@ -712,7 +715,7 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                         continue;
                 }
                 for (i = 0; i < rcvd; i++) {
-                        rd_kafka_message_t *m = batch[i];
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 7 &&
                             !strncmp((const char *)m->payload, "during:", 7))
                                 during_cnt++;
@@ -753,7 +756,8 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err = rd_kafka_share_consume_batch(rkshare, 500, batch, &rcvd);
+                err  = rd_kafka_share_poll(rkshare, 500, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (err) {
                         TEST_SAY(
                             "Phase AFTER: share_consume_batch error: "
@@ -763,7 +767,7 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                         continue;
                 }
                 for (i = 0; i < rcvd; i++) {
-                        rd_kafka_message_t *m = batch[i];
+                        rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 6 &&
                             !strncmp((const char *)m->payload, "after:", 6))
                                 after_cnt++;
@@ -811,7 +815,7 @@ static void test_recreate_during_close(void) {
         const char *group  = "0184-share-recreate-during-close";
         const int n_msgs   = 10;
         const int delay_ms = 5000;
-        rd_kafka_message_t *rkmessages[64];
+        test_share_batch_t rkmessages_acc;
         struct recreate_thread_args thread_args;
         thrd_t recreate_thrd;
         rd_kafka_conf_t *conf;
@@ -846,12 +850,12 @@ static void test_recreate_during_close(void) {
 
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
+        test_share_batch_init(&rkmessages_acc, n_msgs);
         TEST_SAY("Consuming up to %d messages\n", n_msgs);
         while (rcvd < (size_t)n_msgs && attempts < max_attempt) {
-                size_t batch_rcvd =
-                    sizeof(rkmessages) / sizeof(rkmessages[0]) - rcvd;
-                error = rd_kafka_share_consume_batch(
-                    rkshare, 3000, rkmessages + rcvd, &batch_rcvd);
+                size_t batch_rcvd;
+                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
+                batch_rcvd = rkmessages_acc.cnt - rcvd;
                 if (error) {
                         TEST_SAY("Consume attempt %d: %s\n", attempts,
                                  rd_kafka_error_string(error));
@@ -867,7 +871,7 @@ static void test_recreate_during_close(void) {
         TEST_SAY("Staging acks for all %zu messages\n", rcvd);
         for (i = 0; i < (int)rcvd; i++) {
                 rd_kafka_resp_err_t ack_err =
-                    rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
+                    rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
                 TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "ack %d failed: %s", i, rd_kafka_err2str(ack_err));
         }
@@ -910,9 +914,7 @@ static void test_recreate_during_close(void) {
 
         thrd_join(recreate_thrd, NULL);
 
-        for (i = 0; i < (int)rcvd; i++)
-                rd_kafka_message_destroy(rkmessages[i]);
-
+        test_share_batch_destroy(&rkmessages_acc);
         test_share_destroy(rkshare);
         test_mock_cluster_destroy(mcluster);
         SUB_TEST_PASS();

--- a/tests/0184-share_consumer_topic_recreate.c
+++ b/tests/0184-share_consumer_topic_recreate.c
@@ -150,14 +150,15 @@ static int consume_into_msgver(rd_kafka_share_t *rkshare,
                 size_t rcvd = 0;
                 size_t i;
 
-                err  = rd_kafka_share_poll(rkshare, 500, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, 500, &batch);
                 if (err) {
-                        TEST_SAY("share_consume_batch error: %s\n",
+                        TEST_SAY("share_poll error: %s\n",
                                  rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+
+                rcvd = rd_kafka_messages_count(batch);
 
                 for (i = 0; i < rcvd; i++) {
                         rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
@@ -170,7 +171,6 @@ static int consume_into_msgver(rd_kafka_share_t *rkshare,
                                     m->rkt ? rd_kafka_topic_name(m->rkt)
                                            : "(none)",
                                     m->partition);
-                                rd_kafka_message_destroy(m);
                                 continue;
                         }
 
@@ -187,8 +187,10 @@ static int consume_into_msgver(rd_kafka_share_t *rkshare,
                          * dropped. */
                         test_msgver_add_msg(rk, mv, m);
                         rd_kafka_share_acknowledge(rkshare, m);
-                        rd_kafka_message_destroy(m);
                 }
+
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
 
         return mv->msgcnt;
@@ -668,23 +670,24 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err  = rd_kafka_share_poll(rkshare, 200, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, 200, &batch);
                 if (err) {
                         TEST_SAY(
-                            "Phase BEFORE: share_consume_batch error: "
+                            "Phase BEFORE: share_poll error: "
                             "%s\n",
                             rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
                         rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 7 &&
                             !strncmp((const char *)m->payload, "before:", 7))
                                 before_cnt++;
-                        rd_kafka_message_destroy(m);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_SAY("Phase BEFORE: consumed %d \"before:\" record(s)\n",
                  before_cnt);
@@ -704,23 +707,24 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err  = rd_kafka_share_poll(rkshare, 200, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, 200, &batch);
                 if (err) {
                         TEST_SAY(
-                            "Phase DURING: share_consume_batch error: "
+                            "Phase DURING: share_poll error: "
                             "%s\n",
                             rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
                         rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 7 &&
                             !strncmp((const char *)m->payload, "during:", 7))
                                 during_cnt++;
-                        rd_kafka_message_destroy(m);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_SAY(
             "Phase DURING: consumed %d \"during:\" record(s) "
@@ -756,23 +760,24 @@ static void do_test_recreate_survives_concurrent_producer(void) {
                 rd_kafka_error_t *err;
                 size_t rcvd = 0;
                 size_t i;
-                err  = rd_kafka_share_poll(rkshare, 500, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                err = rd_kafka_share_poll(rkshare, 500, &batch);
                 if (err) {
                         TEST_SAY(
-                            "Phase AFTER: share_consume_batch error: "
+                            "Phase AFTER: share_poll error: "
                             "%s\n",
                             rd_kafka_error_string(err));
                         rd_kafka_error_destroy(err);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
                         rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
                         if (!m->err && m->payload && m->len >= 6 &&
                             !strncmp((const char *)m->payload, "after:", 6))
                                 after_cnt++;
-                        rd_kafka_message_destroy(m);
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_SAY("Phase AFTER: consumed %d \"after:\" record(s)\n", after_cnt);
 
@@ -815,7 +820,9 @@ static void test_recreate_during_close(void) {
         const char *group  = "0184-share-recreate-during-close";
         const int n_msgs   = 10;
         const int delay_ms = 5000;
-        test_share_batch_t rkmessages_acc;
+        rd_kafka_message_t *rkmessages[64];
+        rd_kafka_messages_t *batches[64];
+        size_t batches_cnt = 0;
         struct recreate_thread_args thread_args;
         thrd_t recreate_thrd;
         rd_kafka_conf_t *conf;
@@ -850,18 +857,32 @@ static void test_recreate_during_close(void) {
 
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
-        test_share_batch_init(&rkmessages_acc, n_msgs);
         TEST_SAY("Consuming up to %d messages\n", n_msgs);
         while (rcvd < (size_t)n_msgs && attempts < max_attempt) {
+                rd_kafka_messages_t *batch = NULL;
                 size_t batch_rcvd;
-                error = test_share_batch_poll(&rkmessages_acc, rkshare, 3000);
-                batch_rcvd = rkmessages_acc.cnt - rcvd;
+                size_t k;
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         TEST_SAY("Consume attempt %d: %s\n", attempts,
                                  rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
-                } else if (batch_rcvd > 0) {
+                        rd_kafka_messages_destroy(batch);
+                        attempts++;
+                        continue;
+                }
+                batch_rcvd = rd_kafka_messages_count(batch);
+                if (batch_rcvd > 0 &&
+                    batches_cnt < sizeof(batches) / sizeof(batches[0]) &&
+                    rcvd + batch_rcvd <=
+                        sizeof(rkmessages) / sizeof(rkmessages[0])) {
+                        for (k = 0; k < batch_rcvd; k++)
+                                rkmessages[rcvd + k] =
+                                    rd_kafka_messages_get(batch, k);
                         rcvd += batch_rcvd;
+                        batches[batches_cnt++] = batch;
+                } else {
+                        rd_kafka_messages_destroy(batch);
                 }
                 attempts++;
         }
@@ -871,7 +892,7 @@ static void test_recreate_during_close(void) {
         TEST_SAY("Staging acks for all %zu messages\n", rcvd);
         for (i = 0; i < (int)rcvd; i++) {
                 rd_kafka_resp_err_t ack_err =
-                    rd_kafka_share_acknowledge(rkshare, rkmessages_acc.msgs[i]);
+                    rd_kafka_share_acknowledge(rkshare, rkmessages[i]);
                 TEST_ASSERT(ack_err == RD_KAFKA_RESP_ERR_NO_ERROR,
                             "ack %d failed: %s", i, rd_kafka_err2str(ack_err));
         }
@@ -914,7 +935,9 @@ static void test_recreate_during_close(void) {
 
         thrd_join(recreate_thrd, NULL);
 
-        test_share_batch_destroy(&rkmessages_acc);
+        for (i = 0; i < (int)batches_cnt; i++)
+                rd_kafka_messages_destroy(batches[i]);
+
         test_share_destroy(rkshare);
         test_mock_cluster_destroy(mcluster);
         SUB_TEST_PASS();

--- a/tests/0185-share_consumer_max_poll_interval.c
+++ b/tests/0185-share_consumer_max_poll_interval.c
@@ -35,13 +35,13 @@
  * Recreates, for the share consumer, the applicable cases from
  * 0089-max_poll_interval.c and 0091-max_poll_interval_timeout.c:
  *
- *  - A share consumer that stops calling rd_kafka_share_consume_batch() for
+ *  - A share consumer that stops calling rd_kafka_share_poll() for
  *    longer than max.poll.interval.ms is considered failed, leaves the share
  *    group, and surfaces RD_KAFKA_RESP_ERR__MAX_POLL_EXCEEDED — even if it
  *    never polled once.
- *  - The interval is reset only by rd_kafka_share_consume_batch(); other calls
+ *  - The interval is reset only by rd_kafka_share_poll(); other calls
  *    (rd_kafka_poll(), polling the log queue) do not reset it.
- *  - A blocking rd_kafka_share_consume_batch() that waits longer than
+ *  - A blocking rd_kafka_share_poll() that waits longer than
  *    max.poll.interval.ms is not counted against the interval.
  *  - Steady consumption within the interval never triggers the timeout.
  *  - After a timeout the consumer rejoins on the next batch poll.
@@ -49,7 +49,7 @@
  *
  */
 
-/* rd_kafka_share_consume_batch() fills the caller's array with up to
+/* rd_kafka_share_poll() fills the caller's array with up to
  * `share.max.poll.records` messages and reports the count via an *output*
  * parameter — it does not know the array capacity. The buffer must therefore
  * be large enough to hold a full batch. */
@@ -99,8 +99,8 @@ static rd_kafka_share_t *create_share_consumer(const char *bootstraps,
 static int share_consume_once(rd_kafka_share_t *rkshare,
                               int timeout_ms,
                               rd_bool_t *max_poll_exceeded) {
-        rd_kafka_message_t *batch[BATCH_SIZE];
-        size_t rcvd = 0;
+        rd_kafka_messages_t *batch = NULL;
+        size_t rcvd                = 0;
         size_t i;
         int valid = 0;
         rd_kafka_error_t *error;
@@ -108,7 +108,8 @@ static int share_consume_once(rd_kafka_share_t *rkshare,
         if (max_poll_exceeded)
                 *max_poll_exceeded = rd_false;
 
-        error = rd_kafka_share_consume_batch(rkshare, timeout_ms, batch, &rcvd);
+        error = rd_kafka_share_poll(rkshare, timeout_ms, &batch);
+        rcvd  = rd_kafka_messages_count(batch);
         if (error) {
                 if (max_poll_exceeded &&
                     rd_kafka_error_code(error) ==
@@ -119,9 +120,8 @@ static int share_consume_once(rd_kafka_share_t *rkshare,
         }
 
         for (i = 0; i < rcvd; i++) {
-                if (!batch[i]->err)
+                if (!rd_kafka_messages_get(batch, i)->err)
                         valid++;
-                rd_kafka_message_destroy(batch[i]);
         }
 
         return valid;
@@ -459,7 +459,7 @@ static void do_test_log_queue_no_reset(void) {
 /**
  * @brief rd_kafka_poll() on the underlying handle must NOT reset the share
  *        consumer's max.poll.interval.ms timer; only
- *        rd_kafka_share_consume_batch() does.
+ *        rd_kafka_share_poll() does.
  *
  * Inverse of 0089 do_test_max_poll_reset_with_consumer_cb(): the regular
  * consumer's poll resets the timer, the share consumer's does not.
@@ -498,7 +498,7 @@ static void do_test_rd_kafka_poll_does_not_reset(void) {
 
 
 /**
- * @brief A single blocking rd_kafka_share_consume_batch() that waits longer
+ * @brief A single blocking rd_kafka_share_poll() that waits longer
  *        than max.poll.interval.ms must NOT trip the timeout (the wait is time
  *        spent inside librdkafka, not application processing time).
  */

--- a/tests/0185-share_consumer_max_poll_interval.c
+++ b/tests/0185-share_consumer_max_poll_interval.c
@@ -35,13 +35,13 @@
  * Recreates, for the share consumer, the applicable cases from
  * 0089-max_poll_interval.c and 0091-max_poll_interval_timeout.c:
  *
- *  - A share consumer that stops calling rd_kafka_share_consume_batch() for
+ *  - A share consumer that stops calling rd_kafka_share_poll() for
  *    longer than max.poll.interval.ms is considered failed, leaves the share
  *    group, and surfaces RD_KAFKA_RESP_ERR__MAX_POLL_EXCEEDED — even if it
  *    never polled once.
- *  - The interval is reset only by rd_kafka_share_consume_batch(); other calls
+ *  - The interval is reset only by rd_kafka_share_poll(); other calls
  *    (rd_kafka_poll(), polling the log queue) do not reset it.
- *  - A blocking rd_kafka_share_consume_batch() that waits longer than
+ *  - A blocking rd_kafka_share_poll() that waits longer than
  *    max.poll.interval.ms is not counted against the interval.
  *  - Steady consumption within the interval never triggers the timeout.
  *  - After a timeout the consumer rejoins on the next batch poll.
@@ -49,7 +49,7 @@
  *
  */
 
-/* rd_kafka_share_consume_batch() fills the caller's array with up to
+/* rd_kafka_share_poll() fills the caller's array with up to
  * `share.max.poll.records` messages and reports the count via an *output*
  * parameter — it does not know the array capacity. The buffer must therefore
  * be large enough to hold a full batch. */
@@ -462,7 +462,7 @@ static void do_test_log_queue_no_reset(void) {
 /**
  * @brief rd_kafka_poll() on the underlying handle must NOT reset the share
  *        consumer's max.poll.interval.ms timer; only
- *        rd_kafka_share_consume_batch() does.
+ *        rd_kafka_share_poll() does.
  *
  * Inverse of 0089 do_test_max_poll_reset_with_consumer_cb(): the regular
  * consumer's poll resets the timer, the share consumer's does not.
@@ -501,7 +501,7 @@ static void do_test_rd_kafka_poll_does_not_reset(void) {
 
 
 /**
- * @brief A single blocking rd_kafka_share_consume_batch() that waits longer
+ * @brief A single blocking rd_kafka_share_poll() that waits longer
  *        than max.poll.interval.ms must NOT trip the timeout (the wait is time
  *        spent inside librdkafka, not application processing time).
  */

--- a/tests/0185-share_consumer_max_poll_interval.c
+++ b/tests/0185-share_consumer_max_poll_interval.c
@@ -35,13 +35,13 @@
  * Recreates, for the share consumer, the applicable cases from
  * 0089-max_poll_interval.c and 0091-max_poll_interval_timeout.c:
  *
- *  - A share consumer that stops calling rd_kafka_share_poll() for
+ *  - A share consumer that stops calling rd_kafka_share_consume_batch() for
  *    longer than max.poll.interval.ms is considered failed, leaves the share
  *    group, and surfaces RD_KAFKA_RESP_ERR__MAX_POLL_EXCEEDED — even if it
  *    never polled once.
- *  - The interval is reset only by rd_kafka_share_poll(); other calls
+ *  - The interval is reset only by rd_kafka_share_consume_batch(); other calls
  *    (rd_kafka_poll(), polling the log queue) do not reset it.
- *  - A blocking rd_kafka_share_poll() that waits longer than
+ *  - A blocking rd_kafka_share_consume_batch() that waits longer than
  *    max.poll.interval.ms is not counted against the interval.
  *  - Steady consumption within the interval never triggers the timeout.
  *  - After a timeout the consumer rejoins on the next batch poll.
@@ -49,7 +49,7 @@
  *
  */
 
-/* rd_kafka_share_poll() fills the caller's array with up to
+/* rd_kafka_share_consume_batch() fills the caller's array with up to
  * `share.max.poll.records` messages and reports the count via an *output*
  * parameter — it does not know the array capacity. The buffer must therefore
  * be large enough to hold a full batch. */
@@ -109,7 +109,6 @@ static int share_consume_once(rd_kafka_share_t *rkshare,
                 *max_poll_exceeded = rd_false;
 
         error = rd_kafka_share_poll(rkshare, timeout_ms, &batch);
-        rcvd  = rd_kafka_messages_count(batch);
         if (error) {
                 if (max_poll_exceeded &&
                     rd_kafka_error_code(error) ==
@@ -119,10 +118,14 @@ static int share_consume_once(rd_kafka_share_t *rkshare,
                 return 0;
         }
 
+        rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                if (!rd_kafka_messages_get(batch, i)->err)
+                rd_kafka_message_t *msg = rd_kafka_messages_get(batch, i);
+                if (!msg->err)
                         valid++;
         }
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
 
         return valid;
 }
@@ -459,7 +462,7 @@ static void do_test_log_queue_no_reset(void) {
 /**
  * @brief rd_kafka_poll() on the underlying handle must NOT reset the share
  *        consumer's max.poll.interval.ms timer; only
- *        rd_kafka_share_poll() does.
+ *        rd_kafka_share_consume_batch() does.
  *
  * Inverse of 0089 do_test_max_poll_reset_with_consumer_cb(): the regular
  * consumer's poll resets the timer, the share consumer's does not.
@@ -498,7 +501,7 @@ static void do_test_rd_kafka_poll_does_not_reset(void) {
 
 
 /**
- * @brief A single blocking rd_kafka_share_poll() that waits longer
+ * @brief A single blocking rd_kafka_share_consume_batch() that waits longer
  *        than max.poll.interval.ms must NOT trip the timeout (the wait is time
  *        spent inside librdkafka, not application processing time).
  */

--- a/tests/0185-share_consumer_max_poll_interval.c
+++ b/tests/0185-share_consumer_max_poll_interval.c
@@ -49,12 +49,6 @@
  *
  */
 
-/* rd_kafka_share_poll() fills the caller's array with up to
- * `share.max.poll.records` messages and reports the count via an *output*
- * parameter — it does not know the array capacity. The buffer must therefore
- * be large enough to hold a full batch. */
-#define BATCH_SIZE TEST_SHARE_BATCH_SIZE
-
 /* Longer interval for the real-broker tests (matches 0089/0091), giving the
  * group join/assignment enough headroom not to falsely trip. */
 #define REAL_MAX_POLL_INTERVAL_MS 10000

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -93,7 +93,7 @@ static void do_test_no_records_after_fatal_error(void) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "sg-0186-no-records-after-fatal";
@@ -140,13 +140,15 @@ static void do_test_no_records_after_fatal_error(void) {
 
         attempts = 0;
         while (attempts++ < 50) {
-                size_t rcvd = 0;
-                error       = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
-                rcvd        = rd_kafka_messages_count(rkmessages);
+                size_t rcvd;
+                error = rd_kafka_share_poll(rkshare, 1000, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 TEST_ASSERT(rcvd == 0,
                             "no records expected while waiting for the fatal "
                             "error, got %d",
                             (int)rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (error) {
                         TEST_ASSERT(rd_kafka_error_is_fatal(error),
                                     "expected a fatal error, got non-fatal %s",
@@ -170,12 +172,14 @@ static void do_test_no_records_after_fatal_error(void) {
         /* 5. Every subsequent consume_batch call must keep returning zero
          *    records, even though new messages are available. */
         for (i = 0; i < 10; i++) {
-                size_t rcvd = 0;
-                error       = rd_kafka_share_poll(rkshare, 500, &rkmessages);
-                rcvd        = rd_kafka_messages_count(rkmessages);
+                size_t rcvd;
+                error = rd_kafka_share_poll(rkshare, 500, &batch);
+                rcvd  = rd_kafka_messages_count(batch);
                 TEST_ASSERT(rcvd == 0,
                             "expected 0 records on post-fatal call %d, got %d",
                             i, (int)rcvd);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (error)
                         rd_kafka_error_destroy(error);
         }
@@ -212,7 +216,7 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_messages_t *rkmessages = NULL;
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "sg-0186-close-no-leave-after-fatal";
@@ -249,22 +253,27 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         /* 2. Consume at least one batch and acknowledge every record.
          *    Break out as soon as we have received some records. */
         while (consumed == 0 && attempts++ < 30) {
-                size_t rcvd = 0;
+                size_t rcvd;
                 size_t j;
-                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
-                rcvd  = rd_kafka_messages_count(rkmessages);
+                error = rd_kafka_share_poll(rkshare, 3000, &batch);
                 if (error) {
                         rd_kafka_error_destroy(error);
+                        rd_kafka_messages_destroy(batch);
+                        batch = NULL;
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (j = 0; j < rcvd; j++) {
-                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
-                                TEST_CALL_ERR__(rd_kafka_share_acknowledge(
-                                    rkshare,
-                                    rd_kafka_messages_get(rkmessages, j)));
+                        rd_kafka_message_t *rkm =
+                            rd_kafka_messages_get(batch, j);
+                        if (!rkm->err) {
+                                TEST_CALL_ERR__(
+                                    rd_kafka_share_acknowledge(rkshare, rkm));
                                 consumed++;
                         }
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_ASSERT(consumed > 0, "expected to consume and ack > 0 records");
         TEST_SAY("Consumed and acknowledged %d records\n", consumed);
@@ -283,9 +292,9 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
          *    the synchronization point for that handling. */
         attempts = 0;
         while (attempts++ < 50) {
-                rd_kafka_messages_destroy(rkmessages);
-                rkmessages = NULL;
-                error      = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
+                error = rd_kafka_share_poll(rkshare, 1000, &batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
                 if (error) {
                         TEST_ASSERT(rd_kafka_error_is_fatal(error),
                                     "expected a fatal error, got non-fatal %s",

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -283,9 +283,9 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
          *    the synchronization point for that handling. */
         attempts = 0;
         while (attempts++ < 50) {
-                size_t rcvd = 0;
-                error       = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
-                rcvd        = rd_kafka_messages_count(rkmessages);
+                rd_kafka_messages_destroy(rkmessages);
+                rkmessages = NULL;
+                error      = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
                 if (error) {
                         TEST_ASSERT(rd_kafka_error_is_fatal(error),
                                     "expected a fatal error, got non-fatal %s",

--- a/tests/0186-share_consumer_fatal_error.c
+++ b/tests/0186-share_consumer_fatal_error.c
@@ -93,7 +93,7 @@ static void do_test_no_records_after_fatal_error(void) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "sg-0186-no-records-after-fatal";
@@ -141,8 +141,8 @@ static void do_test_no_records_after_fatal_error(void) {
         attempts = 0;
         while (attempts++ < 50) {
                 size_t rcvd = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
-                                                     &rcvd);
+                error       = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
+                rcvd        = rd_kafka_messages_count(rkmessages);
                 TEST_ASSERT(rcvd == 0,
                             "no records expected while waiting for the fatal "
                             "error, got %d",
@@ -171,8 +171,8 @@ static void do_test_no_records_after_fatal_error(void) {
          *    records, even though new messages are available. */
         for (i = 0; i < 10; i++) {
                 size_t rcvd = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 500, rkmessages,
-                                                     &rcvd);
+                error       = rd_kafka_share_poll(rkshare, 500, &rkmessages);
+                rcvd        = rd_kafka_messages_count(rkmessages);
                 TEST_ASSERT(rcvd == 0,
                             "expected 0 records on post-fatal call %d, got %d",
                             i, (int)rcvd);
@@ -212,7 +212,7 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         const char *bootstraps;
         rd_kafka_share_t *rkshare;
         rd_kafka_topic_partition_list_t *subscription;
-        rd_kafka_message_t *rkmessages[CONSUME_ARRAY];
+        rd_kafka_messages_t *rkmessages = NULL;
         rd_kafka_error_t *error;
         const char *topic = test_mk_topic_name(__FUNCTION__, 0);
         const char *group = "sg-0186-close-no-leave-after-fatal";
@@ -251,19 +251,19 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         while (consumed == 0 && attempts++ < 30) {
                 size_t rcvd = 0;
                 size_t j;
-                error = rd_kafka_share_consume_batch(rkshare, 3000, rkmessages,
-                                                     &rcvd);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
+                rcvd  = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         rd_kafka_error_destroy(error);
                         continue;
                 }
                 for (j = 0; j < rcvd; j++) {
-                        if (!rkmessages[j]->err) {
+                        if (!rd_kafka_messages_get(rkmessages, j)->err) {
                                 TEST_CALL_ERR__(rd_kafka_share_acknowledge(
-                                    rkshare, rkmessages[j]));
+                                    rkshare,
+                                    rd_kafka_messages_get(rkmessages, j)));
                                 consumed++;
                         }
-                        rd_kafka_message_destroy(rkmessages[j]);
                 }
         }
         TEST_ASSERT(consumed > 0, "expected to consume and ack > 0 records");
@@ -284,8 +284,8 @@ static void do_test_close_flushes_acks_after_fatal_error(void) {
         attempts = 0;
         while (attempts++ < 50) {
                 size_t rcvd = 0;
-                error = rd_kafka_share_consume_batch(rkshare, 1000, rkmessages,
-                                                     &rcvd);
+                error       = rd_kafka_share_poll(rkshare, 1000, &rkmessages);
+                rcvd        = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         TEST_ASSERT(rd_kafka_error_is_fatal(error),
                                     "expected a fatal error, got non-fatal %s",

--- a/tests/0190-share_consumer_telemetry.c
+++ b/tests/0190-share_consumer_telemetry.c
@@ -174,16 +174,20 @@ static void produce_and_share_consume(const char *topic, const char *group_id) {
                 size_t rcvd = 0;
                 size_t i;
 
-                e    = rd_kafka_share_poll(rkshare, 1000, &batch);
-                rcvd = rd_kafka_messages_count(batch);
+                e = rd_kafka_share_poll(rkshare, 1000, &batch);
                 if (e) {
                         rd_kafka_error_destroy(e);
                         continue;
                 }
+                rcvd = rd_kafka_messages_count(batch);
                 for (i = 0; i < rcvd; i++) {
-                        if (!rd_kafka_messages_get(batch, i)->err)
+                        rd_kafka_message_t *msg =
+                            rd_kafka_messages_get(batch, i);
+                        if (msg && !msg->err)
                                 consumed++;
                 }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
         }
         TEST_SAY("Share-consumed %d messages\n", consumed);
 

--- a/tests/0190-share_consumer_telemetry.c
+++ b/tests/0190-share_consumer_telemetry.c
@@ -169,20 +169,20 @@ static void produce_and_share_consume(const char *topic, const char *group_id) {
 
         deadline_us = test_clock() + 20 * 1000000;
         while (test_clock() < deadline_us) {
-                rd_kafka_message_t *batch[100];
+                rd_kafka_messages_t *batch = NULL;
                 rd_kafka_error_t *e;
                 size_t rcvd = 0;
                 size_t i;
 
-                e = rd_kafka_share_consume_batch(rkshare, 1000, batch, &rcvd);
+                e    = rd_kafka_share_poll(rkshare, 1000, &batch);
+                rcvd = rd_kafka_messages_count(batch);
                 if (e) {
                         rd_kafka_error_destroy(e);
                         continue;
                 }
                 for (i = 0; i < rcvd; i++) {
-                        if (!batch[i]->err)
+                        if (!rd_kafka_messages_get(batch, i)->err)
                                 consumed++;
-                        rd_kafka_message_destroy(batch[i]);
                 }
         }
         TEST_SAY("Share-consumed %d messages\n", consumed);

--- a/tests/test.c
+++ b/tests/test.c
@@ -8059,29 +8059,31 @@ int test_share_consume_batch(rd_kafka_share_t *rk,
                              int *out_valid) {
         rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
-        size_t rcvd;
+        size_t rcvd, i;
         int valid = 0;
-        size_t i;
         int j;
         int ret = 0;
 
         err = rd_kafka_share_poll(rk, timeout_ms, &batch);
         if (err) {
                 rd_kafka_error_destroy(err);
+                rd_kafka_messages_destroy(batch);
                 *out_valid = 0;
                 return 0;
         }
 
         rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
-                if (m->err) {
-                        /* Skip error messages */
+                rd_kafka_message_t *msg = rd_kafka_messages_get(batch, i);
+
+                if (msg->err) {
+                        /* Skip error messages (destroyed by
+                         * rd_kafka_messages_destroy() below) */
                         continue;
                 }
 
                 if (expected_topics) {
-                        const char *msg_topic = rd_kafka_topic_name(m->rkt);
+                        const char *msg_topic = rd_kafka_topic_name(msg->rkt);
                         int found             = 0;
 
                         /* Verify message is from expected topic */
@@ -8103,8 +8105,8 @@ int test_share_consume_batch(rd_kafka_share_t *rk,
                 }
                 valid++;
         }
-        rd_kafka_messages_destroy(batch);
 
+        rd_kafka_messages_destroy(batch);
         *out_valid = valid;
         return ret;
 }
@@ -8341,48 +8343,6 @@ rd_kafka_share_t *test_create_share_consumer_with_cb(
 /**
  * @brief Wait for acknowledgement callbacks while polling.
  */
-void test_share_batch_init(test_share_batch_t *batch, size_t capacity) {
-        memset(batch, 0, sizeof(*batch));
-        batch->capacity        = capacity;
-        batch->msgs            = rd_calloc(capacity, sizeof(*batch->msgs));
-        batch->handle_capacity = 16;
-        batch->handles =
-            rd_calloc(batch->handle_capacity, sizeof(*batch->handles));
-}
-
-rd_kafka_error_t *test_share_batch_poll(test_share_batch_t *batch,
-                                        rd_kafka_share_t *rk,
-                                        int timeout_ms) {
-        rd_kafka_messages_t *msgs = NULL;
-        rd_kafka_error_t *err;
-        size_t got, k;
-
-        err = rd_kafka_share_poll(rk, timeout_ms, &msgs);
-
-        if (batch->handle_cnt == batch->handle_capacity) {
-                batch->handle_capacity *= 2;
-                batch->handles =
-                    rd_realloc(batch->handles, batch->handle_capacity *
-                                                   sizeof(*batch->handles));
-        }
-        batch->handles[batch->handle_cnt++] = msgs;
-
-        got = rd_kafka_messages_count(msgs);
-        for (k = 0; k < got && batch->cnt < batch->capacity; k++)
-                batch->msgs[batch->cnt++] = rd_kafka_messages_get(msgs, k);
-
-        return err;
-}
-
-void test_share_batch_destroy(test_share_batch_t *batch) {
-        size_t i;
-        for (i = 0; i < batch->handle_cnt; i++)
-                rd_kafka_messages_destroy(batch->handles[i]);
-        rd_free(batch->handles);
-        rd_free(batch->msgs);
-        memset(batch, 0, sizeof(*batch));
-}
-
 rd_bool_t test_wait_for_cb_with_poll(test_ack_cb_state_t *state,
                                      rd_kafka_share_t *rkshare,
                                      int min_callbacks,
@@ -8390,25 +8350,21 @@ rd_bool_t test_wait_for_cb_with_poll(test_ack_cb_state_t *state,
         rd_bool_t success = rd_false;
         int elapsed       = 0;
         int poll_interval = 100;
-        rd_kafka_messages_t *rkmessages;
 
         while (elapsed < timeout_ms) {
-                size_t rcvd;
-                rd_kafka_error_t *error = NULL;
-                rkmessages              = NULL;
-                error =
-                    rd_kafka_share_poll(rkshare, poll_interval, &rkmessages);
-                rcvd = rd_kafka_messages_count(rkmessages);
+                rd_kafka_messages_t *batch = NULL;
+                rd_kafka_error_t *error =
+                    rd_kafka_share_poll(rkshare, poll_interval, &batch);
                 if (error) {
                         TEST_SAY(
                             "test_wait_for_cb_with_poll: "
                             "share_poll err=%s (%s) rcvd=%zu\n",
                             rd_kafka_err2name(rd_kafka_error_code(error)),
-                            rd_kafka_error_string(error), rcvd);
+                            rd_kafka_error_string(error),
+                            rd_kafka_messages_count(batch));
                         rd_kafka_error_destroy(error);
                 }
-
-                rd_kafka_messages_destroy(rkmessages);
+                rd_kafka_messages_destroy(batch);
 
                 if (state->callback_cnt >= min_callbacks) {
                         success = rd_true;

--- a/tests/test.c
+++ b/tests/test.c
@@ -8052,11 +8052,11 @@ rd_kafka_share_t *test_create_share_consumer(const char *group_id,
  *
  * @returns 0 on success, -1 if message from unexpected topic received.
  */
-int test_share_consume_batch(rd_kafka_share_t *rk,
-                             int timeout_ms,
-                             const char **expected_topics,
-                             int expected_topic_cnt,
-                             int *out_valid) {
+int test_share_poll(rd_kafka_share_t *rk,
+                    int timeout_ms,
+                    const char **expected_topics,
+                    int expected_topic_cnt,
+                    int *out_valid) {
         rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
         size_t rcvd, i;
@@ -8137,8 +8137,8 @@ int test_share_consume_msgs(rd_kafka_share_t *rk,
                 int batch_cnt = 0;
                 int ret;
 
-                ret = test_share_consume_batch(rk, timeout_ms, expected_topics,
-                                               expected_topic_cnt, &batch_cnt);
+                ret = test_share_poll(rk, timeout_ms, expected_topics,
+                                      expected_topic_cnt, &batch_cnt);
                 if (ret < 0)
                         return -1; /* Wrong topic detected */
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -8057,32 +8057,32 @@ int test_share_consume_batch(rd_kafka_share_t *rk,
                              const char **expected_topics,
                              int expected_topic_cnt,
                              int *out_valid) {
-        rd_kafka_message_t *batch[TEST_SHARE_BATCH_SIZE];
+        rd_kafka_messages_t *batch = NULL;
         rd_kafka_error_t *err;
-        size_t rcvd = 0;
-        int valid   = 0;
+        size_t rcvd;
+        int valid = 0;
         size_t i;
         int j;
         int ret = 0;
 
-        err = rd_kafka_share_consume_batch(rk, timeout_ms, batch, &rcvd);
+        err = rd_kafka_share_poll(rk, timeout_ms, &batch);
         if (err) {
                 rd_kafka_error_destroy(err);
                 *out_valid = 0;
                 return 0;
         }
 
+        rcvd = rd_kafka_messages_count(batch);
         for (i = 0; i < rcvd; i++) {
-                if (batch[i]->err) {
+                rd_kafka_message_t *m = rd_kafka_messages_get(batch, i);
+                if (m->err) {
                         /* Skip error messages */
-                        rd_kafka_message_destroy(batch[i]);
                         continue;
                 }
 
                 if (expected_topics) {
-                        const char *msg_topic =
-                            rd_kafka_topic_name(batch[i]->rkt);
-                        int found = 0;
+                        const char *msg_topic = rd_kafka_topic_name(m->rkt);
+                        int found             = 0;
 
                         /* Verify message is from expected topic */
                         for (j = 0; j < expected_topic_cnt; j++) {
@@ -8102,8 +8102,8 @@ int test_share_consume_batch(rd_kafka_share_t *rk,
                         }
                 }
                 valid++;
-                rd_kafka_message_destroy(batch[i]);
         }
+        rd_kafka_messages_destroy(batch);
 
         *out_valid = valid;
         return ret;
@@ -8341,6 +8341,48 @@ rd_kafka_share_t *test_create_share_consumer_with_cb(
 /**
  * @brief Wait for acknowledgement callbacks while polling.
  */
+void test_share_batch_init(test_share_batch_t *batch, size_t capacity) {
+        memset(batch, 0, sizeof(*batch));
+        batch->capacity        = capacity;
+        batch->msgs            = rd_calloc(capacity, sizeof(*batch->msgs));
+        batch->handle_capacity = 16;
+        batch->handles =
+            rd_calloc(batch->handle_capacity, sizeof(*batch->handles));
+}
+
+rd_kafka_error_t *test_share_batch_poll(test_share_batch_t *batch,
+                                        rd_kafka_share_t *rk,
+                                        int timeout_ms) {
+        rd_kafka_messages_t *msgs = NULL;
+        rd_kafka_error_t *err;
+        size_t got, k;
+
+        err = rd_kafka_share_poll(rk, timeout_ms, &msgs);
+
+        if (batch->handle_cnt == batch->handle_capacity) {
+                batch->handle_capacity *= 2;
+                batch->handles =
+                    rd_realloc(batch->handles, batch->handle_capacity *
+                                                   sizeof(*batch->handles));
+        }
+        batch->handles[batch->handle_cnt++] = msgs;
+
+        got = rd_kafka_messages_count(msgs);
+        for (k = 0; k < got && batch->cnt < batch->capacity; k++)
+                batch->msgs[batch->cnt++] = rd_kafka_messages_get(msgs, k);
+
+        return err;
+}
+
+void test_share_batch_destroy(test_share_batch_t *batch) {
+        size_t i;
+        for (i = 0; i < batch->handle_cnt; i++)
+                rd_kafka_messages_destroy(batch->handles[i]);
+        rd_free(batch->handles);
+        rd_free(batch->msgs);
+        memset(batch, 0, sizeof(*batch));
+}
+
 rd_bool_t test_wait_for_cb_with_poll(test_ack_cb_state_t *state,
                                      rd_kafka_share_t *rkshare,
                                      int min_callbacks,
@@ -8348,23 +8390,25 @@ rd_bool_t test_wait_for_cb_with_poll(test_ack_cb_state_t *state,
         rd_bool_t success = rd_false;
         int elapsed       = 0;
         int poll_interval = 100;
-        rd_kafka_message_t *rkmessages[100];
-        size_t rcvd;
+        rd_kafka_messages_t *rkmessages;
 
         while (elapsed < timeout_ms) {
-                rd_kafka_error_t *error = rd_kafka_share_consume_batch(
-                    rkshare, poll_interval, rkmessages, &rcvd);
+                size_t rcvd;
+                rd_kafka_error_t *error = NULL;
+                rkmessages              = NULL;
+                error =
+                    rd_kafka_share_poll(rkshare, poll_interval, &rkmessages);
+                rcvd = rd_kafka_messages_count(rkmessages);
                 if (error) {
                         TEST_SAY(
                             "test_wait_for_cb_with_poll: "
-                            "consume_batch err=%s (%s) rcvd=%zu\n",
+                            "share_poll err=%s (%s) rcvd=%zu\n",
                             rd_kafka_err2name(rd_kafka_error_code(error)),
                             rd_kafka_error_string(error), rcvd);
                         rd_kafka_error_destroy(error);
                 }
 
-                for (size_t i = 0; i < rcvd; i++)
-                        rd_kafka_message_destroy(rkmessages[i]);
+                rd_kafka_messages_destroy(rkmessages);
 
                 if (state->callback_cnt >= min_callbacks) {
                         success = rd_true;

--- a/tests/test.h
+++ b/tests/test.h
@@ -1050,44 +1050,6 @@ int test_share_consume_msgs(rd_kafka_share_t *rk,
                             const char **expected_topics,
                             int expected_topic_cnt);
 
-/**
- * @brief Flat view of messages collected across one or more
- *        rd_kafka_share_poll() calls.
- *
- * Owns the rd_kafka_messages_t handles returned by each poll, so that the
- * rd_kafka_message_t* pointers in \c msgs[] stay valid until
- * test_share_batch_destroy() is called. Use this when test logic needs
- * indexed access to records that may have arrived across multiple polls
- * (e.g. to ack records 0..N out-of-order, or to compare against tracked
- * offsets after a drain loop).
- */
-typedef struct test_share_batch_s {
-        rd_kafka_message_t **msgs;     /**< flat array of message pointers,
-                                        *   size capacity */
-        size_t cnt;                    /**< number of messages collected */
-        size_t capacity;               /**< maximum messages we will keep */
-        rd_kafka_messages_t **handles; /**< owned message-list handles */
-        size_t handle_cnt;
-        size_t handle_capacity;
-} test_share_batch_t;
-
-void test_share_batch_init(test_share_batch_t *batch, size_t capacity);
-
-/**
- * @brief Poll the share consumer once and append the returned messages
- *        to \p batch.
- *
- * @returns The error from rd_kafka_share_poll() (caller must destroy if
- *          non-NULL). \p batch always takes ownership of the messages
- *          handle, even on error or empty poll.
- */
-rd_kafka_error_t *test_share_batch_poll(test_share_batch_t *batch,
-                                        rd_kafka_share_t *rk,
-                                        int timeout_ms);
-
-/** @brief Destroy all owned handles and free \p batch's storage. */
-void test_share_batch_destroy(test_share_batch_t *batch);
-
 void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
                                          int topic_count,
                                          ...);

--- a/tests/test.h
+++ b/tests/test.h
@@ -1050,6 +1050,44 @@ int test_share_consume_msgs(rd_kafka_share_t *rk,
                             const char **expected_topics,
                             int expected_topic_cnt);
 
+/**
+ * @brief Flat view of messages collected across one or more
+ *        rd_kafka_share_poll() calls.
+ *
+ * Owns the rd_kafka_messages_t handles returned by each poll, so that the
+ * rd_kafka_message_t* pointers in \c msgs[] stay valid until
+ * test_share_batch_destroy() is called. Use this when test logic needs
+ * indexed access to records that may have arrived across multiple polls
+ * (e.g. to ack records 0..N out-of-order, or to compare against tracked
+ * offsets after a drain loop).
+ */
+typedef struct test_share_batch_s {
+        rd_kafka_message_t **msgs;     /**< flat array of message pointers,
+                                        *   size capacity */
+        size_t cnt;                    /**< number of messages collected */
+        size_t capacity;               /**< maximum messages we will keep */
+        rd_kafka_messages_t **handles; /**< owned message-list handles */
+        size_t handle_cnt;
+        size_t handle_capacity;
+} test_share_batch_t;
+
+void test_share_batch_init(test_share_batch_t *batch, size_t capacity);
+
+/**
+ * @brief Poll the share consumer once and append the returned messages
+ *        to \p batch.
+ *
+ * @returns The error from rd_kafka_share_poll() (caller must destroy if
+ *          non-NULL). \p batch always takes ownership of the messages
+ *          handle, even on error or empty poll.
+ */
+rd_kafka_error_t *test_share_batch_poll(test_share_batch_t *batch,
+                                        rd_kafka_share_t *rk,
+                                        int timeout_ms);
+
+/** @brief Destroy all owned handles and free \p batch's storage. */
+void test_share_batch_destroy(test_share_batch_t *batch);
+
 void test_share_consumer_subscribe_multi(rd_kafka_share_t *rk,
                                          int topic_count,
                                          ...);

--- a/tests/test.h
+++ b/tests/test.h
@@ -1037,11 +1037,11 @@ rd_kafka_share_t *test_create_share_consumer(const char *group_id,
 
 #define TEST_SHARE_BATCH_SIZE 10001
 
-int test_share_consume_batch(rd_kafka_share_t *rk,
-                             int timeout_ms,
-                             const char **expected_topics,
-                             int expected_topic_cnt,
-                             int *out_valid);
+int test_share_poll(rd_kafka_share_t *rk,
+                    int timeout_ms,
+                    const char **expected_topics,
+                    int expected_topic_cnt,
+                    int *out_valid);
 
 int test_share_consume_msgs(rd_kafka_share_t *rk,
                             int expected,

--- a/tests/test.h
+++ b/tests/test.h
@@ -1035,8 +1035,6 @@ rd_kafka_t *test_share_consumer_get_rk(rd_kafka_share_t *rkshare);
 rd_kafka_share_t *test_create_share_consumer(const char *group_id,
                                              const char *ack_mode);
 
-#define TEST_SHARE_BATCH_SIZE 10001
-
 int test_share_poll(rd_kafka_share_t *rk,
                     int timeout_ms,
                     const char **expected_topics,


### PR DESCRIPTION
Rename rd_kafka_share_consume_batch → rd_kafka_share_poll; return records via opaque rd_kafka_messages_t
Share consumer poll now allocates its own result, sized to the actual record count, instead of requiring callers to pre-allocate an rd_kafka_message_t ** array of size max.poll.records.

New API in rdkafka.h:


**rd_kafka_error_t *
rd_kafka_share_poll(rd_kafka_share_t *, int timeout_ms, rd_kafka_messages_t **);**

**size_t rd_kafka_messages_count(const rd_kafka_messages_t *);**
**rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *, size_t i);**
**void rd_kafka_messages_destroy(rd_kafka_messages_t *);**
*rkmessages = NULL on error / empty timeout; _destroy(NULL) is a no-op.