### PR TITLE
[KIP-932] Reject out-of-range AcquiredRecords in share fetch reply

### DIFF
--- a/src/rdkafka_fetcher.c
+++ b/src/rdkafka_fetcher.c
@@ -1522,6 +1522,23 @@ static rd_kafka_resp_err_t rd_kafka_share_fetch_reply_handle_partition(
 
                         size = LastOffsets[i] - FirstOffsets[i] + 1;
 
+                        /* size is used both as the int64 fill-loop bound below
+                         * and, truncated to the int32 types_cnt, as the
+                         * allocation count in
+                         * rd_kafka_share_ack_batch_entry_new. A broker-supplied
+                         * range with LastOffset < FirstOffset, or one wider
+                         * than INT32_MAX, would make the truncated allocation
+                         * smaller than the loop bound and overflow
+                         * entry->types. */
+                        if (unlikely(size <= 0 || size > INT32_MAX))
+                                rd_kafka_buf_parse_fail(
+                                    rkbuf,
+                                    "%.*s [%" PRId32
+                                    "]: AcquiredRecords range %" PRId64
+                                    "..%" PRId64 " out of range",
+                                    RD_KAFKAP_STR_PR(topic), PartitionId,
+                                    FirstOffsets[i], LastOffsets[i]);
+
                         rd_rkb_dbg(rkb, FETCH, "SHAREFETCH",
                                    "%.*s [%" PRId32
                                    "]: Acquired Records from offset %" PRId64


### PR DESCRIPTION
A broker-supplied AcquiredRecords range in a ShareFetch response can overflow the per-entry ack-type buffer:
- rd_kafka_share_fetch_reply_handle_partition reads FirstOffset/LastOffset off the wire and computes size = LastOffset - FirstOffset + 1 as int64
- size is truncated to int32 for types_cnt in rd_kafka_share_ack_batch_entry_new, which allocates entry->types with the truncated count, while the loop that fills entry->types iterates the full int64 size
- a range wider than INT32_MAX (e.g. FirstOffset 0, LastOffset 2^32) allocates one element then writes 2^32 of them past it; a negative range (LastOffset < FirstOffset) is also accepted today

Guard the range before allocating, in line with the other broker-input validation in this parser.