### PR TITLE
[KIP-932] Log stalled share fetch in the main-thread re-trigger loop

### DIFF
--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -2363,6 +2363,24 @@ static rd_kafka_broker_t *rd_kafka_share_select_broker(rd_kafka_t *rk,
                                                        rd_kafka_cgrp_t *rkcg);
 
 /**
+ * @brief Rate-limited log for a stalled share fetch (no progress on the
+ *        main-thread re-trigger path).
+ * @locality main thread
+ */
+static void rd_kafka_share_log_fetch_stall(rd_kafka_t *rk, const char *reason) {
+        rd_kafka_cgrp_t *rkcg = rk->rk_cgrp;
+        rd_ts_t now           = rd_clock();
+
+        if (rkcg->rkcg_share.fetch_stall_logged_last_ts == 0 ||
+            now >
+                rkcg->rkcg_share.fetch_stall_logged_last_ts + 5000000 /*5s*/) {
+                rd_kafka_dbg(rk, CONSUMER, "FETCHMORE", "Fetch stalled: %s",
+                             reason);
+                rkcg->rkcg_share.fetch_stall_logged_last_ts = now;
+        }
+}
+
+/**
  * Main loop for Kafka handler thread.
  */
 static int rd_kafka_thread_main(void *arg) {
@@ -2426,19 +2444,35 @@ static int rd_kafka_thread_main(void *arg) {
                     !(rk->rk_cgrp->rkcg_flags & RD_KAFKA_CGRP_F_TERMINATE) &&
                     rk->rk_cgrp->rkcg_share.share_fetch_more_records &&
                     rk->rk_cgrp->rkcg_share
-                            .share_should_fetch_ops_in_flight_cnt == 0 &&
-                    rd_list_cnt(&rk->rk_cgrp->rkcg_toppars) > 0) {
-                        rd_kafka_broker_t *rkb_sel;
-
-                        rkb_sel = rd_kafka_share_select_broker(rk, rk->rk_cgrp);
-                        if (rkb_sel) {
-                                rd_kafka_dbg(rk, CONSUMER, "FETCHMORE",
-                                             "Re-triggering fetch for "
-                                             "share_fetch_more_records=true "
-                                             "and no fetch in-flight");
-                                rd_kafka_share_enqueue_fetch_op(
-                                    rk, rkb_sel, rd_true, rd_false);
-                                rd_kafka_broker_destroy(rkb_sel);
+                            .share_should_fetch_ops_in_flight_cnt == 0) {
+                        if (rd_list_cnt(&rk->rk_cgrp->rkcg_toppars) == 0) {
+                                rd_kafka_share_log_fetch_stall(
+                                    rk,
+                                    "share_fetch_more_records set but no "
+                                    "partitions are assigned");
+                        } else {
+                                rd_kafka_broker_t *rkb_sel =
+                                    rd_kafka_share_select_broker(rk,
+                                                                 rk->rk_cgrp);
+                                if (rkb_sel) {
+                                        rd_kafka_dbg(
+                                            rk, CONSUMER, "FETCHMORE",
+                                            "Re-triggering fetch for "
+                                            "share_fetch_more_records=true "
+                                            "and no fetch in-flight");
+                                        rd_kafka_share_enqueue_fetch_op(
+                                            rk, rkb_sel, rd_true, rd_false);
+                                        rd_kafka_broker_destroy(rkb_sel);
+                                        rk->rk_cgrp->rkcg_share
+                                            .fetch_stall_logged_last_ts = 0;
+                                } else {
+                                        rd_kafka_share_log_fetch_stall(
+                                            rk,
+                                            "no eligible broker (assigned "
+                                            "partition leaders are down, "
+                                            "terminating, or already have a "
+                                            "fetch in flight)");
+                                }
                         }
                 }
 

--- a/src/rdkafka_cgrp.h
+++ b/src/rdkafka_cgrp.h
@@ -438,6 +438,15 @@ typedef struct rd_kafka_cgrp_s {
                                                          *   INT64_MAX.
                                                          *   @locality main
                                                          *   thread */
+                rd_ts_t
+                    fetch_stall_logged_last_ts; /**< Last time the
+                                                 *   main-thread re-trigger
+                                                 *   loop logged a "fetch
+                                                 *   stalled" condition;
+                                                 *   rate-limits that log.
+                                                 *   0 = not currently
+                                                 *   logged.
+                                                 *   @locality main thread */
         } rkcg_share;
 
         /**

--- a/tests/0180-share_consumer_config.c
+++ b/tests/0180-share_consumer_config.c
@@ -1058,6 +1058,7 @@ static void test_share_consumer_fetch_conn_idle_after_drain(void) {
 
 /* Behavioural tests that require a real broker. */
 int main_0180_share_consumer_config(int argc, char **argv) {
+        test_timeout_set(120);
         test_max_poll_records_caps_batch_at_5();
         test_max_poll_records_allows_full_drain_at_10();
         test_fetch_max_bytes_one_is_soft_limit();

--- a/tests/0182-share_consumer_error_handling_mock.c
+++ b/tests/0182-share_consumer_error_handling_mock.c
@@ -2941,6 +2941,140 @@ static void do_test_one_log_on_broker_down_during_active_empty_poll(void) {
 }
 
 
+/* ===================================================================
+ *  Log callback for do_test_fetch_stall_logged_on_no_broker. Counts
+ *  the main-thread "Fetch stalled: no eligible broker" debug log.
+ * =================================================================== */
+static void fetch_stall_log_cb(const rd_kafka_t *rk,
+                               int level,
+                               const char *fac,
+                               const char *buf) {
+        rd_atomic32_t *cnt = rd_kafka_opaque(rk);
+        if (cnt && !strcmp(fac, "FETCHMORE") &&
+            strstr(buf, "Fetch stalled: no eligible broker"))
+                rd_atomic32_add(cnt, 1);
+}
+
+/* ===================================================================
+ *  do_test_fetch_stall_logged_on_no_broker
+ *
+ *  With a partition assigned but the only broker down, the main-thread
+ *  re-trigger loop wants to fetch (share_fetch_more_records set, no op
+ *  in-flight) yet select_broker returns NULL. Verify it emits the
+ *  rate-limited "Fetch stalled: no eligible broker" log: at least once
+ *  (the stall is reported) and bounded (the throttle prevents a flood
+ *  while the empty-poll loop is hot).
+ * =================================================================== */
+static void do_test_fetch_stall_logged_on_no_broker(void) {
+        test_ctx_t ctx;
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        rd_atomic32_t stall_cnt;
+        const char *topic          = "0182-fetch-stall";
+        const char *group          = "sg-0182-fetch-stall";
+        const int msgcnt_recovery  = 5;
+        rd_kafka_messages_t *batch = NULL;
+        rd_kafka_error_t *error;
+        size_t rcvd;
+        int acked, cnt;
+
+        SUB_TEST_QUICK();
+
+        /* Taking the only broker down raises __ALL_BROKERS_DOWN /
+         * __TRANSPORT on the callbacks; none should fail the test. */
+        test_curr->is_fatal_cb = test_error_is_not_fatal_cb;
+
+        ctx = test_ctx_new();
+
+        TEST_ASSERT(rd_kafka_mock_topic_create(ctx.mcluster, topic, 1, 1) ==
+                        RD_KAFKA_RESP_ERR_NO_ERROR,
+                    "create topic");
+
+        rd_atomic32_init(&stall_cnt, 0);
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "bootstrap.servers", ctx.bootstraps);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "explicit");
+        /* The stall log is emitted on the CONSUMER debug context. */
+        test_conf_set(conf, "debug", "consumer");
+        test_conf_set(conf, "reconnect.backoff.ms", "100");
+        test_conf_set(conf, "reconnect.backoff.max.ms", "500");
+        rd_kafka_conf_set_log_cb(conf, fetch_stall_log_cb);
+        rd_kafka_conf_set_opaque(conf, &stall_cnt);
+
+        rkshare = rd_kafka_share_consumer_new(conf, NULL, 0);
+        TEST_ASSERT(rkshare != NULL, "Failed to create share consumer");
+
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* Prime so the share group joins and the partition is assigned —
+         * otherwise the stall reason would be "no partitions assigned". */
+        mock_produce(ctx.producer, topic, 1);
+        acked = consume_and_ack_all(rkshare, 1);
+        TEST_ASSERT(acked == 1, "prime: expected 1 acked, got %d", acked);
+
+        /* Flush the primed ack so the down broker doesn't get an
+         * ack-only op unrelated to the stall we're measuring. */
+        error = rd_kafka_share_commit_async(rkshare);
+        TEST_ASSERT(!error, "commit_async error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+
+        /* Kickstart a poll while the broker is still up so the primed ack
+         * is flushed to the broker — otherwise it is redelivered after
+         * recovery and inflates the post-recovery count. */
+        error = rd_kafka_share_poll(rkshare, 500, &batch);
+        TEST_ASSERT(!error, "kickstart share_poll error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        /* Reset to drop any bring-up noise. */
+        rd_atomic32_set(&stall_cnt, 0);
+
+        /* Take the only broker down, then poll. With the partition still
+         * assigned and no broker reachable, the main-thread loop keeps
+         * wanting to fetch but select_broker returns NULL. The 2s poll
+         * stays inside the throttle window. */
+        rd_kafka_mock_broker_set_down(ctx.mcluster, 1);
+
+        error = rd_kafka_share_poll(rkshare, 2000, &batch);
+        TEST_ASSERT(!error, "down share_poll error: %s",
+                    error ? rd_kafka_error_string(error) : "NULL");
+        rcvd = rd_kafka_messages_count(batch);
+        TEST_ASSERT(rcvd == 0, "expected 0 records, got %zu", rcvd);
+        rd_kafka_messages_destroy(batch);
+        batch = NULL;
+
+        cnt = rd_atomic32_get(&stall_cnt);
+        TEST_SAY("\"Fetch stalled: no eligible broker\" log count: %d\n", cnt);
+        TEST_ASSERT(cnt >= 1,
+                    "expected the stall to be logged at least once, got %d",
+                    cnt);
+        /* Throttled: a 2s hot loop must not flood. Allow a small margin
+         * for a race-window reset + re-log around set_down. */
+        TEST_ASSERT(cnt <= 3,
+                    "stall log must be throttled (<=3 in a 2s window), got %d",
+                    cnt);
+
+        /* Recovery: bring the broker back and confirm the consumer
+         * drains. */
+        rd_kafka_mock_broker_set_up(ctx.mcluster, 1);
+        mock_produce(ctx.producer, topic, msgcnt_recovery);
+        acked = consume_and_ack_all(rkshare, msgcnt_recovery);
+        TEST_ASSERT(acked == msgcnt_recovery,
+                    "post-recovery: expected %d acked, got %d", msgcnt_recovery,
+                    acked);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        test_ctx_destroy(&ctx);
+
+        test_curr->is_fatal_cb = NULL;
+
+        SUB_TEST_PASS();
+}
+
+
 int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
         TEST_SKIP_MOCK_CLUSTER(0);
 
@@ -3018,6 +3152,7 @@ int main_0182_share_consumer_error_handling_mock(int argc, char **argv) {
          * race-window flavours. */
         do_test_no_bounce_loop_on_down_broker();
         do_test_one_log_on_broker_down_during_active_empty_poll();
+        do_test_fetch_stall_logged_on_no_broker();
 
         return 0;
 }

--- a/tests/0184-share_consumer_topic_recreate.c
+++ b/tests/0184-share_consumer_topic_recreate.c
@@ -943,6 +943,136 @@ static void test_recreate_during_close(void) {
         SUB_TEST_PASS();
 }
 
+/* ===================================================================
+ *  Log callback: counts the "no partitions are assigned" fetch-stall
+ *  log emitted while the share consumer's assignment is empty.
+ * =================================================================== */
+static void recreate_stall_log_cb(const rd_kafka_t *rk,
+                                  int level,
+                                  const char *fac,
+                                  const char *buf) {
+        rd_atomic32_t *cnt = rd_kafka_opaque(rk);
+        if (cnt && !strcmp(fac, "FETCHMORE") &&
+            strstr(buf, "no partitions are assigned"))
+                rd_atomic32_add(cnt, 1);
+}
+
+/**
+ * @brief Delete the consumer's only topic so the broker revokes its
+ *        assignment to empty, verify the consumer reports the
+ *        no-partitions fetch stall, then recreate the topic and verify
+ *        records flow again.
+ *
+ * Reproduces the observed delete/recreate latency: with no partitions
+ * assigned the consumer keeps wanting to fetch and emits the
+ * rate-limited "Fetch stalled: ... no partitions are assigned" log
+ * until the recreated topic (fresh topic_id) is reassigned.
+ */
+static void do_test_recreate_stall_then_recover(void) {
+        const char *topic;
+        const char *group = "0184-share-recreate-stall";
+        rd_kafka_share_t *rkshare;
+        rd_kafka_conf_t *conf;
+        rd_atomic32_t stall_cnt;
+        test_msgver_t mv_before, mv_after;
+        uint64_t testid_before, testid_after;
+        rd_kafka_Uuid_t *id_before, *id_after;
+        rd_kafka_messages_t *batch = NULL;
+        rd_ts_t deadline;
+        int got, stalls;
+        char errstr[512];
+
+        SUB_TEST_QUICK();
+
+        rd_atomic32_init(&stall_cnt, 0);
+        testid_before = test_id_generate();
+        testid_after  = test_id_generate();
+
+        topic = test_mk_topic_name("0184-recreate-stall", 1);
+        test_create_topic_wait_exists(common_admin, topic, PARTITION_CNT, -1,
+                                      60 * 1000);
+
+        id_before = fetch_topic_id(topic);
+        test_share_set_auto_offset_reset(group, "earliest");
+
+        /* Fast metadata refresh + debug=consumer so the no-partitions
+         * stall log is emitted and observable via the log callback. */
+        test_conf_init(&conf, NULL, 0);
+        test_conf_set(conf, "group.id", group);
+        test_conf_set(conf, "share.acknowledgement.mode", "explicit");
+        test_conf_set(conf, "topic.metadata.refresh.interval.ms", "500");
+        test_conf_set(conf, "debug", "consumer");
+        rd_kafka_conf_set_log_cb(conf, recreate_stall_log_cb);
+        rd_kafka_conf_set_opaque(conf, &stall_cnt);
+        rkshare = rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+        TEST_ASSERT(rkshare, "Failed to create share consumer: %s", errstr);
+
+        test_share_consumer_subscribe_multi(rkshare, 1, topic);
+
+        /* ---- Phase 1: consume the original generation ---- */
+        produce_phase(topic, testid_before, PARTITION_CNT);
+        test_msgver_init(&mv_before, testid_before);
+        got =
+            consume_into_msgver(rkshare, &mv_before, MSGS_PER_PHASE, 30 * 1000);
+        TEST_ASSERT(got == MSGS_PER_PHASE, "Phase 1: expected %d msgs, got %d",
+                    MSGS_PER_PHASE, got);
+        test_msgver_clear(&mv_before);
+
+        /* ---- Delete: the broker revokes the assignment to empty ---- */
+        TEST_SAY("Deleting topic %s; expecting a no-partitions fetch stall\n",
+                 topic);
+        test_delete_topic(common_admin, topic);
+
+        /* Poll until the no-partitions stall is logged. The log is
+         * rate-limited, so a single occurrence confirms the path. */
+        deadline = test_clock() + (rd_ts_t)60 * 1000 * 1000;
+        while (rd_atomic32_get(&stall_cnt) < 1 && test_clock() < deadline) {
+                rd_kafka_error_t *error =
+                    rd_kafka_share_poll(rkshare, 500, &batch);
+                if (error) {
+                        rd_kafka_error_destroy(error);
+                } else {
+                        /* Ack any straggler so the next poll can proceed
+                         * in explicit mode. */
+                        size_t i, n = rd_kafka_messages_count(batch);
+                        for (i = 0; i < n; i++)
+                                rd_kafka_share_acknowledge(
+                                    rkshare, rd_kafka_messages_get(batch, i));
+                }
+                rd_kafka_messages_destroy(batch);
+                batch = NULL;
+        }
+        stalls = rd_atomic32_get(&stall_cnt);
+        TEST_SAY("\"no partitions assigned\" stall log count: %d\n", stalls);
+        TEST_ASSERT(stalls >= 1,
+                    "expected the no-partitions stall to be logged, got %d",
+                    stalls);
+
+        /* ---- Recreate (fresh topic_id): the broker reassigns ---- */
+        rd_sleep(5); /* let DeleteTopics settle, as in recreate_topic() */
+        test_create_topic_wait_exists(common_admin, topic, PARTITION_CNT, -1,
+                                      60 * 1000);
+        id_after = fetch_topic_id(topic);
+        assert_topic_id_changed(id_before, id_after);
+
+        /* ---- Phase 2: records flow again ---- */
+        produce_phase(topic, testid_after, PARTITION_CNT);
+        test_msgver_init(&mv_after, testid_after);
+        got =
+            consume_into_msgver(rkshare, &mv_after, MSGS_PER_PHASE, 60 * 1000);
+        TEST_ASSERT(got == MSGS_PER_PHASE,
+                    "Phase 2: expected %d msgs after recreate, got %d",
+                    MSGS_PER_PHASE, got);
+        test_msgver_clear(&mv_after);
+
+        test_share_consumer_close(rkshare);
+        test_share_destroy(rkshare);
+        rd_kafka_Uuid_destroy(id_before);
+        rd_kafka_Uuid_destroy(id_after);
+
+        SUB_TEST_PASS();
+}
+
 int main_0184_share_consumer_topic_recreate(int argc, char **argv) {
         /* Topic deletion is not supported against Windows brokers. */
         if (!strcmp(test_getenv("TEST_BROKER_OS", ""), "windows")) {
@@ -969,6 +1099,7 @@ int main_0184_share_consumer_topic_recreate(int argc, char **argv) {
                                    create_consumer_md_first, 2);
         do_test_recreate_chaos();
         do_test_recreate_survives_concurrent_producer();
+        do_test_recreate_stall_then_recover();
 
         rd_kafka_destroy(common_admin);
         rd_kafka_destroy(common_producer);


### PR DESCRIPTION
When a share consumer wants more records but the fetch can't proceed, the main-thread re-trigger loop previously did nothing and logged nothing. Add a rate-limited debug log explaining why, so stalls are diagnosable.