### PR TITLE
  [KIP-932] Config changes to maintain parity with Java Client

### DIFF
--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -1482,7 +1482,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
      "Minimum number of bytes the broker responds with. "
      "If fetch.wait.max.ms expires the accumulated data will "
      "be sent to the client regardless of this setting.",
-     1, 100000000, 1},
+     0, 100000000, 1},
     {_RK_GLOBAL | _RK_CONSUMER | _RK_MED, "fetch.error.backoff.ms", _RK_C_INT,
      _RK(fetch_error_backoff_ms),
      "How long to postpone the next fetch request for a "
@@ -4273,7 +4273,12 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                  * end of the block, before the downstream
                  * group-protocol validation runs so its
                  * CONSUMER-branch checks also apply to share
-                 * consumers. */
+                 * consumers.
+                 *
+                 * TODO KIP-932: evaluate, per property, whether
+                 * rejecting is the right behavior or whether some
+                 * should instead be silently ignored (as the Java
+                 * client does for several of these). */
                 if (conf->share.is_share_consumer) {
                         if (conf->rebalance_cb)
                                 return "`rebalance_cb` is not applicable "
@@ -4312,6 +4317,36 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 return "`partition.assignment.strategy` is "
                                        "not applicable for share consumer";
 
+                        if (rd_kafka_conf_is_modified(
+                                conf, "fetch.message.max.bytes"))
+                                return "`fetch.message.max.bytes` "
+                                       "(`max.partition.fetch.bytes`) is not "
+                                       "applicable for share consumer";
+
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "message.max.bytes"))
+                                return "`message.max.bytes` is not applicable "
+                                       "for share consumer";
+
+                        if (rd_kafka_conf_is_modified(
+                                conf, "receive.message.max.bytes"))
+                                return "`receive.message.max.bytes` is not "
+                                       "applicable for share consumer";
+
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "group.instance.id"))
+                                return "`group.instance.id` is not applicable "
+                                       "for share consumer";
+
+                        if (rd_kafka_conf_is_modified(conf, "isolation.level"))
+                                return "`isolation.level` is not applicable "
+                                       "for share consumer";
+
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "group.remote.assignor"))
+                                return "`group.remote.assignor` is not "
+                                       "applicable for share consumer";
+
                         if (conf->topic_conf &&
                             rd_kafka_topic_conf_is_modified(
                                 conf->topic_conf, "auto.offset.reset"))
@@ -4321,6 +4356,17 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                         conf->enable_auto_commit = 0;
                         conf->group_protocol = RD_KAFKA_GROUP_PROTOCOL_CONSUMER;
                         conf->socket_max_fails = 1;
+                        /* This allows fetch.max.bytes to be set as low as 0 */
+                        conf->max_msg_size = 0;
+                        /* This is only a ceiling check, not a pre-allocation,
+                         * so it does not increase memory usage. */
+                        conf->recv_max_msg_size = INT_MAX;
+                } else if (conf->fetch_min_bytes < 1) {
+                        /* `fetch.min.bytes=0` (broker responds immediately,
+                         * no long-poll) is only supported for share
+                         * consumers. */
+                        return "`fetch.min.bytes` must be >= 1 for non-share "
+                               "consumers";
                 }
 
                 if (conf->group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC) {

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -1482,7 +1482,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
      "Minimum number of bytes the broker responds with. "
      "If fetch.wait.max.ms expires the accumulated data will "
      "be sent to the client regardless of this setting.",
-     0, 100000000, 1},
+     0, INT_MAX, 1},
     {_RK_GLOBAL | _RK_CONSUMER | _RK_MED, "fetch.error.backoff.ms", _RK_C_INT,
      _RK(fetch_error_backoff_ms),
      "How long to postpone the next fetch request for a "
@@ -4288,16 +4288,6 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 return "`RD_KAFKA_EVENT_REBALANCE` is not "
                                        "applicable for share consumer";
 
-                        /* TODO KIP-932: verify whether stats_cb should also
-                         * be rejected. Today we only reject the interval
-                         * because the test framework sets stats_cb
-                         * defensively; with interval=0 the callback is
-                         * never invoked, so the callback alone is inert. */
-                        if (rd_kafka_conf_is_modified(conf,
-                                                      "statistics.interval.ms"))
-                                return "`statistics.interval.ms` is not "
-                                       "applicable for share consumer";
-
                         if (rd_kafka_conf_is_modified(conf,
                                                       "enable.auto.commit"))
                                 return "`enable.auto.commit` is not "
@@ -4318,20 +4308,10 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                        "not applicable for share consumer";
 
                         if (rd_kafka_conf_is_modified(
-                                conf, "fetch.message.max.bytes"))
-                                return "`fetch.message.max.bytes` "
-                                       "(`max.partition.fetch.bytes`) is not "
-                                       "applicable for share consumer";
-
-                        if (rd_kafka_conf_is_modified(conf,
-                                                      "message.max.bytes"))
-                                return "`message.max.bytes` is not applicable "
-                                       "for share consumer";
-
-                        if (rd_kafka_conf_is_modified(
                                 conf, "receive.message.max.bytes"))
-                                return "`receive.message.max.bytes` is not "
-                                       "applicable for share consumer";
+                                return "`receive.message.max.bytes` must be "
+                                       "INT_MAX for share consumer; changing "
+                                       "it is not allowed";
 
                         if (rd_kafka_conf_is_modified(conf,
                                                       "group.instance.id"))
@@ -4372,17 +4352,19 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                         conf->enable_auto_commit = 0;
                         conf->group_protocol = RD_KAFKA_GROUP_PROTOCOL_CONSUMER;
                         conf->socket_max_fails = 1;
-                        /* This allows fetch.max.bytes to be set as low as 0 */
-                        conf->max_msg_size = 0;
                         /* This is only a ceiling check, not a pre-allocation,
-                         * so it does not increase memory usage. */
+                         * so it does not increase memory usage. Java client
+                         * has no client-side receive cap*/
                         conf->recv_max_msg_size = INT_MAX;
-                } else if (conf->fetch_min_bytes < 1) {
-                        /* `fetch.min.bytes=0` (broker responds immediately,
-                         * no long-poll) is only supported for share
-                         * consumers. */
-                        return "`fetch.min.bytes` must be >= 1 for non-share "
-                               "consumers";
+                } else if (conf->fetch_min_bytes < 1 ||
+                           conf->fetch_min_bytes > 100000000) {
+                        /* For non-share consumers preserve librdkafka's
+                         * historical `fetch.min.bytes` range of 1..100000000.
+                         * The property max was raised to INT_MAX so share
+                         * consumers can match the Java client; share consumers
+                         * are exempt from this check. */
+                        return "`fetch.min.bytes` must be in range "
+                               "1..100000000 for non-share consumers";
                 }
 
                 if (conf->group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC) {
@@ -4432,16 +4414,24 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
 
                 /* Automatically adjust `fetch.max.bytes` to be >=
                  * `message.max.bytes` and <= `queued.max.message.kbytes`
-                 * unless set by user. */
-                if (rd_kafka_conf_is_modified(conf, "fetch.max.bytes")) {
-                        if (conf->fetch_max_bytes < conf->max_msg_size)
-                                return "`fetch.max.bytes` must be >= "
-                                       "`message.max.bytes`";
-                } else {
-                        conf->fetch_max_bytes =
-                            RD_MAX(RD_MIN(conf->fetch_max_bytes,
-                                          conf->queued_max_msg_kbytes * 1024),
-                                   conf->max_msg_size);
+                 * unless set by user.
+                 */
+                /* Share consumers are exempt: neither the message.max.bytes
+                 * floor nor the queued.max.messages.kbytes clamp applies
+                 * (both are rejected / not applicable), so fetch.max.bytes is
+                 * used as configured. */
+                if (!conf->share.is_share_consumer) {
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "fetch.max.bytes")) {
+                                if (conf->fetch_max_bytes < conf->max_msg_size)
+                                        return "`fetch.max.bytes` must be >= "
+                                               "`message.max.bytes`";
+                        } else {
+                                conf->fetch_max_bytes = RD_MAX(
+                                    RD_MIN(conf->fetch_max_bytes,
+                                           conf->queued_max_msg_kbytes * 1024),
+                                    conf->max_msg_size);
+                        }
                 }
 
                 /* Automatically adjust 'receive.message.max.bytes' to

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4274,11 +4274,7 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                  * group-protocol validation runs so its
                  * CONSUMER-branch checks also apply to share
                  * consumers.
-                 *
-                 * TODO KIP-932: evaluate, per property, whether
-                 * rejecting is the right behavior or whether some
-                 * should instead be silently ignored (as the Java
-                 * client does for several of these). */
+                 */
                 if (conf->share.is_share_consumer) {
                         if (conf->rebalance_cb)
                                 return "`rebalance_cb` is not applicable "
@@ -4344,10 +4340,21 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                        "applicable for share consumer";
 
                         /* The Azure heuristic (which lowers it to <4 minutes)
-                         * still overrides this for Azure brokers. */
+                         * still overrides this for Azure brokers.
+                         *
+                         * TODO KIP-932: this 9-min default is currently
+                         * undermined because a share consumer reconnects
+                         * immediately after an idle close while it still has
+                         * assigned toppars (see
+                         * rd_kafka_broker_share_consumer_serve). Fix so the
+                         * connection stays closed until a fetch is actually
+                         * required. */
                         if (!rd_kafka_conf_is_modified(
                                 conf, "connections.max.idle.ms"))
                                 conf->connections_max_idle_ms = 9 * 60 * 1000;
+
+                        /* TODO KIP-932: Fix max value for fetch.wait.max.ms to
+                         * keep it at par with Java client */
 
                         conf->enable_auto_commit = 0;
                         conf->group_protocol = RD_KAFKA_GROUP_PROTOCOL_CONSUMER;
@@ -4356,15 +4363,18 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                          * so it does not increase memory usage. Java client
                          * has no client-side receive cap*/
                         conf->recv_max_msg_size = INT_MAX;
-                } else if (conf->fetch_min_bytes < 1 ||
-                           conf->fetch_min_bytes > 100000000) {
-                        /* For non-share consumers preserve librdkafka's
-                         * historical `fetch.min.bytes` range of 1..100000000.
-                         * The property max was raised to INT_MAX so share
-                         * consumers can match the Java client; share consumers
-                         * are exempt from this check. */
-                        return "`fetch.min.bytes` must be in range "
-                               "1..100000000 for non-share consumers";
+                } else {
+                        if (conf->fetch_min_bytes < 1 ||
+                            conf->fetch_min_bytes > 100000000) {
+                                /* For non-share consumers preserve librdkafka's
+                                 * historical `fetch.min.bytes` range
+                                 * of 1..100000000. The property max was raised
+                                 * to INT_MAX so share consumers can match the
+                                 * Java client; share consumers are exempt from
+                                 * this check. */
+                                return "`fetch.min.bytes` must be in range "
+                                       "1..100000000 for non-share consumers";
+                        }
                 }
 
                 if (conf->group_protocol == RD_KAFKA_GROUP_PROTOCOL_CLASSIC) {

--- a/src/rdkafka_conf.c
+++ b/src/rdkafka_conf.c
@@ -4347,11 +4347,27 @@ const char *rd_kafka_conf_finalize(rd_kafka_type_t cltype,
                                 return "`group.remote.assignor` is not "
                                        "applicable for share consumer";
 
+                        if (rd_kafka_conf_is_modified(conf,
+                                                      "queued.min.messages"))
+                                return "`queued.min.messages` is not "
+                                       "applicable for share consumer";
+
+                        if (rd_kafka_conf_is_modified(
+                                conf, "queued.max.messages.kbytes"))
+                                return "`queued.max.messages.kbytes` is not "
+                                       "applicable for share consumer";
+
                         if (conf->topic_conf &&
                             rd_kafka_topic_conf_is_modified(
                                 conf->topic_conf, "auto.offset.reset"))
                                 return "`auto.offset.reset` is not "
                                        "applicable for share consumer";
+
+                        /* The Azure heuristic (which lowers it to <4 minutes)
+                         * still overrides this for Azure brokers. */
+                        if (!rd_kafka_conf_is_modified(
+                                conf, "connections.max.idle.ms"))
+                                conf->connections_max_idle_ms = 9 * 60 * 1000;
 
                         conf->enable_auto_commit = 0;
                         conf->group_protocol = RD_KAFKA_GROUP_PROTOCOL_CONSUMER;

--- a/src/rdkafka_msgset_reader.c
+++ b/src/rdkafka_msgset_reader.c
@@ -1591,6 +1591,11 @@ rd_kafka_msgset_reader_run(rd_kafka_msgset_reader_t *msetr) {
                                 err = RD_KAFKA_RESP_ERR_NO_ERROR;
 
                 } else if (rktp->rktp_fetch_msg_max_bytes < (1 << 30)) {
+                        /* TODO KIP-932: Skip this branch for share consumers.
+                         * ShareFetch has no per-partition MaxBytes field, so
+                         * growing rktp_fetch_msg_max_bytes never changes what
+                         * the broker returns.
+                         */
                         rktp->rktp_fetch_msg_max_bytes *= 2;
                         rd_rkb_dbg(msetr->msetr_rkb, FETCH, "CONSUME",
                                    "Topic %s [%" PRId32

--- a/tests/0171-share_consumer_consume.c
+++ b/tests/0171-share_consumer_consume.c
@@ -1203,12 +1203,11 @@ static void do_test_fetch_max_bytes_small(void) {
         rd_kafka_destroy(prod);
 
         /* Create share consumer with a small session-level fetch cap.
-         * fetch.max.bytes must be >= message.max.bytes per librdkafka
-         * config validation, so lower both to 1500. */
+         * For share consumers `message.max.bytes` does not floor
+         * `fetch.max.bytes` (and is rejected), so set `fetch.max.bytes`
+         * directly to 1500. */
         test_conf_init(&conf, NULL, 60);
         rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
-        rd_kafka_conf_set(conf, "message.max.bytes", "1500", errstr,
-                          sizeof(errstr));
         rd_kafka_conf_set(conf, "fetch.max.bytes", "1500", errstr,
                           sizeof(errstr));
 
@@ -1297,11 +1296,6 @@ static void do_test_record_larger_than_fetch_max_bytes(void) {
 
         test_conf_init(&conf, NULL, 60);
         rd_kafka_conf_set(conf, "group.id", group, errstr, sizeof(errstr));
-
-        char val[32];
-        rd_snprintf(val, sizeof(val), "%d", MAX_BYTES);
-        rd_kafka_conf_set(conf, "message.max.bytes", "1500", errstr,
-                          sizeof(errstr));
         rd_kafka_conf_set(conf, "fetch.max.bytes", "1500", errstr,
                           sizeof(errstr));
 

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -267,6 +267,105 @@ static void test_heartbeat_interval_ms_rejected_at_construction(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief `fetch.message.max.bytes` is a per-partition fetch limit that
+ *        has no corresponding field in the ShareFetch protocol, so it
+ *        is not applicable to share consumers and is rejected.
+ */
+static void test_fetch_message_max_bytes_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("fetch.message.max.bytes",
+                                                 "1048576");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief `max.partition.fetch.bytes` is an alias of
+ *        `fetch.message.max.bytes`; setting the alias must trip the
+ *        same rejection, proving the alias resolves to the same
+ *        backing property.
+ */
+static void
+test_max_partition_fetch_bytes_alias_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("max.partition.fetch.bytes",
+                                                 "1048576");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief `message.max.bytes` is a producer/global property with no role
+ *        in the broker-driven ShareFetch path; it is rejected for share
+ *        consumers (the library forces it internally).
+ */
+static void test_message_max_bytes_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("message.max.bytes",
+                                                 "2000000");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief `receive.message.max.bytes` is forced to INT_MAX for share
+ *        consumers (a ShareFetch response can exceed fetch.max.bytes,
+ *        which is a soft limit); any explicit set by the app is
+ *        rejected.
+ */
+static void test_receive_message_max_bytes_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("receive.message.max.bytes",
+                                                 "100000000");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Static membership (`group.instance.id`) is not supported for
+ *        share groups; the property is rejected for share consumers.
+ */
+static void test_group_instance_id_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("group.instance.id",
+                                                 "share-instance-1");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief `isolation.level` is defined broker-side for share groups; the
+ *        client property is rejected for share consumers.
+ */
+static void test_isolation_level_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("isolation.level",
+                                                 "read_committed");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief Share-group assignment is broker-driven; the client
+ *        `group.remote.assignor` property is rejected for share
+ *        consumers.
+ */
+static void test_group_remote_assignor_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("group.remote.assignor",
+                                                 "uniform");
+
+        SUB_TEST_PASS();
+}
+
 
 /**
  * @brief Build a producer with linger.ms=0 so each rd_kafka_produce()
@@ -285,13 +384,12 @@ static rd_kafka_t *create_no_linger_producer(void) {
 
 
 /**
- * @brief Build a share consumer with the given max.poll.records value.
- *
- * Consumer uses implicit ack mode (default) and auto-offset-reset is
- * left to be set group-side by the caller.
+ * @brief Build a share consumer for \p group_id, optionally setting one
+ *        extra config property \p prop to \p value.
  */
-static rd_kafka_share_t *
-create_share_consumer_with_max_poll(const char *group_id, int max_poll) {
+static rd_kafka_share_t *create_share_consumer_with_prop(const char *group_id,
+                                                         const char *prop,
+                                                         int value) {
         rd_kafka_conf_t *conf;
         rd_kafka_share_t *rkshare;
         char errstr[512];
@@ -299,10 +397,14 @@ create_share_consumer_with_max_poll(const char *group_id, int max_poll) {
 
         test_conf_init(&conf, NULL, 0);
         rd_kafka_conf_set(conf, "group.id", group_id, errstr, sizeof(errstr));
-        rd_snprintf(val, sizeof(val), "%d", max_poll);
-        TEST_ASSERT(rd_kafka_conf_set(conf, "max.poll.records", val, errstr,
-                                      sizeof(errstr)) == RD_KAFKA_CONF_OK,
-                    "max.poll.records=%d: %s", max_poll, errstr);
+
+        if (prop) {
+                rd_snprintf(val, sizeof(val), "%d", value);
+                TEST_ASSERT(rd_kafka_conf_set(conf, prop, val, errstr,
+                                              sizeof(errstr)) ==
+                                RD_KAFKA_CONF_OK,
+                            "%s=%d: %s", prop, value, errstr);
+        }
 
         rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
         TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
@@ -400,6 +502,37 @@ static int consume_record_batches(rd_kafka_share_t *rkshare,
         return batches;
 }
 
+/**
+ * @brief Drain \p msgcnt records from \p topic with a share consumer
+ *        configured by \p set_fetch_max_bytes / \p fetch_max_bytes, and
+ *        return how many non-empty poll batches it took.
+ *
+ * max.poll.records is left at the library default so that the only
+ * thing capping a single poll batch is the byte limit under test.
+ */
+static int drain_count_with_fetch_max_bytes(const char *group,
+                                            const char *topic,
+                                            int msgcnt,
+                                            rd_bool_t set_fetch_max_bytes,
+                                            int fetch_max_bytes) {
+        rd_kafka_share_t *rkshare;
+        int batch_sizes[256] = {0};
+        int batches;
+
+        rkshare = create_share_consumer_with_prop(
+            group, set_fetch_max_bytes ? "fetch.max.bytes" : NULL,
+            fetch_max_bytes);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        batches =
+            consume_record_batches(rkshare, msgcnt, batch_sizes,
+                                   (int)RD_ARRAY_SIZE(batch_sizes), 3000, 200);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        return batches;
+}
 
 /**
  * @brief Verify max.poll.records=5 splits 10 single-record broker
@@ -431,7 +564,8 @@ static void test_max_poll_records_caps_batch_at_5(void) {
 
         produce_one_per_batch(producer, topic, msgcnt, 500);
 
-        rkshare = create_share_consumer_with_max_poll(group, max_poll);
+        rkshare = create_share_consumer_with_prop(group, "max.poll.records",
+                                                  max_poll);
         test_share_set_auto_offset_reset(group, "earliest");
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
@@ -488,7 +622,8 @@ static void test_max_poll_records_allows_full_drain_at_10(void) {
 
         produce_one_per_batch(producer, topic, msgcnt, 500);
 
-        rkshare = create_share_consumer_with_max_poll(group, max_poll);
+        rkshare = create_share_consumer_with_prop(group, "max.poll.records",
+                                                  max_poll);
         test_share_set_auto_offset_reset(group, "earliest");
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
@@ -525,11 +660,145 @@ static void test_max_poll_records_allows_full_drain_at_10(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief Verify fetch.max.bytes behaves as a soft per-fetch byte limit
+ *        for share consumers.
+ *
+ * Produces msgcnt single-record broker batches (linger.ms=0 producer
+ * with a gap between produces). Then:
+ *
+ *  - With fetch.max.bytes UNSET (library default 50 MB): the broker can
+ *    pack many batches into one ShareFetch response, so the records
+ *    drain in far fewer poll calls than there are batches.
+ *
+ *  - With fetch.max.bytes=1: the limit is a soft cap and the broker's
+ *    "return at least one batch" guarantee yields
+ *    exactly one broker batch per ShareFetch response, so draining
+ *    takes one poll per produced batch.
+ * The two phases use distinct topics/groups so their share sessions and
+ * offsets do not interfere.
+ */
+static void test_fetch_max_bytes_one_is_soft_limit(void) {
+        const char *topic_default;
+        const char *topic_one;
+        const int msgcnt = 10;
+        rd_kafka_t *producer;
+        int drains_default;
+        int drains_one;
+
+        SUB_TEST();
+
+        producer = create_no_linger_producer();
+
+        /* Phase 1: default fetch.max.bytes. */
+        topic_default = test_mk_topic_name("0180-fmb-default", 1);
+        test_create_topic_wait_exists(NULL, topic_default, 1, -1, 60 * 1000);
+        produce_one_per_batch(producer, topic_default, msgcnt, 200);
+
+        drains_default = drain_count_with_fetch_max_bytes(
+            "0180-fetch-max-bytes-default", topic_default, msgcnt,
+            rd_false /*unset*/, 0);
+        TEST_SAY(
+            "fetch.max.bytes default: %d record(s) drained in %d poll "
+            "batch(es)\n",
+            msgcnt, drains_default);
+
+        /* Phase 2: fetch.max.bytes=1. */
+        topic_one = test_mk_topic_name("0180-fmb-one", 1);
+        test_create_topic_wait_exists(NULL, topic_one, 1, -1, 60 * 1000);
+        produce_one_per_batch(producer, topic_one, msgcnt, 200);
+
+        drains_one = drain_count_with_fetch_max_bytes(
+            "0180-fetch-max-bytes-one", topic_one, msgcnt, rd_true /*set*/, 1);
+        TEST_SAY(
+            "fetch.max.bytes=1: %d record(s) drained in %d poll "
+            "batch(es)\n",
+            msgcnt, drains_one);
+
+        /* With fetch.max.bytes=1 the broker returns one batch per fetch,
+         * so the number of poll batches equals the number of produced
+         * broker batches (msgcnt single-record batches). */
+        TEST_ASSERT(drains_one == msgcnt,
+                    "fetch.max.bytes=1 should drain one batch per fetch: "
+                    "expected %d poll batches, got %d",
+                    msgcnt, drains_one);
+
+        /* The default (large) limit must drain in strictly fewer poll
+         * batches than the one-per-fetch case. */
+        TEST_ASSERT(drains_default < drains_one,
+                    "default fetch.max.bytes (%d poll batches) should drain "
+                    "in fewer batches than fetch.max.bytes=1 (%d poll "
+                    "batches)",
+                    drains_default, drains_one);
+
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Verify fetch.min.bytes=0 is functional for share consumers.
+ *
+ * Unlike fetch.max.bytes=0 (which the broker treats as "return nothing"),
+ * fetch.min.bytes=0 means "respond immediately, even with no accumulated
+ * bytes" (no broker-side long-poll). This matches the Java client, which also
+ * receives all records with fetch.min.bytes=0.
+ */
+static void test_fetch_min_bytes_zero_drains_all(void) {
+        const char *topic;
+        const char *group = "0180-fetch-min-bytes-zero";
+        const int msgcnt  = 10;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *rkshare;
+        int batch_sizes[64] = {0};
+        int batches;
+        int i;
+        int total = 0;
+
+        SUB_TEST();
+
+        producer = create_no_linger_producer();
+
+        topic = test_mk_topic_name("0180-fmin-zero", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        produce_one_per_batch(producer, topic, msgcnt, 200);
+
+        rkshare = create_share_consumer_with_prop(group, "fetch.min.bytes", 0);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        batches =
+            consume_record_batches(rkshare, msgcnt, batch_sizes,
+                                   (int)RD_ARRAY_SIZE(batch_sizes), 3000, 60);
+
+        for (i = 0; i < batches && i < (int)RD_ARRAY_SIZE(batch_sizes); i++)
+                total += batch_sizes[i];
+
+        TEST_SAY(
+            "fetch.min.bytes=0: drained %d/%d record(s) in %d poll "
+            "batch(es)\n",
+            total, msgcnt, batches);
+
+        TEST_ASSERT(total == msgcnt,
+                    "fetch.min.bytes=0 should drain all records: expected "
+                    "%d, got %d",
+                    msgcnt, total);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_destroy(producer);
+
+        SUB_TEST_PASS();
+}
+
 
 /* Behavioural tests that require a real broker. */
 int main_0180_share_consumer_config(int argc, char **argv) {
         test_max_poll_records_caps_batch_at_5();
         test_max_poll_records_allows_full_drain_at_10();
+        test_fetch_max_bytes_one_is_soft_limit();
+        test_fetch_min_bytes_zero_drains_all();
         return 0;
 }
 
@@ -547,5 +816,12 @@ int main_0180_share_consumer_config_local(int argc, char **argv) {
         test_partition_assignment_strategy_rejected_at_construction();
         test_group_protocol_type_rejected_at_construction();
         test_heartbeat_interval_ms_rejected_at_construction();
+        test_fetch_message_max_bytes_rejected_at_construction();
+        test_max_partition_fetch_bytes_alias_rejected_at_construction();
+        test_message_max_bytes_rejected_at_construction();
+        test_receive_message_max_bytes_rejected_at_construction();
+        test_group_instance_id_rejected_at_construction();
+        test_isolation_level_rejected_at_construction();
+        test_group_remote_assignor_rejected_at_construction();
         return 0;
 }

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -89,6 +89,44 @@ static void verify_share_consumer_conf_prop_rejected(const char *prop_name,
         rd_kafka_conf_destroy(conf);
 }
 
+/**
+ * @brief Verify that creating a REGULAR (non-share) consumer with
+ *        prop_name=value fails at construction (rd_kafka_new returns
+ *        NULL) with an errstr that mentions prop_name.
+ *
+ * group.id is set so the consumer reaches the consumer-specific
+ * finalize validation.
+ */
+static void verify_regular_consumer_conf_prop_rejected(const char *prop_name,
+                                                       const char *value) {
+        rd_kafka_conf_t *conf;
+        rd_kafka_t *rk;
+        char errstr[512];
+
+        conf = rd_kafka_conf_new();
+        TEST_ASSERT(rd_kafka_conf_set(conf, "group.id", "0180-regular", errstr,
+                                      sizeof(errstr)) == RD_KAFKA_CONF_OK,
+                    "group.id: %s", errstr);
+        TEST_ASSERT(rd_kafka_conf_set(conf, prop_name, value, errstr,
+                                      sizeof(errstr)) == RD_KAFKA_CONF_OK,
+                    "[%s=%s] precondition rd_kafka_conf_set failed: %s",
+                    prop_name, value, errstr);
+
+        errstr[0] = '\0';
+        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rk == NULL,
+                    "[%s=%s] expected regular consumer creation to fail, "
+                    "got non-NULL",
+                    prop_name, value);
+        TEST_ASSERT(strstr(errstr, prop_name) != NULL,
+                    "[%s=%s] errstr should mention '%s', got: %s", prop_name,
+                    value, prop_name, errstr);
+        TEST_SAY("[%s=%s] regular consumer rejected with: %s\n", prop_name,
+                 value, errstr);
+        /* rd_kafka_new failed, so it did not take ownership of conf. */
+        rd_kafka_conf_destroy(conf);
+}
+
 /* Unused stub used only as a non-NULL function-pointer value for
  * rd_kafka_conf_set_rebalance_cb in the rejection test. */
 static void unused_rebalance_cb(rd_kafka_t *rk,
@@ -134,22 +172,6 @@ static void test_event_rebalance_rejected_at_construction(void) {
 }
 
 /**
- * @brief Share consumer does not emit periodic stats; the
- *        statistics.interval.ms property is rejected so the user
- *        cannot enable stats emission. (stats_cb alone is inert with
- *        interval=0 and is not rejected — see the TODO in
- *        rdkafka_conf.c.)
- */
-static void test_statistics_interval_ms_rejected_at_construction(void) {
-        SUB_TEST_QUICK();
-
-        verify_share_consumer_conf_prop_rejected("statistics.interval.ms",
-                                                 "1000");
-
-        SUB_TEST_PASS();
-}
-
-/**
  * @brief Share consumer locks enable.auto.commit to false internally.
  *        Any explicit set by the app (true or false) is rejected so
  *        the value can only come from the library default.
@@ -188,6 +210,25 @@ static void test_socket_max_fails_rejected_at_construction(void) {
 
         verify_share_consumer_conf_prop_rejected("socket.max.fails", "1");
         verify_share_consumer_conf_prop_rejected("socket.max.fails", "5");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief For non-share (regular) consumers, fetch.min.bytes must stay in
+ *        the historical range 1..100000000. The property bounds were
+ *        widened to 0..INT_MAX for share-consumer parity with the Java
+ *        client; regular consumers are re-restricted at finalize, so 0
+ *        and values above 100000000 (e.g. INT_MAX) are rejected.
+ */
+static void test_fetch_min_bytes_regular_consumer_range_rejected(void) {
+        SUB_TEST_QUICK();
+
+        /* 0 is below the regular-consumer minimum of 1. */
+        verify_regular_consumer_conf_prop_rejected("fetch.min.bytes", "0");
+        /* INT_MAX exceeds the regular-consumer maximum of 100000000. */
+        verify_regular_consumer_conf_prop_rejected("fetch.min.bytes",
+                                                   "2147483647");
 
         SUB_TEST_PASS();
 }
@@ -263,50 +304,6 @@ static void test_heartbeat_interval_ms_rejected_at_construction(void) {
 
         verify_share_consumer_conf_prop_rejected("heartbeat.interval.ms",
                                                  "3000");
-
-        SUB_TEST_PASS();
-}
-
-/**
- * @brief `fetch.message.max.bytes` is a per-partition fetch limit that
- *        has no corresponding field in the ShareFetch protocol, so it
- *        is not applicable to share consumers and is rejected.
- */
-static void test_fetch_message_max_bytes_rejected_at_construction(void) {
-        SUB_TEST_QUICK();
-
-        verify_share_consumer_conf_prop_rejected("fetch.message.max.bytes",
-                                                 "1048576");
-
-        SUB_TEST_PASS();
-}
-
-/**
- * @brief `max.partition.fetch.bytes` is an alias of
- *        `fetch.message.max.bytes`; setting the alias must trip the
- *        same rejection, proving the alias resolves to the same
- *        backing property.
- */
-static void
-test_max_partition_fetch_bytes_alias_rejected_at_construction(void) {
-        SUB_TEST_QUICK();
-
-        verify_share_consumer_conf_prop_rejected("max.partition.fetch.bytes",
-                                                 "1048576");
-
-        SUB_TEST_PASS();
-}
-
-/**
- * @brief `message.max.bytes` is a producer/global property with no role
- *        in the broker-driven ShareFetch path; it is rejected for share
- *        consumers (the library forces it internally).
- */
-static void test_message_max_bytes_rejected_at_construction(void) {
-        SUB_TEST_QUICK();
-
-        verify_share_consumer_conf_prop_rejected("message.max.bytes",
-                                                 "2000000");
 
         SUB_TEST_PASS();
 }
@@ -393,6 +390,31 @@ static void test_queued_max_messages_kbytes_rejected_at_construction(void) {
         SUB_TEST_PASS();
 }
 
+struct idle_reconnect_counters {
+        rd_atomic32_t idle_closes;
+        rd_atomic32_t reconnects_after_idle;
+};
+
+/* ===================================================================
+ *  Log callback for the fetch-connection idle test. Same as
+ *  idle_reconnect_log_cb but filtered to the FETCH (leader) connection
+ *  only: the broker name is prefixed into buf, so coordinator lines
+ *  contain "GroupCoordinator" and fetch-broker lines do not.
+ * =================================================================== */
+static void fetch_idle_log_cb(const rd_kafka_t *rk,
+                              int level,
+                              const char *fac,
+                              const char *buf) {
+        struct idle_reconnect_counters *c = rd_kafka_opaque(rk);
+        if (!c || strstr(buf, "GroupCoordinator"))
+                return; /* ignore the coordinator connection */
+        if (!strcmp(fac, "FAIL") &&
+            strstr(buf, "Connection max idle time exceeded"))
+                rd_atomic32_add(&c->idle_closes, 1);
+        else if (!strcmp(fac, "CONNECT") && strstr(buf, "connecting") &&
+                 rd_atomic32_get(&c->idle_closes) > 0)
+                rd_atomic32_add(&c->reconnects_after_idle, 1);
+}
 
 /**
  * @brief Build a producer with linger.ms=0 so each rd_kafka_produce()
@@ -765,17 +787,22 @@ static void test_fetch_max_bytes_one_is_soft_limit(void) {
 
 
 /**
- * @brief Verify fetch.min.bytes=0 is functional for share consumers.
+ * @brief Drain msgcnt records from a fresh topic with a share consumer
+ *        configured with fetch.min.bytes=\p value, and assert all
+ *        records are received.
  *
- * Unlike fetch.max.bytes=0 (which the broker treats as "return nothing"),
- * fetch.min.bytes=0 means "respond immediately, even with no accumulated
- * bytes" (no broker-side long-poll). This matches the Java client, which also
- * receives all records with fetch.min.bytes=0.
+ * Confirms fetch.min.bytes is functional end-to-end for share consumers
+ * across its range:
+ *  - 0       : broker responds immediately (no long-poll).
+ *  - INT_MAX : broker can never satisfy the threshold, so it responds
+ *              when fetch.max.wait.ms elapses.
+ * In both cases all records must still drain (matches the Java client).
  */
-static void test_fetch_min_bytes_zero_drains_all(void) {
+static void verify_share_fetch_min_bytes_drains_all(const char *group,
+                                                    const char *topic_suffix,
+                                                    int value) {
         const char *topic;
-        const char *group = "0180-fetch-min-bytes-zero";
-        const int msgcnt  = 10;
+        const int msgcnt = 10;
         rd_kafka_t *producer;
         rd_kafka_share_t *rkshare;
         int batch_sizes[64] = {0};
@@ -783,15 +810,14 @@ static void test_fetch_min_bytes_zero_drains_all(void) {
         int i;
         int total = 0;
 
-        SUB_TEST();
-
         producer = create_no_linger_producer();
 
-        topic = test_mk_topic_name("0180-fmin-zero", 1);
+        topic = test_mk_topic_name(topic_suffix, 1);
         test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
         produce_one_per_batch(producer, topic, msgcnt, 200);
 
-        rkshare = create_share_consumer_with_prop(group, "fetch.min.bytes", 0);
+        rkshare =
+            create_share_consumer_with_prop(group, "fetch.min.bytes", value);
         test_share_set_auto_offset_reset(group, "earliest");
         test_share_consumer_subscribe_multi(rkshare, 1, topic);
 
@@ -803,20 +829,189 @@ static void test_fetch_min_bytes_zero_drains_all(void) {
                 total += batch_sizes[i];
 
         TEST_SAY(
-            "fetch.min.bytes=0: drained %d/%d record(s) in %d poll "
+            "fetch.min.bytes=%d: drained %d/%d record(s) in %d poll "
             "batch(es)\n",
-            total, msgcnt, batches);
+            value, total, msgcnt, batches);
 
         TEST_ASSERT(total == msgcnt,
-                    "fetch.min.bytes=0 should drain all records: expected "
+                    "fetch.min.bytes=%d should drain all records: expected "
                     "%d, got %d",
-                    msgcnt, total);
+                    value, msgcnt, total);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_destroy(producer);
+}
+
+/**
+ * @brief fetch.min.bytes=0 is functional for share consumers (broker
+ *        responds immediately, no long-poll). Matches the Java client.
+ */
+static void test_fetch_min_bytes_zero_drains_all(void) {
+        SUB_TEST();
+        verify_share_fetch_min_bytes_drains_all("0180-fetch-min-bytes-zero",
+                                                "0180-fmin-zero", 0);
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief fetch.min.bytes=INT_MAX is functional for share consumers: the
+ *        broker can't satisfy the threshold, so it responds when
+ *        fetch.max.wait.ms elapses and all records still drain. Confirms
+ *        the INT_MAX upper bound (raised for Java parity) works
+ *        end-to-end.
+ */
+static void test_fetch_min_bytes_max_drains_all(void) {
+        SUB_TEST();
+        verify_share_fetch_min_bytes_drains_all("0180-fetch-min-bytes-max",
+                                                "0180-fmin-max", 2147483647);
+        SUB_TEST_PASS();
+}
+
+
+/**
+ * @brief Verify fetch.max.bytes=0 returns no records for a share consumer.
+ *
+ * fetch.max.bytes=0 is accepted, but a ShareFetch with MaxBytes=0 returns
+ * no records. This matches the Java client.
+ * This test pins the resulting behavior so it does not silently change.
+ */
+static void test_fetch_max_bytes_zero_returns_no_records(void) {
+        const char *topic;
+        const char *group = "0180-fetch-max-bytes-zero";
+        const int msgcnt  = 10;
+        rd_kafka_t *producer;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_messages_t *batch = NULL;
+        int received               = 0;
+        int call;
+
+        SUB_TEST();
+
+        producer = create_no_linger_producer();
+
+        topic = test_mk_topic_name("0180-fmax-zero", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        produce_one_per_batch(producer, topic, msgcnt, 200);
+
+        rkshare = create_share_consumer_with_prop(group, "fetch.max.bytes", 0);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* Poll a bounded number of times; with fetch.max.bytes=0 the broker
+         * returns no records, so every poll must be empty. */
+        for (call = 0; call < 5; call++) {
+                rd_kafka_error_t *error =
+                    rd_kafka_share_poll(rkshare, 1000, &batch);
+                TEST_ASSERT(!error, "fetch.max.bytes=0 poll #%d failed: %s",
+                            call, error ? rd_kafka_error_string(error) : "");
+                received += (int)rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+        }
+
+        TEST_SAY("fetch.max.bytes=0: received %d record(s) over 5 polls\n",
+                 received);
+
+        TEST_ASSERT(received == 0,
+                    "fetch.max.bytes=0 should return no records, got %d",
+                    received);
 
         test_share_consumer_close(rkshare);
         test_share_destroy(rkshare);
         rd_kafka_destroy(producer);
 
         SUB_TEST_PASS();
+}
+
+/**
+ * @brief Characterize the FETCH connection's idle behavior after the
+ *        consumer has drained all records and stopped polling.
+ *
+ * While records are available the share fetch loop self-perpetuates and
+ * the fetch connection stays busy. Once all records are consumed,
+ * share_fetch_more_records clears and no further ShareFetch is enqueued,
+ * so the fetch (leader) connection goes idle. This test produces a few
+ * records, drains them, then stops polling and sleeps past
+ * connections.max.idle.ms, and asserts the fetch connection idle-closed
+ * and then reconnected (current behavior: a persistent connection is
+ * requested while the broker has an assignment and is not UP).
+ */
+static void test_share_consumer_fetch_conn_idle_after_drain(void) {
+        const char *topic;
+        const char *group = "0180-fetch-idle";
+        const int msgcnt  = 5;
+        const int idle_ms = 5000;
+        rd_kafka_conf_t *conf;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_t *producer;
+        struct idle_reconnect_counters counters;
+        rd_kafka_messages_t *batch = NULL;
+        char errstr[512];
+        int drained = 0;
+        int i;
+
+        SUB_TEST();
+
+        rd_atomic32_init(&counters.idle_closes, 0);
+        rd_atomic32_init(&counters.reconnects_after_idle, 0);
+
+        producer = create_no_linger_producer();
+        topic    = test_mk_topic_name("0180-fetch-idle", 1);
+        test_create_topic_wait_exists(NULL, topic, 1, -1, 60 * 1000);
+        produce_one_per_batch(producer, topic, msgcnt, 100);
+
+        test_conf_init(&conf, NULL, 60);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "debug", "all");
+        /* Short idle timeout so the test runs fast (overrides the 9-min
+         * share-consumer default). */
+        test_conf_set(conf, "connections.max.idle.ms", "5000");
+        rd_kafka_conf_set_log_cb(conf, fetch_idle_log_cb);
+        rd_kafka_conf_set_opaque(conf, &counters);
+
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
+        test_share_set_auto_offset_reset(group, "earliest");
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* Drain all records so share_fetch_more_records clears and the
+         * fetch loop quiesces. */
+        for (i = 0; i < 30 && drained < msgcnt; i++) {
+                rd_kafka_error_t *error =
+                    rd_kafka_share_poll(rkshare, 1000, &batch);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                        continue;
+                }
+                drained += (int)rd_kafka_messages_count(batch);
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+        }
+        TEST_ASSERT(drained >= msgcnt, "expected to drain %d records, got %d",
+                    msgcnt, drained);
+
+        /* Stop polling and idle past the timeout (~2x) so the fetch
+         * connection can be closed by connections.max.idle.ms. */
+        rd_sleep((idle_ms * 2) / 1000 + 2);
+
+        TEST_SAY("fetch-conn idle closes=%d, reconnects-after-idle=%d\n",
+                 rd_atomic32_get(&counters.idle_closes),
+                 rd_atomic32_get(&counters.reconnects_after_idle));
+
+        TEST_ASSERT(rd_atomic32_get(&counters.idle_closes) >= 1,
+                    "expected the idle fetch connection to be closed by "
+                    "connections.max.idle.ms, got %d closes",
+                    rd_atomic32_get(&counters.idle_closes));
+        TEST_ASSERT(rd_atomic32_get(&counters.reconnects_after_idle) >= 1,
+                    "expected the fetch connection to reconnect after the "
+                    "idle close (persistent connection requested while the "
+                    "broker has an assignment), got %d",
+                    rd_atomic32_get(&counters.reconnects_after_idle));
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_destroy(producer);
 }
 
 
@@ -826,6 +1021,9 @@ int main_0180_share_consumer_config(int argc, char **argv) {
         test_max_poll_records_allows_full_drain_at_10();
         test_fetch_max_bytes_one_is_soft_limit();
         test_fetch_min_bytes_zero_drains_all();
+        test_fetch_min_bytes_max_drains_all();
+        test_fetch_max_bytes_zero_returns_no_records();
+        test_share_consumer_fetch_conn_idle_after_drain();
         return 0;
 }
 
@@ -834,7 +1032,6 @@ int main_0180_share_consumer_config(int argc, char **argv) {
 int main_0180_share_consumer_config_local(int argc, char **argv) {
         test_rebalance_cb_rejected_at_construction();
         test_event_rebalance_rejected_at_construction();
-        test_statistics_interval_ms_rejected_at_construction();
         test_enable_auto_commit_rejected_at_construction();
         test_group_protocol_rejected_at_construction();
         test_socket_max_fails_rejected_at_construction();
@@ -843,14 +1040,19 @@ int main_0180_share_consumer_config_local(int argc, char **argv) {
         test_partition_assignment_strategy_rejected_at_construction();
         test_group_protocol_type_rejected_at_construction();
         test_heartbeat_interval_ms_rejected_at_construction();
-        test_fetch_message_max_bytes_rejected_at_construction();
-        test_max_partition_fetch_bytes_alias_rejected_at_construction();
-        test_message_max_bytes_rejected_at_construction();
         test_receive_message_max_bytes_rejected_at_construction();
         test_group_instance_id_rejected_at_construction();
         test_isolation_level_rejected_at_construction();
         test_group_remote_assignor_rejected_at_construction();
         test_queued_min_messages_rejected_at_construction();
         test_queued_max_messages_kbytes_rejected_at_construction();
+        test_fetch_min_bytes_regular_consumer_range_rejected();
         return 0;
 }
+
+
+/*
+ * 1. receive.message.max.bytes - using normal consumer, we produce the record
+ * with 5KB size and set this to 1KB and try to see if we are getting the record
+ * or not
+ */

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -366,6 +366,33 @@ static void test_group_remote_assignor_rejected_at_construction(void) {
         SUB_TEST_PASS();
 }
 
+/**
+ * @brief `queued.min.messages` tunes the per-partition prefetch queue,
+ *        which share consumers (broker-driven via max.poll.records) do
+ *        not use; it is rejected for share consumers.
+ */
+static void test_queued_min_messages_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("queued.min.messages", "1000");
+
+        SUB_TEST_PASS();
+}
+
+/**
+ * @brief `queued.max.messages.kbytes` tunes the per-partition prefetch
+ *        queue, which share consumers do not use; it is rejected for
+ *        share consumers.
+ */
+static void test_queued_max_messages_kbytes_rejected_at_construction(void) {
+        SUB_TEST_QUICK();
+
+        verify_share_consumer_conf_prop_rejected("queued.max.messages.kbytes",
+                                                 "1024");
+
+        SUB_TEST_PASS();
+}
+
 
 /**
  * @brief Build a producer with linger.ms=0 so each rd_kafka_produce()
@@ -823,5 +850,7 @@ int main_0180_share_consumer_config_local(int argc, char **argv) {
         test_group_instance_id_rejected_at_construction();
         test_isolation_level_rejected_at_construction();
         test_group_remote_assignor_rejected_at_construction();
+        test_queued_min_messages_rejected_at_construction();
+        test_queued_max_messages_kbytes_rejected_at_construction();
         return 0;
 }


### PR DESCRIPTION
Rule: for configs Java has, mirror Java (reject the ones Java rejects, accept+match
  min/max/default otherwise); for librdkafka-specific configs, reject if inapplicable
  or forced. Regular-consumer behavior is never changed.



| Config | What we did |
  | --- | --- |
  | `fetch.message.max.bytes` (alias `max.partition.fetch.bytes`) | **Accept** — Java accepts+ignores it. |
  | `message.max.bytes` | **Accept** — kept its value (functional for LZ4 decompress) and skipped the `fetch.max.bytes` floor for share consumers. |
  | `receive.message.max.bytes` | **Reject** user-set value and force to `INT_MAX` for share consumers ceiling check only (no extra memory), and Java has no client-side receive cap. |
  | `fetch.max.bytes` | **Accept** — floor gated for share so it can be set as low as `0` (Java parity); regular consumers unchanged. Note: `0` returns no records on both clients — intentionally allowed for parity. |
  | `fetch.min.bytes` | **Accept** — min lowered 1→0 and max raised to INT_MAX for share (full Java parity) ; non-share consumers re-restricted to `1..100000000`. |
  | `fetch.wait.max.ms` | **No change** — min (0) and default (500) match Java. Max differs: librdkafka caps at 300000 vs Java INT_MAX; left as-is (overflow-safety bound, added to `socket.timeout.ms` in an int deadline). |
  | `max.poll.records` | **No change** — already at parity (min 1, max INT_MAX, default 500; it is the share consumer's per-fetch record limit). |
  | `connections.max.idle.ms` | **Default 9 min for share consumers** (was `0`/disabled), matching Java; regular consumers unchanged. Azure heuristic still overrides to ~3m50s; user-set values honored. Note: disable sentinel differs — librdkafka uses `0`; Java `0` = expire-immediately, Java disables via `-1`. |
  | `coordinator.query.interval.ms` | **No change** — applicable; drives periodic coordinator re-query via the shared cgrp path. librdkafka-specific (Java re-queries only reactively on coordinator loss). |
  | `queued.min.messages` | **Reject** for share consumers — per-partition prefetch-queue tuning that share consumers (broker-driven via `max.poll.records`) don't use. No Java equivalent. |
  | `queued.max.messages.kbytes` | **Reject** for share consumers — same prefetch-queue tuning; also removed from the derived `fetch.max.bytes` clamp. No Java equivalent. |
  | `statistics.interval.ms` | **Accept** — removed earlier reject; applicable to share consumers, default `0` = disabled. |
  | `group.instance.id` | **Reject** for share consumers — static membership not supported for share groups (matches Java). |
  | `isolation.level` | **Reject** for share consumers — defined broker-side for share groups (matches Java). |
  | `group.remote.assignor` | **Reject** for share consumers — assignment is broker-driven (matches Java). |