### PR TITLE
[KIP-932] Share consumer Preview warning, example improvements, and docs

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2054,7 +2054,9 @@ There are two acknowledgement modes, selected by `share.acknowledgement.mode`:
   `rd_kafka_share_acknowledge_type()` or `rd_kafka_share_acknowledge_offset()`)
   before the next poll. If any record from the previous batch is still
   unacknowledged, `rd_kafka_share_poll()` returns
-  `RD_KAFKA_RESP_ERR__STATE`.
+  `RD_KAFKA_RESP_ERR__STATE`. Records you have acknowledged but not yet
+  committed are also committed when the consumer is closed (unless it is
+  destroyed with `RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE`).
 
 Acknowledgements are sent to the broker as part of the next poll, or flushed
 explicitly with `rd_kafka_share_commit_async()` (fire-and-forget) or

--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -2037,6 +2037,9 @@ Every acquired record is acknowledged with one of three types:
 * **REJECT** (`RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT`) — do not deliver the
   record again.
 
+**Note**: RENEW (acquisition-lock renewal) is not yet available; see
+[Current limitations](#share-consumer-current-limitations).
+
 The number of times a record has already been delivered is available via
 `rd_kafka_message_delivery_count()`, which is useful to detect and reject a
 "poison" record after a threshold. The broker also enforces its own maximum

--- a/examples/share_consumer.c
+++ b/examples/share_consumer.c
@@ -28,9 +28,16 @@
  */
 
 /**
- * Simple high-level balanced Apache Kafka consumer
- * using the Kafka driver from librdkafka
- * (https://github.com/confluentinc/librdkafka)
+ * Example KIP-932 share consumer in the default (implicit) ack mode.
+ *
+ * Consumers in a share group share partitions like a queue. In implicit
+ * mode each record is acknowledged for you on the next rd_kafka_share_poll();
+ * there is nothing to ack from the application. If this consumer crashes
+ * before the next poll, the records it held are redelivered to another
+ * consumer in the group.
+ *
+ * Usage:
+ *   share_consumer <broker> <group.id> <topic1> [topic2 ...]
  */
 
 #ifndef _POSIX_C_SOURCE
@@ -85,6 +92,7 @@ int main(int argc, char **argv) {
         int topic_cnt; /* Number of topics to subscribe to */
         rd_kafka_topic_partition_list_t *subscription; /* Subscribed topics */
         int i;
+        int ret = 0; /* Process exit code */
 
         /*
          * Argument validation
@@ -198,10 +206,17 @@ int main(int argc, char **argv) {
                 error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
-                        fprintf(stderr, "%% Consume error: %s\n",
+                        int fatal = rd_kafka_error_is_fatal(error);
+                        fprintf(stderr, "%% Consume error%s: %s\n",
+                                fatal ? " (fatal)" : "",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         rd_kafka_messages_destroy(rkmessages);
+                        /* A fatal error is unrecoverable: stop consuming. */
+                        if (fatal) {
+                                ret = 1;
+                                goto done;
+                        }
                         continue;
                 }
 
@@ -212,6 +227,14 @@ int main(int argc, char **argv) {
                             rd_kafka_messages_get(rkmessages, i);
 
                         if (rkm->err) {
+                                /* A record delivered with an error has already
+                                 * been acknowledged for you by the library:
+                                 * RELEASE (put back for retry) for decompression
+                                 * errors, and REJECT (give up) for CRC or
+                                 * unsupported-format errors. You can still
+                                 * override that by acknowledging the offset
+                                 * yourself if your application needs different
+                                 * handling. */
                                 fprintf(stderr,
                                         "%% Consumer error: %d: "
                                         "%s\n",
@@ -244,6 +267,7 @@ int main(int argc, char **argv) {
         }
 
 
+done:
         /* Close the consumer: commit final offsets and leave the group. */
         fprintf(stderr, "%% Closing share consumer\n");
         rd_kafka_share_consumer_close(rkshare);
@@ -252,5 +276,5 @@ int main(int argc, char **argv) {
         /* Destroy the consumer */
         rd_kafka_share_destroy(rkshare);
 
-        return 0;
+        return ret;
 }

--- a/examples/share_consumer.c
+++ b/examples/share_consumer.c
@@ -41,25 +41,12 @@
 #include <signal.h>
 #include <string.h>
 #include <ctype.h>
-#include <time.h>
 
 
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is builtin from within the librdkafka source tree and thus differs. */
 // #include <librdkafka/rdkafka.h>
 #include "rdkafka.h"
-
-#define TIME_BLOCK_MS(elapsed_var, expr)                                       \
-        do {                                                                   \
-                struct timespec __t0, __t1;                                    \
-                if (clock_gettime(CLOCK_MONOTONIC, &__t0) != 0)                \
-                        perror("clock_gettime");                               \
-                expr;                                                          \
-                if (clock_gettime(CLOCK_MONOTONIC, &__t1) != 0)                \
-                        perror("clock_gettime");                               \
-                (elapsed_var) = (__t1.tv_sec - __t0.tv_sec) * 1000.0 +         \
-                                (__t1.tv_nsec - __t0.tv_nsec) / 1e6;           \
-        } while (0)
 
 
 static volatile sig_atomic_t run = 1;
@@ -207,14 +194,8 @@ int main(int argc, char **argv) {
                 size_t rcvd_msgs                = 0;
                 size_t i;
                 rd_kafka_error_t *error;
-                double __elapsed_ms;
 
-                TIME_BLOCK_MS(__elapsed_ms, error = rd_kafka_share_poll(
-                                                rkshare, 3000, &rkmessages));
-                fprintf(stdout,
-                        "%% rd_kafka_share_poll() took "
-                        "%.3f ms\n",
-                        __elapsed_ms);
+                error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
                         fprintf(stderr, "%% Consume error: %s\n",

--- a/examples/share_consumer.c
+++ b/examples/share_consumer.c
@@ -229,12 +229,12 @@ int main(int argc, char **argv) {
                         if (rkm->err) {
                                 /* A record delivered with an error has already
                                  * been acknowledged for you by the library:
-                                 * RELEASE (put back for retry) for decompression
-                                 * errors, and REJECT (give up) for CRC or
-                                 * unsupported-format errors. You can still
-                                 * override that by acknowledging the offset
-                                 * yourself if your application needs different
-                                 * handling. */
+                                 * RELEASE (put back for retry) for
+                                 * decompression errors, and REJECT (give up)
+                                 * for CRC or unsupported-format errors. You can
+                                 * still override that by acknowledging the
+                                 * offset yourself if your application needs
+                                 * different handling. */
                                 fprintf(stderr,
                                         "%% Consumer error: %d: "
                                         "%s\n",

--- a/examples/share_consumer_commit_async.c
+++ b/examples/share_consumer_commit_async.c
@@ -35,11 +35,11 @@
  *
  * This example demonstrates:
  *  - Consuming records with rd_kafka_share_poll()
- *  - Explicitly acknowledging individual records with
- *    rd_kafka_share_acknowledge_type() using ACCEPT or RELEASE
- *    (RELEASE at ~50% rate to simulate redelivery)
- *  - Committing acknowledgements asynchronously with
- *    rd_kafka_share_commit_async() at ~10% rate mid-batch
+ *  - Explicitly acknowledging each record with
+ *    rd_kafka_share_acknowledge_type() (ACCEPT)
+ *  - Committing the batch's acknowledgements asynchronously with
+ *    rd_kafka_share_commit_async() once per poll; the broker's reply is
+ *    delivered later to the acknowledgement-commit callback
  */
 
 #ifndef _POSIX_C_SOURCE
@@ -50,8 +50,6 @@
 #include <signal.h>
 #include <string.h>
 #include <ctype.h>
-#include <stdlib.h>
-#include <time.h>
 
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is builtin from within the librdkafka source tree and thus differs. */
@@ -82,6 +80,68 @@ static int is_printable(const char *buf, size_t size) {
 }
 
 
+/**
+ * @brief Acknowledgement-commit callback.
+ *
+ * rd_kafka_share_commit_async() does not block; its result is reported here.
+ * @p partitions lists each partition with the offsets that were committed;
+ * @p err is set if the commit failed.
+ */
+static void
+acknowledgement_commit_cb(rd_kafka_share_t *rkshare,
+                          rd_kafka_share_partition_offsets_list_t *partitions,
+                          rd_kafka_resp_err_t err,
+                          void *opaque) {
+        size_t i, cnt;
+
+        if (err) {
+                fprintf(stderr, "%% Acknowledgement commit failed: %s\n",
+                        rd_kafka_err2str(err));
+                return;
+        }
+
+        cnt = rd_kafka_share_partition_offsets_list_count(partitions);
+        for (i = 0; i < cnt; i++) {
+                const rd_kafka_share_partition_offsets_t *po =
+                    rd_kafka_share_partition_offsets_list_get(partitions, i);
+                const rd_kafka_topic_partition_t *tp =
+                    rd_kafka_share_partition_offsets_partition(po);
+                size_t offset_cnt =
+                    rd_kafka_share_partition_offsets_offsets_cnt(po);
+
+                fprintf(stderr,
+                        "%% Committed %s [%" PRId32 "]: %zu offset(s)\n",
+                        tp->topic, tp->partition, offset_cnt);
+        }
+}
+
+
+/**
+ * @brief Process a received record.
+ *
+ * Replace this with your own handling. The return value tells the caller how
+ * to acknowledge the record:
+ *   0   success           -> ACCEPT  (done, never redeliver it)
+ *   > 0 transient failure  -> RELEASE (retry later, maybe another consumer)
+ *   < 0 permanent failure  -> REJECT  (give up; the broker archives it)
+ */
+static int process_message(const rd_kafka_message_t *rkm) {
+        printf("Message on %s [%" PRId32 "] at offset %" PRId64,
+               rd_kafka_topic_name(rkm->rkt), rkm->partition, rkm->offset);
+
+        if (rkm->key && is_printable(rkm->key, rkm->key_len))
+                printf(" Key: %.*s", (int)rkm->key_len, (const char *)rkm->key);
+
+        if (rkm->payload && is_printable(rkm->payload, rkm->len))
+                printf(" Value: %.*s", (int)rkm->len,
+                       (const char *)rkm->payload);
+
+        printf("\n");
+
+        return 0;
+}
+
+
 int main(int argc, char **argv) {
         rd_kafka_share_t *rkshare;
         rd_kafka_conf_t *conf;
@@ -92,7 +152,9 @@ int main(int argc, char **argv) {
         char **topics;
         int topic_cnt;
         rd_kafka_topic_partition_list_t *subscription;
+        rd_kafka_error_t *cb_error;
         int i;
+        int ret = 0; /* Process exit code */
 
         if (argc < 4) {
                 fprintf(stderr,
@@ -139,6 +201,20 @@ int main(int argc, char **argv) {
 
         conf = NULL;
 
+        /* Register the acknowledgement-commit callback that
+         * rd_kafka_share_commit_async() reports its result to. */
+        cb_error = rd_kafka_share_set_acknowledgement_commit_cb(
+            rkshare, acknowledgement_commit_cb, NULL);
+        if (cb_error) {
+                fprintf(stderr,
+                        "%% Failed to set acknowledgement commit callback: "
+                        "%s\n",
+                        rd_kafka_error_string(cb_error));
+                rd_kafka_error_destroy(cb_error);
+                rd_kafka_share_destroy(rkshare);
+                return 1;
+        }
+
         subscription = rd_kafka_topic_partition_list_new(topic_cnt);
         for (i = 0; i < topic_cnt; i++)
                 rd_kafka_topic_partition_list_add(subscription, topics[i],
@@ -162,22 +238,26 @@ int main(int argc, char **argv) {
 
         signal(SIGINT, stop);
 
-        srand((unsigned int)time(NULL));
-
         while (run) {
                 rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd_msgs;
                 rd_kafka_error_t *error;
+                size_t rcvd_msgs;
                 size_t k;
 
-                printf("Calling rd_kafka_share_poll()\n");
                 error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
-                        fprintf(stderr, "%% Consume error: %s\n",
+                        int fatal = rd_kafka_error_is_fatal(error);
+                        fprintf(stderr, "%% Consume error%s: %s\n",
+                                fatal ? " (fatal)" : "",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         rd_kafka_messages_destroy(rkmessages);
+                        /* A fatal error is unrecoverable: stop consuming. */
+                        if (fatal) {
+                                ret = 1;
+                                goto done;
+                        }
                         continue;
                 }
 
@@ -192,39 +272,37 @@ int main(int argc, char **argv) {
                 for (k = 0; k < rcvd_msgs; k++) {
                         rd_kafka_message_t *rkm =
                             rd_kafka_messages_get(rkmessages, k);
+                        rd_kafka_share_AcknowledgeType_t ack_type;
+                        int rc;
 
                         if (rkm->err) {
+                                /* A record delivered with an error has already
+                                 * been acknowledged for you by the library:
+                                 * RELEASE (put back for retry) for decompression
+                                 * errors, and REJECT (give up) for CRC or
+                                 * unsupported-format errors. You can still
+                                 * override that by acknowledging the offset
+                                 * yourself if your application needs different
+                                 * handling. */
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
                                 continue;
                         }
 
-                        /* Randomly RELEASE ~50% of messages,
-                         * ACCEPT the rest. */
-                        rd_kafka_share_AcknowledgeType_t ack_type =
-                            ((rand() % 100) < 50)
-                                ? RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE
-                                : RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
-
-                        printf("Message on %s [%" PRId32 "] at offset %" PRId64
-                               " -> %s",
-                               rd_kafka_topic_name(rkm->rkt), rkm->partition,
-                               rkm->offset,
-                               ack_type ==
-                                       RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT
-                                   ? "ACCEPT"
-                                   : "RELEASE");
-
-                        if (rkm->key && is_printable(rkm->key, rkm->key_len))
-                                printf(" Key: %.*s", (int)rkm->key_len,
-                                       (const char *)rkm->key);
-
-                        if (rkm->payload &&
-                            is_printable(rkm->payload, rkm->len))
-                                printf(" Value: %.*s", (int)rkm->len,
-                                       (const char *)rkm->payload);
-
-                        printf("\n");
+                        /* Decide how to acknowledge based on the processing
+                         * outcome: ACCEPT on success, RELEASE on a transient
+                         * failure so the record can be retried, REJECT on a
+                         * permanent failure so the broker archives it. */
+                        rc = process_message(rkm);
+                        if (rc == 0)
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
+                        else if (rc > 0)
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
+                        else
+                                ack_type =
+                                    RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
 
                         err = rd_kafka_share_acknowledge_type(rkshare, rkm,
                                                               ack_type);
@@ -235,30 +313,26 @@ int main(int argc, char **argv) {
                                         rd_kafka_topic_name(rkm->rkt),
                                         rkm->partition, rkm->offset,
                                         rd_kafka_err2str(err));
-
-                        /* Randomly commit ~10% of the time to
-                         * exercise async commit mid-batch. */
-                        if (run && (rand() % 100) < 10) {
-                                printf(
-                                    "Calling "
-                                    "rd_kafka_share_commit_async()\n");
-                                error = rd_kafka_share_commit_async(rkshare);
-                                if (error) {
-                                        fprintf(stderr,
-                                                "%% Commit async "
-                                                "error: %s\n",
-                                                rd_kafka_error_string(error));
-                                        rd_kafka_error_destroy(error);
-                                }
-                        }
                 }
+
+                /* Flush this batch's acknowledgements before the next poll().
+                 * commit_async() does not block; the result is delivered to
+                 * the acknowledgement-commit callback. */
+                error = rd_kafka_share_commit_async(rkshare);
+                if (error) {
+                        fprintf(stderr, "%% Commit async error: %s\n",
+                                rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                }
+
                 rd_kafka_messages_destroy(rkmessages);
         }
 
+done:
         fprintf(stderr, "%% Closing share consumer\n");
         rd_kafka_share_consumer_close(rkshare);
 
         rd_kafka_share_destroy(rkshare);
 
-        return 0;
+        return ret;
 }

--- a/examples/share_consumer_commit_async.c
+++ b/examples/share_consumer_commit_async.c
@@ -278,12 +278,12 @@ int main(int argc, char **argv) {
                         if (rkm->err) {
                                 /* A record delivered with an error has already
                                  * been acknowledged for you by the library:
-                                 * RELEASE (put back for retry) for decompression
-                                 * errors, and REJECT (give up) for CRC or
-                                 * unsupported-format errors. You can still
-                                 * override that by acknowledging the offset
-                                 * yourself if your application needs different
-                                 * handling. */
+                                 * RELEASE (put back for retry) for
+                                 * decompression errors, and REJECT (give up)
+                                 * for CRC or unsupported-format errors. You can
+                                 * still override that by acknowledging the
+                                 * offset yourself if your application needs
+                                 * different handling. */
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
                                 continue;

--- a/examples/share_consumer_commit_sync.c
+++ b/examples/share_consumer_commit_sync.c
@@ -231,12 +231,12 @@ int main(int argc, char **argv) {
                         if (rkm->err) {
                                 /* A record delivered with an error has already
                                  * been acknowledged for you by the library:
-                                 * RELEASE (put back for retry) for decompression
-                                 * errors, and REJECT (give up) for CRC or
-                                 * unsupported-format errors. You can still
-                                 * override that by acknowledging the offset
-                                 * yourself if your application needs different
-                                 * handling. */
+                                 * RELEASE (put back for retry) for
+                                 * decompression errors, and REJECT (give up)
+                                 * for CRC or unsupported-format errors. You can
+                                 * still override that by acknowledging the
+                                 * offset yourself if your application needs
+                                 * different handling. */
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
                                 continue;

--- a/examples/share_consumer_commit_sync.c
+++ b/examples/share_consumer_commit_sync.c
@@ -35,11 +35,12 @@
  *
  * This example demonstrates:
  *  - Consuming records with rd_kafka_share_poll()
- *  - Explicitly acknowledging individual records with
- *    rd_kafka_share_acknowledge_type() using ACCEPT, RELEASE, or REJECT
- *  - Committing acknowledgements synchronously with
- *    rd_kafka_share_commit_sync() at ~10% rate mid-batch,
- *    printing per-partition results
+ *  - Explicitly acknowledging each record with
+ *    rd_kafka_share_acknowledge_type(): ACCEPT on successful processing,
+ *    RELEASE on a processing failure so the record can be redelivered
+ *  - Committing the batch's acknowledgements synchronously with
+ *    rd_kafka_share_commit_sync() once per poll, printing any
+ *    per-partition errors
  */
 
 #ifndef _POSIX_C_SOURCE
@@ -50,8 +51,6 @@
 #include <signal.h>
 #include <string.h>
 #include <ctype.h>
-#include <stdlib.h>
-#include <time.h>
 
 /* Typical include path would be <librdkafka/rdkafka.h>, but this program
  * is builtin from within the librdkafka source tree and thus differs. */
@@ -81,17 +80,31 @@ static int is_printable(const char *buf, size_t size) {
         return 1;
 }
 
-static const char *ack_type_to_str(rd_kafka_share_AcknowledgeType_t type) {
-        switch (type) {
-        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT:
-                return "ACCEPT";
-        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE:
-                return "RELEASE";
-        case RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT:
-                return "REJECT";
-        default:
-                return "UNKNOWN";
-        }
+/**
+ * @brief Process a received record.
+ *
+ * Replace this with your own handling. The return value tells the caller how
+ * to acknowledge the record:
+ *   0   success           -> ACCEPT  (done, never redeliver it)
+ *   > 0 transient failure  -> RELEASE (retry later, maybe another consumer)
+ *   < 0 permanent failure  -> REJECT  (give up; the broker archives it)
+ */
+static int process_message(const rd_kafka_message_t *rkm) {
+        printf("Message on %s [%" PRId32 "] at offset %" PRId64
+               " (delivery count: %" PRId16 ")",
+               rd_kafka_topic_name(rkm->rkt), rkm->partition, rkm->offset,
+               rd_kafka_message_delivery_count(rkm));
+
+        if (rkm->key && is_printable(rkm->key, rkm->key_len))
+                printf(" Key: %.*s", (int)rkm->key_len, (const char *)rkm->key);
+
+        if (rkm->payload && is_printable(rkm->payload, rkm->len))
+                printf(" Value: %.*s", (int)rkm->len,
+                       (const char *)rkm->payload);
+
+        printf("\n");
+
+        return 0;
 }
 
 
@@ -106,6 +119,7 @@ int main(int argc, char **argv) {
         int topic_cnt;
         rd_kafka_topic_partition_list_t *subscription;
         int i;
+        int ret = 0; /* Process exit code */
 
         if (argc < 4) {
                 fprintf(stderr,
@@ -175,22 +189,28 @@ int main(int argc, char **argv) {
 
         signal(SIGINT, stop);
 
-        srand((unsigned int)time(NULL));
-
         while (run) {
-                rd_kafka_messages_t *rkmessages = NULL;
-                size_t rcvd_msgs;
+                rd_kafka_messages_t *rkmessages            = NULL;
+                rd_kafka_topic_partition_list_t *committed = NULL;
                 rd_kafka_error_t *error;
+                size_t rcvd_msgs;
                 size_t k;
+                int j;
 
-                printf("Calling rd_kafka_share_poll()\n");
                 error = rd_kafka_share_poll(rkshare, 3000, &rkmessages);
 
                 if (error) {
-                        fprintf(stderr, "%% Consume error: %s\n",
+                        int fatal = rd_kafka_error_is_fatal(error);
+                        fprintf(stderr, "%% Consume error%s: %s\n",
+                                fatal ? " (fatal)" : "",
                                 rd_kafka_error_string(error));
                         rd_kafka_error_destroy(error);
                         rd_kafka_messages_destroy(rkmessages);
+                        /* A fatal error is unrecoverable: stop consuming. */
+                        if (fatal) {
+                                ret = 1;
+                                goto done;
+                        }
                         continue;
                 }
 
@@ -206,44 +226,36 @@ int main(int argc, char **argv) {
                         rd_kafka_message_t *rkm =
                             rd_kafka_messages_get(rkmessages, k);
                         rd_kafka_share_AcknowledgeType_t ack_type;
-                        int r;
+                        int rc;
 
                         if (rkm->err) {
+                                /* A record delivered with an error has already
+                                 * been acknowledged for you by the library:
+                                 * RELEASE (put back for retry) for decompression
+                                 * errors, and REJECT (give up) for CRC or
+                                 * unsupported-format errors. You can still
+                                 * override that by acknowledging the offset
+                                 * yourself if your application needs different
+                                 * handling. */
                                 fprintf(stderr, "%% Consumer error: %d: %s\n",
                                         rkm->err, rd_kafka_message_errstr(rkm));
                                 continue;
                         }
 
-                        /* Randomly choose ack type:
-                         *   50% ACCEPT, 30% RELEASE, 20% REJECT */
-                        r = rand() % 100;
-                        if (r < 50)
+                        /* Decide how to acknowledge based on the processing
+                         * outcome: ACCEPT on success, RELEASE on a transient
+                         * failure so the record can be retried, REJECT on a
+                         * permanent failure so the broker archives it. */
+                        rc = process_message(rkm);
+                        if (rc == 0)
                                 ack_type =
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT;
-                        else if (r < 80)
+                        else if (rc > 0)
                                 ack_type =
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE;
                         else
                                 ack_type =
                                     RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT;
-
-                        printf("Message on %s [%" PRId32 "] at offset %" PRId64
-                               " (delivery count: %" PRId16 ") -> %s",
-                               rd_kafka_topic_name(rkm->rkt), rkm->partition,
-                               rkm->offset,
-                               rd_kafka_message_delivery_count(rkm),
-                               ack_type_to_str(ack_type));
-
-                        if (rkm->key && is_printable(rkm->key, rkm->key_len))
-                                printf(" Key: %.*s", (int)rkm->key_len,
-                                       (const char *)rkm->key);
-
-                        if (rkm->payload &&
-                            is_printable(rkm->payload, rkm->len))
-                                printf(" Value: %.*s", (int)rkm->len,
-                                       (const char *)rkm->payload);
-
-                        printf("\n");
 
                         err = rd_kafka_share_acknowledge_type(rkshare, rkm,
                                                               ack_type);
@@ -254,54 +266,39 @@ int main(int argc, char **argv) {
                                         rd_kafka_topic_name(rkm->rkt),
                                         rkm->partition, rkm->offset,
                                         rd_kafka_err2str(err));
-
-                        /* Randomly commit ~10% of the time to
-                         * exercise sync commit mid-batch. */
-                        if (run && (rand() % 100) < 10) {
-                                rd_kafka_topic_partition_list_t *partitions =
-                                    NULL;
-
-                                printf(
-                                    "Calling "
-                                    "rd_kafka_share_commit_sync()\n");
-                                error = rd_kafka_share_commit_sync(
-                                    rkshare, 30000, &partitions);
-                                if (error) {
-                                        fprintf(stderr,
-                                                "%% Commit sync error: %s\n",
-                                                rd_kafka_error_string(error));
-                                        rd_kafka_error_destroy(error);
-                                } else if (partitions) {
-                                        int j;
-                                        printf(
-                                            "Commit sync results "
-                                            "(%d partitions):\n",
-                                            partitions->cnt);
-                                        for (j = 0; j < partitions->cnt; j++) {
-                                                rd_kafka_topic_partition_t
-                                                    *rktpar =
-                                                        &partitions->elems[j];
-                                                printf("  %s [%" PRId32
-                                                       "]: %s\n",
-                                                       rktpar->topic,
-                                                       rktpar->partition,
-                                                       rd_kafka_err2str(
-                                                           rktpar->err));
-                                        }
-                                        rd_kafka_topic_partition_list_destroy(
-                                            partitions);
-                                } else {
-                                        printf("No pending acks to commit\n");
-                                }
-                        }
                 }
+
+                /* Flush this batch's acknowledgements before the next poll().
+                 * commit_sync() blocks for the broker reply and reports the
+                 * per-partition outcome. */
+                error = rd_kafka_share_commit_sync(rkshare, 30000, &committed);
+                if (error) {
+                        fprintf(stderr, "%% Commit sync error: %s\n",
+                                rd_kafka_error_string(error));
+                        rd_kafka_error_destroy(error);
+                } else if (committed) {
+                        for (j = 0; j < committed->cnt; j++) {
+                                rd_kafka_topic_partition_t *rktpar =
+                                    &committed->elems[j];
+                                if (rktpar->err)
+                                        fprintf(stderr,
+                                                "%% Commit failed for "
+                                                "%s [%" PRId32 "]: %s\n",
+                                                rktpar->topic,
+                                                rktpar->partition,
+                                                rd_kafka_err2str(rktpar->err));
+                        }
+                        rd_kafka_topic_partition_list_destroy(committed);
+                }
+
                 rd_kafka_messages_destroy(rkmessages);
         }
 
+done:
         fprintf(stderr, "%% Closing share consumer\n");
         rd_kafka_share_consumer_close(rkshare);
 
         rd_kafka_share_destroy(rkshare);
 
-        return 0;
+        return ret;
 }

--- a/src/rdkafka.c
+++ b/src/rdkafka.c
@@ -3134,6 +3134,10 @@ rd_kafka_share_t *rd_kafka_share_consumer_new(rd_kafka_conf_t *conf,
                 return NULL;
         }
 
+        rd_kafka_log(rk, LOG_WARNING, "SHARECONSUMER",
+                     "The share consumer is in \"Preview\" and is not "
+                     "recommended for production use");
+
         rkshare                           = rd_calloc(1, sizeof(*rkshare));
         rkshare->rkshare_rk               = rk;
         rkshare->rkshare_unacked_cnt      = 0;

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5335,7 +5335,9 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *    rd_kafka_share_acknowledge_type() or rd_kafka_share_acknowledge_offset(),
  *    before the next poll. If any record from the previous batch is still
  *    unacknowledged, rd_kafka_share_poll() returns
- *    RD_KAFKA_RESP_ERR__STATE.
+ *    RD_KAFKA_RESP_ERR__STATE. Records you have acknowledged but not yet
+ *    committed are also committed when the consumer is closed (unless it is
+ *    destroyed with RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE).
  *
  * @par Committing acknowledgements
  * Acknowledgements are sent to the broker as part of the next poll, or

--- a/src/rdkafka.h
+++ b/src/rdkafka.h
@@ -5317,6 +5317,8 @@ rd_kafka_resp_err_t rd_kafka_purge(rd_kafka_t *rk, int purge_flags);
  *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE — not processed; make available
  *    again for redelivery.
  *  - #RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT  — do not deliver again.
+ * @note RENEW (acquisition-lock renewal) is not yet available; see
+ *       "Current limitations" below.
  * The number of times a record has been delivered is available via
  * rd_kafka_message_delivery_count(), which can be used to detect and reject
  * "poison" records after a threshold. The broker also enforces its own maximum

--- a/tests/0155-share_group_heartbeat_mock.c
+++ b/tests/0155-share_group_heartbeat_mock.c
@@ -1623,9 +1623,10 @@ static void do_test_multiple_members_partition_distribution(void) {
         rd_kafka_topic_partition_list_t *share_c1_assign, *share_c2_assign,
             *share_c3_assign;
         rd_kafka_share_t *share_c1, *share_c2, *share_c3;
-        const char *topic = test_mk_topic_name(__FUNCTION__, 0);
-        const char *group = "test-share-group-distribution";
-        int total_partitions;
+        const char *topic    = test_mk_topic_name(__FUNCTION__, 0);
+        const char *group    = "test-share-group-distribution";
+        int total_partitions = 0;
+        rd_bool_t converged;
         int64_t dl;
 
         SUB_TEST_QUICK();
@@ -1649,8 +1650,21 @@ static void do_test_multiple_members_partition_distribution(void) {
         TEST_CALL_ERR__(rd_kafka_share_subscribe(share_c3, subscription));
         rd_kafka_topic_partition_list_destroy(subscription);
 
-        /* Wait for all 3 consumers to get at least 1 partition each
-         * and total >= 6. */
+        /* Wait until all 3 consumers have converged on a fair distribution
+         * (each member holds at least 1 partition and the total is >= 6) and
+         * assert on the snapshot that satisfied that check.
+         *
+         * The assignment is driven by the heartbeat thread and churns while
+         * the three members are still joining, so a member may transiently
+         * hold partitions and then have them reassigned. Re-reading the
+         * assignment after convergence would race against that churn and
+         * observe an intermediate state, so the lists that satisfied the
+         * check are kept and asserted on directly. */
+        TEST_SAY(
+            "Waiting for 3 members to converge on a fair distribution "
+            "of 6 partitions...\n");
+        share_c1_assign = share_c2_assign = share_c3_assign = NULL;
+        converged                                           = rd_false;
         dl = test_clock() + 15000 * 1000;
         while (test_clock() < dl) {
                 TEST_CALL_ERR__(rd_kafka_assignment(
@@ -1661,39 +1675,29 @@ static void do_test_multiple_members_partition_distribution(void) {
                     test_share_consumer_get_rk(share_c3), &share_c3_assign));
                 total_partitions = share_c1_assign->cnt + share_c2_assign->cnt +
                                    share_c3_assign->cnt;
+                TEST_SAY(
+                    "Current assignment: share consumer 1=%d, "
+                    "share consumer 2=%d, share consumer 3=%d (total=%d)\n",
+                    share_c1_assign->cnt, share_c2_assign->cnt,
+                    share_c3_assign->cnt, total_partitions);
                 if (share_c1_assign->cnt >= 1 && share_c2_assign->cnt >= 1 &&
                     share_c3_assign->cnt >= 1 && total_partitions >= 6) {
-                        rd_kafka_topic_partition_list_destroy(share_c1_assign);
-                        rd_kafka_topic_partition_list_destroy(share_c2_assign);
-                        rd_kafka_topic_partition_list_destroy(share_c3_assign);
+                        converged = rd_true;
+                        TEST_SAY(
+                            "All 3 members converged, fair distribution "
+                            "reached\n");
                         break;
                 }
                 rd_kafka_topic_partition_list_destroy(share_c1_assign);
                 rd_kafka_topic_partition_list_destroy(share_c2_assign);
                 rd_kafka_topic_partition_list_destroy(share_c3_assign);
+                TEST_SAY("Not yet converged, retrying in 200ms...\n");
                 rd_usleep(200 * 1000, 0);
         }
-        /* Final check */
-        TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c1), &share_c1_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c2), &share_c2_assign));
-        TEST_CALL_ERR__(rd_kafka_assignment(
-            test_share_consumer_get_rk(share_c3), &share_c3_assign));
-        total_partitions =
-            share_c1_assign->cnt + share_c2_assign->cnt + share_c3_assign->cnt;
-        TEST_ASSERT(share_c1_assign->cnt >= 1,
-                    "Expected share_c1 to have at least 1 partition, got %d",
-                    share_c1_assign->cnt);
-        TEST_ASSERT(share_c2_assign->cnt >= 1,
-                    "Expected share_c2 to have at least 1 partition, got %d",
-                    share_c2_assign->cnt);
-        TEST_ASSERT(share_c3_assign->cnt >= 1,
-                    "Expected share_c3 to have at least 1 partition, got %d",
-                    share_c3_assign->cnt);
-        TEST_ASSERT(total_partitions >= 6,
-                    "Expected at least 6 total partition assignments, got %d",
-                    total_partitions);
+
+        TEST_ASSERT(converged,
+                    "Consumers did not converge on a fair distribution "
+                    "(each member >= 1 partition, total >= 6) within timeout");
 
         TEST_SAY(
             "Partition distribution: share consumer 1=%d, share consumer 2=%d, "


### PR DESCRIPTION
Preview-readiness changes for the KIP-932 share consumer:

- **Preview warning:** log a warning on share consumer creation that it is in
  Preview and not recommended for production use.
- **Examples:** acknowledge by processing outcome (ACCEPT/RELEASE/REJECT),
  commit once per batch, demonstrate the async ack-commit callback, and stop
  on a fatal poll error. Drop the ad-hoc poll-timing code.
- **Docs:** note that RENEW is not yet available where the ack types are
  introduced; clarify that acknowledged-but-uncommitted records commit on close.