### PR TITLE
OSS-Fuzz: Add new fuzzer targets protocol

### DIFF
--- a/tests/fuzzers/Makefile
+++ b/tests/fuzzers/Makefile
@@ -1,4 +1,4 @@
-PROGRAMS?=fuzz_regex
+PROGRAMS?=fuzz_regex fuzz_protocol
 
 all: $(PROGRAMS)
 
@@ -6,6 +6,13 @@ all: $(PROGRAMS)
 fuzz_%:
 	$(CC) -fsanitize=address -D WITH_MAIN -g -Wall \
 		-I../../src $@.c -o $@ ../../src/librdkafka.a
+
+# fuzz_protocol drives the full client (rd_kafka_new), so it needs librdkafka's
+# transitive link dependencies rather than just librdkafka.a.
+fuzz_protocol:
+	$(CC) -fsanitize=address -D WITH_MAIN -g -Wall \
+		-I../../src fuzz_protocol.c -o $@ ../../src/librdkafka.a \
+		-lssl -lcrypto -lz -lcurl -lm -ldl -lpthread -lrt
 
 
 clean:

--- a/tests/fuzzers/README.md
+++ b/tests/fuzzers/README.md
@@ -13,7 +13,8 @@ python3 infra/helper.py build_image librdkafka
 python3 infra/helper.py build_fuzzers librdkafka
 python3 infra/helper.py run_fuzzer librdkafka FUZZ_NAME
 ```
-where FUZZ_NAME references the name of the fuzzer. Currently the only fuzzer we have is fuzz_regex
+where FUZZ_NAME references the name of the fuzzer. Currently we have fuzz_regex (the builtin
+regexp engine) and fuzz_protocol (the Fetch-response MessageSet/record-batch decoder)
 
 Notice that the OSS-Fuzz `helper.py` script above will create a Docker image in which the code of librdkafka will be built. As such, depending on how you installed Docker, you may be asked to have root access (i.e. run with `sudo`).
 

--- a/tests/fuzzers/fuzz_protocol.c
+++ b/tests/fuzzers/fuzz_protocol.c
@@ -1,0 +1,122 @@
+/*
+ * librdkafka - Apache Kafka C library
+ *
+ * Copyright (c) 2026, librdkafka contributors.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Fuzzer for the Kafka Fetch-response MessageSet / record-batch decoder
+ * (src/rdkafka_msgset_reader.c). The fuzz bytes are treated as the MessageSet
+ * payload of a broker Fetch response and decoded via rd_kafka_msgset_parse().
+ * A consumer instance, topic and toppar are created once so the decoder runs
+ * against valid state and crashes are genuine parser bugs.
+ */
+
+#include "rdkafka_int.h"
+#include "rdkafka_buf.h"
+#include "rdkafka_msgset.h"
+#include "rdkafka_partition.h"
+#include "rdkafka_broker.h"
+#include "rdkafka_proto.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+static rd_kafka_t *rk;
+static rd_kafka_topic_t *rkt;
+static rd_kafka_toppar_t *rktp;
+static rd_kafka_broker_t *rkb;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+        char errstr[256];
+        rd_kafka_conf_t *conf = rd_kafka_conf_new();
+
+        rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
+        if (!rk)
+                return 0;
+
+        rkb = rd_kafka_broker_internal(rk);
+        rkt = rd_kafka_topic_new(rk, "fuzz", NULL);
+        if (rkt)
+                rktp = rd_kafka_toppar_new(rkt, 0);
+
+        return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+        rd_kafka_buf_t *rkbuf;
+        rd_kafka_buf_t *request;
+        struct rd_kafka_toppar_ver tver;
+
+        if (!rktp || !rkb || size == 0 || size > (1u << 20))
+                return 0;
+
+        /* Shadow buffer is created read-ready (rd_slice_init_full). */
+        rkbuf = rd_kafka_buf_new_shadow(data, size, NULL);
+        if (!rkbuf)
+                return 0;
+        rkbuf->rkbuf_rkb = rkb;
+
+        /* The decoder selects its wire format from the (request) ApiVersion. */
+        request                          = rd_kafka_buf_new(1, 0);
+        request->rkbuf_reqhdr.ApiKey     = RD_KAFKAP_Fetch;
+        request->rkbuf_reqhdr.ApiVersion = 11;
+
+        memset(&tver, 0, sizeof(tver));
+        tver.rktp    = rktp;
+        tver.version = 0;
+
+        (void)rd_kafka_msgset_parse(rkbuf, request, rktp, NULL, &tver);
+
+        /* Drop any messages the decoder enqueued so they don't accumulate. */
+        rd_kafka_q_purge(rktp->rktp_fetchq);
+
+        /* Don't let buf destroy decref our shared internal broker. */
+        rkbuf->rkbuf_rkb = NULL;
+        rd_kafka_buf_destroy(rkbuf);
+        rd_kafka_buf_destroy(request);
+
+        return 0;
+}
+
+#if WITH_MAIN
+#include "helpers.h"
+
+int main(int argc, char **argv) {
+        int i;
+
+        LLVMFuzzerInitialize(&argc, &argv);
+
+        for (i = 1; i < argc; i++) {
+                size_t size;
+                uint8_t *buf = read_file(argv[i], &size);
+                LLVMFuzzerTestOneInput(buf, size);
+                free(buf);
+        }
+
+        return 0;
+}
+#endif


### PR DESCRIPTION
This PR adds a new OSS-Fuzz fuzzer targets protocol processing, together with the fix in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/15772).