### PR TITLE
[KIP-932] Document share consumer (Queues for Kafka) - Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,52 @@
-# Unreleased
+# librdkafka v2.15.0
 
-librdkafka Unreleased is a maintenance release:
+librdkafka v2.15.0 is a feature release:
 
-* Fix compilation with CMake when CURL is disabled (#5136).
-* Fix `rd_atomic{32,64}_set` returning the new value in CMake builds, restoring the `ALL_BROKERS_DOWN` event (#5136).
+
+## [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka) Queues for Kafka – Now in **Preview**
+
+- Added a preview implementation of the **share consumer** (Queues for Kafka,
+  [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka)).
+  Members of a share group cooperatively consume from the same partitions with
+  per-record acquire/acknowledge semantics and redelivery, providing queue-like
+  consumption on top of Kafka.
+- New `rd_kafka_share_*` public API, with a dedicated `rd_kafka_share_t` handle
+  created via `rd_kafka_share_consumer_new()`:
+  - Subscription: `rd_kafka_share_subscribe()`, `rd_kafka_share_unsubscribe()`,
+    `rd_kafka_share_subscription()`.
+  - Batch polling: `rd_kafka_share_poll()` returns an `rd_kafka_messages_t`
+    batch (`rd_kafka_messages_count()` / `rd_kafka_messages_get()` /
+    `rd_kafka_messages_destroy()`).
+  - Acknowledgement: `rd_kafka_share_acknowledge()`,
+    `rd_kafka_share_acknowledge_type()`, `rd_kafka_share_acknowledge_offset()`
+    with ACCEPT / RELEASE / REJECT types, and
+    `rd_kafka_message_delivery_count()`.
+  - Commit: `rd_kafka_share_commit_sync()`, `rd_kafka_share_commit_async()` and
+    the acknowledgement-commit callback
+    (`rd_kafka_share_set_acknowledgement_commit_cb()`).
+  - Lifecycle: `rd_kafka_share_consumer_close()`,
+    `rd_kafka_share_consumer_close_queue()`, `rd_kafka_share_destroy()`.
+- Two acknowledgement modes selected by `share.acknowledgement.mode`
+  (default `implicit`; `explicit` requires the application to acknowledge every
+  record before the next poll).
+- New `max.poll.records` property (default 500) and adjusted defaults for
+  several network properties for share consumers (`receive.message.max.bytes`,
+  `connections.max.idle.ms`, `reconnect.backoff.ms`,
+  `reconnect.backoff.max.ms`).
+- See the *Share consumers (Queues for Kafka)* section of
+  [INTRODUCTION.md](INTRODUCTION.md#share-consumers-queues-for-kafka), the
+  *Share consumer* section in [rdkafka.h](src/rdkafka.h), and the
+  `examples/share_consumer*` programs.
+
+> [!Note]
+> The [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka)
+> share consumer is currently in **Preview** and should not be used in
+> production environments. The public interfaces may change before General
+> Availability, and known limitations apply (see
+> [INTRODUCTION.md](INTRODUCTION.md#share-consumer-current-limitations)). The
+> share consumer is single-threaded and not thread-safe by design. It requires
+> a broker with share groups enabled (generally available in Apache Kafka
+> 4.2.0).
 
 
 ## Fixes

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1958,9 +1958,14 @@ lock, processed, and then *acknowledged*. The lock duration is a broker/group
 setting (`group.share.record.lock.duration.ms`, 30 seconds by default) and is
 not configured on this client. A record that is not acknowledged before its
 lock expires, or that is explicitly released, becomes available again and may
-be redelivered — possibly to a different member. This makes it possible to
-scale the number of consumers beyond the number of partitions and to distribute
-work like a traditional queue.
+be redelivered — possibly to a different member. A record thus moves through the
+states *available* → *acquired* → *acknowledged*; a rejected record, or one that
+exceeds the broker's delivery-count limit, becomes *archived* and is no longer
+delivered. This makes it possible to scale the number of consumers beyond the
+number of partitions and to distribute work like a traditional queue.
+
+For a conceptual overview of share groups and Queues for Kafka, see the
+[Confluent share consumer documentation](https://docs.confluent.io/platform/current/clients/share-consumers.html).
 
 A share consumer is a distinct handle type, `rd_kafka_share_t`, created with
 `rd_kafka_share_consumer_new()` (not `rd_kafka_new()`). The full API reference
@@ -1993,7 +1998,10 @@ rd_kafka_share_destroy()        # free the handle
 
 Configure the handle through the normal `rd_kafka_conf_t` interface before
 creating it. `group.id` is required. `share.acknowledgement.mode` is optional
-and defaults to `implicit` (see below).
+and defaults to `implicit` (see below). It is the only share-specific client
+property: other share-group settings (acquisition-lock duration, delivery-count
+limit, session/heartbeat timeouts, isolation level, acquire mode and offset
+reset) are broker/group settings and are not exposed by this client.
 
 Several classic-consumer properties do not apply to share consumers and are
 rejected or ignored — for example `partition.assignment.strategy`,
@@ -2032,7 +2040,9 @@ Every acquired record is acknowledged with one of three types:
 
 The number of times a record has already been delivered is available via
 `rd_kafka_message_delivery_count()`, which is useful to detect and reject a
-"poison" record after a threshold.
+"poison" record after a threshold. The broker also enforces its own maximum
+delivery count (`group.share.delivery.count.limit`, default 5); once a record
+exceeds it the broker archives the record and stops redelivering it.
 
 There are two acknowledgement modes, selected by `share.acknowledgement.mode`:
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1949,10 +1949,10 @@ for the help with the usage) for the consumer.
 > See [Current limitations](#share-consumer-current-limitations) below.
 
 Share groups ([KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka))
-bring queue-like semantics to Kafka. Where a classic consumer group assigns
+bring queue-like semantics to Kafka. Where a consumer group assigns
 each partition to exactly one member at a time, a *share group* lets multiple
 members consume from the **same** partitions cooperatively. The unit of
-progress is the individual record rather than the partition offset: each
+progress is the individual record rather than the committed offset: each
 delivered record is *acquired* by a member under a time-limited acquisition
 lock, processed, and then *acknowledged*. The lock duration is a broker/group
 setting (`group.share.record.lock.duration.ms`, 30 seconds by default) and is
@@ -1976,10 +1976,9 @@ the **C API only**; there is no C++ (`rdkafkacpp.h`) wrapper yet.
 #### Broker requirement
 
 A share consumer requires a broker with **share groups enabled**. Share groups
-are generally available in **Apache Kafka 4.2.0** (early access in 4.0.0,
-preview in 4.1.0). Partition assignment is entirely broker-driven (via the
-share group heartbeat); there is no client-side rebalance callback or
-`assign()` step.
+are available since **Apache Kafka 4.2.0**. Partition assignment is entirely
+broker-driven (via the share group heartbeat); there is no client-side
+rebalance callback or `assign()` step.
 
 #### Lifecycle
 
@@ -2003,7 +2002,7 @@ property: other share-group settings (acquisition-lock duration, delivery-count
 limit, session/heartbeat timeouts, isolation level, acquire mode and offset
 reset) are broker/group settings and are not exposed by this client.
 
-Several classic-consumer properties do not apply to share consumers and are
+Several regular-consumer properties do not apply to share consumers and are
 rejected or ignored — for example `partition.assignment.strategy`,
 `enable.auto.commit`, `auto.offset.reset` semantics, `isolation.level`,
 `enable.partition.eof`, `group.instance.id`, `group.remote.assignor`, and the
@@ -2017,7 +2016,7 @@ the authoritative list and the share-consumer default values.
 #### Polling and message batches
 
 `rd_kafka_share_poll()` returns a **batch** of messages in a single call
-(unlike the classic single-message poll), as an opaque `rd_kafka_messages_t`
+(unlike the regular single-message poll), as an opaque `rd_kafka_messages_t`
 handle. Iterate it with `rd_kafka_messages_count()` and
 `rd_kafka_messages_get()`, and release it with `rd_kafka_messages_destroy()`
 (which is NULL-safe). `max.poll.records` (default 500) bounds the batch size.
@@ -2066,13 +2065,13 @@ for each partition.
 
 #### Example: explicit acknowledgement
 
-The example below walks the full share-consumer lifecycle in explicit mode
+The example below shows the full share-consumer lifecycle in explicit mode
 (configure, create, subscribe, poll, acknowledge, commit, close, destroy) and
 focuses on the per-record acknowledgement logic. It uses the real librdkafka
 APIs but is not a complete program: call-level error handling (the
 `rd_kafka_error_t` returned by `rd_kafka_share_poll()`, the acknowledge calls
 and the commit calls, and the return value of `rd_kafka_conf_set()`) is omitted
-for brevity. See the [examples](examples/) for complete programs.
+for brevity.
 
 ```c
 char errstr[512];
@@ -2090,7 +2089,7 @@ rd_kafka_share_t *rkshare =
 rd_kafka_share_subscribe(rkshare, topics);
 
 while (run) {
-        rd_kafka_messages_t *batch;
+        rd_kafka_messages_t *batch = NULL;
 
         rd_kafka_share_poll(rkshare, timeout_ms, &batch);
 
@@ -2151,7 +2150,7 @@ The share consumer handle is **not thread-safe by design**: a single
 `rd_kafka_share_t` handle must not be used concurrently from multiple threads.
 This follows the share consumer design in
 [KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka),
-where the share consumer — like the classic consumer — is single-threaded and
+where the share consumer — like the regular consumer — is single-threaded and
 the application owns the threading model (typically one handle per thread, or
 serialised access to a handle). Concurrent use is detected on a best-effort
 basis and rejected with `RD_KAFKA_RESP_ERR__CONFLICT`. There is no wakeup
@@ -2623,7 +2622,7 @@ The [Apache Kafka Implementation Proposals (KIPs)](https://cwiki.apache.org/conf
 | KIP-1082 - Require Client-Generated IDs over the ConsumerGroupHeartbeat  | 4.0.0                       | Supported                                                                                     |
 | KIP-1102 - Enable clients to rebootstrap based on timeout or error code  | 4.0.0                       | Supported                                                                                     |
 | KIP-1139 - Add support for OAuth jwt-bearer grant type                   | 4.1.0 (WIP)                 | Supported                                                                                     |
-| KIP-932 - Queues for Kafka (share groups / share consumer)               | 4.0.0                       | Preview (C API; see the [Share consumers](#share-consumers-queues-for-kafka) usage section and the ShareConsumer section in [rdkafka.h](src/rdkafka.h)) |
+| KIP-932 - Queues for Kafka (share groups / share consumer)               | 4.2.0                       | Preview (C API; see the [Share consumers](#share-consumers-queues-for-kafka) usage section and the Share consumer (Queues for Kafka) section in [rdkafka.h](src/rdkafka.h)) |
 
 
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -97,6 +97,7 @@ librdkafka also provides a native C++ interface.
       - [Upgrade and Downgrade](#upgrade-and-downgrade)
       - [Migration Checklist (Next-Gen Protocol / KIP-848)](#migration-checklist-next-gen-protocol--kip-848)
     - [Note on Batch consume APIs](#note-on-batch-consume-apis)
+    - [Share consumers (Queues for Kafka)](#share-consumers-queues-for-kafka)
     - [Topics](#topics)
       - [Unknown or unauthorized topics](#unknown-or-unauthorized-topics)
       - [Topic metadata propagation for newly created topics](#topic-metadata-propagation-for-newly-created-topics)
@@ -1939,6 +1940,247 @@ set `rebalance_cb` configuration property (refer [examples/rdkafka_complex_consu
 for the help with the usage) for the consumer.
 
 
+<a name="share-consumers-queues-for-kafka"></a>
+### Share consumers (Queues for Kafka)
+
+> **Preview feature.** The share consumer is provided as a preview. Its public
+> interfaces (the `rd_kafka_share_*` APIs in [rdkafka.h](src/rdkafka.h)) may
+> change in a future release and it is not recommended for production use.
+> See [Current limitations](#share-consumer-current-limitations) below.
+
+Share groups ([KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka))
+bring queue-like semantics to Kafka. Where a classic consumer group assigns
+each partition to exactly one member at a time, a *share group* lets multiple
+members consume from the **same** partitions cooperatively. The unit of
+progress is the individual record rather than the partition offset: each
+delivered record is *acquired* by a member, processed, and then
+*acknowledged*. Records that are not acknowledged in time, or that are
+explicitly released, become available again and may be redelivered — possibly
+to a different member. This makes it possible to scale the number of consumers
+beyond the number of partitions and to distribute work like a traditional
+queue.
+
+A share consumer is a distinct handle type, `rd_kafka_share_t`, created with
+`rd_kafka_share_consumer_new()` (not `rd_kafka_new()`). The full API reference
+lives in the *Share consumer (Queues for Kafka)* section of
+[rdkafka.h](src/rdkafka.h).
+
+#### Broker requirement
+
+A share consumer requires a broker with **share groups enabled**. Share groups
+are generally available in **Apache Kafka 4.2.0** (early access in 4.0.0,
+preview in 4.1.0). Partition assignment is entirely broker-driven (via the
+share group heartbeat); there is no client-side rebalance callback or
+`assign()` step.
+
+#### Lifecycle
+
+```
+rd_kafka_share_consumer_new()   # create handle from an rd_kafka_conf_t
+rd_kafka_share_subscribe()      # subscribe to a set of topics
+  loop:
+    rd_kafka_share_poll()       # fetch a batch of messages
+    ... process / acknowledge ...
+    rd_kafka_share_commit_*()   # (optional) flush acknowledgements
+rd_kafka_share_consumer_close() # send pending acks, leave the group
+rd_kafka_share_destroy()        # free the handle
+```
+
+#### Configuration
+
+Configure the handle through the normal `rd_kafka_conf_t` interface before
+creating it. `group.id` is required. `share.acknowledgement.mode` is optional
+and defaults to `implicit` (see below).
+
+Several classic-consumer properties do not apply to share consumers and are
+rejected or ignored — for example `partition.assignment.strategy`,
+`enable.auto.commit`, `auto.offset.reset` semantics, `isolation.level`,
+`enable.partition.eof`, `group.instance.id`, `group.remote.assignor`, and the
+per-partition fetch-queue tuning (`queued.min.messages`,
+`queued.max.messages.kbytes`, `fetch.message.max.bytes`, etc.). A few network
+defaults also differ for share consumers (for example `receive.message.max.bytes`,
+`connections.max.idle.ms`, `reconnect.backoff.ms`). See
+[CONFIGURATION.md](CONFIGURATION.md), where these properties are annotated, for
+the authoritative list and the share-consumer default values.
+
+#### Polling and message batches
+
+`rd_kafka_share_poll()` returns a **batch** of messages in a single call
+(unlike the classic single-message poll), as an opaque `rd_kafka_messages_t`
+handle. Iterate it with `rd_kafka_messages_count()` and
+`rd_kafka_messages_get()`, and release it with `rd_kafka_messages_destroy()`
+(which is NULL-safe). `max.poll.records` (default 500) bounds the batch size.
+
+Record-level errors are surfaced as individual messages with a non-zero
+`rd_kafka_message_t.err` field (the topic, partition and offset remain valid),
+so the application should check each message's `err` before treating it as
+data.
+
+#### Acknowledgement
+
+Every acquired record is acknowledged with one of three types:
+
+* **ACCEPT** (`RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT`) — processed
+  successfully.
+* **RELEASE** (`RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE`) — not processed; make
+  the record available again for redelivery.
+* **REJECT** (`RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT`) — do not deliver the
+  record again.
+
+The number of times a record has already been delivered is available via
+`rd_kafka_message_delivery_count()`, which is useful to detect and reject a
+"poison" record after a threshold.
+
+There are two acknowledgement modes, selected by `share.acknowledgement.mode`:
+
+* **implicit** (default) — the application does not call the acknowledge APIs.
+  All records returned by a poll are automatically accepted (ACCEPT) on the
+  next `rd_kafka_share_poll()` / `rd_kafka_share_commit_sync()` /
+  `rd_kafka_share_commit_async()`.
+* **explicit** — the application must acknowledge every record returned by a
+  poll (with `rd_kafka_share_acknowledge()`,
+  `rd_kafka_share_acknowledge_type()` or `rd_kafka_share_acknowledge_offset()`)
+  before the next poll. If any record from the previous batch is still
+  unacknowledged, `rd_kafka_share_poll()` returns
+  `RD_KAFKA_RESP_ERR__STATE`.
+
+Acknowledgements are sent to the broker as part of the next poll, or flushed
+explicitly with `rd_kafka_share_commit_async()` (fire-and-forget) or
+`rd_kafka_share_commit_sync()` (blocks for broker replies, reporting
+per-partition results). The acknowledgement-commit callback registered with
+`rd_kafka_share_set_acknowledgement_commit_cb()` is invoked with the outcome
+for each partition.
+
+#### Example: explicit acknowledgement
+
+The example below walks the full share-consumer lifecycle in explicit mode
+(configure, create, subscribe, poll, acknowledge, commit, close, destroy) and
+focuses on the per-record acknowledgement logic. It uses the real librdkafka
+APIs but is not a complete program: call-level error handling (the
+`rd_kafka_error_t` returned by `rd_kafka_share_poll()`, the acknowledge calls
+and the commit calls, and the return value of `rd_kafka_conf_set()`) is omitted
+for brevity. See the [examples](examples/) for complete programs.
+
+```c
+char errstr[512];
+
+rd_kafka_conf_t *conf = rd_kafka_conf_new();
+rd_kafka_conf_set(conf, "bootstrap.servers", "localhost:9092",
+                  errstr, sizeof(errstr));
+rd_kafka_conf_set(conf, "group.id", "my-share-group", errstr, sizeof(errstr));
+rd_kafka_conf_set(conf, "share.acknowledgement.mode", "explicit",
+                  errstr, sizeof(errstr));
+
+rd_kafka_share_t *rkshare =
+    rd_kafka_share_consumer_new(conf, errstr, sizeof(errstr));
+
+rd_kafka_share_subscribe(rkshare, topics);
+
+while (run) {
+        rd_kafka_messages_t *batch;
+
+        rd_kafka_share_poll(rkshare, timeout_ms, &batch);
+
+        size_t cnt = rd_kafka_messages_count(batch);
+        for (size_t i = 0; i < cnt; i++) {
+                rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+
+                if (rkm->err) {
+                        /* Records carrying a record-level error (rkm->err set)
+                         * have already been acknowledged internally by
+                         * librdkafka: RELEASEd for decompression failures,
+                         * REJECTed for corrupt/unsupported batches. The
+                         * application can re-acknowledge them here if required
+                         * (e.g. to override the internal decision); otherwise
+                         * it only acknowledges the records it received. */
+                        continue;
+                }
+
+                switch (process(rkm)) {
+                case PROCESS_OK:
+                        /* Processed successfully. */
+                        rd_kafka_share_acknowledge_type(
+                            rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+                        break;
+                case PROCESS_TEMPORARY_FAILURE:
+                        /* Release for redelivery (possibly to another member). */
+                        rd_kafka_share_acknowledge_type(
+                            rkshare, rkm,
+                            RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+                        break;
+                case PROCESS_PERMANENT_FAILURE:
+                        /* Reject a "poison" record so it is not redelivered. */
+                        rd_kafka_share_acknowledge_type(
+                            rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+                        break;
+                }
+        }
+        rd_kafka_messages_destroy(batch);
+
+        /* Flush the acknowledgements; the next poll would also send them.
+         * Use rd_kafka_share_commit_sync(rkshare, timeout_ms, &partitions)
+         * to block and inspect the per-partition result. */
+        rd_kafka_share_commit_async(rkshare);
+}
+
+rd_kafka_share_consumer_close(rkshare);
+rd_kafka_share_destroy(rkshare);
+```
+
+Complete runnable programs are in the examples directory:
+[share_consumer.c](examples/share_consumer.c),
+[share_consumer_commit_sync.c](examples/share_consumer_commit_sync.c) and
+[share_consumer_commit_async.c](examples/share_consumer_commit_async.c).
+
+#### Thread safety
+
+The share consumer handle is **not thread-safe by design**: a single
+`rd_kafka_share_t` handle must not be used concurrently from multiple threads.
+This follows the share consumer design in
+[KIP-932](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka),
+where the share consumer — like the classic consumer — is single-threaded and
+the application owns the threading model (typically one handle per thread, or
+serialised access to a handle). Concurrent use is detected on a best-effort
+basis and rejected with `RD_KAFKA_RESP_ERR__CONFLICT`. There is no wakeup
+mechanism in this preview, so a blocking poll/commit ends only when its timeout
+expires.
+
+<a name="share-consumer-current-limitations"></a>
+#### Current limitations (preview)
+
+The preview differs from the Apache Kafka Java share consumer in a number of
+ways. The most important for application authors:
+
+* **Record limit is a soft bound.** `max.poll.records` (default 500) does not
+  strictly bound the number of records returned per poll (the strict-limit and
+  acquire-mode work of KIP-1206 is not implemented).
+* **Acknowledgement types are limited to ACCEPT / RELEASE / REJECT.** There is
+  no acquisition-lock renewal (KIP-1222), so a long-running handler cannot
+  extend a record's lock and the record may be redelivered.
+* **No wakeup API.** A blocking poll/commit can only be ended by its timeout.
+* **`close()` has no timeout argument.** `rd_kafka_share_consumer_close()`
+  takes no timeout argument; close is bounded internally to roughly
+  `socket.timeout.ms`.
+* **No deserialization in the C core**, hence no automatic RELEASE on a
+  deserialization failure.
+* **No share-group admin operations** (describe/list/alter/delete share
+  groups and offsets) and **no share-consumer client-metrics APIs**.
+* **No auto topic creation.** Share topics are resolved by topic id;
+  `allow.auto.create.topics` has no effect.
+* **Failed acknowledgements are not retried** automatically; the error is
+  reported through the acknowledgement-commit callback or the
+  `rd_kafka_share_commit_sync()` per-partition results.
+* **Some error codes differ** because librdkafka generates certain failures
+  locally without a broker round-trip (for example
+  `RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER`, `RD_KAFKA_RESP_ERR__TRANSPORT`,
+  `RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH`). Applications that branch on
+  error codes should account for this.
+* **Single-broker fetch per poll.** Each poll fetches from one broker
+  (round-robin over the assigned partitions); other brokers' partitions are
+  served on subsequent polls. This is a throughput/latency detail, not a
+  correctness one — all brokers are served across successive polls.
+
+
 <a name="topics"></a>
 ### Topics
 
@@ -2368,6 +2610,7 @@ The [Apache Kafka Implementation Proposals (KIPs)](https://cwiki.apache.org/conf
 | KIP-1082 - Require Client-Generated IDs over the ConsumerGroupHeartbeat  | 4.0.0                       | Supported                                                                                     |
 | KIP-1102 - Enable clients to rebootstrap based on timeout or error code  | 4.0.0                       | Supported                                                                                     |
 | KIP-1139 - Add support for OAuth jwt-bearer grant type                   | 4.1.0 (WIP)                 | Supported                                                                                     |
+| KIP-932 - Queues for Kafka (share groups / share consumer)               | 4.0.0                       | Preview (C API; see the [Share consumers](#share-consumers-queues-for-kafka) usage section and the ShareConsumer section in [rdkafka.h](src/rdkafka.h)) |
 
 
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1965,7 +1965,8 @@ work like a traditional queue.
 A share consumer is a distinct handle type, `rd_kafka_share_t`, created with
 `rd_kafka_share_consumer_new()` (not `rd_kafka_new()`). The full API reference
 lives in the *Share consumer (Queues for Kafka)* section of
-[rdkafka.h](src/rdkafka.h).
+[rdkafka.h](src/rdkafka.h). The share consumer is currently available through
+the **C API only**; there is no C++ (`rdkafkacpp.h`) wrapper yet.
 
 #### Broker requirement
 

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1953,12 +1953,14 @@ bring queue-like semantics to Kafka. Where a classic consumer group assigns
 each partition to exactly one member at a time, a *share group* lets multiple
 members consume from the **same** partitions cooperatively. The unit of
 progress is the individual record rather than the partition offset: each
-delivered record is *acquired* by a member, processed, and then
-*acknowledged*. Records that are not acknowledged in time, or that are
-explicitly released, become available again and may be redelivered — possibly
-to a different member. This makes it possible to scale the number of consumers
-beyond the number of partitions and to distribute work like a traditional
-queue.
+delivered record is *acquired* by a member under a time-limited acquisition
+lock, processed, and then *acknowledged*. The lock duration is a broker/group
+setting (`group.share.record.lock.duration.ms`, 30 seconds by default) and is
+not configured on this client. A record that is not acknowledged before its
+lock expires, or that is explicitly released, becomes available again and may
+be redelivered — possibly to a different member. This makes it possible to
+scale the number of consumers beyond the number of partitions and to distribute
+work like a traditional queue.
 
 A share consumer is a distinct handle type, `rd_kafka_share_t`, created with
 `rd_kafka_share_consumer_new()` (not `rd_kafka_new()`). The full API reference

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ affiliation with and is not endorsed by The Apache Software Foundation.
   * Full Exactly-Once-Semantics (EOS) support
   * High-level producer, including Idempotent and Transactional producers
   * High-level balanced KafkaConsumer (requires broker >= 0.9)
+  * Share consumer / Queues for Kafka ([KIP-932](INTRODUCTION.md#share-consumers-queues-for-kafka)) — **Preview** (requires a broker with share groups enabled; generally available in Apache Kafka 4.2.0). The share consumer is single-threaded and **not thread-safe by design**, per KIP-932.
   * Simple (legacy) consumer
   * Admin client
   * Compression: snappy, gzip, lz4, zstd
@@ -147,6 +148,7 @@ See [getting Started with Apache Kafka and C/C++](https://developer.confluent.io
 
     * Producers: basic producers, idempotent producers, transactional producers.
     * Consumers: basic consumers, reading batches of messages.
+    * Share consumers (Queues for Kafka, KIP-932, Preview): see the `share_consumer*` examples.
     * Performance and latency testing tools.
 
 2. Refer to the [examples GitHub repo](https://github.com/confluentinc/examples/tree/master/clients/cloud/c) for code connecting to a cloud streaming data service based on Apache Kafka

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ affiliation with and is not endorsed by The Apache Software Foundation.
   * Full Exactly-Once-Semantics (EOS) support
   * High-level producer, including Idempotent and Transactional producers
   * High-level balanced KafkaConsumer (requires broker >= 0.9)
-  * Share consumer / Queues for Kafka ([KIP-932](INTRODUCTION.md#share-consumers-queues-for-kafka)) — **Preview** (requires a broker with share groups enabled; generally available in Apache Kafka 4.2.0). The share consumer is single-threaded and **not thread-safe by design**, per KIP-932.
+  * Share consumer / Queues for Kafka ([KIP-932](INTRODUCTION.md#share-consumers-queues-for-kafka)) — **Preview** (requires broker >= 4.2)
   * Simple (legacy) consumer
   * Admin client
   * Compression: snappy, gzip, lz4, zstd

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ affiliation with and is not endorsed by The Apache Software Foundation.
   * Full Exactly-Once-Semantics (EOS) support
   * High-level producer, including Idempotent and Transactional producers
   * High-level balanced KafkaConsumer (requires broker >= 0.9)
-  * Share consumer / Queues for Kafka ([KIP-932](INTRODUCTION.md#share-consumers-queues-for-kafka)) — **Preview** (requires broker >= 4.2)
+  * Share consumer / Queues for Kafka ([KIP-932](INTRODUCTION.md#share-consumers-queues-for-kafka)) — **Preview**, C API only (requires broker >= 4.2)
   * Simple (legacy) consumer
   * Admin client
   * Compression: snappy, gzip, lz4, zstd

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -76,4 +76,13 @@ if(NOT WIN32)
     add_executable(kafkatest_verifiable_client kafkatest_verifiable_client.cpp)
     target_link_libraries(kafkatest_verifiable_client PUBLIC rdkafka++)
 
+    add_executable(share_consumer share_consumer.c)
+    target_link_libraries(share_consumer PUBLIC rdkafka)
+
+    add_executable(share_consumer_commit_sync share_consumer_commit_sync.c)
+    target_link_libraries(share_consumer_commit_sync PUBLIC rdkafka)
+
+    add_executable(share_consumer_commit_async share_consumer_commit_async.c)
+    target_link_libraries(share_consumer_commit_async PUBLIC rdkafka)
+
 endif(NOT WIN32)

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,12 @@ Begin with the following examples:
  * [misc.c](misc.c) - a collection of miscellaneous usage examples.
 
 
+For the share consumer (Queues for Kafka, [KIP-932](../INTRODUCTION.md#share-consumers-queues-for-kafka), **Preview**), see:
+ * [share_consumer.c](share_consumer.c) - a basic share consumer (poll + acknowledge).
+ * [share_consumer_commit_sync.c](share_consumer_commit_sync.c) - share consumer with explicit acknowledgement and synchronous commit.
+ * [share_consumer_commit_async.c](share_consumer_commit_async.c) - share consumer with explicit acknowledgement and asynchronous commit.
+
+
 For more complex uses, see:
  * [rdkafka_example.c](rdkafka_example.c) - simple consumer, producer, metadata listing, kitchen sink, etc.
  * [rdkafka_example.cpp](rdkafka_example.cpp) - simple consumer, producer, metadata listing in C++.

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5254,7 +5254,15 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * (\c group.share.record.lock.duration.ms, 30 seconds by default) and is not
  * configured on this client. A record that is not acknowledged before its lock
  * expires, or that is released, becomes available again and may be redelivered
- * (possibly to a different member).
+ * (possibly to a different member). A record thus moves through the states
+ * *available* -> *acquired* -> *acknowledged*; a rejected record, or one that
+ * exceeds the broker's delivery-count limit, becomes *archived* and is no
+ * longer delivered.
+ *
+ * For a conceptual overview of share groups and Queues for Kafka, see KIP-932
+ * (https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka)
+ * and the Confluent share consumer documentation
+ * (https://docs.confluent.io/platform/current/clients/share-consumers.html).
  *
  * A share consumer is created with rd_kafka_share_consumer_new() rather than
  * rd_kafka_new(), and is represented by the opaque \c rd_kafka_share_t handle.
@@ -5272,7 +5280,11 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * Configure the handle through the normal \c rd_kafka_conf_t interface before
  * calling rd_kafka_share_consumer_new(). \c group.id is required.
  * \c share.acknowledgement.mode is optional and selects the acknowledgement
- * mode (see below); when unset it defaults to \c implicit.
+ * mode (see below); when unset it defaults to \c implicit. It is the only
+ * share-specific client property: other share-group settings (acquisition-lock
+ * duration, delivery-count limit, session/heartbeat timeouts, isolation level,
+ * acquire mode and offset reset) are broker/group settings and are not exposed
+ * by this client.
  * Several classic-consumer properties are not applicable to share consumers
  * (for example \c partition.assignment.strategy, \c enable.auto.commit,
  * \c isolation.level, \c enable.partition.eof and the per-partition fetch
@@ -5308,7 +5320,9 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT  — do not deliver again.
  * The number of times a record has been delivered is available via
  * rd_kafka_message_delivery_count(), which can be used to detect and reject
- * "poison" records after a threshold.
+ * "poison" records after a threshold. The broker also enforces its own maximum
+ * delivery count (\c group.share.delivery.count.limit, default 5); once a
+ * record exceeds it the broker archives the record and stops redelivering it.
  *
  * @par Acknowledgement modes
  * The acknowledgement mode is fixed at creation by

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5244,11 +5244,11 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * @par Overview
  * A share consumer lets multiple members of a *share group* cooperatively
  * consume records from the same topic partitions, providing queue-like
- * semantics on top of Kafka. This differs from the classic balanced consumer
- * (\c rd_kafka_subscribe et.al.) where each partition is assigned to exactly
+ * semantics on top of Kafka. This differs from consumers in a consumer group
+ * (rd_kafka_subscribe(), et.al.) where each partition is assigned to exactly
  * one member of the group at a time. In a share group a single partition may
  * be consumed by several members at once, and individual records — rather than
- * partition offsets — are the unit of progress: each delivered record is
+ * the committed offset — are the unit of progress: each delivered record is
  * *acquired* by a member under a time-limited acquisition lock, processed, and
  * then *acknowledged*. The lock duration is a broker/group setting
  * (\c group.share.record.lock.duration.ms, 30 seconds by default) and is not
@@ -5266,15 +5266,14 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *
  * A share consumer is created with rd_kafka_share_consumer_new() rather than
  * rd_kafka_new(), and is represented by the opaque \c rd_kafka_share_t handle.
- * Its lifecycle mirrors the classic consumer:
+ * Its lifecycle mirrors the regular consumer:
  * subscribe -> poll/acknowledge (loop) -> close -> destroy.
  *
  * @par Broker compatibility
- * Requires a broker with share groups enabled. Share groups are generally
- * available in Apache Kafka 4.2.0 (early access in Apache Kafka 4.0.0, preview
- * in 4.1.0). The set of partitions assigned to each member is decided entirely
- * by the broker (driven by the share group heartbeat); there is no client-side
- * rebalance callback or assign() step.
+ * Requires a broker with share groups enabled. Share groups are available
+ * since Apache Kafka 4.2.0. The set of partitions assigned to each member is
+ * decided entirely by the broker (driven by the share group heartbeat); there
+ * is no client-side rebalance callback or assign() step.
  *
  * @par Configuration
  * Configure the handle through the normal \c rd_kafka_conf_t interface before
@@ -5285,7 +5284,7 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * duration, delivery-count limit, session/heartbeat timeouts, isolation level,
  * acquire mode and offset reset) are broker/group settings and are not exposed
  * by this client.
- * Several classic-consumer properties are not applicable to share consumers
+ * Several regular-consumer properties are not applicable to share consumers
  * (for example \c partition.assignment.strategy, \c enable.auto.commit,
  * \c isolation.level, \c enable.partition.eof and the per-partition fetch
  * queue tuning). A few network-related defaults also differ for share
@@ -5302,7 +5301,7 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *
  * @par Polling
  * rd_kafka_share_poll() returns a *batch* of messages in a single call (unlike
- * the classic single-message poll), as an opaque \c rd_kafka_messages_t handle.
+ * the regular single-message poll), as an opaque \c rd_kafka_messages_t handle.
  * Iterate it with rd_kafka_messages_count() and rd_kafka_messages_get(), and
  * release it with rd_kafka_messages_destroy(). Record-level errors are surfaced
  * as individual messages with a non-zero \c rd_kafka_message_t.err field
@@ -5421,7 +5420,7 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * threads. This matches the share consumer design in KIP-932. Use one handle
  * per thread, or serialise all access to a handle. Concurrent use is detected
  * on a best-effort basis and rejected with RD_KAFKA_RESP_ERR__CONFLICT. Unlike
- * the classic consumer there is no wakeup mechanism in this preview, so a
+ * the regular consumer there is no wakeup mechanism in this preview, so a
  * blocking poll/commit ends only when its timeout expires.
  *
  * @par Closing

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -1579,13 +1579,15 @@ rd_kafka_message_t *rd_kafka_messages_get(const rd_kafka_messages_t *messages,
 /**
  * @brief Destroys \p messages and all messages it contains.
  *
- * After this call any \c rd_kafka_message_t pointer previously obtained via
- * rd_kafka_messages_get() on \p messages is invalid. Users should only use
- * this method to destroy the \p messages handle returned by
- * rd_kafka_share_poll() and set the pointer to NULL after destroying to avoid
- * use-after-free bugs.
- *
  * @param messages Message list to destroy. NULL is a safe no-op.
+ *
+ * @remark After this call the \p messages handle itself, and any
+ *         \c rd_kafka_message_t pointer previously obtained from it via
+ *         rd_kafka_messages_get(), are invalid and must not be accessed —
+ *         doing so reads freed memory. Users should only use this method to
+ *         destroy the \p messages handle returned by rd_kafka_share_poll() and
+ *         set the pointer to NULL after destroying to avoid use-after-free
+ *         bugs.
  */
 RD_EXPORT
 void rd_kafka_messages_destroy(rd_kafka_messages_t *messages);
@@ -5229,15 +5231,226 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
 
 
 /**
- * @name ShareConsumer
- * @brief Share consumer specific APIs
+ * @name Share consumer (Queues for Kafka)
+ * @brief Cooperative, queue-style consumption with a share group (KIP-932)
  * @{
  *
+ * @warning **Preview feature.** The share consumer is provided as a preview:
+ *          the public interfaces may change in a future release and it is not
+ *          recommended for production use. See the "Current limitations"
+ *          section below.
  *
+ * @par Overview
+ * A share consumer lets multiple members of a *share group* cooperatively
+ * consume records from the same topic partitions, providing queue-like
+ * semantics on top of Kafka. This differs from the classic balanced consumer
+ * (\c rd_kafka_subscribe et.al.) where each partition is assigned to exactly
+ * one member of the group at a time. In a share group a single partition may
+ * be consumed by several members at once, and individual records — rather than
+ * partition offsets — are the unit of progress: each delivered record is
+ * *acquired* by a member, processed, and then *acknowledged*. Records that are
+ * not acknowledged in time, or that are released, become available again and
+ * may be redelivered (possibly to a different member).
  *
- */
-/*
- * TODO KIP-932: Update descriptions of all the below APIs.
+ * A share consumer is created with rd_kafka_share_consumer_new() rather than
+ * rd_kafka_new(), and is represented by the opaque \c rd_kafka_share_t handle.
+ * Its lifecycle mirrors the classic consumer:
+ * subscribe -> poll/acknowledge (loop) -> close -> destroy.
+ *
+ * @par Broker compatibility
+ * Requires a broker with share groups enabled. Share groups are generally
+ * available in Apache Kafka 4.2.0 (early access in Apache Kafka 4.0.0, preview
+ * in 4.1.0). The set of partitions assigned to each member is decided entirely
+ * by the broker (driven by the share group heartbeat); there is no client-side
+ * rebalance callback or assign() step.
+ *
+ * @par Configuration
+ * Configure the handle through the normal \c rd_kafka_conf_t interface before
+ * calling rd_kafka_share_consumer_new(). \c group.id is required.
+ * \c share.acknowledgement.mode is optional and selects the acknowledgement
+ * mode (see below); when unset it defaults to \c implicit.
+ * Several classic-consumer properties are not applicable to share consumers
+ * (for example \c partition.assignment.strategy, \c enable.auto.commit,
+ * \c isolation.level, \c enable.partition.eof and the per-partition fetch
+ * queue tuning). A few network-related defaults also differ for share
+ * consumers: \c receive.message.max.bytes, \c connections.max.idle.ms,
+ * \c reconnect.backoff.ms and \c reconnect.backoff.max.ms. See
+ * \ref CONFIGURATION.md, where such properties are marked, for the
+ * authoritative list and the share-consumer default values.
+ *
+ * @par Subscription
+ * Subscribe to a set of topics with rd_kafka_share_subscribe() (exact topic
+ * names only; wildcard/regex subscriptions are not supported), inspect the
+ * current subscription with rd_kafka_share_subscription(), and clear it with
+ * rd_kafka_share_unsubscribe().
+ *
+ * @par Polling
+ * rd_kafka_share_poll() returns a *batch* of messages in a single call (unlike
+ * the classic single-message poll), as an opaque \c rd_kafka_messages_t handle.
+ * Iterate it with rd_kafka_messages_count() and rd_kafka_messages_get(), and
+ * release it with rd_kafka_messages_destroy(). Record-level errors are surfaced
+ * as individual messages with a non-zero \c rd_kafka_message_t.err field
+ * (topic, partition and offset remain valid), so the application should check
+ * each message's \c err before treating it as data. \c max.poll.records bounds
+ * the batch size; in this preview it is a soft bound and the actual count may
+ * differ.
+ *
+ * @par Acknowledgement types
+ * Each acquired record is acknowledged with one of
+ * #rd_kafka_share_AcknowledgeType_t:
+ *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT  — processed successfully.
+ *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE — not processed; make available
+ *    again for redelivery.
+ *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT  — do not deliver again.
+ * The number of times a record has been delivered is available via
+ * rd_kafka_message_delivery_count(), which can be used to detect and reject
+ * "poison" records after a threshold.
+ *
+ * @par Acknowledgement modes
+ * The acknowledgement mode is fixed at creation by
+ * \c share.acknowledgement.mode:
+ *  - \b implicit (default): the application does not call the acknowledge APIs.
+ *    All records returned by a poll are automatically accepted (ACCEPT) when
+ *    the next rd_kafka_share_poll() / rd_kafka_share_commit_sync() /
+ *    rd_kafka_share_commit_async() is issued.
+ *  - \b explicit: the application must acknowledge every record returned by a
+ *    poll, using rd_kafka_share_acknowledge(),
+ *    rd_kafka_share_acknowledge_type() or rd_kafka_share_acknowledge_offset(),
+ *    before the next poll. If any record from the previous batch is still
+ *    unacknowledged, rd_kafka_share_poll() returns
+ *    RD_KAFKA_RESP_ERR__STATE.
+ *
+ * @par Committing acknowledgements
+ * Acknowledgements are sent to the broker as part of the next poll, or
+ * explicitly with rd_kafka_share_commit_async() (fire-and-forget) or
+ * rd_kafka_share_commit_sync() (blocks for the broker replies and reports
+ * per-partition results). The acknowledgement-commit callback registered with
+ * rd_kafka_share_set_acknowledgement_commit_cb() is invoked with the outcome
+ * for each partition. Failed acknowledgements are not retried automatically;
+ * the error is reported to the application.
+ *
+ * @par Example: implicit acknowledgement (default)
+ * @code
+ *   rd_kafka_share_t *rkshare = rd_kafka_share_consumer_new(conf, errstr,
+ *                                                           sizeof(errstr));
+ *   rd_kafka_share_subscribe(rkshare, topics);
+ *   while (run) {
+ *       rd_kafka_messages_t *batch = NULL;
+ *       rd_kafka_error_t *error = rd_kafka_share_poll(rkshare, 500, &batch);
+ *       if (error) {
+ *           // handle/log error
+ *           rd_kafka_error_destroy(error);
+ *       } else {
+ *           size_t cnt = rd_kafka_messages_count(batch);
+ *           for (size_t i = 0 ; i < cnt ; i++) {
+ *               rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+ *               if (rkm->err) {
+ *                   // Record-level error. The acknowledgement has already
+ *                   // been applied internally based on the error type:
+ *                   // corrupt/CRC (RD_KAFKA_RESP_ERR__BAD_MSG) and
+ *                   // unsupported (RD_KAFKA_RESP_ERR__NOT_IMPLEMENTED) batches
+ *                   // are REJECTed; decompression failures are RELEASEd for
+ *                   // redelivery. In implicit mode the application only needs
+ *                   // to inspect rkm->err.
+ *               } else {
+ *                   // process rkm (auto-accepted on next poll)
+ *               }
+ *           }
+ *       }
+ *       rd_kafka_messages_destroy(batch); // NULL-safe
+ *   }
+ *   rd_kafka_share_consumer_close(rkshare);
+ *   rd_kafka_share_destroy(rkshare);
+ * @endcode
+ *
+ * @par Example: explicit acknowledgement
+ * @code
+ *   // Created with conf "share.acknowledgement.mode" = "explicit".
+ *   rd_kafka_messages_t *batch = NULL;
+ *   rd_kafka_error_t *error = rd_kafka_share_poll(rkshare, 500, &batch);
+ *   if (!error) {
+ *       size_t cnt = rd_kafka_messages_count(batch);
+ *       for (size_t i = 0 ; i < cnt ; i++) {
+ *           rd_kafka_message_t *rkm = rd_kafka_messages_get(batch, i);
+ *           if (process(rkm) == OK)
+ *               // Processed successfully.
+ *               rd_kafka_share_acknowledge_type(
+ *                   rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT);
+ *           else if (is_temporary(rkm))
+ *               // Temporary failure: release for redelivery (possibly to
+ *               // another member) so it can be retried.
+ *               rd_kafka_share_acknowledge_type(
+ *                   rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE);
+ *           else
+ *               // Permanent failure (e.g. a "poison" record): reject so it
+ *               // is not delivered again.
+ *               rd_kafka_share_acknowledge_type(
+ *                   rkshare, rkm, RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT);
+ *       }
+ *       // Every record must be acknowledged before the next poll.
+ *   }
+ *   rd_kafka_error_destroy(error); // NULL-safe
+ *   rd_kafka_messages_destroy(batch);
+ * @endcode
+ *
+ * For complete runnable programs see \c examples/share_consumer.c,
+ * \c examples/share_consumer_commit_sync.c and
+ * \c examples/share_consumer_commit_async.c.
+ *
+ * @par Thread safety
+ * The share consumer handle is **not thread-safe by design**: a single
+ * \c rd_kafka_share_t handle must not be used concurrently from multiple
+ * threads. This matches the share consumer design in KIP-932. Use one handle
+ * per thread, or serialise all access to a handle. Concurrent use is detected
+ * on a best-effort basis and rejected with RD_KAFKA_RESP_ERR__CONFLICT. Unlike
+ * the classic consumer there is no wakeup mechanism in this preview, so a
+ * blocking poll/commit ends only when its timeout expires.
+ *
+ * @par Closing
+ * Close the consumer with rd_kafka_share_consumer_close() (or the asynchronous
+ * rd_kafka_share_consumer_close_queue()), which sends any pending
+ * acknowledgements and leaves the share group, then free the handle with
+ * rd_kafka_share_destroy(). Close takes no timeout argument in this preview and
+ * is bounded internally to roughly \c socket.timeout.ms.
+ *
+ * @par Current limitations (preview)
+ *  - No strict per-poll record limit: \c max.poll.records is a soft bound.
+ *  - Acknowledgement types are limited to ACCEPT / RELEASE / REJECT; there is
+ *    no acquisition-lock renewal, so a long-running handler cannot extend a
+ *    record's lock and the record may be redelivered.
+ *  - No wakeup API; blocking calls end only at their timeout.
+ *  - No share-group admin operations and no share-consumer client metrics APIs.
+ *  - Topics are resolved by id; auto topic creation is not performed.
+ *  - Some app-visible error codes differ from other clients because librdkafka
+ *    generates certain failures locally (for example
+ *    RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER, RD_KAFKA_RESP_ERR__TRANSPORT,
+ *    RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH).
+ *
+ * @sa rd_kafka_share_consumer_new()
+ * @sa rd_kafka_share_set_acknowledgement_commit_cb()
+ * @sa rd_kafka_share_subscribe()
+ * @sa rd_kafka_share_unsubscribe()
+ * @sa rd_kafka_share_subscription()
+ * @sa rd_kafka_share_poll()
+ * @sa rd_kafka_messages_count()
+ * @sa rd_kafka_messages_get()
+ * @sa rd_kafka_messages_destroy()
+ * @sa rd_kafka_message_delivery_count()
+ * @sa rd_kafka_share_acknowledge()
+ * @sa rd_kafka_share_acknowledge_type()
+ * @sa rd_kafka_share_acknowledge_offset()
+ * @sa rd_kafka_share_commit_sync()
+ * @sa rd_kafka_share_commit_async()
+ * @sa rd_kafka_share_consumer_close()
+ * @sa rd_kafka_share_consumer_close_queue()
+ * @sa rd_kafka_share_consumer_closed()
+ * @sa rd_kafka_share_destroy()
+ * @sa rd_kafka_share_destroy_flags()
+ * @sa rd_kafka_share_set_log_queue()
+ * @sa rd_kafka_share_sasl_background_callbacks_enable()
+ * @sa rd_kafka_share_sasl_set_credentials()
+ * @sa rd_kafka_share_oauthbearer_set_token()
+ * @sa rd_kafka_share_oauthbearer_set_token_failure()
  */
 
 /**
@@ -5356,6 +5569,12 @@ RD_EXPORT size_t rd_kafka_share_partition_offsets_offsets_cnt(
  * @returns The share consumer handle on success or NULL on error
  *          (see \p errstr).
  *
+ * @remark \c group.id is required. \c share.acknowledgement.mode is optional
+ *         and defaults to \c implicit. See \ref CONFIGURATION.md for
+ *         share-consumer defaults and the properties that are not supported
+ *         for share consumers.
+ *
+ * @sa rd_kafka_share_subscribe()
  * @sa rd_kafka_share_destroy()
  */
 RD_EXPORT
@@ -5387,13 +5606,13 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
  *         calling this function during which the new registration state
  *         is not yet visible to the main thread.
  *
- * @returns NULL on success, or an rd_kafka_error_t* on failure:
- *          - RD_KAFKA_RESP_ERR__STATE if called from within the callback or
- *            after the share consumer has been closed.
- *          - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently
- *            inside a share consumer API.
- *          The caller must destroy the returned error with
- *          rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an rd_kafka_error_t* (which must be freed
+ *          with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been closed, or the call is made from inside the
+ *    acknowledgement-commit callback, etc.
  */
 RD_EXPORT rd_kafka_error_t *rd_kafka_share_set_acknowledgement_commit_cb(
     rd_kafka_share_t *rkshare,
@@ -5429,11 +5648,17 @@ RD_EXPORT rd_kafka_error_t *rd_kafka_share_set_acknowledgement_commit_cb(
  *         rd_kafka_share_unsubscribe(): the subscription is cleared and
  *         RD_KAFKA_RESP_ERR_NO_ERROR is returned.
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or when \p topics is empty
- *          (treated as unsubscribe),
- *          RD_KAFKA_RESP_ERR__INVALID_ARG if \p topics contains empty topic
- *          names or duplicate entries,
- *          RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success, or when \p topics is empty
+ *    (treated as unsubscribe).
+ *  - RD_KAFKA_RESP_ERR__INVALID_ARG if \p topics contains empty topic names or
+ *    duplicate entries.
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been (or is being) closed, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *  - RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
  */
 RD_EXPORT rd_kafka_resp_err_t
 rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
@@ -5443,7 +5668,18 @@ rd_kafka_share_subscribe(rd_kafka_share_t *rkshare,
 /**
  * @brief Unsubscribe from the current subscription set.
  *
+ * Clears the subscription; the broker removes the member from the share group.
+ *
  * @param rkshare Share consumer instance.
+ *
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success.
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been (or is being) closed, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *  - Otherwise, an error code from the underlying unsubscribe.
  */
 RD_EXPORT
 rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare);
@@ -5456,8 +5692,15 @@ rd_kafka_resp_err_t rd_kafka_share_unsubscribe(rd_kafka_share_t *rkshare);
  * @param topics  Output pointer to a newly allocated topic list (possibly
  *                empty) on success.
  *
- * @returns An error code on failure, otherwise \p topics is updated
- *          to point to a newly allocated topic list (possibly empty).
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success, in which case \p topics is updated
+ *    to point to a newly allocated topic list (possibly empty).
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been (or is being) closed, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *  - Otherwise, an error code from the underlying subscription query.
  *
  * @remark The application is responsible for calling
  *         rd_kafka_topic_partition_list_destroy on the returned list.
@@ -5488,11 +5731,36 @@ rd_kafka_share_subscription(rd_kafka_share_t *rkshare,
  * Use rd_kafka_messages_count() and rd_kafka_messages_get() to access the
  * returned messages.
  *
- * @note The rkmessages should always be pointing to NULL otherwise it will
- *       be lost and there will be memory leak.
+ * @returns NULL on success (including a timeout with no messages, in which
+ *          case \c *rkmessages is NULL), otherwise an \c rd_kafka_error_t
+ *          (which must be freed with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is not subscribed, it has been closed, or (explicit mode) records
+ *    from the previous poll have not all been acknowledged, etc.
+ *  - RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED if the caller is not
+ *    authorized to read one of the subscribed topics or the share group.
+ *  - A fatal-flagged error (rd_kafka_error_is_fatal() is true) carrying the
+ *    specific error code, if a fatal error has been raised on the handle.
+ *  - Another error code for any other failure encountered while fetching.
  *
- * @returns NULL on success or an \c rd_kafka_error_t (caller must
- *          rd_kafka_error_destroy()) on failure.
+ * @note \c *rkmessages must point to NULL on entry. The function
+ * unconditionally overwrites \c *rkmessages, so any non-NULL value it held on
+ * entry is overwritten and leaked.
+ *
+ * @remark A single call returns either an error or messages, never both: on
+ *         failure a non-NULL error is returned and \c *rkmessages is NULL; on
+ *         success the error is NULL and \c *rkmessages points to the batch.
+ *         On a timeout with no messages both are NULL.
+ *
+ * @remark Record-level errors are delivered as messages with a non-zero
+ *         \c rd_kafka_message_t.err field (topic/partition/offset intact);
+ *         the application should inspect each message's \c err.
+ *
+ * @remark In explicit acknowledgement mode every record returned by the
+ *         previous poll must be acknowledged before calling this function
+ *         again.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
@@ -5509,12 +5777,15 @@ rd_kafka_error_t *rd_kafka_share_poll(rd_kafka_share_t *rkshare,
  * @param rkshare Share consumer handle.
  * @param rkmessage Message to acknowledge.
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success,
- *          RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters
- *          (e.g. rkmessage is NULL),
- *          RD_KAFKA_RESP_ERR__STATE if there is some internal discrepancy
- *          like we are not in explicit acknowledgement mode or
- *          offset is a GAP record.
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success.
+ *  - RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters (e.g. rkmessage
+ *    is NULL).
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is not in explicit acknowledgement mode, it has been closed, or
+ *    the message is unknown, etc.
  */
 RD_EXPORT
 rd_kafka_resp_err_t
@@ -5528,12 +5799,15 @@ rd_kafka_share_acknowledge(rd_kafka_share_t *rkshare,
  * @param rkmessage Message to acknowledge.
  * @param type Acknowledgement type (ACCEPT, RELEASE, or REJECT).
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success,
- *          RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters
- *          (e.g. rkmessage is NULL),
- *          RD_KAFKA_RESP_ERR__STATE if there is some internal discrepancy
- *          like we are not in explicit acknowledgement mode or
- *          offset is a GAP record.
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success.
+ *  - RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters (e.g. rkmessage
+ *    is NULL or \p type is out of range).
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is not in explicit acknowledgement mode, it has been closed, or
+ *    the message is unknown, etc.
  */
 RD_EXPORT
 rd_kafka_resp_err_t
@@ -5554,12 +5828,15 @@ rd_kafka_share_acknowledge_type(rd_kafka_share_t *rkshare,
  * @param offset Offset to acknowledge.
  * @param type Acknowledgement type (ACCEPT, RELEASE, or REJECT).
  *
- * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success,
- *          RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters
- *          (e.g. topic is NULL or partition < 0),
- *          RD_KAFKA_RESP_ERR__STATE if there is some internal discrepancy
- *          like we are not in explicit acknowledgement mode or
- *          offset is a GAP record.
+ * @returns
+ *  - RD_KAFKA_RESP_ERR_NO_ERROR on success.
+ *  - RD_KAFKA_RESP_ERR__INVALID_ARG on invalid input parameters (e.g. topic is
+ *    NULL, partition < 0, offset < 0, or \p type is out of range).
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is not in explicit acknowledgement mode, it has been closed, or
+ *    the offset is unknown, etc.
  */
 RD_EXPORT
 rd_kafka_resp_err_t
@@ -5578,10 +5855,21 @@ rd_kafka_share_acknowledge_offset(rd_kafka_share_t *rkshare,
  * This function returns immediately — the acknowledgements are sent
  * asynchronously via the broker threads.
  *
+ * The per-partition outcome is delivered to the acknowledgement-commit
+ * callback registered with rd_kafka_share_set_acknowledgement_commit_cb().
+ * Failed acknowledgements are not retried automatically.
+ *
  * @param rkshare Share consumer instance.
  *
- * @returns NULL on success, or an rd_kafka_error_t* on failure.
- *          The returned error must be freed with rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an \c rd_kafka_error_t* (which must be
+ *          freed with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been (or is being) closed, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *
+ * @sa rd_kafka_share_set_acknowledgement_commit_cb()
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare);
@@ -5596,16 +5884,31 @@ rd_kafka_error_t *rd_kafka_share_commit_async(rd_kafka_share_t *rkshare);
  * In implicit ack mode, all ACQUIRED records from the previous poll
  * are first converted to ACCEPT before committing.
  *
+ * Failed acknowledgements are not retried automatically; the per-partition
+ * error is reported through \p partitions.
+ *
  * @param rkshare Share consumer instance.
  * @param timeout_ms Timeout in milliseconds.
  * @param partitions [out] Per-partition results. Each partition's err
- *                   field contains the result for that partition.
+ *                   field contains the result for that partition — for example
+ *                   RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT (on timeout),
+ *                   RD_KAFKA_RESP_ERR_NOT_LEADER_OR_FOLLOWER,
+ *                   RD_KAFKA_RESP_ERR__TRANSPORT, or a share-session error such
+ *                   as RD_KAFKA_RESP_ERR_INVALID_SHARE_SESSION_EPOCH, etc.
  *                   The caller must destroy the returned list with
  *                   rd_kafka_topic_partition_list_destroy().
  *                   Set to NULL if no acks were pending.
  *
- * @returns NULL on success, or an rd_kafka_error_t* on failure.
- *          The returned error must be freed with rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an \c rd_kafka_error_t* (which must be
+ *          freed with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer has been (or is being) closed, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *
+ *          A non-NULL error reflects a call-level failure; per-partition
+ *          failures are reported through \p partitions.
  */
 RD_EXPORT
 rd_kafka_error_t *
@@ -5623,11 +5926,14 @@ rd_kafka_share_commit_sync(rd_kafka_share_t *rkshare,
  *
  * @param rkshare Share consumer instance.
  *
- * @returns NULL on success, or an error object describing the failure.
- *          The returned error object must be freed with
- *          rd_kafka_error_destroy(). If the consumer has raised a fatal
- *          error, the returned error's code will be
- *          RD_KAFKA_RESP_ERR__FATAL.
+ * @returns NULL on success, otherwise an error object (which must be freed
+ *          with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is already closed or closing, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
+ *  - RD_KAFKA_RESP_ERR__FATAL if the consumer has raised a fatal error.
  *
  * @remark The application still needs to call rd_kafka_share_destroy() after
  *         this call finishes to clean up the underlying handle resources.
@@ -5649,7 +5955,13 @@ rd_kafka_error_t *rd_kafka_share_consumer_close(rd_kafka_share_t *rkshare);
  * @param rkshare Share consumer instance.
  * @param rkqu    Queue to forward close callbacks to.
  *
- * @returns an error object if the consumer close failed, else NULL.
+ * @returns NULL on success, otherwise an error object (which must be freed
+ *          with rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently inside a
+ *    share consumer API.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    consumer is already closed or closing, or the call is made from inside
+ *    the acknowledgement-commit callback, etc.
  *
  * @sa rd_kafka_share_consumer_closed()
  */
@@ -5679,12 +5991,15 @@ int rd_kafka_share_consumer_closed(rd_kafka_share_t *rkshare);
  *
  * @param rkshare Share consumer instance.
  *
- * @returns NULL on success, or an error object if another thread is
- *          concurrently using the share consumer (including a call made from
- *          inside the acknowledgement callback). In the error case the instance
- *          is NOT destroyed; the application must ensure no other thread is
- *          using it and call destroy again. The returned error object must be
- *          freed with rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an error object (which must be freed with
+ *          rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently using the
+ *    share consumer.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    call is made from inside the acknowledgement-commit callback, etc.
+ *
+ *          In the error case the instance is NOT destroyed; the application
+ *          must ensure no other thread is using it and call destroy again.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_destroy(rd_kafka_share_t *rkshare);
@@ -5697,10 +6012,14 @@ rd_kafka_error_t *rd_kafka_share_destroy(rd_kafka_share_t *rkshare);
  *
  * @param flags Destroy flags (see RD_KAFKA_DESTROY_F_* defines).
  *
- * @returns NULL on success, or an error object if another thread is
- *          concurrently using the share consumer. In the error case the
- *          instance is NOT destroyed. The returned error object must be freed
- *          with rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an error object (which must be freed with
+ *          rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__CONFLICT if another thread is concurrently using the
+ *    share consumer.
+ *  - RD_KAFKA_RESP_ERR__STATE if called in an invalid state — for example the
+ *    call is made from inside the acknowledgement-commit callback, etc.
+ *
+ *          In the error case the instance is NOT destroyed.
  */
 RD_EXPORT
 rd_kafka_error_t *rd_kafka_share_destroy_flags(rd_kafka_share_t *rkshare,
@@ -5728,13 +6047,10 @@ rd_kafka_error_t *rd_kafka_share_destroy_flags(rd_kafka_share_t *rkshare,
  *
  * @remark librdkafka maintains its own reference to the provided queue.
  *
- * @returns NULL on success or an error object on failure.
- *          The error code will be RD_KAFKA_RESP_ERR__INVALID_ARG if rkshare
- *          is NULL or uninitialized, or RD_KAFKA_RESP_ERR__NOT_CONFIGURED
- *          when log.queue is not set to true.
- *
- *          The returned error object (if any) must be destroyed with
- *          rd_kafka_error_destroy().
+ * @returns NULL on success, otherwise an error object (which must be freed with
+ *          rd_kafka_error_destroy()) with one of:
+ *  - RD_KAFKA_RESP_ERR__INVALID_ARG if \p rkshare is NULL or uninitialized.
+ *  - RD_KAFKA_RESP_ERR__NOT_CONFIGURED if `log.queue` is not set to true.
  *
  * @sa rd_kafka_set_log_queue
  */

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5237,8 +5237,9 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *
  * @warning **Preview feature.** The share consumer is provided as a preview:
  *          the public interfaces may change in a future release and it is not
- *          recommended for production use. See the "Current limitations"
- *          section below.
+ *          recommended for production use. It is currently available through
+ *          the C API only; there is no C++ wrapper yet. See the "Current
+ *          limitations" section below.
  *
  * @par Overview
  * A share consumer lets multiple members of a *share group* cooperatively

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5248,9 +5248,12 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  * one member of the group at a time. In a share group a single partition may
  * be consumed by several members at once, and individual records — rather than
  * partition offsets — are the unit of progress: each delivered record is
- * *acquired* by a member, processed, and then *acknowledged*. Records that are
- * not acknowledged in time, or that are released, become available again and
- * may be redelivered (possibly to a different member).
+ * *acquired* by a member under a time-limited acquisition lock, processed, and
+ * then *acknowledged*. The lock duration is a broker/group setting
+ * (\c group.share.record.lock.duration.ms, 30 seconds by default) and is not
+ * configured on this client. A record that is not acknowledged before its lock
+ * expires, or that is released, becomes available again and may be redelivered
+ * (possibly to a different member).
  *
  * A share consumer is created with rd_kafka_share_consumer_new() rather than
  * rd_kafka_new(), and is represented by the opaque \c rd_kafka_share_t handle.


### PR DESCRIPTION
Add user-facing docs for the preview share consumer: rdkafka.h API reference, INTRODUCTION.md usage section + KIP table row, README feature bullet, CHANGELOG 2.15.0 entry, and examples listing.