### PR TITLE
[KIP-932] use int64 for offset count in share ack commit offsets list

### DIFF
--- a/src/rdkafka_share_acknowledgement.c
+++ b/src/rdkafka_share_acknowledgement.c
@@ -1130,14 +1130,13 @@ rd_kafka_share_build_partition_offsets_list(
         rd_kafka_share_partition_offsets_list_t *list;
         rd_kafka_share_partition_offsets_t *elem;
         rd_kafka_share_ack_batch_entry_t *entry;
-        int total_offsets = 0;
-        int offset_idx    = 0;
+        int64_t total_offsets = 0;
+        int64_t offset_idx    = 0;
         int j;
 
         /* Count total offsets */
         RD_LIST_FOREACH(entry, &batches->entries, j) {
-                total_offsets +=
-                    (int)(entry->end_offset - entry->start_offset + 1);
+                total_offsets += entry->end_offset - entry->start_offset + 1;
         }
 
         list = rd_kafka_share_partition_offsets_list_new(1);


### PR DESCRIPTION
Offset count overflow in rd_kafka_share_build_partition_offsets_list:
- total_offsets is a 32-bit int but sums int64 ranges from broker AcquiredRecords; past INT_MAX it overflows
- the overflowed value sizes rd_kafka_share_partition_offsets_new while the fill loop writes one int64 per offset over the full range
- offset_idx is also int and can wrap to a negative index
- the sibling rd_kafka_share_build_response_rko already keeps this count in int64_t

Widened both to int64_t to match the int64 offsets array and that sibling.