### PR TITLE
[KIP-932] Mock broker fix to scope share-session lock release to the current leader

### DIFF
--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4289,7 +4289,22 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                                 }
 
                                 /* Release ACQUIRED records for this
-                                 * member on this partition. */
+                                 * member on this partition, but only
+                                 * if this broker currently leads it:
+                                 * forgetting a partition that moved to
+                                 * another leader must not release the
+                                 * locks now held through the new
+                                 * leader's session. */
+                                rd_kafka_mock_topic_t *ftopic =
+                                    rd_kafka_mock_topic_find_by_id(mcluster,
+                                                                   ftid);
+                                rd_kafka_mock_partition_t *fpart =
+                                    ftopic ? rd_kafka_mock_partition_find(
+                                                 ftopic, ftp->partition)
+                                           : NULL;
+                                if (!fpart || fpart->leader != mconn->broker)
+                                        continue;
+
                                 pmeta = rd_kafka_mock_sgrp_partmeta_find(
                                     sgrp, ftid, ftp->partition);
                                 if (pmeta) {

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4590,8 +4590,8 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 /* epoch=-1 (final fetch) → release remaining acquired
                  * records and close the session. */
                 if (!err && session && SessionEpoch == -1) {
-                        rd_kafka_mock_sgrp_release_member_locks(
-                            sgrp, session->member_id);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
+                                                                  session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -4838,8 +4838,8 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                 /* epoch=-1 (final ack) → release remaining
                  * acquired records and close the session. */
                 if (!err && session && SessionEpoch == -1) {
-                        rd_kafka_mock_sgrp_release_member_locks(
-                            sgrp, session->member_id);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
+                                                                  session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);

--- a/src/rdkafka_mock_handlers.c
+++ b/src/rdkafka_mock_handlers.c
@@ -4590,8 +4590,7 @@ static int rd_kafka_mock_handle_ShareFetch(rd_kafka_mock_connection_t *mconn,
                 /* epoch=-1 (final fetch) → release remaining acquired
                  * records and close the session. */
                 if (!err && session && SessionEpoch == -1) {
-                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
-                                                                  session);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp, session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -4838,8 +4837,7 @@ rd_kafka_mock_handle_ShareAcknowledge(rd_kafka_mock_connection_t *mconn,
                 /* epoch=-1 (final ack) → release remaining
                  * acquired records and close the session. */
                 if (!err && session && SessionEpoch == -1) {
-                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
-                                                                  session);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp, session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);

--- a/src/rdkafka_mock_int.h
+++ b/src/rdkafka_mock_int.h
@@ -757,8 +757,9 @@ void rd_kafka_mock_sgrp_record_release(
     rd_kafka_mock_sharegroup_t *mshgrp,
     rd_kafka_mock_sgrp_partmeta_t *pmeta,
     rd_kafka_mock_sgrp_record_state_t *state);
-void rd_kafka_mock_sgrp_release_member_locks(rd_kafka_mock_sharegroup_t *mshgrp,
-                                             const char *member_id);
+void rd_kafka_mock_sgrp_release_session_locks(
+    rd_kafka_mock_sharegroup_t *mshgrp,
+    const rd_kafka_mock_sgrp_fetch_session_t *session);
 void rd_kafka_mock_sgrp_fetch_session_tmr_cb(rd_kafka_timers_t *rkts,
                                              void *arg);
 

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -994,10 +994,25 @@ void rd_kafka_mock_sgrp_release_session_locks(
 
         TAILQ_FOREACH(pmeta, &mshgrp->partitions, link) {
                 rd_kafka_mock_sgrp_record_state_t *state, *tmp;
+                rd_kafka_mock_topic_t *mtopic;
+                rd_kafka_mock_partition_t *mpart;
 
                 if (rd_kafka_topic_partition_list_find_idx_by_id(
                         session->partitions, pmeta->topic_id,
                         pmeta->partition) < 0)
+                        continue;
+
+                /* A session can only release locks for partitions its
+                 * broker currently leads: a session's partition list
+                 * can be stale after a leader change, while the locks
+                 * now belong to the new leader's session. */
+                mtopic = rd_kafka_mock_topic_find_by_id(mshgrp->cluster,
+                                                        pmeta->topic_id);
+                mpart  = mtopic ? rd_kafka_mock_partition_find(mtopic,
+                                                               pmeta->partition)
+                                : NULL;
+                if (!mpart || !mpart->leader ||
+                    mpart->leader->id != session->node_id)
                         continue;
 
                 TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link, tmp) {

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -899,8 +899,7 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
          *    fresh one. */
         if (SessionEpoch == 0) {
                 if (session) {
-                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
-                                                                  session);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp, session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -930,8 +929,7 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
                          * The client handles this by resetting its
                          * per-broker epoch to 0 (opening a fresh session
                          * on the next fetch). */
-                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
-                                                                  session);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp, session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -1132,7 +1130,7 @@ void rd_kafka_mock_sharegrps_node_connection_closed(
                         if (session->node_id != node_id)
                                 continue;
                         rd_kafka_mock_sgrp_release_session_locks(mshgrp,
-                                                                  session);
+                                                                 session);
                         TAILQ_REMOVE(&mshgrp->fetch_sessions, session, link);
                         mshgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);

--- a/src/rdkafka_mock_sharegrp.c
+++ b/src/rdkafka_mock_sharegrp.c
@@ -899,8 +899,8 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
          *    fresh one. */
         if (SessionEpoch == 0) {
                 if (session) {
-                        rd_kafka_mock_sgrp_release_member_locks(
-                            sgrp, session->member_id);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
+                                                                  session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -930,8 +930,8 @@ rd_kafka_resp_err_t rd_kafka_mock_sgrp_session_validate(
                          * The client handles this by resetting its
                          * per-broker epoch to 0 (opening a fresh session
                          * on the next fetch). */
-                        rd_kafka_mock_sgrp_release_member_locks(
-                            sgrp, session->member_id);
+                        rd_kafka_mock_sgrp_release_session_locks(sgrp,
+                                                                  session);
                         TAILQ_REMOVE(&sgrp->fetch_sessions, session, link);
                         sgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);
@@ -972,26 +972,43 @@ void rd_kafka_mock_sgrp_record_release(
 }
 
 /**
- * @brief Release all ACQUIRED records owned by \p member_id across all
- *        share-partition metadata in the share group.
+ * @brief Release all ACQUIRED records owned by \p session's member on
+ *        the partitions belonging to \p session.
  *
- * This is called when a session is closed (epoch=-1), when a session
- * times out, or as part of periodic lock-expiry reclamation.
+ * Share sessions are per-broker: closing one broker's session must
+ * only release the records acquired through that session (the
+ * partitions that broker leads), never the member's locks held
+ * through other brokers' intact sessions.
+ *
+ * This is called when a session is closed (epoch=-1), replaced
+ * (epoch=0), invalidated (epoch mismatch), times out, or its
+ * connection is closed.
  *
  * @locks mcluster->lock MUST be held.
  */
-void rd_kafka_mock_sgrp_release_member_locks(rd_kafka_mock_sharegroup_t *mshgrp,
-                                             const char *member_id) {
+void rd_kafka_mock_sgrp_release_session_locks(
+    rd_kafka_mock_sharegroup_t *mshgrp,
+    const rd_kafka_mock_sgrp_fetch_session_t *session) {
         rd_kafka_mock_sgrp_partmeta_t *pmeta;
+
+        if (!session->partitions)
+                return;
 
         TAILQ_FOREACH(pmeta, &mshgrp->partitions, link) {
                 rd_kafka_mock_sgrp_record_state_t *state, *tmp;
+
+                if (rd_kafka_topic_partition_list_find_idx_by_id(
+                        session->partitions, pmeta->topic_id,
+                        pmeta->partition) < 0)
+                        continue;
+
                 TAILQ_FOREACH_SAFE(state, &pmeta->inflight, link, tmp) {
                         if (state->state != RD_KAFKA_MOCK_SGRP_RECORD_ACQUIRED)
                                 continue;
                         if (!state->owner_member_id)
                                 continue;
-                        if (strcmp(state->owner_member_id, member_id) != 0)
+                        if (strcmp(state->owner_member_id,
+                                   session->member_id) != 0)
                                 continue;
 
                         rd_kafka_mock_sgrp_record_release(mshgrp, pmeta, state);
@@ -1054,8 +1071,7 @@ void rd_kafka_mock_sgrp_fetch_session_tmr_cb(rd_kafka_timers_t *rkts,
 
                 /* Release all locks held by this member before
                  * destroying the session. */
-                rd_kafka_mock_sgrp_release_member_locks(mshgrp,
-                                                        session->member_id);
+                rd_kafka_mock_sgrp_release_session_locks(mshgrp, session);
 
                 TAILQ_REMOVE(&mshgrp->fetch_sessions, session, link);
                 mshgrp->fetch_session_cnt--;
@@ -1115,8 +1131,8 @@ void rd_kafka_mock_sharegrps_node_connection_closed(
                                    tmp) {
                         if (session->node_id != node_id)
                                 continue;
-                        rd_kafka_mock_sgrp_release_member_locks(
-                            mshgrp, session->member_id);
+                        rd_kafka_mock_sgrp_release_session_locks(mshgrp,
+                                                                  session);
                         TAILQ_REMOVE(&mshgrp->fetch_sessions, session, link);
                         mshgrp->fetch_session_cnt--;
                         rd_kafka_mock_sgrp_fetch_session_destroy(session);


### PR DESCRIPTION
Fixes intermittent failures in 0183 (do_test_leader_change_consume_recovery),
e.g. "expected 102 records after leader change, got 137" — records delivered
twice. Failed only on slow CI, never locally.

Root cause: in the mock, share-group record state is cluster-global, and
rd_kafka_mock_sgrp_release_member_locks() released a member's acquired locks
across ALL partitions in the group on any single-broker session event
(connection close, epoch reset, timeout). So when one broker's session
closed, records still held through other brokers' intact sessions were
wrongly released and redelivered. A real broker can't do this — each broker
only holds lock state for partitions it leads.

Fix enforces the invariant "only a partition's current leader may release its
locks":
 - release is scoped to the closing session's partitions, and
 - guarded by a check that this broker is the partition's current leader
   (a session's partition list can be stale after a leader change).
The same leader guard is applied to the ShareFetch forgotten-partitions
release path.
