### PR TITLE
[KIP-932] Let share ops through during SASL reauth; share-path isolation and cleanup

### DIFF
--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -3668,39 +3668,34 @@ rd_kafka_broker_op_serve(rd_kafka_broker_t *rkb, rd_kafka_op_t *rko) {
                            rd_kafka_broker_name(rkb),
                            rko->rko_u.share_fetch.should_fetch,
                            rko->rko_u.share_fetch.should_leave);
-                /* This is only temporary handling for testing to avoid crashing
-                 * on assert  - the code below will automatically enqueue a
-                 * reply which is not the final behaviour. */
-                /* Insert errors randomly for testing, remove this code once
-                 * actual errors can be tested via the mock broker. */
-                // if (rd_jitter(0, 10) > 7) {
-                //         rd_rkb_dbg(rkb, CGRP, "SHAREFETCH",
-                //                    "Injecting error! %s : %d",
-                //                    rd_kafka_broker_name(rkb),
-                //                    rko->rko_u.share_fetch.should_fetch);
 
-                //         rd_kafka_op_reply(rko, RD_KAFKA_RESP_ERR__STATE);
-                //         rko = NULL;
-                // }
-                /* TODO KIP-932: Verify handling of this op */
                 if (rd_kafka_broker_or_instance_terminating(rkb)) {
                         rd_kafka_dbg(rkb->rkb_rk, BROKER, "SHAREFETCH",
                                      "Ignoring SHARE_FETCH op: "
                                      "instance or broker is terminating");
                         rd_kafka_share_fetch_op_reply_and_update_ack_details_with_err(
                             rko, rd_kafka_broker_destroy_error(rkb->rkb_rk));
-                } else if (rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP) {
-                        /* Backstop: the main thread filters on rkb_state
-                         * in rd_kafka_share_select_broker, so this only
-                         * fires when the broker transitioned to !UP
-                         * after that unlocked check. */
+                } else if (rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP &&
+                           !rkb->rkb_reauth_in_progress) {
+                        /* Broker not usable for a share RPC yet.
+                         *
+                         * Exception: during SASL reauthentication the
+                         * connection and share session stay live, so the op is
+                         * let through (it waits in the output queue until
+                         * reauth completes) instead of being bounced, to avoid
+                         * failing acks for records already acquired on the
+                         * broker, which would otherwise be redelivered when
+                         * their lock lapses.
+                         *
+                         * __TRANSPORT signals the caller that the broker is
+                         * transiently unwritable and the op may be retried. */
                         rd_kafka_dbg(
                             rkb->rkb_rk, BROKER, "SHAREFETCH",
                             "Ignoring SHARE_FETCH op: "
                             "broker not up (state %s)",
                             rd_kafka_broker_state_names[rkb->rkb_state]);
                         rd_kafka_share_fetch_op_reply_and_update_ack_details_with_err(
-                            rko, RD_KAFKA_RESP_ERR__STATE);
+                            rko, RD_KAFKA_RESP_ERR__TRANSPORT);
                 } else if (rko->rko_u.share_fetch.should_leave) {
                         rd_kafka_broker_share_fetch_session_leave(rkb, rko,
                                                                   rd_clock());
@@ -4612,8 +4607,6 @@ static void rd_kafka_broker_share_consumer_serve(rd_kafka_broker_t *rkb,
 
                 if (min_backoff > abs_timeout)
                         min_backoff = abs_timeout;
-
-                // rd_kafka_broker_update_share_fetch_session(rkb);
 
                 if (rd_kafka_broker_ops_io_serve(rkb, min_backoff))
                         return; /* Wakeup */

--- a/src/rdkafka_broker.c
+++ b/src/rdkafka_broker.c
@@ -4565,9 +4565,7 @@ static void rd_kafka_broker_producer_serve(rd_kafka_broker_t *rkb,
 }
 
 /**
- * Consumer serving
- *
- * TODO KIP-932: Fix timeouts.
+ * @brief Share consumer serving
  */
 static void rd_kafka_broker_share_consumer_serve(rd_kafka_broker_t *rkb,
                                                  rd_ts_t abs_timeout) {
@@ -4585,9 +4583,9 @@ static void rd_kafka_broker_share_consumer_serve(rd_kafka_broker_t *rkb,
 
                 rd_kafka_broker_unlock(rkb);
 
-                /*
-                 * TODO KIP-932: Check the below connection handling properly.
-                 */
+                /* Drives reconnection: requests a persistent connection so a
+                 * down broker reconnects on its own (fetches are op-driven and
+                 * ops only target UP brokers). */
                 if (rkb->rkb_toppar_cnt > 0 &&
                     rkb->rkb_share_fetch_session.epoch >= 0 &&
                     rkb->rkb_state != RD_KAFKA_BROKER_STATE_UP) {
@@ -4596,12 +4594,10 @@ static void rd_kafka_broker_share_consumer_serve(rd_kafka_broker_t *rkb,
                         rkb->rkb_persistconn.internal++;
                 }
 
-                /**
-                 * TODO KIP-932: Check if the below is needed. Currently, used
-                 *               as it is from the original consumer serve
-                 * function.
-                 */
-                /* Check and move retry buffers */
+                /* Move due retry buffers back to the output queue and shorten
+                 * the wakeup to the next pending retry. Used by
+                 * connection-setup and metadata requests (ApiVersion, SASL,
+                 * Metadata), not by ShareFetch/ShareAcknowledge. */
                 if (unlikely(rd_atomic32_get(&rkb->rkb_retrybufs.rkbq_cnt) > 0))
                         rd_kafka_broker_retry_bufs_move(rkb, &min_backoff);
 

--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -2253,38 +2253,15 @@ static void rd_kafka_broker_share_acknowledge_reply(rd_kafka_t *rk,
                 case RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH:
                 case RD_KAFKA_RESP_ERR__TRANSPORT:
                 case RD_KAFKA_RESP_ERR__TIMED_OUT:
-                        /* __TRANSPORT means connection is already
-                         * dead.
-                         * TODO KIP-932: For __TIMED_OUT:
-                         * 1) Ensure socket.max.fails cannot be set
-                         *    for share consumer, or if it can be set,
-                         *    tear down the connection for each
-                         *    ShareFetch/ShareAcknowledge timed out
-                         *    request regardless of the threshold so
-                         *    that timeouts always force a reconnect.
-                         * 2) Ensure reconnect after teardown. Verify
-                         *    that sparse connection's need_connection
-                         *    is updated after the connection is torn
-                         *    down so that the broker reconnects. */
+                        /* __TRANSPORT means connection is already dead.
+                         * On __TIMED_OUT the connection is torn down by the
+                         * request-timeout scan (socket.max.fails is forced to
+                         * 1 for share consumers and cannot be changed) and the
+                         * broker reconnects via the share-serve persistent
+                         * connection driver; here we only reset the session so
+                         * it re-establishes at epoch 0. */
                         rd_kafka_broker_session_reset(rkb);
                         break;
-
-                case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_OR_PART:
-                case RD_KAFKA_RESP_ERR_NOT_LEADER_FOR_PARTITION:
-                case RD_KAFKA_RESP_ERR_UNKNOWN_TOPIC_ID: {
-                        char tmp[128];
-                        /* TODO KIP-932: The response already carries
-                         * per-partition currentLeader + nodeEndpoints;
-                         * use that to update partition leadership
-                         * directly instead of triggering a full
-                         * metadata refresh RPC. */
-                        rd_snprintf(tmp, sizeof(tmp),
-                                    "ShareAcknowledge failed: %s",
-                                    rd_kafka_err2str(err));
-                        rd_kafka_metadata_refresh_known_topics(
-                            rkb->rkb_rk, NULL, rd_true /*force*/, tmp);
-                        break;
-                }
 
                 case RD_KAFKA_RESP_ERR__BAD_MSG:
                 case RD_KAFKA_RESP_ERR__UNDERFLOW:
@@ -2388,19 +2365,12 @@ static void rd_kafka_broker_share_fetch_reply(rd_kafka_t *rk,
                          * or connection/request failed.
                          * Reset session state so the next request
                          * re-establishes a new session (epoch 0).
-                         * __TRANSPORT means connection is already
-                         * dead.
-                         * TODO KIP-932: For __TIMED_OUT:
-                         * 1) Ensure socket.max.fails cannot be set
-                         *    for share consumer, or if it can be set,
-                         *    tear down the connection for each
-                         *    ShareFetch/ShareAcknowledge timed out
-                         *    request regardless of the threshold so
-                         *    that timeouts always force a reconnect.
-                         * 2) Ensure reconnect after teardown. Verify
-                         *    that sparse connection's need_connection
-                         *    is updated after the connection is torn
-                         *    down so that the broker reconnects. */
+                         * __TRANSPORT means connection is already dead.
+                         * On __TIMED_OUT the connection is torn down by the
+                         * request-timeout scan (socket.max.fails is forced to
+                         * 1 for share consumers and cannot be changed) and the
+                         * broker reconnects via the share-serve persistent
+                         * connection driver. */
                         rd_kafka_broker_session_reset(rkb);
                         break;
 

--- a/src/rdkafka_op.h
+++ b/src/rdkafka_op.h
@@ -772,7 +772,6 @@ struct rd_kafka_op_s {
                         rd_bool_t should_fetch;
 
                         /** Absolute timeout left to complete this share-fetch.
-                         * TODO KIP-932: Use timeout properly.
                          */
                         rd_ts_t abs_timeout;
 

--- a/src/rdkafka_partition.c
+++ b/src/rdkafka_partition.c
@@ -2164,6 +2164,8 @@ static rd_kafka_op_res_t rd_kafka_toppar_op_serve(rd_kafka_t *rk,
         rd_kafka_toppar_t *rktp = NULL;
         int outdated            = 0;
 
+        rd_dassert(!RD_KAFKA_IS_SHARE_CONSUMER(rk));
+
         if (rko->rko_rktp)
                 rktp = rko->rko_rktp;
 
@@ -2368,6 +2370,16 @@ rd_kafka_resp_err_t rd_kafka_toppar_op_fetch_start(rd_kafka_toppar_t *rktp,
                                                    rd_kafka_replyq_t replyq) {
         int32_t version;
 
+        rd_dassert(!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "CONSUMER",
+                             "consume_start is not supported for share "
+                             "consumers: %s [%" PRId32 "]: ignored",
+                             rd_kafka_topic_name_safe(rktp->rktp_rkt),
+                             rktp->rktp_partition);
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+        }
+
         rd_kafka_q_lock(rktp->rktp_fetchq);
         if (fwdq && !(rktp->rktp_fetchq->rkq_flags & RD_KAFKA_Q_F_FWD_APP))
                 rd_kafka_q_fwd_set0(rktp->rktp_fetchq, fwdq, 0, /* no do_lock */
@@ -2400,6 +2412,16 @@ rd_kafka_resp_err_t rd_kafka_toppar_op_fetch_stop(rd_kafka_toppar_t *rktp,
                                                   rd_kafka_replyq_t replyq) {
         int32_t version;
 
+        rd_dassert(!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "CONSUMER",
+                             "consume_stop is not supported for share "
+                             "consumers: %s [%" PRId32 "]: ignored",
+                             rd_kafka_topic_name_safe(rktp->rktp_rkt),
+                             rktp->rktp_partition);
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+        }
+
         /* Bump version barrier. */
         version = rd_kafka_toppar_version_new_barrier(rktp);
 
@@ -2428,6 +2450,16 @@ rd_kafka_resp_err_t rd_kafka_toppar_op_seek(rd_kafka_toppar_t *rktp,
                                             rd_kafka_fetch_pos_t pos,
                                             rd_kafka_replyq_t replyq) {
         int32_t version;
+
+        rd_dassert(!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC, "CONSUMER",
+                             "seek is not supported for share consumers: "
+                             "%s [%" PRId32 "]: ignored",
+                             rd_kafka_topic_name_safe(rktp->rktp_rkt),
+                             rktp->rktp_partition);
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+        }
 
         /* Bump version barrier. */
         version = rd_kafka_toppar_version_new_barrier(rktp);
@@ -2458,7 +2490,20 @@ rd_kafka_resp_err_t rd_kafka_toppar_op_pause_resume(rd_kafka_toppar_t *rktp,
                                                     int flag,
                                                     rd_kafka_replyq_t replyq) {
         int32_t version;
-        rd_kafka_op_t *rko = rd_kafka_op_new(RD_KAFKA_OP_PAUSE);
+        rd_kafka_op_t *rko;
+
+        rd_dassert(!RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk));
+        if (RD_KAFKA_IS_SHARE_CONSUMER(rktp->rktp_rkt->rkt_rk)) {
+                rd_kafka_dbg(rktp->rktp_rkt->rkt_rk, TOPIC,
+                             pause ? "PAUSE" : "RESUME",
+                             "Pause/resume is not supported for share "
+                             "consumers: %s [%" PRId32 "]: ignored",
+                             rd_kafka_topic_name_safe(rktp->rktp_rkt),
+                             rktp->rktp_partition);
+                return RD_KAFKA_RESP_ERR_NO_ERROR;
+        }
+
+        rko = rd_kafka_op_new(RD_KAFKA_OP_PAUSE);
 
         if (!pause) {
                 /* If partitions isn't paused, avoid bumping its version,

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -284,6 +284,12 @@ struct rd_kafka_toppar_s {                           /* rd_kafka_toppar_t */
          *   Broker thread: Recv IO FetchResponse with tver=2 which
          *                  is same as rktp_version so message is forwarded
          *                  to app.
+         *
+         * Share consumers: all three versions remain 0 for the toppar's
+         * lifetime. rktp_version is initialised to 0 and
+         * rd_kafka_toppar_op_version_bump() short-circuits, so no op ever
+         * carries a non-zero rko_version. Any code that bumps rktp_version
+         * directly MUST guard on RD_KAFKA_IS_SHARE_CONSUMER.
          */
         rd_atomic32_t rktp_version; /* Latest op version.
                                      * Authoritative (app thread)*/
@@ -1088,6 +1094,11 @@ rd_kafka_toppar_ver_destroy(struct rd_kafka_toppar_ver *tver) {
  */
 static RD_INLINE RD_UNUSED int rd_kafka_op_version_outdated(rd_kafka_op_t *rko,
                                                             int version) {
+        rd_dassert(
+            !rko->rko_rktp ||
+            !RD_KAFKA_IS_SHARE_CONSUMER(rko->rko_rktp->rktp_rkt->rkt_rk) ||
+            rko->rko_version == 0);
+
         if (!rko->rko_version)
                 return 0;
 

--- a/src/rdkafka_partition.h
+++ b/src/rdkafka_partition.h
@@ -1094,11 +1094,6 @@ rd_kafka_toppar_ver_destroy(struct rd_kafka_toppar_ver *tver) {
  */
 static RD_INLINE RD_UNUSED int rd_kafka_op_version_outdated(rd_kafka_op_t *rko,
                                                             int version) {
-        rd_dassert(
-            !rko->rko_rktp ||
-            !RD_KAFKA_IS_SHARE_CONSUMER(rko->rko_rktp->rktp_rkt->rkt_rk) ||
-            rko->rko_version == 0);
-
         if (!rko->rko_version)
                 return 0;
 

--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -295,9 +295,6 @@ rd_kafka_share_find_ack_batch(rd_list_t *ack_list,
         int i;
 
         RD_LIST_FOREACH(existing, ack_list, i) {
-                /* TODO KIP-932: We might need to use leader id and epoch
-                 * as well to understand about the stale topic partition
-                 * information */
                 if (rd_kafka_topic_partition_by_id_cmp(existing->rktpar,
                                                        rktpar) == 0)
                         return existing;

--- a/src/rdkafka_subscription.c
+++ b/src/rdkafka_subscription.c
@@ -94,8 +94,10 @@ static size_t _invalid_topic_cb(const rd_kafka_topic_partition_t *rktpar,
 
 
 /** @returns 1 if the topic is empty (invalid for the share consumer),
- *           else 0. Share consumer does not support regex/wildcard
- *           subscriptions; entries are forwarded verbatim to the broker. */
+ *           else 0. Share consumer subscriptions are plain topic names:
+ *           entries are forwarded to the broker verbatim and are never
+ *           expanded as regex/wildcards, so a leading '^' is treated as a
+ *           literal character rather than a pattern marker. */
 static size_t _share_invalid_topic_cb(const rd_kafka_topic_partition_t *rktpar,
                                       void *opaque) {
         if (!*rktpar->topic)
@@ -168,9 +170,10 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
                 goto done;
         }
 
-        /* Share consumer subscriptions are literal topic names only:
-         * regex/wildcard entries are not supported. Reject empty
-         * entries; pass everything else through to the broker via the
+        /* Share consumer subscriptions are plain topic names forwarded to
+         * the broker verbatim; entries are never expanded as regex/wildcards
+         * (a leading '^' is a literal character, not a pattern marker).
+         * Reject only empty entries; pass everything else through via the
          * heartbeat. */
         if (rd_kafka_topic_partition_list_sum(topics, _share_invalid_topic_cb,
                                               NULL) > 0) {


### PR DESCRIPTION
Main change: during SASL reauthentication the connection and share session stay
live, so the broker-thread SHARE_FETCH op handler now queues the op (sent once
reauth completes) instead of bouncing it — avoiding failed acks for records
already acquired on the broker (which would otherwise be redelivered after the
lock lapses). Not-up bounce error code: `__STATE` → `__TRANSPORT` (retryable).

Also in this PR:
- Isolate share consumers from the rktp version/fetch machinery they don't use:
  `op_fetch_start/stop`, `op_seek`, `op_pause_resume` no-op for share handles;
  devel dasserts enforce `rktp_version == 0`.
- Devel-build fix: drop an `op_version_outdated` dassert that deref'd `rk_conf`
  on an incomplete `rd_kafka_t`.
- Comment/TODO cleanups on the share broker-serve loop and ShareAcknowledge
  handler (no behavior change).
